### PR TITLE
Add Qwen3 support and fix GQA repeat_kv head ordering

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 #[derive(Debug, Clone, PartialEq)]
 pub enum ModelArchitecture {
     Qwen2,
+    Qwen3,
     Qwen35,
     Gemma2,
     Gemma3,
@@ -78,6 +79,10 @@ pub struct RawConfig {
     // Gemma3-specific
     pub sliding_window_pattern: Option<usize>,
 
+    // Qwen3-specific (flat, not nested; kept for potential future use)
+    #[allow(dead_code)]
+    pub layer_types: Option<Vec<String>>,
+
     // Qwen3.5-specific (nested text_config)
     pub text_config: Option<TextConfig>,
 }
@@ -96,7 +101,10 @@ impl RawConfig {
                 if arch.contains("Qwen3_5") {
                     return Ok(ModelArchitecture::Qwen35);
                 }
-                if arch.contains("Qwen2") || arch.contains("Qwen3") {
+                if arch.contains("Qwen3") {
+                    return Ok(ModelArchitecture::Qwen3);
+                }
+                if arch.contains("Qwen2") {
                     return Ok(ModelArchitecture::Qwen2);
                 }
                 if arch.contains("Gemma3") {
@@ -110,7 +118,8 @@ impl RawConfig {
 
         if let Some(model_type) = &self.model_type {
             match model_type.as_str() {
-                "qwen2" | "qwen2_5" | "qwen3" => return Ok(ModelArchitecture::Qwen2),
+                "qwen2" | "qwen2_5" => return Ok(ModelArchitecture::Qwen2),
+                "qwen3" => return Ok(ModelArchitecture::Qwen3),
                 "qwen3_5" => return Ok(ModelArchitecture::Qwen35),
                 "gemma3" => return Ok(ModelArchitecture::Gemma3),
                 "gemma2" => return Ok(ModelArchitecture::Gemma2),
@@ -196,6 +205,44 @@ impl RawConfig {
             sliding_window: self.sliding_window.unwrap_or(1024),
             sliding_window_pattern: self.sliding_window_pattern.unwrap_or(6),
             max_position_embeddings: self.max_position_embeddings.unwrap_or(131072),
+        }
+    }
+
+    /// Build a Qwen3Config (all-full-attention transformer with gated q_proj).
+    /// Qwen3 is the same architecture as the full-attention layers in Qwen3.5
+    /// but all layers are full-attention and weights live under `model.*` (not
+    /// `model.language_model.*`).
+    pub fn to_qwen3_config(
+        &self,
+        dtype: DType,
+        device: Device,
+    ) -> crate::models::qwen3::Qwen3Config {
+        use crate::models::qwen3::Qwen3Config;
+
+        let vocab_size = self.vocab_size.unwrap_or(151936);
+        let hidden_size = self.hidden_size.unwrap_or(1024);
+        let intermediate_size = self.intermediate_size.unwrap_or(3072);
+        let num_hidden_layers = self.num_hidden_layers.unwrap_or(28);
+        let num_attention_heads = self.num_attention_heads.unwrap_or(16);
+        let num_key_value_heads = self.num_key_value_heads.unwrap_or(8);
+        let head_dim = self.head_dim.unwrap_or(hidden_size / num_attention_heads);
+        let rms_norm_eps = self.rms_norm_eps.unwrap_or(1e-6);
+        let tie_word_embeddings = self.tie_word_embeddings.unwrap_or(true);
+        let rope_theta = self.rope_theta.unwrap_or(1_000_000.0);
+
+        Qwen3Config {
+            vocab_size,
+            hidden_size,
+            intermediate_size,
+            num_hidden_layers,
+            num_attention_heads,
+            num_key_value_heads,
+            head_dim,
+            rms_norm_eps,
+            tie_word_embeddings,
+            rope_theta,
+            dtype,
+            device,
         }
     }
 
@@ -290,6 +337,7 @@ impl RawConfig {
             }
             ModelArchitecture::Gemma2 => self.max_position_embeddings.unwrap_or(8192),
             ModelArchitecture::Qwen2 => self.max_position_embeddings.unwrap_or(131072),
+            ModelArchitecture::Qwen3 => self.max_position_embeddings.unwrap_or(40960),
             ModelArchitecture::Qwen35 => {
                 let tc = self.text_config.as_ref();
                 // Qwen3.5 uses linear attention for most layers; the full-attn
@@ -307,6 +355,14 @@ impl RawConfig {
     /// layers are excluded).
     pub fn kv_cache_params(&self, arch: &ModelArchitecture) -> (usize, usize, usize) {
         match arch {
+            ModelArchitecture::Qwen3 => {
+                let num_kv_heads = self.num_key_value_heads.unwrap_or(8);
+                let num_attention_heads = self.num_attention_heads.unwrap_or(16);
+                let hidden_size = self.hidden_size.unwrap_or(1024);
+                let head_dim = self.head_dim.unwrap_or(hidden_size / num_attention_heads);
+                let num_layers = self.num_hidden_layers.unwrap_or(28);
+                (num_kv_heads, head_dim, num_layers)
+            }
             ModelArchitecture::Qwen35 => {
                 let tc = self.text_config.as_ref();
                 let num_kv_heads = tc.and_then(|t| t.num_key_value_heads).unwrap_or(2);
@@ -393,6 +449,7 @@ mod tests {
             attn_logit_softcapping: None,
             query_pre_attn_scalar: None,
             sliding_window_pattern: None,
+            layer_types: None,
             text_config: None,
         }
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,6 +3,7 @@
 //! We use candle-transformers' model implementations directly, wrapping them
 //! with a unified trait for the engine to use.
 
+pub mod qwen3;
 pub mod qwen3_5;
 
 use anyhow::Result;
@@ -86,6 +87,32 @@ impl CausalLM for Gemma3Model {
     }
 }
 
+/// A Qwen3 model wrapper.
+struct Qwen3ModelWrapper {
+    inner: qwen3::Qwen3Model,
+}
+
+impl CausalLM for Qwen3ModelWrapper {
+    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        self.inner.forward(input_ids, seqlen_offset)
+    }
+
+    fn forward_paged(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        block_table: &BlockTable,
+        kv_store: &mut PagedKvStore,
+    ) -> Result<Tensor> {
+        self.inner
+            .forward_paged(input_ids, seqlen_offset, block_table, kv_store)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.inner.clear_kv_cache();
+    }
+}
+
 /// A Qwen3.5 model wrapper.
 struct Qwen35ModelWrapper {
     inner: qwen3_5::Qwen35Model,
@@ -128,6 +155,20 @@ pub fn load_model(
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&paths_ref, dtype, device)? };
 
     match arch {
+        ModelArchitecture::Qwen3 => {
+            let config = raw_config.to_qwen3_config(dtype, device.clone());
+            tracing::info!(
+                "Qwen3 config: {} layers, {} heads, {} hidden, {} kv_heads, head_dim={}",
+                config.num_hidden_layers,
+                config.num_attention_heads,
+                config.hidden_size,
+                config.num_key_value_heads,
+                config.head_dim,
+            );
+            let model = qwen3::Qwen3Model::new(&config, vb)?;
+            tracing::info!("Model loaded successfully");
+            Ok(Box::new(Qwen3ModelWrapper { inner: model }))
+        }
         ModelArchitecture::Qwen2 => {
             let config = raw_config.to_qwen2_config();
             tracing::info!(

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -1,0 +1,584 @@
+//! Qwen3 model implementation.
+//!
+//! Qwen3 is a standard transformer with:
+//!   - GQA with QK-norm (per-head RMSNorm on queries and keys)
+//!   - No bias on attention/MLP projections
+//!   - SwiGLU MLP
+//!   - Full RoPE (no partial rotary factor)
+//!   - Explicit head_dim from config (may differ from hidden_size / num_heads)
+//!
+//! Weights live under `model.*` (not `model.language_model.*` like Qwen3.5).
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::{
+    embedding, linear_no_bias, rms_norm, rotary_emb, Embedding, Linear, RmsNorm, VarBuilder,
+};
+
+use crate::kv_cache::{BlockTable, PagedKvStore};
+
+/// Paged-attention context passed to each layer.
+pub struct PagedCtx<'a> {
+    pub cos: &'a Tensor,
+    pub sin: &'a Tensor,
+    pub block_table: &'a BlockTable,
+    pub kv_store: &'a mut PagedKvStore,
+    pub layer_idx: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Qwen3Config {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    /// Explicit head dimension (may differ from hidden_size / num_attention_heads).
+    pub head_dim: usize,
+    pub rms_norm_eps: f64,
+    #[allow(dead_code)]
+    pub tie_word_embeddings: bool,
+    pub rope_theta: f64,
+    pub dtype: DType,
+    pub device: Device,
+}
+
+// ---------------------------------------------------------------------------
+// RoPE utilities
+// ---------------------------------------------------------------------------
+
+/// Precompute (cos, sin) for positions 0..max_seq_len.
+/// Qwen3 uses full-head-dim rotation (no partial factor).
+fn precompute_rope(
+    head_dim: usize,
+    rope_theta: f64,
+    max_seq_len: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<(Tensor, Tensor)> {
+    let half = head_dim / 2;
+
+    // freqs: [half]
+    let freqs: Vec<f32> = (0..half)
+        .map(|i| {
+            let exp = 2.0 * i as f32 / head_dim as f32;
+            1.0 / (rope_theta as f32).powf(exp)
+        })
+        .collect();
+    let freqs = Tensor::new(freqs.as_slice(), device)?;
+
+    // positions: [max_seq_len]
+    let positions: Vec<f32> = (0..max_seq_len).map(|i| i as f32).collect();
+    let positions = Tensor::new(positions.as_slice(), device)?;
+
+    // outer product -> [max_seq_len, half]
+    let emb = positions
+        .unsqueeze(1)?
+        .broadcast_mul(&freqs.unsqueeze(0)?)?;
+
+    let cos = emb.cos()?.to_dtype(dtype)?;
+    let sin = emb.sin()?.to_dtype(dtype)?;
+    Ok((cos, sin))
+}
+
+/// Apply full rotary embedding to query/key tensors using candle's built-in kernel.
+/// x: [batch, n_heads, seq_len, head_dim]
+/// cos/sin: [seq_len, head_dim/2]
+fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let (_b, _h, seq_len, _d) = x.dims4()?;
+    let cos = cos.narrow(0, 0, seq_len)?.contiguous()?;
+    let sin = sin.narrow(0, 0, seq_len)?.contiguous()?;
+    rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
+// GQA repeat_kv
+// ---------------------------------------------------------------------------
+
+/// Repeat KV heads for GQA: each kv_head is repeated `n_rep` times consecutively.
+///
+/// For `num_heads=16, num_kv_heads=8` the output layout is:
+///   [kv0, kv0, kv1, kv1, ..., kv7, kv7]
+/// so that query head h maps to kv_head h // n_rep.
+///
+/// This matches the HF `repeat_kv` implementation.
+fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
+    if n_rep == 1 {
+        return Ok(xs);
+    }
+    let (b, n_kv_heads, seq_len, head_dim) = xs.dims4()?;
+    // Concatenate along the seq_len dimension, then reshape so that
+    // each kv_head appears n_rep times consecutively in the head dimension.
+    let xs_cat = Tensor::cat(&vec![&xs; n_rep], 2)?; // [b, n_kv, seq*n_rep, d]
+    xs_cat
+        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
+        .map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
+// SwiGLU MLP
+// ---------------------------------------------------------------------------
+
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    fn new(cfg: &Qwen3Config, vb: VarBuilder) -> Result<Self> {
+        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward(x)?.silu()?;
+        let up = self.up_proj.forward(x)?;
+        let hidden = (gate * up)?;
+        self.down_proj.forward(&hidden).map_err(Into::into)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Attention layer (GQA + QK-norm + RoPE, no bias)
+// ---------------------------------------------------------------------------
+
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    kv_cache: Option<(Tensor, Tensor)>,
+}
+
+impl Attention {
+    fn new(cfg: &Qwen3Config, vb: VarBuilder) -> Result<Self> {
+        let q_out = cfg.num_attention_heads * cfg.head_dim;
+        let kv_out = cfg.num_key_value_heads * cfg.head_dim;
+
+        let q_proj = linear_no_bias(cfg.hidden_size, q_out, vb.pp("q_proj"))?;
+        let k_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("k_proj"))?;
+        let v_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("v_proj"))?;
+        let o_proj = linear_no_bias(q_out, cfg.hidden_size, vb.pp("o_proj"))?;
+        let q_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads: cfg.num_attention_heads,
+            num_kv_heads: cfg.num_key_value_heads,
+            head_dim: cfg.head_dim,
+            kv_cache: None,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor> {
+        let (b, t, _) = x.dims3()?;
+
+        // Project
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        // Reshape to [b, heads, t, head_dim]
+        let q = q
+            .reshape((b, t, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // Per-head QK norms
+        let q = apply_rms_norm_heads(&q, &self.q_norm)?;
+        let k = apply_rms_norm_heads(&k, &self.k_norm)?;
+
+        // RoPE
+        let cos_slice = cos.narrow(0, seqlen_offset, t)?;
+        let sin_slice = sin.narrow(0, seqlen_offset, t)?;
+        let q = apply_rope(&q, &cos_slice, &sin_slice)?;
+        let k = apply_rope(&k, &cos_slice, &sin_slice)?;
+
+        // Append to KV cache
+        let (k, v) = match &self.kv_cache {
+            None => (k, v),
+            Some((k_cache, v_cache)) => {
+                let k = Tensor::cat(&[k_cache, &k], 2)?;
+                let v = Tensor::cat(&[v_cache, &v], 2)?;
+                (k, v)
+            }
+        };
+        self.kv_cache = Some((k.clone(), v.clone()));
+
+        let kv_len = k.dim(2)?;
+
+        // GQA: repeat each kv_head consecutively to match query head count
+        let groups = self.num_heads / self.num_kv_heads;
+        let k = repeat_kv(k, groups)?;
+        let v = repeat_kv(v, groups)?;
+
+        // Scaled dot-product attention
+        let scale = (self.head_dim as f64).sqrt();
+        let attn = q
+            .contiguous()?
+            .matmul(&k.transpose(2, 3)?.contiguous()?)?
+            .affine(1.0 / scale, 0.0)?;
+
+        // Causal mask (only needed for prefill)
+        let attn = if t > 1 {
+            let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
+            attn.broadcast_add(&mask)?
+        } else {
+            attn
+        };
+
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn.matmul(&v.contiguous()?)?; // [b, heads, t, head_dim]
+
+        // Reshape back: [b, t, heads*head_dim]
+        let out = out
+            .transpose(1, 2)?
+            .reshape((b, t, self.num_heads * self.head_dim))?
+            .contiguous()?;
+
+        self.o_proj.forward(&out).map_err(Into::into)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.kv_cache = None;
+    }
+
+    fn forward_paged(
+        &self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        ctx: &mut PagedCtx,
+    ) -> Result<Tensor> {
+        let (b, t, _) = x.dims3()?;
+
+        // Project
+        let q = self.q_proj.forward(x)?;
+        let k = self.k_proj.forward(x)?;
+        let v = self.v_proj.forward(x)?;
+
+        // Reshape to [b, heads, t, head_dim]
+        let q = q
+            .reshape((b, t, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let k = k
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v = v
+            .reshape((b, t, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        // Per-head QK norms
+        let q = apply_rms_norm_heads(&q, &self.q_norm)?;
+        let k = apply_rms_norm_heads(&k, &self.k_norm)?;
+
+        // RoPE
+        let cos_slice = ctx.cos.narrow(0, seqlen_offset, t)?;
+        let sin_slice = ctx.sin.narrow(0, seqlen_offset, t)?;
+        let q = apply_rope(&q, &cos_slice, &sin_slice)?;
+        let k = apply_rope(&k, &cos_slice, &sin_slice)?;
+
+        // Write new K/V into paged store
+        for ti in 0..t {
+            let position = seqlen_offset + ti;
+            let slot_id = ctx.block_table.slot_for(position).ok_or_else(|| {
+                anyhow::anyhow!("paged attention: no slot for position {}", position)
+            })?;
+            let k_tok = k.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
+            let v_tok = v.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
+            ctx.kv_store
+                .write_slot(ctx.layer_idx, slot_id as usize, &k_tok, &v_tok)?;
+        }
+
+        // Gather full K/V context
+        let total_tokens = seqlen_offset + t;
+        let slot_ids: Vec<u32> = (0..total_tokens)
+            .map(|pos| {
+                ctx.block_table.slot_for(pos).ok_or_else(|| {
+                    anyhow::anyhow!("paged attention: missing slot for position {}", pos)
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let (k_full, v_full) = ctx.kv_store.gather_slots(ctx.layer_idx, &slot_ids)?;
+
+        let kv_len = total_tokens;
+        let k_full = k_full
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let v_full = v_full
+            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let groups = self.num_heads / self.num_kv_heads;
+        let k_full = repeat_kv(k_full, groups)?;
+        let v_full = repeat_kv(v_full, groups)?;
+
+        let scale = (self.head_dim as f64).sqrt();
+        let attn = q
+            .contiguous()?
+            .matmul(&k_full.transpose(2, 3)?.contiguous()?)?
+            .affine(1.0 / scale, 0.0)?;
+
+        let attn = if t > 1 {
+            let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
+            attn.broadcast_add(&mask)?
+        } else {
+            attn
+        };
+
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn.matmul(&v_full.contiguous()?)?;
+
+        let out = out
+            .transpose(1, 2)?
+            .reshape((b, t, self.num_heads * self.head_dim))?
+            .contiguous()?;
+
+        self.o_proj.forward(&out).map_err(Into::into)
+    }
+}
+
+/// Apply RmsNorm to last dimension of a 4D tensor [b, h, t, d].
+fn apply_rms_norm_heads(x: &Tensor, norm: &RmsNorm) -> Result<Tensor> {
+    let (b, h, t, d) = x.dims4()?;
+    let x_flat = x.contiguous()?.reshape((b * h * t, d))?;
+    let out = norm.forward(&x_flat)?;
+    out.reshape((b, h, t, d)).map_err(Into::into)
+}
+
+/// Build a causal attention bias [1, 1, q_len, kv_len].
+fn causal_mask(
+    q_len: usize,
+    kv_len: usize,
+    offset: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let mask: Vec<f32> = (0..q_len)
+        .flat_map(|i| {
+            (0..kv_len).map(move |j| {
+                let qi = offset + i;
+                if j <= qi {
+                    0.0f32
+                } else {
+                    f32::NEG_INFINITY
+                }
+            })
+        })
+        .collect();
+    let mask = Tensor::new(mask.as_slice(), device)?
+        .reshape((1, 1, q_len, kv_len))?
+        .to_dtype(dtype)?;
+    Ok(mask)
+}
+
+// ---------------------------------------------------------------------------
+// Decoder layer
+// ---------------------------------------------------------------------------
+
+struct DecoderLayer {
+    attn: Attention,
+    mlp: Mlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(cfg: &Qwen3Config, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            attn: Attention::new(cfg, vb.pp("self_attn"))?,
+            mlp: Mlp::new(cfg, vb.pp("mlp"))?,
+            input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
+            post_attention_layernorm: rms_norm(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor> {
+        let residual = x.clone();
+        let normed = self.input_layernorm.forward(x)?;
+        let attn_out = self.attn.forward(&normed, seqlen_offset, cos, sin)?;
+        let x = (residual + attn_out)?;
+        let residual = x.clone();
+        let normed = self.post_attention_layernorm.forward(&x)?;
+        let mlp_out = self.mlp.forward(&normed)?;
+        (residual + mlp_out).map_err(Into::into)
+    }
+
+    fn forward_paged(
+        &mut self,
+        x: &Tensor,
+        seqlen_offset: usize,
+        ctx: &mut PagedCtx,
+    ) -> Result<Tensor> {
+        let residual = x.clone();
+        let normed = self.input_layernorm.forward(x)?;
+        let attn_out = self.attn.forward_paged(&normed, seqlen_offset, ctx)?;
+        let x = (residual + attn_out)?;
+        let residual = x.clone();
+        let normed = self.post_attention_layernorm.forward(&x)?;
+        let mlp_out = self.mlp.forward(&normed)?;
+        (residual + mlp_out).map_err(Into::into)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.attn.clear_kv_cache();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level model
+// ---------------------------------------------------------------------------
+
+pub struct Qwen3Model {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    lm_head_weight: Tensor,
+    cos: Tensor,
+    sin: Tensor,
+}
+
+impl Qwen3Model {
+    pub fn new(cfg: &Qwen3Config, vb: VarBuilder) -> Result<Self> {
+        // Weights live under model.*
+        let model_vb = vb.pp("model");
+
+        let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, model_vb.pp("embed_tokens"))?;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
+            let layer_vb = model_vb.pp("layers").pp(i.to_string());
+            let layer =
+                DecoderLayer::new(cfg, layer_vb).with_context(|| format!("loading layer {}", i))?;
+            layers.push(layer);
+        }
+
+        let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, model_vb.pp("norm"))?;
+
+        // lm_head weight: prefer the separate lm_head.weight tensor from the file.
+        // Even when tie_word_embeddings=true the safetensors file typically stores
+        // lm_head.weight as a distinct tensor (same values, different storage).
+        let lm_head_weight = vb
+            .pp("lm_head")
+            .get((cfg.vocab_size, cfg.hidden_size), "weight")
+            .unwrap_or_else(|_| embed_tokens.embeddings().clone());
+
+        // Precompute RoPE tables (large enough for typical sequences)
+        let max_seq = 65536;
+        let (cos, sin) = precompute_rope(
+            cfg.head_dim,
+            cfg.rope_theta,
+            max_seq,
+            cfg.dtype,
+            &cfg.device,
+        )?;
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            norm,
+            lm_head_weight,
+            cos,
+            sin,
+        })
+    }
+
+    /// Forward pass. Returns logits for the last position: [batch, 1, vocab_size]
+    pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+        let (_b, t) = input_ids.dims2()?;
+
+        let mut x = self.embed_tokens.forward(input_ids)?;
+
+        for layer in &mut self.layers {
+            x = layer.forward(&x, seqlen_offset, &self.cos, &self.sin)?;
+        }
+
+        x = self.norm.forward(&x)?;
+
+        let last = x.narrow(1, t - 1, 1)?; // [b, 1, hidden]
+        let last_2d = last.squeeze(1)?.contiguous()?; // [b, hidden]
+        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
+        logits.unsqueeze(1).map_err(Into::into) // [b, 1, vocab]
+    }
+
+    /// Paged-attention forward pass.
+    pub fn forward_paged(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        block_table: &BlockTable,
+        kv_store: &mut PagedKvStore,
+    ) -> Result<Tensor> {
+        let (_b, t) = input_ids.dims2()?;
+
+        let mut x = self.embed_tokens.forward(input_ids)?;
+
+        for (layer_idx, layer) in self.layers.iter_mut().enumerate() {
+            let mut ctx = PagedCtx {
+                cos: &self.cos,
+                sin: &self.sin,
+                block_table,
+                kv_store,
+                layer_idx,
+            };
+            x = layer.forward_paged(&x, seqlen_offset, &mut ctx)?;
+        }
+
+        x = self.norm.forward(&x)?;
+
+        let last = x.narrow(1, t - 1, 1)?;
+        let last_2d = last.squeeze(1)?.contiguous()?;
+        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?;
+        logits.unsqueeze(1).map_err(Into::into)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        for layer in &mut self.layers {
+            layer.clear_kv_cache();
+        }
+    }
+}

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -282,10 +282,10 @@ impl FullAttention {
 
         let kv_len = k.dim(2)?;
 
-        // GQA: repeat k/v heads to match q heads
+        // GQA: repeat k/v heads so each query head has a corresponding k/v head.
         let groups = self.num_heads / self.num_kv_heads;
-        let k = k.repeat(&[1, groups, 1, 1])?;
-        let v = v.repeat(&[1, groups, 1, 1])?;
+        let k = repeat_kv(k, groups)?;
+        let v = repeat_kv(v, groups)?;
 
         // Scaled dot-product attention — matmul requires contiguous on Metal
         let scale = (self.head_dim as f64).sqrt();
@@ -414,8 +414,8 @@ impl FullAttention {
 
         // ── GQA expand ───────────────────────────────────────────────────────
         let groups = self.num_heads / self.num_kv_heads;
-        let k_full = k_full.repeat(&[1, groups, 1, 1])?;
-        let v_full = v_full.repeat(&[1, groups, 1, 1])?;
+        let k_full = repeat_kv(k_full, groups)?;
+        let v_full = repeat_kv(v_full, groups)?;
 
         // ── Scaled dot-product attention ─────────────────────────────────────
         let scale = (self.head_dim as f64).sqrt();
@@ -443,6 +443,18 @@ impl FullAttention {
 
         self.o_proj.forward(&out).map_err(Into::into)
     }
+}
+
+/// Repeat KV heads for GQA: each kv_head is repeated `n_rep` times consecutively.
+fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
+    if n_rep == 1 {
+        return Ok(xs);
+    }
+    let (b, n_kv_heads, seq_len, head_dim) = xs.dims4()?;
+    let xs_cat = Tensor::cat(&vec![&xs; n_rep], 2)?;
+    xs_cat
+        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
+        .map_err(Into::into)
 }
 
 /// Apply RmsNorm to last dimension of a 4D tensor [b, h, t, d].


### PR DESCRIPTION
- Add Qwen3 as a new ModelArchitecture variant with custom implementation in src/models/qwen3.rs (GQA + QK-norm + full RoPE, weights under model.*)
- Wire detection: Qwen3ForCausalLM / model_type=qwen3 → Qwen3 arch
- Fix GQA repeat_kv in both qwen3.rs and qwen3_5.rs: tensor.repeat along the head dim tiles heads ([kv0..kv7, kv0..kv7]) instead of interleaving them ([kv0,kv0, kv1,kv1, ...]) as required by HF repeat_kv semantics