### PR TITLE
Make TurboQuant 4-bit KV cache compression the default

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -62,7 +62,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
         &model_files.weight_paths,
         dtype,
         &device,
-        serve.turbo_quant,
+        Some(4),
     )?;
 
     let mut engine = Engine::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,11 +107,6 @@ pub struct ServeArgs {
     #[arg(long)]
     pub paged_attention: Option<f64>,
 
-    /// Enable TurboQuant KV cache compression.
-    /// Use as a flag (`--turbo-quant`) for the default 4-bit compression, or with an explicit
-    /// bit-width (`--turbo-quant=2`) for 1–8 bits.  Reduces KV cache memory by (dtype_bits/bits)×.
-    #[arg(long, num_args(0..=1), default_missing_value("4"), require_equals(true))]
-    pub turbo_quant: Option<u8>,
 }
 
 impl ServeArgs {

--- a/src/run.rs
+++ b/src/run.rs
@@ -71,12 +71,6 @@ pub struct RunArgs {
     /// When unset (the default) the standard concat-based KV cache is used.
     #[arg(long)]
     pub paged_attention: Option<f64>,
-
-    /// Enable TurboQuant KV cache compression.
-    /// Use as a flag (`--turbo-quant`) for the default 4-bit compression, or with an explicit
-    /// bit-width (`--turbo-quant=2`) for 1–8 bits.  Reduces KV cache memory by (dtype_bits/bits)×.
-    #[arg(long, num_args(0..=1), default_missing_value("4"), require_equals(true))]
-    pub turbo_quant: Option<u8>,
 }
 
 impl RunArgs {
@@ -99,7 +93,6 @@ impl RunArgs {
             top_k: self.top_k,
             max_tokens: self.max_tokens,
             paged_attention: self.paged_attention,
-            turbo_quant: self.turbo_quant,
         }
     }
 }
@@ -153,7 +146,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         &model_files.weight_paths,
         dtype,
         &device,
-        args.turbo_quant,
+        Some(4),
     )?;
 
     // Engine tokenizer (separate instance — engine runs on its own thread)

--- a/src/server.rs
+++ b/src/server.rs
@@ -172,7 +172,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         &model_files.weight_paths,
         dtype,
         &device,
-        args.turbo_quant,
+        Some(4),
     )?;
 
     // Effective sequence-length cap for this model.


### PR DESCRIPTION
Remove the --turbo-quant CLI flag from run, serve, and bench; pass Some(4) directly to load_model so compression is always enabled.