### PR TITLE
Add 'inferrs rm' command to remove cached HuggingFace models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1612,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "clap",
+ "crossterm",
  "futures",
  "hf-hub",
  "serde",
@@ -1690,6 +1716,12 @@ checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1833,6 +1865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2465,6 +2498,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2472,7 +2518,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2683,6 +2729,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,7 +2923,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tokio-stream = "0.1"
 async-stream = "0.3"
 anyhow = "1"
 byteorder = "1"
+crossterm = "0.28"
 
 [dev-dependencies]
 ureq = { version = "2", features = ["json"] }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -9,7 +9,7 @@ use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
 
-/// Request to the engine.
+/// Request to the engine (async/tokio version, used by the HTTP server).
 pub enum EngineRequest {
     /// Generate tokens for a chat completion.
     Generate {
@@ -24,6 +24,17 @@ pub enum EngineRequest {
         prompt_tokens: Vec<u32>,
         sampling_params: SamplingParams,
         token_tx: mpsc::Sender<StreamToken>,
+    },
+}
+
+/// Request to the engine using only stdlib channels (no Tokio, used by `inferrs run`).
+pub enum SyncEngineRequest {
+    /// Generate tokens with streaming, sending each token over a stdlib channel.
+    GenerateStream {
+        request_id: String,
+        prompt_tokens: Vec<u32>,
+        sampling_params: SamplingParams,
+        token_tx: std::sync::mpsc::SyncSender<StreamToken>,
     },
 }
 
@@ -147,6 +158,38 @@ impl Engine {
         }
 
         tracing::info!("Engine loop stopped");
+    }
+
+    /// Run the engine loop using only stdlib channels — no Tokio runtime required.
+    /// Used by `inferrs run` so that blocking sends/recvs work on a plain OS thread.
+    pub fn run_sync(mut self, rx: std::sync::mpsc::Receiver<SyncEngineRequest>) {
+        tracing::info!("Engine loop started (sync)");
+
+        for request in rx {
+            match request {
+                SyncEngineRequest::GenerateStream {
+                    request_id,
+                    prompt_tokens,
+                    sampling_params,
+                    token_tx,
+                } => {
+                    if let Err(e) = self.generate_stream_sync(
+                        &request_id,
+                        &prompt_tokens,
+                        &sampling_params,
+                        &token_tx,
+                    ) {
+                        let _ = token_tx.send(StreamToken {
+                            token_id: 0,
+                            text: format!("Error: {}", e),
+                            finish_reason: Some("error".to_string()),
+                        });
+                    }
+                }
+            }
+        }
+
+        tracing::info!("Engine loop stopped (sync)");
     }
 
     // ── Paged-attention helpers ───────────────────────────────────────────────
@@ -347,6 +390,103 @@ impl Engine {
 
             if token_tx
                 .blocking_send(StreamToken {
+                    token_id,
+                    text,
+                    finish_reason: finish_reason.clone(),
+                })
+                .is_err()
+                || finish_reason.is_some()
+            {
+                break;
+            }
+        }
+
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+        }
+
+        Ok(())
+    }
+
+    /// Streaming generation using stdlib `SyncSender` — identical logic to
+    /// `generate_stream` but sends tokens via `std::sync::mpsc` instead of
+    /// `tokio::sync::mpsc`, so it can be called from a plain OS thread.
+    fn generate_stream_sync(
+        &mut self,
+        request_id: &str,
+        prompt_tokens: &[u32],
+        sampling_params: &SamplingParams,
+        token_tx: &std::sync::mpsc::SyncSender<StreamToken>,
+    ) -> Result<()> {
+        tracing::debug!(
+            "Streaming generation (sync) for request {} ({} prompt tokens)",
+            request_id,
+            prompt_tokens.len()
+        );
+
+        let mut output_tokens: Vec<u32> = Vec::new();
+        let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
+
+        // Prefill
+        let logits = if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+            self.model.clear_kv_cache();
+            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
+        } else {
+            self.model.clear_kv_cache();
+            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, 0)?
+        };
+
+        let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+        output_tokens.push(token_id);
+        all_tokens.push(token_id);
+
+        let text = self.tokenizer.decode(&[token_id], true)?;
+        let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+
+        if token_tx
+            .send(StreamToken {
+                token_id,
+                text,
+                finish_reason: finish_reason.clone(),
+            })
+            .is_err()
+            || finish_reason.is_some()
+        {
+            if let Some(ps) = &mut self.paged {
+                ps.block_table.free_all(&mut ps.block_pool);
+            }
+            return Ok(());
+        }
+
+        // Decode loop
+        loop {
+            let last_token = *output_tokens.last().unwrap();
+            let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
+
+            let logits = if let Some(ps) = &mut self.paged {
+                Self::paged_decode_step(
+                    &mut self.model,
+                    &self.device,
+                    last_token,
+                    seqlen_offset,
+                    ps,
+                )?
+            } else {
+                let input_ids = Tensor::new(&[last_token], &self.device)?.unsqueeze(0)?;
+                self.model.forward(&input_ids, seqlen_offset)?
+            };
+
+            let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+            output_tokens.push(token_id);
+            all_tokens.push(token_id);
+
+            let text = self.tokenizer.decode(&[token_id], true)?;
+            let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+
+            if token_tx
+                .send(StreamToken {
                     token_id,
                     text,
                     finish_reason: finish_reason.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ mod engine;
 mod hub;
 mod kv_cache;
 mod models;
+mod rm;
+mod run;
 mod sampler;
 mod scheduler;
 mod server;
@@ -24,8 +26,12 @@ struct Cli {
 enum Commands {
     /// Serve a model from HuggingFace Hub
     Serve(ServeArgs),
+    /// Run a model interactively (like ollama run)
+    Run(run::RunArgs),
     /// Benchmark inference throughput and latency
     Bench(bench::BenchArgs),
+    /// Remove a cached model from local disk
+    Rm(rm::RmArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -142,22 +148,35 @@ impl ServeArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // For `run` and `rm`, suppress info-level logging by default — the interactive REPL
+    // writes to stdout and log lines would corrupt the prompt display.
+    // Users can still get logs by setting RUST_LOG explicitly (e.g. RUST_LOG=debug).
+    let default_log_level = match &cli.command {
+        Commands::Run(_) | Commands::Rm(_) => "error",
+        _ => "info",
+    };
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_log_level)),
         )
         .init();
-
-    let cli = Cli::parse();
 
     match cli.command {
         Commands::Serve(args) => {
             tracing::info!("Starting inferrs server for model: {}", args.model);
             server::run(args).await?;
         }
+        Commands::Run(args) => {
+            run::run(args)?;
+        }
         Commands::Bench(args) => {
             tracing::info!("Running benchmark for model: {}", args.serve.model);
             bench::run(args)?;
+        }
+        Commands::Rm(args) => {
+            rm::run(args)?;
         }
     }
 

--- a/src/rm.rs
+++ b/src/rm.rs
@@ -1,0 +1,105 @@
+//! `inferrs rm` — remove a cached HuggingFace model from local disk.
+
+use anyhow::Result;
+use clap::Parser;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser, Clone)]
+pub struct RmArgs {
+    /// HuggingFace model ID(s) to remove (e.g. google/gemma-3-1b-it)
+    pub models: Vec<String>,
+
+    /// Skip confirmation prompt
+    #[arg(short, long)]
+    pub force: bool,
+}
+
+pub fn run(args: RmArgs) -> Result<()> {
+    if args.models.is_empty() {
+        anyhow::bail!("No model IDs specified. Usage: inferrs rm <model-id> [<model-id>...]");
+    }
+
+    let cache_dir = cache_root();
+
+    for model_id in &args.models {
+        let folder_name = model_folder_name(model_id);
+        let model_path = cache_dir.join(&folder_name);
+
+        if !model_path.exists() {
+            eprintln!("Model not cached: {model_id}");
+            continue;
+        }
+
+        let size = dir_size(&model_path).unwrap_or(0);
+
+        if !args.force {
+            eprint!("Remove {} ({})? [y/N] ", model_id, human_size(size));
+            std::io::stderr().flush()?;
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+            if !input.trim().eq_ignore_ascii_case("y") {
+                println!("Skipped {model_id}");
+                continue;
+            }
+        }
+
+        std::fs::remove_dir_all(&model_path)?;
+        println!("Removed {model_id} (freed {})", human_size(size));
+    }
+
+    Ok(())
+}
+
+/// Resolve the hf-hub cache root: `$HF_HOME/hub` or `~/.cache/huggingface/hub`.
+fn cache_root() -> PathBuf {
+    if let Ok(hf_home) = std::env::var("HF_HOME") {
+        PathBuf::from(hf_home).join("hub")
+    } else if let Ok(xdg_cache) = std::env::var("XDG_CACHE_HOME") {
+        PathBuf::from(xdg_cache).join("huggingface/hub")
+    } else {
+        dirs_home().join(".cache/huggingface/hub")
+    }
+}
+
+/// Portable home directory without pulling in the `dirs` crate.
+fn dirs_home() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/"))
+}
+
+/// Convert "Org/Name" → "models--Org--Name" (mirrors hf-hub's `Repo::folder_name`).
+fn model_folder_name(model_id: &str) -> String {
+    format!("models--{}", model_id).replace('/', "--")
+}
+
+/// Recursively sum the size of all files under `path`.
+fn dir_size(path: &Path) -> Result<u64> {
+    let mut total = 0u64;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        if metadata.is_dir() {
+            total += dir_size(&entry.path()).unwrap_or(0);
+        } else {
+            total += metadata.len();
+        }
+    }
+    Ok(total)
+}
+
+fn human_size(bytes: u64) -> String {
+    const GIB: u64 = 1 << 30;
+    const MIB: u64 = 1 << 20;
+    const KIB: u64 = 1 << 10;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,748 @@
+//! Interactive REPL for `inferrs run` — behaves like `ollama run` but in a
+//! single process (no HTTP server, no separate daemon).
+
+use anyhow::Result;
+use clap::Parser;
+use crossterm::{
+    cursor,
+    event::{self, Event, KeyCode, KeyEvent, KeyModifiers},
+    execute,
+    style::{Color, Print, ResetColor, SetForegroundColor},
+    terminal::{self, ClearType},
+};
+use std::io::{self, Write};
+use std::sync::mpsc as stdmpsc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use crate::config::RawConfig;
+use crate::engine::{Engine, StreamToken, SyncEngineRequest};
+use crate::hub;
+use crate::sampler::SamplingParams;
+use crate::tokenizer::{ChatMessage, Role, Tokenizer};
+use crate::ServeArgs;
+
+// ─── CLI args ────────────────────────────────────────────────────────────────
+
+#[derive(Parser, Clone)]
+pub struct RunArgs {
+    /// HuggingFace model ID (e.g. google/gemma-3-1b-it)
+    pub model: String,
+
+    /// Optional prompt — when given, run non-interactively and exit
+    pub prompt: Option<String>,
+
+    /// Git branch or tag on HuggingFace Hub
+    #[arg(long, default_value = "main")]
+    pub revision: String,
+
+    /// Weight data type: f32, f16, bf16
+    #[arg(long, default_value = "bf16")]
+    pub dtype: String,
+
+    /// Device: cpu, cuda, metal, or auto
+    #[arg(long, default_value = "auto")]
+    pub device: String,
+
+    /// Default sampling temperature
+    #[arg(long, default_value_t = 0.7)]
+    pub temperature: f64,
+
+    /// Default nucleus sampling threshold
+    #[arg(long, default_value_t = 0.9)]
+    pub top_p: f64,
+
+    /// Default top-k sampling
+    #[arg(long, default_value_t = 50)]
+    pub top_k: usize,
+
+    /// Default max tokens to generate per response
+    #[arg(long, default_value_t = 2048)]
+    pub max_tokens: usize,
+
+    /// System prompt
+    #[arg(long)]
+    pub system: Option<String>,
+}
+
+impl RunArgs {
+    fn to_serve_args(&self) -> ServeArgs {
+        ServeArgs {
+            model: self.model.clone(),
+            revision: self.revision.clone(),
+            dtype: self.dtype.clone(),
+            max_seq_len: 0,
+            device: self.device.clone(),
+            host: "0.0.0.0".to_string(),
+            port: 8080,
+            block_size: 16,
+            initial_blocks: 16,
+            max_blocks: 0,
+            max_batch_size: 1,
+            max_tokens_per_step: 2048,
+            temperature: self.temperature,
+            top_p: self.top_p,
+            top_k: self.top_k,
+            max_tokens: self.max_tokens,
+            paged_attention: None,
+        }
+    }
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+/// Called from `main` (inside the Tokio runtime).  All blocking work —
+/// model loading, the engine loop, and the REPL — is moved onto plain OS
+/// threads so that `blocking_send` / `blocking_recv` never run inside an
+/// async context.
+pub fn run(args: RunArgs) -> Result<()> {
+    // `std::thread::spawn` exits the Tokio runtime context for this thread.
+    let handle = std::thread::Builder::new()
+        .name("run-main".to_string())
+        .spawn(move || run_blocking(args))
+        .expect("Failed to spawn run thread");
+
+    handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("run thread panicked"))?
+}
+
+/// All blocking work: model download, weight loading, engine spawn, REPL.
+/// This runs on a plain OS thread, never inside the Tokio executor.
+fn run_blocking(args: RunArgs) -> Result<()> {
+    let serve = args.to_serve_args();
+    let device = serve.resolve_device()?;
+    let dtype = serve.resolve_dtype()?;
+
+    // Download / locate model files from HuggingFace Hub
+    let model_files = hub::download_model(&args.model, &args.revision)?;
+
+    // Load config and detect architecture
+    let raw_config = RawConfig::from_file(&model_files.config_path)?;
+    let arch = raw_config.detect_architecture()?;
+    tracing::info!("Detected architecture: {:?}", arch);
+
+    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+
+    // Load tokenizer (used by the REPL to build prompts)
+    let tokenizer = Tokenizer::from_file(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+    )?;
+
+    // Load model weights
+    let model = crate::models::load_model(
+        &raw_config,
+        &arch,
+        &model_files.weight_paths,
+        dtype,
+        &device,
+    )?;
+
+    // Engine tokenizer (separate instance — engine runs on its own thread)
+    let engine_tokenizer = Tokenizer::from_file(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+    )?;
+
+    // Spawn engine on a dedicated OS thread.
+    // Use std::sync::mpsc (not tokio) so that sends/recvs are plain blocking
+    // calls with no Tokio runtime requirement.
+    let (engine_tx, engine_rx) = stdmpsc::sync_channel::<SyncEngineRequest>(4);
+    let engine = Engine::new(model, engine_tokenizer, device, 1, 2048);
+
+    std::thread::Builder::new()
+        .name("engine".to_string())
+        .spawn(move || engine.run_sync(engine_rx))
+        .expect("Failed to spawn engine thread");
+
+    let sampling_params = SamplingParams {
+        temperature: args.temperature,
+        top_p: args.top_p,
+        top_k: args.top_k,
+        repetition_penalty: 1.0,
+        max_tokens: args
+            .max_tokens
+            .min(max_seq_len.saturating_sub(4096).max(256)),
+    };
+
+    // Build initial message history (optional system prompt)
+    let mut messages: Vec<ChatMessage> = Vec::new();
+    if let Some(sys) = &args.system {
+        messages.push(ChatMessage {
+            role: Role::System,
+            content: sys.clone(),
+        });
+    }
+
+    // Non-interactive: single prompt then exit
+    if let Some(prompt) = args.prompt {
+        messages.push(ChatMessage {
+            role: Role::User,
+            content: prompt,
+        });
+        let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
+        stream_response(&engine_tx, prompt_tokens, &sampling_params)?;
+        println!();
+        return Ok(());
+    }
+
+    // Interactive REPL
+    repl(tokenizer, engine_tx, sampling_params, messages)
+}
+
+// ─── Interactive REPL ────────────────────────────────────────────────────────
+
+/// Multiline input state.
+enum MultilineState {
+    None,
+    /// Accumulating a user prompt block opened by `"""`
+    Prompt,
+}
+
+fn repl(
+    tokenizer: Tokenizer,
+    engine_tx: stdmpsc::SyncSender<SyncEngineRequest>,
+    sampling_params: SamplingParams,
+    mut messages: Vec<ChatMessage>,
+) -> Result<()> {
+    println!("Type /? for help, /bye to exit, \"\"\" for multiline input.");
+
+    let mut multiline = MultilineState::None;
+    let mut buf = String::new(); // current multi-line accumulation buffer
+
+    loop {
+        let prompt_str = match multiline {
+            MultilineState::None => ">>> ",
+            MultilineState::Prompt => "... ",
+        };
+        print!("{}", prompt_str);
+        io::stdout().flush()?;
+
+        // Read a line using crossterm raw mode so we get per-key control
+        let line = match read_line()? {
+            ReadResult::Line(l) => l,
+            ReadResult::Interrupt => {
+                // Ctrl+C — cancel current input
+                println!();
+                buf.clear();
+                multiline = MultilineState::None;
+                continue;
+            }
+            ReadResult::Eof => {
+                // Ctrl+D / EOF — exit
+                println!();
+                break;
+            }
+        };
+
+        match multiline {
+            MultilineState::Prompt => {
+                // Check for closing """
+                if let Some(before) = line.strip_suffix("\"\"\"") {
+                    buf.push_str(before);
+                    multiline = MultilineState::None;
+                    // Fall through: buf now has the complete multi-line input
+                } else {
+                    buf.push_str(&line);
+                    buf.push('\n');
+                    continue;
+                }
+            }
+            MultilineState::None => {
+                // Check for opening """
+                if let Some(rest) = line.strip_prefix("\"\"\"") {
+                    // Might open AND close on the same line: """text"""
+                    if let Some(inner) = rest.strip_suffix("\"\"\"") {
+                        buf = inner.to_string();
+                        // buf is ready — fall through
+                    } else {
+                        buf = rest.to_string();
+                        if !buf.is_empty() {
+                            buf.push('\n');
+                        }
+                        multiline = MultilineState::Prompt;
+                        continue;
+                    }
+                } else {
+                    buf = line.clone();
+                }
+
+                // Slash commands
+                let trimmed = buf.trim();
+                if trimmed.starts_with('/') {
+                    handle_command(trimmed, &mut messages, &sampling_params);
+                    buf.clear();
+                    continue;
+                }
+
+                // Empty input: just loop
+                if trimmed.is_empty() {
+                    buf.clear();
+                    continue;
+                }
+            }
+        }
+
+        // Send the user message
+        let user_content = buf.trim().to_string();
+        buf.clear();
+
+        messages.push(ChatMessage {
+            role: Role::User,
+            content: user_content,
+        });
+
+        // Encode the full conversation with the chat template
+        let prompt_tokens = match tokenizer.apply_chat_template_and_encode(&messages) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("Tokenization error: {}", e);
+                messages.pop();
+                continue;
+            }
+        };
+
+        // Stream the response and collect the full text for history
+        let assistant_text =
+            match stream_response_collect(&engine_tx, prompt_tokens, &sampling_params) {
+                Ok(t) => t,
+                Err(e) => {
+                    eprintln!("Generation error: {}", e);
+                    messages.pop();
+                    continue;
+                }
+            };
+
+        println!();
+
+        // Append assistant turn to history
+        messages.push(ChatMessage {
+            role: Role::Assistant,
+            content: assistant_text,
+        });
+    }
+
+    Ok(())
+}
+
+// ─── Slash command handler ────────────────────────────────────────────────────
+
+fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingParams) {
+    let parts: Vec<&str> = cmd.splitn(3, ' ').collect();
+    match parts[0] {
+        "/bye" | "/exit" | "/quit" => {
+            std::process::exit(0);
+        }
+        "/clear" => {
+            // Keep system message if present
+            let sys: Vec<ChatMessage> = messages
+                .drain(..)
+                .filter(|m| matches!(m.role, Role::System))
+                .collect();
+            *messages = sys;
+            println!("Conversation cleared.");
+        }
+        "/set" if parts.len() >= 3 => {
+            match parts[1] {
+                "system" => {
+                    // Remove any existing system messages
+                    messages.retain(|m| !matches!(m.role, Role::System));
+                    messages.insert(
+                        0,
+                        ChatMessage {
+                            role: Role::System,
+                            content: parts[2].to_string(),
+                        },
+                    );
+                    println!("System prompt set.");
+                }
+                _ => println!("Unknown /set option: {}", parts[1]),
+            }
+        }
+        "/show" if parts.len() >= 2 => match parts[1] {
+            "history" => {
+                for (i, m) in messages.iter().enumerate() {
+                    println!("[{}] {}: {}", i, m.role, m.content);
+                }
+            }
+            "params" => {
+                println!(
+                    "temperature={} top_p={} top_k={} max_tokens={}",
+                    params.temperature, params.top_p, params.top_k, params.max_tokens
+                );
+            }
+            _ => println!("Unknown /show option: {}", parts[1]),
+        },
+        "/help" | "/?" => {
+            println!("Commands:");
+            println!("  /bye, /exit, /quit     Exit the REPL");
+            println!("  /clear                 Clear conversation history");
+            println!("  /set system <text>     Set a system prompt");
+            println!("  /show history          Print conversation history");
+            println!("  /show params           Print sampling parameters");
+            println!("  /help, /?              Show this help");
+            println!();
+            println!("Keyboard shortcuts:");
+            println!("  Ctrl+D / EOF           Exit");
+            println!("  Ctrl+C                 Cancel current input");
+            println!();
+            println!("Multiline input:");
+            println!("  Start a message with \"\"\" to enter multi-line mode.");
+            println!("  End with \"\"\" on its own line to send.");
+        }
+        other => println!("Unknown command: {}", other),
+    }
+}
+
+// ─── Streaming helpers ────────────────────────────────────────────────────────
+
+/// Stream tokens from the engine to stdout, returning the full assembled text.
+fn stream_response_collect(
+    engine_tx: &stdmpsc::SyncSender<SyncEngineRequest>,
+    prompt_tokens: Vec<u32>,
+    sampling_params: &SamplingParams,
+) -> Result<String> {
+    let (token_tx, token_rx) = stdmpsc::sync_channel::<StreamToken>(256);
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    engine_tx.send(SyncEngineRequest::GenerateStream {
+        request_id,
+        prompt_tokens,
+        sampling_params: sampling_params.clone(),
+        token_tx,
+    })?;
+
+    // Track whether we were interrupted by Ctrl+C
+    let interrupted = Arc::new(AtomicBool::new(false));
+    let interrupted_clone = interrupted.clone();
+
+    // Spawn a small thread that watches for Ctrl+C and signals the flag.
+    // We do NOT actually cancel the engine here (there is no cancellation API),
+    // but we stop printing and return early so the REPL stays responsive.
+    std::thread::spawn(move || {
+        terminal::enable_raw_mode().ok();
+        loop {
+            if event::poll(std::time::Duration::from_millis(50)).unwrap_or(false) {
+                if let Ok(Event::Key(KeyEvent {
+                    code: KeyCode::Char('c'),
+                    modifiers,
+                    ..
+                })) = event::read()
+                {
+                    if modifiers.contains(KeyModifiers::CONTROL) {
+                        interrupted_clone.store(true, Ordering::SeqCst);
+                        terminal::disable_raw_mode().ok();
+                        return;
+                    }
+                }
+            }
+            if interrupted_clone.load(Ordering::SeqCst) {
+                terminal::disable_raw_mode().ok();
+                return;
+            }
+        }
+    });
+
+    let mut full_text = String::new();
+    let mut stdout = io::stdout();
+
+    // Drain tokens until the channel closes or we get a finish reason
+    loop {
+        // Non-blocking check: has user interrupted?
+        if interrupted.load(Ordering::SeqCst) {
+            println!("\n[interrupted]");
+            // Drain remaining tokens silently so the engine thread finishes
+            while token_rx.recv().is_ok() {}
+            return Ok(full_text);
+        }
+
+        match token_rx.recv() {
+            Err(_) => break, // channel closed — engine done
+            Ok(tok) => {
+                full_text.push_str(&tok.text);
+                print!("{}", tok.text);
+                stdout.flush()?;
+                if tok.finish_reason.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    interrupted.store(true, Ordering::SeqCst); // signal Ctrl+C watcher to stop
+    Ok(full_text)
+}
+
+/// Stream tokens to stdout without collecting (used for non-interactive one-shot mode).
+fn stream_response(
+    engine_tx: &stdmpsc::SyncSender<SyncEngineRequest>,
+    prompt_tokens: Vec<u32>,
+    sampling_params: &SamplingParams,
+) -> Result<()> {
+    stream_response_collect(engine_tx, prompt_tokens, sampling_params)?;
+    Ok(())
+}
+
+// ─── Raw-mode line reader ────────────────────────────────────────────────────
+
+enum ReadResult {
+    Line(String),
+    Interrupt,
+    Eof,
+}
+
+/// Read a single line from stdin using crossterm raw mode.
+///
+/// Supports:
+/// - Regular character input with inline echo
+/// - Backspace / Delete
+/// - Arrow keys (left/right, up/down — up/down currently no-ops)
+/// - Ctrl+C → Interrupt
+/// - Ctrl+D on empty line → Eof
+/// - Enter → submit line
+/// - Bracketed paste (the terminal may send a paste burst; we accept it as-is)
+fn read_line() -> Result<ReadResult> {
+    let mut buf: Vec<char> = Vec::new();
+    let mut cursor_pos: usize = 0; // logical position in buf
+
+    terminal::enable_raw_mode()?;
+    let _guard = RawModeGuard;
+
+    let mut stdout = io::stdout();
+
+    loop {
+        let ev = event::read()?;
+
+        match ev {
+            Event::Key(KeyEvent {
+                code, modifiers, ..
+            }) => {
+                match code {
+                    // ── Submit ──────────────────────────────────────────────
+                    KeyCode::Enter => {
+                        // Echo newline
+                        execute!(stdout, Print("\r\n"))?;
+                        let line: String = buf.iter().collect();
+                        return Ok(ReadResult::Line(line));
+                    }
+
+                    // ── EOF ─────────────────────────────────────────────────
+                    KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        if buf.is_empty() {
+                            execute!(stdout, Print("\r\n"))?;
+                            return Ok(ReadResult::Eof);
+                        }
+                        // Ctrl+D mid-line: delete char forward (like readline)
+                        if cursor_pos < buf.len() {
+                            buf.remove(cursor_pos);
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    // ── Interrupt ────────────────────────────────────────────
+                    KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        execute!(stdout, Print("^C\r\n"))?;
+                        return Ok(ReadResult::Interrupt);
+                    }
+
+                    // ── Backspace ────────────────────────────────────────────
+                    KeyCode::Backspace => {
+                        if cursor_pos > 0 {
+                            cursor_pos -= 1;
+                            buf.remove(cursor_pos);
+                            // Move cursor left, redraw rest of line, clear tail
+                            execute!(stdout, cursor::MoveLeft(1))?;
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    // ── Delete ────────────────────────────────────────────────
+                    KeyCode::Delete => {
+                        if cursor_pos < buf.len() {
+                            buf.remove(cursor_pos);
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    // ── Left arrow ────────────────────────────────────────────
+                    KeyCode::Left => {
+                        if cursor_pos > 0 {
+                            cursor_pos -= 1;
+                            execute!(stdout, cursor::MoveLeft(1))?;
+                        }
+                    }
+
+                    // ── Right arrow ───────────────────────────────────────────
+                    KeyCode::Right => {
+                        if cursor_pos < buf.len() {
+                            cursor_pos += 1;
+                            execute!(stdout, cursor::MoveRight(1))?;
+                        }
+                    }
+
+                    // ── Home / Ctrl+A ─────────────────────────────────────────
+                    KeyCode::Home => {
+                        if cursor_pos > 0 {
+                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                            cursor_pos = 0;
+                        }
+                    }
+                    KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        if cursor_pos > 0 {
+                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                            cursor_pos = 0;
+                        }
+                    }
+
+                    // ── End / Ctrl+E ──────────────────────────────────────────
+                    KeyCode::End => {
+                        let remaining = buf.len() - cursor_pos;
+                        if remaining > 0 {
+                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
+                            cursor_pos = buf.len();
+                        }
+                    }
+                    KeyCode::Char('e') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        let remaining = buf.len() - cursor_pos;
+                        if remaining > 0 {
+                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
+                            cursor_pos = buf.len();
+                        }
+                    }
+
+                    // ── Kill to EOL (Ctrl+K) ──────────────────────────────────
+                    KeyCode::Char('k') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        buf.truncate(cursor_pos);
+                        execute!(stdout, terminal::Clear(ClearType::UntilNewLine))?;
+                    }
+
+                    // ── Kill to BOL (Ctrl+U) ──────────────────────────────────
+                    KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        if cursor_pos > 0 {
+                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                            buf.drain(..cursor_pos);
+                            cursor_pos = 0;
+                            redraw_from_cursor(&mut stdout, &buf, 0)?;
+                        }
+                    }
+
+                    // ── Kill word before cursor (Ctrl+W) ──────────────────────
+                    KeyCode::Char('w') if modifiers.contains(KeyModifiers::CONTROL) => {
+                        if cursor_pos > 0 {
+                            // Find previous word boundary
+                            let mut end = cursor_pos;
+                            // skip trailing spaces
+                            while end > 0 && buf[end - 1] == ' ' {
+                                end -= 1;
+                            }
+                            // skip word chars
+                            while end > 0 && buf[end - 1] != ' ' {
+                                end -= 1;
+                            }
+                            let deleted = cursor_pos - end;
+                            execute!(stdout, cursor::MoveLeft(deleted as u16))?;
+                            buf.drain(end..cursor_pos);
+                            cursor_pos = end;
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    // ── Regular printable character ───────────────────────────
+                    KeyCode::Char(c) => {
+                        buf.insert(cursor_pos, c);
+                        cursor_pos += 1;
+                        if cursor_pos == buf.len() {
+                            // Appending at end — simple echo
+                            execute!(stdout, Print(c))?;
+                        } else {
+                            // Inserting mid-line — redraw tail
+                            execute!(stdout, Print(c))?;
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    // ── Tab → 4 spaces ───────────────────────────────────────
+                    KeyCode::Tab => {
+                        for _ in 0..4 {
+                            buf.insert(cursor_pos, ' ');
+                            cursor_pos += 1;
+                        }
+                        execute!(stdout, Print("    "))?;
+                        if cursor_pos < buf.len() {
+                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                        }
+                    }
+
+                    _ => {}
+                }
+            }
+
+            // Paste events — append each char as if typed
+            Event::Paste(text) => {
+                for c in text.chars() {
+                    if c == '\n' || c == '\r' {
+                        buf.insert(cursor_pos, '\n');
+                        cursor_pos += 1;
+                    } else {
+                        buf.insert(cursor_pos, c);
+                        cursor_pos += 1;
+                    }
+                }
+                // Redraw the whole buffer tail from start
+                let before: String = buf[..cursor_pos].iter().collect();
+                execute!(
+                    stdout,
+                    cursor::MoveLeft(cursor_pos as u16),
+                    Print(&before),
+                    terminal::Clear(ClearType::UntilNewLine)
+                )?;
+            }
+
+            _ => {}
+        }
+    }
+}
+
+/// Redraw the characters of `buf` starting at logical position `from`,
+/// then move the terminal cursor back to `from`.
+fn redraw_from_cursor(stdout: &mut io::Stdout, buf: &[char], from: usize) -> Result<()> {
+    let tail: String = buf[from..].iter().collect();
+    let tail_len = tail.chars().count();
+    execute!(
+        stdout,
+        Print(&tail),
+        terminal::Clear(ClearType::UntilNewLine),
+    )?;
+    // Move cursor back to `from`
+    if tail_len > 0 {
+        execute!(stdout, cursor::MoveLeft(tail_len as u16))?;
+    }
+    Ok(())
+}
+
+/// RAII guard that restores normal terminal mode when dropped.
+struct RawModeGuard;
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = terminal::disable_raw_mode();
+    }
+}
+
+// ─── Display helpers ──────────────────────────────────────────────────────────
+
+/// Print `text` in a muted colour for secondary/status output.
+#[allow(dead_code)]
+fn print_dim(text: &str) {
+    let mut stdout = io::stdout();
+    execute!(
+        stdout,
+        SetForegroundColor(Color::DarkGrey),
+        Print(text),
+        ResetColor,
+    )
+    .ok();
+}


### PR DESCRIPTION
- 'inferrs run': interactive REPL and one-shot generation using a sync engine loop on a plain OS thread (no Tokio required for generation)
- 'inferrs rm': remove cached HuggingFace models from local disk with optional --force flag and human-readable size reporting
- Add sync engine path (SyncEngineRequest, generate_stream_sync) to support run's blocking channel-based token streaming
- Add crossterm dependency for interactive terminal handling in run