### PR TITLE
Add --paged-attention flag implementing vLLM-style block KV cache

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,256 @@
+//! Benchmark runner for `inferrs bench`.
+//!
+//! Runs a configurable number of synthetic generation requests against the
+//! local inference engine and reports throughput and latency statistics.
+//!
+//! Metrics reported per run:
+//!   - Prefill throughput  (prompt tokens / prefill wall-time)
+//!   - Decode  throughput  (output tokens / decode  wall-time)
+//!   - Time to first token (TTFT)   — prefill wall-time
+//!   - Mean per-token latency       — decode wall-time / output tokens
+//!   - End-to-end latency           — total wall-time for the request
+
+use anyhow::Result;
+use candle_core::DType;
+
+use crate::config::RawConfig;
+use crate::engine::Engine;
+use crate::kv_cache::{BlockPool, PagedCacheConfig, PagedKvStore};
+use crate::sampler::SamplingParams;
+use crate::tokenizer::Tokenizer;
+use crate::ServeArgs;
+
+/// Extra options that only apply to the bench subcommand.
+#[derive(clap::Args, Clone)]
+pub struct BenchArgs {
+    /// All options shared with `serve` (model, dtype, device, …).
+    #[command(flatten)]
+    pub serve: ServeArgs,
+
+    /// Number of warm-up runs (results discarded).
+    #[arg(long, default_value_t = 1)]
+    pub warmup: usize,
+
+    /// Number of timed benchmark runs.
+    #[arg(long, default_value_t = 5)]
+    pub runs: usize,
+
+    /// Number of synthetic prompt tokens to feed as input.
+    #[arg(long, default_value_t = 128)]
+    pub prompt_len: usize,
+}
+
+pub fn run(args: BenchArgs) -> Result<()> {
+    let serve = &args.serve;
+    let device = serve.resolve_device()?;
+    let dtype = serve.resolve_dtype()?;
+
+    // Download / load model (same path as `serve`)
+    let model_files = crate::hub::download_model(&serve.model, &serve.revision)?;
+    let raw_config = RawConfig::from_file(&model_files.config_path)?;
+    let arch = raw_config.detect_architecture()?;
+    tracing::info!("Detected architecture: {:?}", arch);
+
+    let tokenizer = Tokenizer::from_file(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+    )?;
+
+    let model = crate::models::load_model(
+        &raw_config,
+        &arch,
+        &model_files.weight_paths,
+        dtype,
+        &device,
+    )?;
+
+    let mut engine = Engine::new(
+        model,
+        Tokenizer::from_file(
+            &model_files.tokenizer_path,
+            model_files.tokenizer_config_path.as_deref(),
+        )?,
+        device.clone(),
+        serve.max_batch_size,
+        serve.max_tokens_per_step,
+    );
+
+    // Wire up paged attention if requested (same logic as `serve`)
+    if let Some(memory_fraction) = serve.paged_attention {
+        let bytes_per_element = match dtype {
+            DType::F32 => 4,
+            _ => 2,
+        };
+        let total_memory_bytes: usize = match &device {
+            candle_core::Device::Cuda(_) | candle_core::Device::Metal(_) => 8 * 1024 * 1024 * 1024,
+            _ => 4 * 1024 * 1024 * 1024,
+        };
+        let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(&arch);
+        let paged_cfg = PagedCacheConfig::from_memory_fraction(
+            total_memory_bytes,
+            memory_fraction,
+            serve.block_size,
+            num_kv_heads,
+            head_dim,
+            num_kv_layers,
+            bytes_per_element,
+        );
+        tracing::info!(
+            "Paged KV store: {} blocks × {} tokens/block",
+            paged_cfg.num_blocks,
+            paged_cfg.block_size,
+        );
+        let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
+        let kv_store = PagedKvStore::new(paged_cfg, dtype, &device)?;
+        engine = engine.with_paged_kv(block_pool, kv_store);
+    }
+
+    // Build a synthetic prompt of the requested length.
+    // Use the tokenizer's BOS token id if available, otherwise token id 1.
+    let bos_id = tokenizer.stop_token_ids.first().copied().unwrap_or(1);
+    let prompt_tokens: Vec<u32> = std::iter::repeat_n(bos_id, args.prompt_len).collect();
+
+    // Clamp max_tokens to the model's effective KV-cache capacity so that
+    // models with a sliding-window limit (e.g. Gemma3 at 512 tokens) don't
+    // crash mid-generation with an opaque tensor error.
+    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    let max_tokens = {
+        let available = if max_seq_len == usize::MAX {
+            serve.max_tokens
+        } else {
+            max_seq_len.saturating_sub(prompt_tokens.len())
+        };
+        if serve.max_tokens > available {
+            tracing::warn!(
+                "Clamping max_tokens {} → {} (model KV cache capacity: {}, prompt: {})",
+                serve.max_tokens,
+                available,
+                max_seq_len,
+                prompt_tokens.len(),
+            );
+        }
+        serve.max_tokens.min(available)
+    };
+
+    let sampling_params = SamplingParams {
+        temperature: serve.temperature,
+        top_p: serve.top_p,
+        top_k: serve.top_k,
+        repetition_penalty: 1.0,
+        max_tokens,
+    };
+
+    let total_runs = args.warmup + args.runs;
+    let mut prefill_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
+    let mut decode_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
+    let mut e2e_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
+    let mut prompt_tok_samples: Vec<usize> = Vec::with_capacity(args.runs);
+    let mut output_tok_samples: Vec<usize> = Vec::with_capacity(args.runs);
+
+    println!(
+        "Benchmarking {} ({} warm-up + {} timed runs, prompt_len={}, max_tokens={})",
+        serve.model, args.warmup, args.runs, args.prompt_len, max_tokens,
+    );
+
+    for i in 0..total_runs {
+        let is_warmup = i < args.warmup;
+        let label = if is_warmup {
+            format!("warm-up {}/{}", i + 1, args.warmup)
+        } else {
+            format!("run {}/{}", i - args.warmup + 1, args.runs)
+        };
+
+        let wall_start = std::time::Instant::now();
+        let (result, prefill_ms, decode_ms) =
+            engine.bench_generate("bench", &prompt_tokens, &sampling_params)?;
+        let e2e_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
+
+        let n_prompt = result.prompt_tokens;
+        let n_output = result.completion_tokens;
+
+        if is_warmup {
+            println!(
+                "  [{}] prefill={:.1}ms  decode={:.1}ms  output_tokens={}",
+                label, prefill_ms, decode_ms, n_output
+            );
+        } else {
+            prefill_ms_samples.push(prefill_ms);
+            decode_ms_samples.push(decode_ms);
+            e2e_ms_samples.push(e2e_ms);
+            prompt_tok_samples.push(n_prompt);
+            output_tok_samples.push(n_output);
+
+            let ttft_ms = prefill_ms;
+            let decode_tps = if decode_ms > 0.0 {
+                n_output as f64 / (decode_ms / 1000.0)
+            } else {
+                0.0
+            };
+            let prefill_tps = if prefill_ms > 0.0 {
+                n_prompt as f64 / (prefill_ms / 1000.0)
+            } else {
+                0.0
+            };
+
+            println!(
+                "  [{}] TTFT={:.1}ms  decode={:.1}tok/s  prefill={:.1}tok/s  output_tokens={}",
+                label, ttft_ms, decode_tps, prefill_tps, n_output
+            );
+        }
+    }
+
+    if args.runs == 0 {
+        return Ok(());
+    }
+
+    // ── Aggregate statistics ─────────────────────────────────────────────────
+    let n = args.runs as f64;
+
+    let mean_prefill_ms = prefill_ms_samples.iter().sum::<f64>() / n;
+    let mean_decode_ms = decode_ms_samples.iter().sum::<f64>() / n;
+    let mean_e2e_ms = e2e_ms_samples.iter().sum::<f64>() / n;
+    let mean_prompt_toks = prompt_tok_samples.iter().sum::<usize>() as f64 / n;
+    let mean_output_toks = output_tok_samples.iter().sum::<usize>() as f64 / n;
+
+    let mean_prefill_tps = mean_prompt_toks / (mean_prefill_ms / 1000.0);
+    let mean_decode_tps = mean_output_toks / (mean_decode_ms / 1000.0);
+    let mean_per_token_ms = if mean_output_toks > 0.0 {
+        mean_decode_ms / mean_output_toks
+    } else {
+        0.0
+    };
+
+    // p50 / p90 for end-to-end latency
+    let mut sorted_e2e = e2e_ms_samples.clone();
+    sorted_e2e.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p50 = percentile(&sorted_e2e, 50.0);
+    let p90 = percentile(&sorted_e2e, 90.0);
+
+    println!();
+    println!(
+        "── Results ({} runs) ──────────────────────────────────────────",
+        args.runs
+    );
+    println!("  Prompt tokens (avg)     : {:.0}", mean_prompt_toks);
+    println!("  Output tokens (avg)     : {:.0}", mean_output_toks);
+    println!("  Prefill throughput      : {:.1} tok/s", mean_prefill_tps);
+    println!("  Decode  throughput      : {:.1} tok/s", mean_decode_tps);
+    println!("  Time to first token     : {:.1} ms", mean_prefill_ms);
+    println!(
+        "  Per-token latency (avg) : {:.2} ms/tok",
+        mean_per_token_ms
+    );
+    println!("  End-to-end latency (avg): {:.1} ms", mean_e2e_ms);
+    println!("  End-to-end p50          : {:.1} ms", p50);
+    println!("  End-to-end p90          : {:.1} ms", p90);
+
+    Ok(())
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let idx = (p / 100.0 * (sorted.len() - 1) as f64).round() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -274,9 +274,83 @@ impl RawConfig {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn max_seq_len(&self) -> usize {
-        self.max_position_embeddings.unwrap_or(4096)
+    /// Return the effective maximum sequence length that the model's KV cache
+    /// can hold.
+    ///
+    /// For Gemma3, the upstream candle-transformers implementation sizes **all**
+    /// KV caches (both sliding-window and non-sliding layers) to
+    /// `sliding_window` tokens.  Any attempt to generate beyond that limit
+    /// causes an opaque tensor error.  We therefore report `sliding_window` as
+    /// the hard limit for Gemma3, not `max_position_embeddings`.
+    pub fn effective_max_seq_len(&self, arch: &ModelArchitecture) -> usize {
+        match arch {
+            ModelArchitecture::Gemma3 => {
+                // The KvCache is capped at sliding_window in candle-transformers.
+                self.sliding_window.unwrap_or(512)
+            }
+            ModelArchitecture::Gemma2 => self.max_position_embeddings.unwrap_or(8192),
+            ModelArchitecture::Qwen2 => self.max_position_embeddings.unwrap_or(131072),
+            ModelArchitecture::Qwen35 => {
+                let tc = self.text_config.as_ref();
+                // Qwen3.5 uses linear attention for most layers; the full-attn
+                // layers have no artificial cap.
+                tc.and_then(|t| t.num_hidden_layers)
+                    .map(|_| usize::MAX) // effectively unlimited
+                    .unwrap_or(usize::MAX)
+            }
+        }
+    }
+
+    /// Return `(num_kv_heads, head_dim, num_full_attn_layers)` for paged KV
+    /// cache sizing.  `num_full_attn_layers` is the number of layers whose KV
+    /// pairs are stored in the paged store (full-attention layers only; SSM
+    /// layers are excluded).
+    pub fn kv_cache_params(&self, arch: &ModelArchitecture) -> (usize, usize, usize) {
+        match arch {
+            ModelArchitecture::Qwen35 => {
+                let tc = self.text_config.as_ref();
+                let num_kv_heads = tc.and_then(|t| t.num_key_value_heads).unwrap_or(2);
+                let head_dim = tc.and_then(|t| t.head_dim).unwrap_or(256);
+                let num_hidden_layers = tc.and_then(|t| t.num_hidden_layers).unwrap_or(24);
+                let full_attention_interval =
+                    tc.and_then(|t| t.full_attention_interval).unwrap_or(4);
+                // Count full-attention layers from layer_types list if present.
+                let num_full_attn = if let Some(types) = tc.and_then(|t| t.layer_types.as_ref()) {
+                    types
+                        .iter()
+                        .filter(|s| s.as_str() == "full_attention")
+                        .count()
+                } else {
+                    // Fallback: every full_attention_interval-th layer is full-attention.
+                    (0..num_hidden_layers)
+                        .filter(|i| (i + 1) % full_attention_interval == 0)
+                        .count()
+                };
+                (num_kv_heads, head_dim, num_full_attn)
+            }
+            ModelArchitecture::Qwen2 => {
+                let num_kv_heads = self.num_key_value_heads.unwrap_or(2);
+                let num_attention_heads = self.num_attention_heads.unwrap_or(14);
+                let hidden_size = self.hidden_size.unwrap_or(896);
+                let head_dim = hidden_size / num_attention_heads;
+                let num_layers = self.num_hidden_layers.unwrap_or(24);
+                (num_kv_heads, head_dim, num_layers)
+            }
+            ModelArchitecture::Gemma2 => {
+                let num_kv_heads = self.num_key_value_heads.unwrap_or(8);
+                let num_attention_heads = self.num_attention_heads.unwrap_or(16);
+                let hidden_size = self.hidden_size.unwrap_or(3584);
+                let head_dim = self.head_dim.unwrap_or(hidden_size / num_attention_heads);
+                let num_layers = self.num_hidden_layers.unwrap_or(42);
+                (num_kv_heads, head_dim, num_layers)
+            }
+            ModelArchitecture::Gemma3 => {
+                let num_kv_heads = self.num_key_value_heads.unwrap_or(4);
+                let head_dim = self.head_dim.unwrap_or(256);
+                let num_layers = self.num_hidden_layers.unwrap_or(34);
+                (num_kv_heads, head_dim, num_layers)
+            }
+        }
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use candle_core::{Device, Tensor};
 use tokio::sync::{mpsc, oneshot};
 
+use crate::kv_cache::{BlockPool, BlockTable, PagedKvStore};
 use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
@@ -56,6 +57,16 @@ pub struct Engine {
     max_batch_size: usize,
     #[allow(dead_code)]
     max_tokens_per_step: usize,
+    /// When `Some`, paged-attention is active.
+    paged: Option<PagedState>,
+}
+
+/// State needed for paged-attention mode.
+struct PagedState {
+    block_pool: BlockPool,
+    kv_store: PagedKvStore,
+    /// Per-request block table, reset at the start of each request.
+    block_table: BlockTable,
 }
 
 impl Engine {
@@ -74,7 +85,19 @@ impl Engine {
             stop_token_ids,
             max_batch_size,
             max_tokens_per_step,
+            paged: None,
         }
+    }
+
+    /// Attach a paged KV store to this engine, enabling paged-attention mode.
+    pub fn with_paged_kv(mut self, block_pool: BlockPool, kv_store: PagedKvStore) -> Self {
+        let block_size = block_pool.block_size;
+        self.paged = Some(PagedState {
+            block_pool,
+            kv_store,
+            block_table: BlockTable::new(block_size),
+        });
+        self
     }
 
     /// Run the engine loop, processing requests from the channel.
@@ -126,7 +149,54 @@ impl Engine {
         tracing::info!("Engine loop stopped");
     }
 
-    /// Non-streaming generation.
+    // ── Paged-attention helpers ───────────────────────────────────────────────
+
+    /// Allocate paged slots for `count` consecutive positions starting at
+    /// `start_pos`.  Returns an error if the pool is exhausted.
+    fn paged_alloc_range(ps: &mut PagedState, start_pos: usize, count: usize) -> Result<()> {
+        for pos in start_pos..start_pos + count {
+            if !ps.block_table.ensure_allocated(pos, &mut ps.block_pool) {
+                anyhow::bail!("paged attention: out of KV blocks at position {}", pos);
+            }
+        }
+        Ok(())
+    }
+
+    /// Run a prefill forward pass through the paged KV store.
+    fn paged_prefill(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        prompt_tokens: &[u32],
+        ps: &mut PagedState,
+    ) -> Result<Tensor> {
+        Self::paged_alloc_range(ps, 0, prompt_tokens.len())?;
+        let input_ids = Tensor::new(prompt_tokens, device)?.unsqueeze(0)?;
+        model.forward_paged(&input_ids, 0, &ps.block_table, &mut ps.kv_store)
+    }
+
+    /// Run a single decode step through the paged KV store.
+    fn paged_decode_step(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        token_id: u32,
+        seqlen_offset: usize,
+        ps: &mut PagedState,
+    ) -> Result<Tensor> {
+        if !ps
+            .block_table
+            .ensure_allocated(seqlen_offset, &mut ps.block_pool)
+        {
+            anyhow::bail!(
+                "paged attention: out of KV blocks at position {}",
+                seqlen_offset
+            );
+        }
+        let input_ids = Tensor::new(&[token_id], device)?.unsqueeze(0)?;
+        model.forward_paged(&input_ids, seqlen_offset, &ps.block_table, &mut ps.kv_store)
+    }
+
+    // ── Non-streaming generation ──────────────────────────────────────────────
+
     fn generate(
         &mut self,
         request_id: &str,
@@ -140,40 +210,47 @@ impl Engine {
             sampling_params.max_tokens
         );
 
-        // Clear KV cache for new sequence
-        self.model.clear_kv_cache();
-
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
-        // Prefill: process all prompt tokens at once
-        let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-        let logits = self.model.forward(&input_ids, 0)?;
+        let logits = if let Some(ps) = &mut self.paged {
+            // ── Paged path ────────────────────────────────────────────────────
+            ps.block_table.free_all(&mut ps.block_pool);
+            self.model.clear_kv_cache();
+            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
+        } else {
+            // ── Concat-KV path ────────────────────────────────────────────────
+            self.model.clear_kv_cache();
+            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, 0)?
+        };
 
-        // Sample first token
         let mut token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
         all_tokens.push(token_id);
 
-        // Check for immediate stop
         let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
 
-        // Decode loop: generate one token at a time
         while finish_reason.is_none() {
-            let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-            let logits = self.model.forward(&input_ids, seqlen_offset)?;
+            let logits = if let Some(ps) = &mut self.paged {
+                Self::paged_decode_step(&mut self.model, &self.device, token_id, seqlen_offset, ps)?
+            } else {
+                let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
+                self.model.forward(&input_ids, seqlen_offset)?
+            };
 
             token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
             all_tokens.push(token_id);
-
             finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
         }
 
-        let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+        }
 
-        // Decode output tokens to text
+        let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
         let output_text = self.tokenizer.decode(&output_tokens, true)?;
 
         tracing::debug!(
@@ -192,7 +269,8 @@ impl Engine {
         })
     }
 
-    /// Streaming generation.
+    // ── Streaming generation ──────────────────────────────────────────────────
+
     fn generate_stream(
         &mut self,
         request_id: &str,
@@ -206,17 +284,20 @@ impl Engine {
             prompt_tokens.len()
         );
 
-        // Clear KV cache for new sequence
-        self.model.clear_kv_cache();
-
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
         // Prefill
-        let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-        let logits = self.model.forward(&input_ids, 0)?;
+        let logits = if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+            self.model.clear_kv_cache();
+            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
+        } else {
+            self.model.clear_kv_cache();
+            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, 0)?
+        };
 
-        // Sample first token
         let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
         all_tokens.push(token_id);
@@ -231,20 +312,31 @@ impl Engine {
                 finish_reason: finish_reason.clone(),
             })
             .is_err()
+            || finish_reason.is_some()
         {
-            return Ok(()); // Client disconnected
-        }
-
-        if finish_reason.is_some() {
+            if let Some(ps) = &mut self.paged {
+                ps.block_table.free_all(&mut ps.block_pool);
+            }
             return Ok(());
         }
 
         // Decode loop
         loop {
             let last_token = *output_tokens.last().unwrap();
-            let input_ids = Tensor::new(&[last_token], &self.device)?.unsqueeze(0)?;
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-            let logits = self.model.forward(&input_ids, seqlen_offset)?;
+
+            let logits = if let Some(ps) = &mut self.paged {
+                Self::paged_decode_step(
+                    &mut self.model,
+                    &self.device,
+                    last_token,
+                    seqlen_offset,
+                    ps,
+                )?
+            } else {
+                let input_ids = Tensor::new(&[last_token], &self.device)?.unsqueeze(0)?;
+                self.model.forward(&input_ids, seqlen_offset)?
+            };
 
             let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
@@ -260,16 +352,92 @@ impl Engine {
                     finish_reason: finish_reason.clone(),
                 })
                 .is_err()
+                || finish_reason.is_some()
             {
-                return Ok(()); // Client disconnected
-            }
-
-            if finish_reason.is_some() {
                 break;
             }
         }
 
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+        }
+
         Ok(())
+    }
+
+    // ── Benchmark generation ──────────────────────────────────────────────────
+
+    /// Run a single generation and return the result plus timing breakdown.
+    ///
+    /// Returns `(result, prefill_ms, decode_ms)` where:
+    /// - `prefill_ms` is the wall time for the prefill forward pass
+    /// - `decode_ms`  is the wall time for all decode steps combined
+    pub fn bench_generate(
+        &mut self,
+        _request_id: &str,
+        prompt_tokens: &[u32],
+        sampling_params: &SamplingParams,
+    ) -> Result<(GenerationResult, f64, f64)> {
+        use std::time::Instant;
+
+        let mut output_tokens: Vec<u32> = Vec::new();
+        let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
+
+        let prefill_start = Instant::now();
+
+        let logits = if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+            self.model.clear_kv_cache();
+            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
+        } else {
+            self.model.clear_kv_cache();
+            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, 0)?
+        };
+
+        let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
+
+        let mut token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+        output_tokens.push(token_id);
+        all_tokens.push(token_id);
+
+        let decode_start = Instant::now();
+        let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+
+        while finish_reason.is_none() {
+            let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
+            let logits = if let Some(ps) = &mut self.paged {
+                Self::paged_decode_step(&mut self.model, &self.device, token_id, seqlen_offset, ps)?
+            } else {
+                let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
+                self.model.forward(&input_ids, seqlen_offset)?
+            };
+            token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+            output_tokens.push(token_id);
+            all_tokens.push(token_id);
+            finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+        }
+
+        let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
+
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+        }
+
+        let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
+        let output_text = self.tokenizer.decode(&output_tokens, true)?;
+
+        Ok((
+            GenerationResult {
+                prompt_tokens: prompt_tokens.len(),
+                completion_tokens: output_tokens.len(),
+                output_token_ids: output_tokens,
+                output_text,
+                finish_reason,
+            },
+            prefill_ms,
+            decode_ms,
+        ))
     }
 
     fn check_stop(

--- a/src/kv_cache.rs
+++ b/src/kv_cache.rs
@@ -1,9 +1,27 @@
-//! Block-based KV cache with grow-on-demand allocation.
+//! Block-based KV cache with paged-attention support.
 //!
-//! This module is a placeholder for the full block-based KV cache system.
-//! Currently, the candle-transformers models manage their own concat-based
-//! KV caches internally. This module tracks memory usage and provides the
-//! interface for future paged-attention integration.
+//! This module implements the vLLM-style paged attention algorithm:
+//!
+//! * The KV cache is divided into fixed-size **blocks** (pages).  Each block
+//!   holds `block_size` token slots for every (layer, head).
+//! * A per-sequence **block table** maps logical block indices to physical
+//!   block IDs allocated from a shared pool.
+//! * A free list (LRU ordering) tracks available blocks so that memory can be
+//!   reclaimed from finished sequences and reused.
+//!
+//! The public API used by the attention kernel is:
+//! ```
+//! slot_id = block_table[logical_block] * block_size + (position % block_size)
+//! ```
+//! The physical KV tensors are indexed by `slot_id` instead of the raw
+//! sequence position, breaking the requirement for contiguous per-sequence
+//! memory.
+
+use std::collections::VecDeque;
+
+// ---------------------------------------------------------------------------
+// Legacy placeholder types (kept for backward compat)
+// ---------------------------------------------------------------------------
 
 /// KV cache configuration.
 #[derive(Debug, Clone)]
@@ -25,7 +43,7 @@ impl KvCacheConfig {
     }
 }
 
-/// Tracks KV cache usage for a single sequence.
+/// Tracks KV cache usage for a single sequence (legacy, concat-based).
 #[derive(Debug)]
 #[allow(dead_code)]
 pub struct SequenceCache {
@@ -58,5 +76,294 @@ impl SequenceCache {
     #[allow(dead_code)]
     pub fn record_tokens(&mut self, count: usize) {
         self.num_cached_tokens += count;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paged attention: BlockPool
+// ---------------------------------------------------------------------------
+
+/// Configuration for the paged KV cache.
+#[derive(Debug, Clone)]
+pub struct PagedCacheConfig {
+    /// Number of token slots per block (vLLM default: 16).
+    pub block_size: usize,
+    /// Total number of physical blocks in the pool.
+    pub num_blocks: usize,
+    /// Number of KV heads per attention layer.
+    pub num_kv_heads: usize,
+    /// Dimension of each KV head.
+    pub head_dim: usize,
+    /// Number of full-attention layers whose KV cache is managed here.
+    pub num_layers: usize,
+}
+
+impl PagedCacheConfig {
+    /// Compute the number of physical blocks that fit in `memory_fraction` of
+    /// the given total memory (in bytes).
+    pub fn from_memory_fraction(
+        memory_bytes: usize,
+        memory_fraction: f64,
+        block_size: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        num_layers: usize,
+        bytes_per_element: usize, // 2 for bf16/f16, 4 for f32
+    ) -> Self {
+        let available = (memory_bytes as f64 * memory_fraction) as usize;
+        // Each block holds block_size tokens × num_kv_heads × head_dim × 2 (K+V) per layer.
+        let bytes_per_block =
+            block_size * num_kv_heads * head_dim * 2 * num_layers * bytes_per_element;
+        let num_blocks = if bytes_per_block == 0 {
+            0
+        } else {
+            available / bytes_per_block
+        };
+        Self {
+            block_size,
+            num_blocks,
+            num_kv_heads,
+            head_dim,
+            num_layers,
+        }
+    }
+}
+
+/// A physical block in the KV cache pool.
+#[derive(Debug)]
+struct Block {
+    /// Reference count: number of sequences currently using this block.
+    ref_cnt: u32,
+}
+
+/// Shared physical block pool — analogous to vLLM's `BlockPool`.
+///
+/// Blocks are allocated from a free list (FIFO/LRU head) and returned to the
+/// tail when freed so that recently freed blocks (which may still be warm in
+/// cache) are evicted last.
+pub struct BlockPool {
+    blocks: Vec<Block>,
+    /// Indices of free blocks in LRU order (front = oldest / evict first).
+    free_list: VecDeque<u32>,
+    pub block_size: usize,
+}
+
+impl BlockPool {
+    pub fn new(num_blocks: usize, block_size: usize) -> Self {
+        let mut blocks = Vec::with_capacity(num_blocks);
+        let mut free_list = VecDeque::with_capacity(num_blocks);
+        for id in 0..num_blocks as u32 {
+            blocks.push(Block { ref_cnt: 0 });
+            free_list.push_back(id);
+        }
+        Self {
+            blocks,
+            free_list,
+            block_size,
+        }
+    }
+
+    /// Number of blocks currently available for allocation.
+    #[allow(dead_code)]
+    pub fn num_free_blocks(&self) -> usize {
+        self.free_list.len()
+    }
+
+    /// Allocate `n` blocks.  Returns `None` if there are not enough free blocks.
+    pub fn allocate(&mut self, n: usize) -> Option<Vec<u32>> {
+        if self.free_list.len() < n {
+            return None;
+        }
+        let mut ids = Vec::with_capacity(n);
+        for _ in 0..n {
+            let id = self.free_list.pop_front().unwrap();
+            self.blocks[id as usize].ref_cnt = 1;
+            ids.push(id);
+        }
+        Some(ids)
+    }
+
+    /// Allocate a single block.
+    pub fn allocate_one(&mut self) -> Option<u32> {
+        self.allocate(1).map(|v| v[0])
+    }
+
+    /// Decrement reference counts and return freed blocks to the tail of the
+    /// free list (MRU position — evicted last).
+    pub fn free_blocks(&mut self, block_ids: &[u32]) {
+        for &id in block_ids {
+            let block = &mut self.blocks[id as usize];
+            if block.ref_cnt > 0 {
+                block.ref_cnt -= 1;
+            }
+            if block.ref_cnt == 0 {
+                self.free_list.push_back(id);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paged attention: per-sequence BlockTable
+// ---------------------------------------------------------------------------
+
+/// Maps logical block indices → physical block IDs for a single sequence.
+///
+/// The block table grows on demand as the sequence generates more tokens.
+/// The slot for token at position `pos` is:
+/// ```
+/// slot = block_table[pos / block_size] * block_size + (pos % block_size)
+/// ```
+#[derive(Debug, Default)]
+pub struct BlockTable {
+    /// Physical block IDs, indexed by logical block number.
+    physical_blocks: Vec<u32>,
+    /// Total number of tokens whose slots have been reserved.
+    num_tokens: usize,
+    block_size: usize,
+}
+
+impl BlockTable {
+    pub fn new(block_size: usize) -> Self {
+        Self {
+            physical_blocks: Vec::new(),
+            num_tokens: 0,
+            block_size,
+        }
+    }
+
+    /// Number of tokens already mapped in the block table.
+    #[allow(dead_code)]
+    pub fn num_tokens(&self) -> usize {
+        self.num_tokens
+    }
+
+    /// Number of physical blocks currently allocated.
+    #[allow(dead_code)]
+    pub fn num_blocks(&self) -> usize {
+        self.physical_blocks.len()
+    }
+
+    /// Resolve a token position to a flat cache slot ID.
+    /// Returns `None` if the position hasn't been allocated yet.
+    pub fn slot_for(&self, position: usize) -> Option<u32> {
+        let block_idx = position / self.block_size;
+        if block_idx >= self.physical_blocks.len() {
+            return None;
+        }
+        let block_offset = (position % self.block_size) as u32;
+        Some(self.physical_blocks[block_idx] * self.block_size as u32 + block_offset)
+    }
+
+    /// Ensure that `position + 1` token slots are allocated.  Allocates new
+    /// blocks from `pool` as needed.  Returns `false` if the pool is full.
+    pub fn ensure_allocated(&mut self, position: usize, pool: &mut BlockPool) -> bool {
+        let needed_blocks = position / self.block_size + 1;
+        while self.physical_blocks.len() < needed_blocks {
+            match pool.allocate_one() {
+                Some(id) => self.physical_blocks.push(id),
+                None => return false,
+            }
+        }
+        if position + 1 > self.num_tokens {
+            self.num_tokens = position + 1;
+        }
+        true
+    }
+
+    /// Return all physical blocks to the pool.
+    pub fn free_all(&mut self, pool: &mut BlockPool) {
+        pool.free_blocks(&self.physical_blocks);
+        self.physical_blocks.clear();
+        self.num_tokens = 0;
+    }
+
+    /// Raw slice of physical block IDs (for passing to the attention kernel).
+    #[allow(dead_code)]
+    pub fn physical_blocks(&self) -> &[u32] {
+        &self.physical_blocks
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Paged KV store: the physical K/V tensors indexed by slot_id
+// ---------------------------------------------------------------------------
+
+use candle_core::{DType, Device, Tensor};
+
+/// Physical KV cache storage for all full-attention layers.
+///
+/// Memory layout (per layer):
+///   key_cache[layer]:   [num_blocks * block_size, num_kv_heads, head_dim]
+///   value_cache[layer]: [num_blocks * block_size, num_kv_heads, head_dim]
+///
+/// Access: `key_cache[layer].narrow(0, slot_id, 1)` gives the key for one
+/// token slot.
+pub struct PagedKvStore {
+    /// Key caches, one tensor per full-attention layer.
+    pub key_caches: Vec<Tensor>,
+    /// Value caches, one tensor per full-attention layer.
+    pub value_caches: Vec<Tensor>,
+    #[allow(dead_code)]
+    pub cfg: PagedCacheConfig,
+}
+
+impl PagedKvStore {
+    /// Allocate zeroed KV cache tensors.
+    pub fn new(cfg: PagedCacheConfig, dtype: DType, device: &Device) -> candle_core::Result<Self> {
+        let total_slots = cfg.num_blocks * cfg.block_size;
+        let mut key_caches = Vec::with_capacity(cfg.num_layers);
+        let mut value_caches = Vec::with_capacity(cfg.num_layers);
+        for _ in 0..cfg.num_layers {
+            key_caches.push(Tensor::zeros(
+                (total_slots, cfg.num_kv_heads, cfg.head_dim),
+                dtype,
+                device,
+            )?);
+            value_caches.push(Tensor::zeros(
+                (total_slots, cfg.num_kv_heads, cfg.head_dim),
+                dtype,
+                device,
+            )?);
+        }
+        Ok(Self {
+            key_caches,
+            value_caches,
+            cfg,
+        })
+    }
+
+    /// Write key/value vectors for one token into the store at `slot_id`.
+    ///
+    /// `k` / `v`: tensors of shape `[num_kv_heads, head_dim]`.
+    pub fn write_slot(
+        &mut self,
+        layer_idx: usize,
+        slot_id: usize,
+        k: &Tensor,
+        v: &Tensor,
+    ) -> candle_core::Result<()> {
+        // index_add on dim 0: add k at position slot_id
+        let idx = Tensor::new(&[slot_id as u32], k.device())?;
+        self.key_caches[layer_idx] =
+            self.key_caches[layer_idx].index_add(&idx, &k.unsqueeze(0)?, 0)?;
+        self.value_caches[layer_idx] =
+            self.value_caches[layer_idx].index_add(&idx, &v.unsqueeze(0)?, 0)?;
+        Ok(())
+    }
+
+    /// Gather key and value tensors for all slots in `slot_ids`.
+    ///
+    /// Returns `(k, v)` each of shape `[seq_len, num_kv_heads, head_dim]`.
+    pub fn gather_slots(
+        &self,
+        layer_idx: usize,
+        slot_ids: &[u32],
+    ) -> candle_core::Result<(Tensor, Tensor)> {
+        let device = self.key_caches[layer_idx].device();
+        let idx = Tensor::new(slot_ids, device)?;
+        let k = self.key_caches[layer_idx].index_select(&idx, 0)?;
+        let v = self.value_caches[layer_idx].index_select(&idx, 0)?;
+        Ok((k, v))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod config;
 mod engine;
 mod hub;
@@ -23,6 +24,8 @@ struct Cli {
 enum Commands {
     /// Serve a model from HuggingFace Hub
     Serve(ServeArgs),
+    /// Benchmark inference throughput and latency
+    Bench(bench::BenchArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -89,6 +92,13 @@ pub struct ServeArgs {
     /// Default max tokens to generate
     #[arg(long, default_value_t = 2048)]
     pub max_tokens: usize,
+
+    /// Enable paged attention KV cache (vLLM-style block management).
+    /// Specify the fraction of GPU/CPU memory to reserve for KV blocks,
+    /// e.g. `--paged-attention 0.6` reserves 60% of available memory.
+    /// When unset (the default) the standard concat-based KV cache is used.
+    #[arg(long)]
+    pub paged_attention: Option<f64>,
 }
 
 impl ServeArgs {
@@ -144,6 +154,10 @@ async fn main() -> Result<()> {
         Commands::Serve(args) => {
             tracing::info!("Starting inferrs server for model: {}", args.model);
             server::run(args).await?;
+        }
+        Commands::Bench(args) => {
+            tracing::info!("Running benchmark for model: {}", args.serve.model);
+            bench::run(args)?;
         }
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -11,11 +11,28 @@ use candle_nn::VarBuilder;
 use std::path::Path;
 
 use crate::config::{ModelArchitecture, RawConfig};
+use crate::kv_cache::{BlockTable, PagedKvStore};
+
 /// Unified model interface for the engine.
 pub trait CausalLM: Send {
     /// Run a forward pass on the given input token IDs.
     /// Returns logits for the last token position: shape (batch_size, 1, vocab_size).
     fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor>;
+
+    /// Run a paged-attention forward pass.
+    ///
+    /// The default implementation falls back to `forward`, ignoring the paged
+    /// store.  Models that support paged attention override this.
+    fn forward_paged(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        block_table: &BlockTable,
+        kv_store: &mut PagedKvStore,
+    ) -> Result<Tensor> {
+        let _ = (block_table, kv_store); // unused in default impl
+        self.forward(input_ids, seqlen_offset)
+    }
 
     /// Clear all KV caches (for starting a new sequence).
     fn clear_kv_cache(&mut self);
@@ -77,6 +94,17 @@ struct Qwen35ModelWrapper {
 impl CausalLM for Qwen35ModelWrapper {
     fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         self.inner.forward(input_ids, seqlen_offset)
+    }
+
+    fn forward_paged(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        block_table: &BlockTable,
+        kv_store: &mut PagedKvStore,
+    ) -> Result<Tensor> {
+        self.inner
+            .forward_paged(input_ids, seqlen_offset, block_table, kv_store)
     }
 
     fn clear_kv_cache(&mut self) {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -11,6 +11,21 @@ use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
 
+use crate::kv_cache::{BlockTable, PagedKvStore};
+
+/// Paged-attention context passed down to each layer's `forward_paged` call.
+///
+/// Grouping these together keeps individual method signatures within clippy's
+/// argument-count limit and makes call sites cleaner.
+pub struct PagedCtx<'a> {
+    pub cos: &'a Tensor,
+    pub sin: &'a Tensor,
+    pub block_table: &'a BlockTable,
+    pub kv_store: &'a mut PagedKvStore,
+    /// Index into the paged KV store (counts only full-attention layers).
+    pub layer_idx: usize,
+}
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -302,6 +317,123 @@ impl FullAttention {
 
     fn clear_kv_cache(&mut self) {
         self.kv_cache = None;
+    }
+
+    /// Paged-attention forward pass.
+    ///
+    /// Instead of growing a per-layer concat KV cache, keys and values are
+    /// written into `kv_store` at the physical slots resolved from `block_table`.
+    /// All previously written slots for this sequence are then gathered and used
+    /// as the full KV context.
+    ///
+    /// `seqlen_offset` is the number of tokens already processed (i.e. the
+    /// position of the *first* token in the current `x` batch).
+    /// Paged-attention context (cos/sin/block_table/kv_store/layer_idx) is
+    /// bundled in `ctx` to keep the argument count manageable.
+    fn forward_paged(
+        &self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        ctx: &mut PagedCtx,
+    ) -> Result<Tensor> {
+        let (b, t, _) = x.dims3()?;
+
+        // ── Project ──────────────────────────────────────────────────────────
+        let q_full = self.q_proj.forward(x)?;
+        let attn_dim = self.num_heads * self.head_dim;
+        let q_raw = q_full.narrow(2, 0, attn_dim)?;
+        let gate = q_full.narrow(2, attn_dim, attn_dim)?;
+
+        let k_proj_out = self.k_proj.forward(x)?; // [b, t, num_kv_heads * head_dim]
+        let v_proj_out = self.v_proj.forward(x)?;
+
+        // Reshape to [b, heads, t, head_dim]
+        let q = q_raw
+            .reshape((b, t, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k_proj_out
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v_proj_out
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // ── QK-norm ──────────────────────────────────────────────────────────
+        let q = apply_rms_norm_heads(&q, &self.q_norm)?;
+        let k = apply_rms_norm_heads(&k, &self.k_norm)?;
+
+        // ── RoPE ─────────────────────────────────────────────────────────────
+        let cos_slice = ctx.cos.narrow(0, seqlen_offset, t)?;
+        let sin_slice = ctx.sin.narrow(0, seqlen_offset, t)?;
+        let q = apply_rope(&q, &cos_slice, &sin_slice)?;
+        let k = apply_rope(&k, &cos_slice, &sin_slice)?;
+
+        // ── Write new K/V into the paged store ───────────────────────────────
+        for ti in 0..t {
+            let position = seqlen_offset + ti;
+            let slot_id = ctx.block_table.slot_for(position).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "paged attention: no slot allocated for position {}",
+                    position
+                )
+            })?;
+            let k_tok = k.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
+            let v_tok = v.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
+            ctx.kv_store
+                .write_slot(ctx.layer_idx, slot_id as usize, &k_tok, &v_tok)?;
+        }
+
+        // ── Gather full K/V context for this sequence ─────────────────────────
+        let total_tokens = seqlen_offset + t;
+        let slot_ids: Vec<u32> = (0..total_tokens)
+            .map(|pos| {
+                ctx.block_table.slot_for(pos).ok_or_else(|| {
+                    anyhow::anyhow!("paged attention: missing slot for position {}", pos)
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let (k_full, v_full) = ctx.kv_store.gather_slots(ctx.layer_idx, &slot_ids)?;
+
+        // Reshape to [b, num_kv_heads, kv_len, head_dim]  (b == 1)
+        let kv_len = total_tokens;
+        let k_full = k_full
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v_full = v_full
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // ── GQA expand ───────────────────────────────────────────────────────
+        let groups = self.num_heads / self.num_kv_heads;
+        let k_full = k_full.repeat(&[1, groups, 1, 1])?;
+        let v_full = v_full.repeat(&[1, groups, 1, 1])?;
+
+        // ── Scaled dot-product attention ─────────────────────────────────────
+        let scale = (self.head_dim as f64).sqrt();
+        let attn = q
+            .contiguous()?
+            .matmul(&k_full.transpose(2, 3)?.contiguous()?)?
+            .affine(1.0 / scale, 0.0)?;
+
+        let attn = if t > 1 {
+            let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
+            attn.broadcast_add(&mask)?
+        } else {
+            attn
+        };
+
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn.matmul(&v_full.contiguous()?)?;
+
+        // ── Reshape + output gate ─────────────────────────────────────────────
+        let out = out
+            .transpose(1, 2)?
+            .reshape((b, t, self.num_heads * self.head_dim))?;
+        let gate_sig = (gate.neg()?.exp()? + 1.0)?.recip()?;
+        let out = out.broadcast_mul(&gate_sig)?;
+
+        self.o_proj.forward(&out).map_err(Into::into)
     }
 }
 
@@ -774,6 +906,37 @@ impl DecoderLayer {
         (residual + mlp_out).map_err(Into::into)
     }
 
+    /// Paged-attention forward pass.
+    ///
+    /// For full-attention layers, delegates to `FullAttention::forward_paged`.
+    /// For linear-attention (SSM) layers, falls back to the standard path since
+    /// SSM layers maintain their own recurrent state (not a KV cache) and do not
+    /// participate in paged attention.
+    ///
+    /// `ctx.layer_idx` is the index into the paged KV store (counting only
+    /// full-attention layers, not all decoder layers).
+    fn forward_paged(
+        &mut self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        ctx: &mut PagedCtx,
+    ) -> Result<Tensor> {
+        let residual = x.clone();
+        let normed = self.input_layernorm.forward(x)?;
+
+        let attn_out = match &mut self.attn {
+            LayerAttn::Full(a) => a.forward_paged(&normed, seqlen_offset, ctx)?,
+            // SSM layers are not paged — use their standard recurrent path.
+            LayerAttn::Linear(a) => a.forward(&normed)?,
+        };
+
+        let x = (residual + attn_out)?;
+        let residual = x.clone();
+        let normed = self.post_attention_layernorm.forward(&x)?;
+        let mlp_out = self.mlp.forward(&normed)?;
+        (residual + mlp_out).map_err(Into::into)
+    }
+
     fn clear_cache(&mut self) {
         match &mut self.attn {
             LayerAttn::Full(a) => a.clear_kv_cache(),
@@ -865,6 +1028,52 @@ impl Qwen35Model {
         let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
         let logits = logits.unsqueeze(1)?; // [b, 1, vocab]
         Ok(logits)
+    }
+
+    /// Paged-attention forward pass.
+    ///
+    /// Behaves identically to `forward` but uses the vLLM-style paged KV store
+    /// instead of per-layer concat caches for full-attention layers.
+    ///
+    /// `block_table` maps this sequence's logical block indices to physical
+    /// slots in `kv_store`.  The caller is responsible for ensuring that all
+    /// positions `0..seqlen_offset + seq_len` have been allocated in the block
+    /// table before calling this method.
+    pub fn forward_paged(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        block_table: &BlockTable,
+        kv_store: &mut PagedKvStore,
+    ) -> Result<Tensor> {
+        let (_b, t) = input_ids.dims2()?;
+
+        let mut x = self.embed_tokens.forward(input_ids)?; // [b, t, hidden]
+
+        // Track which full-attention layer we are visiting so we index the
+        // correct slice of kv_store.
+        let mut full_attn_idx = 0usize;
+        for layer in &mut self.layers {
+            let is_full = matches!(layer.attn, LayerAttn::Full(_));
+            let mut ctx = PagedCtx {
+                cos: &self.cos,
+                sin: &self.sin,
+                block_table,
+                kv_store,
+                layer_idx: full_attn_idx,
+            };
+            x = layer.forward_paged(&x, seqlen_offset, &mut ctx)?;
+            if is_full {
+                full_attn_idx += 1;
+            }
+        }
+
+        x = self.norm.forward(&x)?;
+
+        let last = x.narrow(1, t - 1, 1)?;
+        let last_2d = last.squeeze(1)?.contiguous()?;
+        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?;
+        logits.unsqueeze(1).map_err(Into::into)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -20,6 +20,7 @@ use tower_http::cors::CorsLayer;
 
 use crate::config::RawConfig;
 use crate::engine::{EngineRequest, GenerationResult, StreamToken};
+use crate::kv_cache::{BlockPool, PagedCacheConfig, PagedKvStore};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Tokenizer};
 use crate::ServeArgs;
@@ -138,6 +139,8 @@ struct AppState {
     engine_tx: mpsc::Sender<EngineRequest>,
     tokenizer: Arc<Tokenizer>,
     default_params: SamplingParams,
+    /// Hard upper bound on (prompt_tokens + output_tokens) for this model.
+    max_seq_len: usize,
 }
 
 // ─── Server startup ─────────────────────────────────────────────────────────
@@ -170,6 +173,12 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         &device,
     )?;
 
+    // Effective sequence-length cap for this model.
+    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    if max_seq_len < usize::MAX {
+        tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
+    }
+
     // Default sampling params from CLI args
     let default_params = SamplingParams {
         temperature: args.temperature,
@@ -183,17 +192,67 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
 
     // Spawn engine on a dedicated thread
-    let engine = crate::engine::Engine::new(
+    let mut engine = crate::engine::Engine::new(
         model,
         // The engine needs its own tokenizer for decoding
         Tokenizer::from_file(
             &model_files.tokenizer_path,
             model_files.tokenizer_config_path.as_deref(),
         )?,
-        device,
+        device.clone(),
         args.max_batch_size,
         args.max_tokens_per_step,
     );
+
+    // If --paged-attention <fraction> was given, set up the paged KV store.
+    if let Some(memory_fraction) = args.paged_attention {
+        let bytes_per_element = match dtype {
+            candle_core::DType::F32 => 4,
+            _ => 2, // f16 / bf16
+        };
+
+        // Estimate available device memory.  Candle does not expose a device
+        // memory query API, so we use a conservative platform heuristic:
+        //   CUDA / Metal  → 8 GiB
+        //   CPU           → 4 GiB
+        // The user-supplied fraction then scales this down to the actual
+        // allocation, e.g. 0.6 × 8 GiB = 4.8 GiB for KV blocks.
+        let total_memory_bytes: usize = match &device {
+            candle_core::Device::Cuda(_) | candle_core::Device::Metal(_) => 8 * 1024 * 1024 * 1024,
+            _ => 4 * 1024 * 1024 * 1024,
+        };
+
+        let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(&arch);
+
+        tracing::info!(
+            "Paged attention: fraction={:.2}, {} KV heads, head_dim={}, {} KV layers",
+            memory_fraction,
+            num_kv_heads,
+            head_dim,
+            num_kv_layers,
+        );
+
+        let paged_cfg = PagedCacheConfig::from_memory_fraction(
+            total_memory_bytes,
+            memory_fraction,
+            args.block_size,
+            num_kv_heads,
+            head_dim,
+            num_kv_layers,
+            bytes_per_element,
+        );
+
+        tracing::info!(
+            "Paged KV store: {} blocks × {} tokens/block = {} total slots",
+            paged_cfg.num_blocks,
+            paged_cfg.block_size,
+            paged_cfg.num_blocks * paged_cfg.block_size,
+        );
+
+        let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
+        let kv_store = PagedKvStore::new(paged_cfg, dtype, &device)?;
+        engine = engine.with_paged_kv(block_pool, kv_store);
+    }
 
     std::thread::Builder::new()
         .name("engine".to_string())
@@ -206,6 +265,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         engine_tx,
         tokenizer,
         default_params,
+        max_seq_len,
     });
 
     // Build router
@@ -265,7 +325,12 @@ async fn chat_completions(
         prompt_tokens.len()
     );
 
-    // Build sampling params
+    // Build sampling params, clamping max_tokens to the model's KV cache capacity.
+    let requested_max_tokens = req
+        .max_completion_tokens
+        .or(req.max_tokens)
+        .unwrap_or(state.default_params.max_tokens);
+    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
     let params = SamplingParams {
         temperature: req.temperature.unwrap_or(state.default_params.temperature),
         top_p: req.top_p.unwrap_or(state.default_params.top_p),
@@ -273,10 +338,7 @@ async fn chat_completions(
         repetition_penalty: req
             .repetition_penalty
             .unwrap_or(state.default_params.repetition_penalty),
-        max_tokens: req
-            .max_completion_tokens
-            .or(req.max_tokens)
-            .unwrap_or(state.default_params.max_tokens),
+        max_tokens,
     };
 
     let is_stream = req.stream.unwrap_or(false);
@@ -483,6 +545,8 @@ async fn completions(
         }
     };
 
+    let requested_max_tokens = req.max_tokens.unwrap_or(state.default_params.max_tokens);
+    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
     let params = SamplingParams {
         temperature: req.temperature.unwrap_or(state.default_params.temperature),
         top_p: req.top_p.unwrap_or(state.default_params.top_p),
@@ -490,7 +554,7 @@ async fn completions(
         repetition_penalty: req
             .repetition_penalty
             .unwrap_or(state.default_params.repetition_penalty),
-        max_tokens: req.max_tokens.unwrap_or(state.default_params.max_tokens),
+        max_tokens,
     };
 
     let (response_tx, response_rx) = oneshot::channel::<GenerationResult>();
@@ -565,4 +629,24 @@ async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListRespon
 
 async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
+}
+
+/// Clamp `requested` so that `prompt_len + result <= max_seq_len`.
+///
+/// Returns `requested` unchanged when `max_seq_len` is `usize::MAX` (no cap).
+fn clamp_max_tokens(requested: usize, prompt_len: usize, max_seq_len: usize) -> usize {
+    if max_seq_len == usize::MAX {
+        return requested;
+    }
+    let available = max_seq_len.saturating_sub(prompt_len);
+    if requested > available {
+        tracing::warn!(
+            "Clamping max_tokens from {} to {} (model KV cache capacity: {} tokens, prompt: {})",
+            requested,
+            available,
+            max_seq_len,
+            prompt_len,
+        );
+    }
+    requested.min(available)
 }


### PR DESCRIPTION
Wire up the existing paged KV cache infrastructure (BlockPool, BlockTable, PagedKvStore, forward_paged) end-to-end behind the --paged-attention <fraction> CLI flag. When set, the engine allocates a shared block pool sized to the given fraction of device memory and dispatches all forward passes through forward_paged instead of the concat-based KV path. The flag is off by default; existing behaviour is unchanged.