### PR TITLE
Pass arch to tokenizer and add <turn|> stop token

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub struct RopeParameters {
     pub partial_rotary_factor: Option<f64>,
 }
 
-/// Qwen3.5 text_config nested object.
+/// Shared text_config nested object (used by Qwen3.5).
 #[derive(Debug, Deserialize)]
 pub struct TextConfig {
     pub vocab_size: Option<usize>,
@@ -83,7 +83,6 @@ pub struct RawConfig {
     #[allow(dead_code)]
     pub layer_types: Option<Vec<String>>,
 
-    // Qwen3.5-specific (nested text_config)
     pub text_config: Option<TextConfig>,
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -140,9 +140,10 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     let max_seq_len = raw_config.effective_max_seq_len(&arch);
 
     // Load tokenizer (used by the REPL to build prompts)
-    let tokenizer = Tokenizer::from_file(
+    let tokenizer = Tokenizer::from_file_with_arch(
         &model_files.tokenizer_path,
         model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
     )?;
 
     // Load model weights
@@ -156,9 +157,10 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     )?;
 
     // Engine tokenizer (separate instance — engine runs on its own thread)
-    let engine_tokenizer = Tokenizer::from_file(
+    let engine_tokenizer = Tokenizer::from_file_with_arch(
         &model_files.tokenizer_path,
         model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
     )?;
 
     // Spawn engine on a dedicated OS thread.

--- a/src/server.rs
+++ b/src/server.rs
@@ -158,9 +158,10 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     tracing::info!("Detected architecture: {:?}", arch);
 
     // Load tokenizer
-    let tokenizer = Tokenizer::from_file(
+    let tokenizer = Tokenizer::from_file_with_arch(
         &model_files.tokenizer_path,
         model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
     )?;
     let tokenizer = Arc::new(tokenizer);
 
@@ -196,9 +197,10 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     let mut engine = crate::engine::Engine::new(
         model,
         // The engine needs its own tokenizer for decoding
-        Tokenizer::from_file(
+        Tokenizer::from_file_with_arch(
             &model_files.tokenizer_path,
             model_files.tokenizer_config_path.as_deref(),
+            Some(&arch),
         )?,
         device.clone(),
         args.max_batch_size,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -98,13 +98,21 @@ pub struct Tokenizer {
 
 impl Tokenizer {
     pub fn from_file(tokenizer_path: &Path, tokenizer_config_path: Option<&Path>) -> Result<Self> {
+        Self::from_file_with_arch(tokenizer_path, tokenizer_config_path, None)
+    }
+
+    pub fn from_file_with_arch(
+        tokenizer_path: &Path,
+        tokenizer_config_path: Option<&Path>,
+        arch_override: Option<&crate::config::ModelArchitecture>,
+    ) -> Result<Self> {
         let inner = tokenizers::Tokenizer::from_file(tokenizer_path)
             .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {}", e))?;
 
         let config = tokenizer_config_path.and_then(|p| TokenizerConfig::from_file(p).ok());
 
-        // Detect chat template
         let chat_template = detect_chat_template(&config);
+        let _ = arch_override; // reserved for future architecture-specific overrides
 
         let eos_token = config.as_ref().and_then(|c| c.eos_token_str());
 
@@ -118,7 +126,7 @@ impl Tokenizer {
         if let Some(id) = eos_token_id {
             stop_token_ids.push(id);
         }
-        for extra in &["<|endoftext|>", "<|im_end|>", "<end_of_turn>"] {
+        for extra in &["<|endoftext|>", "<|im_end|>", "<end_of_turn>", "<turn|>"] {
             if let Some(id) = inner.token_to_id(extra) {
                 if !stop_token_ids.contains(&id) {
                     stop_token_ids.push(id);


### PR DESCRIPTION
Add from_file_with_arch() to Tokenizer so callers can pass the detected model architecture; from_file() becomes a thin wrapper around it. All call sites in run.rs and server.rs updated to pass Some(&arch).

The arch_override parameter is currently unused (reserved for future template selection), but wiring it through now means we can act on it without changing call sites again.

Also add <turn|> to the default stop token list so Gemma-style models that use turn delimiters stop cleanly.