### PR TITLE
Implement TurboQuant 4-bit KV cache quantization

### DIFF
--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -522,8 +522,9 @@ impl Qwen3Model {
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, model_vb.pp("embed_tokens"))?;
 
         // Build a shared TurboQuant codec if requested.
-        let tq_codec: Option<std::sync::Arc<crate::turbo_quant::TurboQuantCodec>> =
-            cfg.turbo_quant_bits.map(|bits| {
+        let tq_codec: Option<std::sync::Arc<crate::turbo_quant::TurboQuantCodec>> = cfg
+            .turbo_quant_bits
+            .map(|bits| {
                 let tq_cfg = TurboQuantConfig {
                     bits,
                     head_dim: cfg.head_dim,
@@ -533,8 +534,9 @@ impl Qwen3Model {
                     bits,
                     16 / bits as u32
                 );
-                build_codec(&tq_cfg)
-            });
+                build_codec(&tq_cfg, &cfg.device)
+            })
+            .transpose()?;
 
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for i in 0..cfg.num_hidden_layers {

--- a/src/turbo_quant.rs
+++ b/src/turbo_quant.rs
@@ -20,13 +20,13 @@
 //!
 //! ## Integration
 //!
-//! `TurboQuantKvCache` wraps the per-layer KV concat-cache.  On the hot path it is a
-//! pure device-side operation: `append()` does a single `Tensor::cat` on the GPU/Metal
-//! tensors (identical to the standard KV path) and `dequantize()` is an O(1) clone.
-//! No CPU round-trip occurs during inference.
+//! `TurboQuantKvCache` wraps the per-layer KV concat-cache.  `append()` rotates the
+//! incoming K/V tensors and quantizes each head vector to `bits`-bit indices with
+//! per-vector affine scale/zero-point.  `dequantize()` reconstructs full-precision
+//! tensors by reversing the affine mapping and applying the inverse rotation.
 
 use anyhow::Result;
-use candle_core::Tensor;
+use candle_core::{DType, Device, Tensor};
 
 // ---------------------------------------------------------------------------
 // TurboQuantConfig
@@ -35,32 +35,164 @@ use candle_core::Tensor;
 /// Configuration for TurboQuant KV cache quantization.
 #[derive(Debug, Clone)]
 pub struct TurboQuantConfig {
-    /// Number of bits per coordinate (1–8). Stored for future use / logging.
+    /// Number of bits per coordinate (1–8). Currently 4-bit is the primary path.
     pub bits: u8,
     /// Head dimension (d in the paper).
     pub head_dim: usize,
 }
 
 // ---------------------------------------------------------------------------
-// TurboQuantCodec — shared across layers, kept for future CPU dequant use
+// TurboQuantCodec — shared across layers
 // ---------------------------------------------------------------------------
 
-/// Shared codec handle.  Currently a thin wrapper; retained so the public API
-/// (`build_codec` / `Arc<TurboQuantCodec>`) stays stable for callers.
+/// Shared codec.  Holds the fixed random rotation matrix Π (and its transpose
+/// Π⊤) used by every layer's `TurboQuantKvCache`.  The rotation is generated
+/// once from a fixed seed so it is deterministic across saves/loads.
 pub struct TurboQuantCodec {
+    pub bits: u8,
     #[allow(dead_code)]
-    bits: u8,
-    #[allow(dead_code)]
-    head_dim: usize,
+    pub head_dim: usize,
+    /// Rotation matrix Π: [head_dim, head_dim], f32, on the target device.
+    pub rotation: Tensor,
+    /// Transpose Π⊤: [head_dim, head_dim], f32, on the target device.
+    pub rotation_t: Tensor,
 }
 
 impl TurboQuantCodec {
-    pub fn new(cfg: &TurboQuantConfig) -> Self {
-        Self {
+    pub fn new(cfg: &TurboQuantConfig, device: &Device) -> Result<Self> {
+        let d = cfg.head_dim;
+
+        // Build an orthogonal rotation matrix on CPU via Gram-Schmidt.
+        // We seed with a deterministic pseudo-random normal matrix.
+        let rot_cpu = random_orthogonal(d)?;
+        let rot_t_cpu = rot_cpu.t()?.contiguous()?;
+
+        // Move to target device as f32 (we always do rotation arithmetic in f32
+        // to avoid precision loss, then cast back to the original dtype).
+        let rotation = rot_cpu.to_device(device)?;
+        let rotation_t = rot_t_cpu.to_device(device)?;
+
+        Ok(Self {
             bits: cfg.bits,
-            head_dim: cfg.head_dim,
+            head_dim: d,
+            rotation,
+            rotation_t,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/// Build a deterministic orthogonal matrix of shape [d, d] on CPU (f32).
+///
+/// Uses a simple LCG to produce a reproducible pseudo-random normal matrix,
+/// then applies one step of Gram-Schmidt orthogonalisation to make it unitary.
+/// This is sufficient for the rotation's purpose (isotropic coordinate spread).
+fn random_orthogonal(d: usize) -> Result<Tensor> {
+    // --- deterministic pseudo-random normal numbers (Box-Muller, LCG seed) ---
+    let n = d * d;
+    let mut vals = Vec::<f32>::with_capacity(n);
+    let mut state: u64 = 0x_dead_beef_cafe_1234;
+    for _ in 0..n {
+        // LCG step
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let u1 = ((state >> 33) as f32 + 0.5) / (u32::MAX as f32 + 1.0);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let u2 = ((state >> 33) as f32 + 0.5) / (u32::MAX as f32 + 1.0);
+        // Box-Muller transform → N(0,1)
+        let z = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
+        vals.push(z);
+    }
+
+    // Build as [d, d] row-major
+    let mat = Tensor::from_vec(vals, (d, d), &Device::Cpu)?;
+
+    // Gram-Schmidt orthogonalisation column by column.
+    // We work with the *rows* so that the result is a proper rotation matrix
+    // (each row is a unit vector orthogonal to all previous rows).
+    let mut rows: Vec<Vec<f32>> = (0..d)
+        .map(|i| {
+            mat.get(i)
+                .and_then(|r| r.to_vec1::<f32>())
+                .unwrap_or_else(|_| vec![0.0f32; d])
+        })
+        .collect();
+
+    for i in 0..d {
+        // Subtract projections onto all previous rows
+        for j in 0..i {
+            let dot: f32 = rows[i].iter().zip(rows[j].iter()).map(|(a, b)| a * b).sum();
+            let rj = rows[j].clone();
+            for (x, r) in rows[i].iter_mut().zip(rj.iter()) {
+                *x -= dot * r;
+            }
+        }
+        // Normalise
+        let norm: f32 = rows[i].iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 1e-8 {
+            for x in rows[i].iter_mut() {
+                *x /= norm;
+            }
         }
     }
+
+    let flat: Vec<f32> = rows.into_iter().flatten().collect();
+    Ok(Tensor::from_vec(flat, (d, d), &Device::Cpu)?)
+}
+
+/// Quantize a float tensor (any dtype) to `bits`-bit indices using per-vector
+/// affine (min/max) mapping.
+///
+/// `x` shape: `[batch, heads, seq, head_dim]`
+///
+/// Returns:
+/// - `indices` — u8 tensor, same shape as `x`
+/// - `scales`  — f32 tensor `[batch, heads, seq, 1]`
+/// - `zeros`   — f32 tensor `[batch, heads, seq, 1]`
+fn quantize(x: &Tensor, bits: u8) -> Result<(Tensor, Tensor, Tensor)> {
+    let levels = ((1u32 << bits) - 1) as f32; // e.g. 15 for 4-bit
+
+    // Work in f32 for the quantization arithmetic.
+    let xf = x.to_dtype(DType::F32)?;
+
+    // Per-vector min and max along the last dimension (head_dim).
+    let xmin = xf.min_keepdim(candle_core::D::Minus1)?;
+    let xmax = xf.max_keepdim(candle_core::D::Minus1)?;
+
+    // scale = (xmax - xmin) / levels  (avoid div-by-zero)
+    let range = xmax.broadcast_sub(&xmin)?;
+    let scale = (range + 1e-8f64)?.affine(1.0 / levels as f64, 0.0)?;
+
+    // indices = round((x - xmin) / scale)  clamped to [0, levels]
+    let shifted = xf.broadcast_sub(&xmin)?;
+    let idx_f = shifted.broadcast_div(&scale)?;
+    let idx_f = idx_f.round()?;
+    let idx_f = idx_f.clamp(0f64, levels as f64)?;
+    let indices = idx_f.to_dtype(DType::U8)?;
+
+    Ok((indices, scale, xmin))
+}
+
+/// Dequantize u8 indices back to f32, then cast to `target_dtype`.
+///
+/// `indices` shape: `[batch, heads, seq, head_dim]`
+/// `scales` / `zeros` shape: `[batch, heads, seq, 1]`
+fn dequantize_tensor(
+    indices: &Tensor,
+    scales: &Tensor,
+    zeros: &Tensor,
+    target_dtype: DType,
+) -> Result<Tensor> {
+    let idx_f = indices.to_dtype(DType::F32)?;
+    let x = idx_f.broadcast_mul(scales)?;
+    let x = x.broadcast_add(zeros)?;
+    Ok(x.to_dtype(target_dtype)?)
 }
 
 // ---------------------------------------------------------------------------
@@ -69,26 +201,39 @@ impl TurboQuantCodec {
 
 /// Quantized KV cache for a single attention layer.
 ///
-/// Hot-path design: `append()` is a single `Tensor::cat` on the device (identical
-/// to the standard concat-KV path).  `dequantize()` is an O(1) clone of the cached
-/// device tensors.  No CPU round-trip occurs.
+/// `append()` rotates incoming K/V tensors with the shared rotation matrix Π
+/// and quantizes each head vector to `bits`-bit indices using per-vector
+/// affine scaling.  `dequantize()` reverses the process: reconstruct
+/// full-precision tensors from the stored indices/scales and apply Π⊤.
 pub struct TurboQuantKvCache {
-    /// Cached device tensor [1, num_kv_heads, seq_len, head_dim], updated in append().
-    k_cache_t: Option<Tensor>,
-    /// Cached device V tensor.
-    v_cache_t: Option<Tensor>,
+    codec: std::sync::Arc<TurboQuantCodec>,
+    orig_dtype: DType,
+    // Quantized K cache: u8 [1, heads, seq, head_dim]
+    k_idx: Option<Tensor>,
+    k_scale: Option<Tensor>,
+    k_zero: Option<Tensor>,
+    // Quantized V cache: u8 [1, heads, seq, head_dim]
+    v_idx: Option<Tensor>,
+    v_scale: Option<Tensor>,
+    v_zero: Option<Tensor>,
 }
 
 impl TurboQuantKvCache {
     pub fn new(
-        _codec: std::sync::Arc<TurboQuantCodec>,
+        codec: std::sync::Arc<TurboQuantCodec>,
         _num_kv_heads: usize,
-        _dtype: candle_core::DType,
-        _device: candle_core::Device,
+        dtype: DType,
+        _device: Device,
     ) -> Self {
         Self {
-            k_cache_t: None,
-            v_cache_t: None,
+            codec,
+            orig_dtype: dtype,
+            k_idx: None,
+            k_scale: None,
+            k_zero: None,
+            v_idx: None,
+            v_scale: None,
+            v_zero: None,
         }
     }
 
@@ -96,19 +241,51 @@ impl TurboQuantKvCache {
     ///
     /// `k` and `v`: shape `[batch=1, num_kv_heads, seq_len, head_dim]`
     ///
-    /// This is a single `Tensor::cat` on the device — identical cost to the
-    /// standard concat-KV path.
+    /// Rotates with Π, quantizes to `bits`-bit indices (per-vector affine),
+    /// and concatenates onto the running cache along the sequence dimension.
     pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<()> {
-        let k_new = match &self.k_cache_t {
-            None => k.clone(),
-            Some(prev) => Tensor::cat(&[prev, k], 2)?,
+        let rot = &self.codec.rotation; // [head_dim, head_dim]
+
+        // Cast to f32 for rotation arithmetic, then apply Π.
+        // k shape: [1, heads, seq, head_dim]  →  matmul with [head_dim, head_dim]
+        // broadcast matmul: last two dims are [seq, head_dim] x [head_dim, head_dim]
+        let kf = k.to_dtype(DType::F32)?;
+        let vf = v.to_dtype(DType::F32)?;
+        let k_rot = kf.broadcast_matmul(rot)?;
+        let v_rot = vf.broadcast_matmul(rot)?;
+
+        // Quantize the rotated tensors.
+        let (k_new_idx, k_new_scale, k_new_zero) = quantize(&k_rot, self.codec.bits)?;
+        let (v_new_idx, v_new_scale, v_new_zero) = quantize(&v_rot, self.codec.bits)?;
+
+        // Concatenate along the sequence dimension (dim 2).
+        let (k_idx, k_scale, k_zero) = match (&self.k_idx, &self.k_scale, &self.k_zero) {
+            (None, _, _) => (k_new_idx, k_new_scale, k_new_zero),
+            (Some(prev_idx), Some(prev_scale), Some(prev_zero)) => (
+                Tensor::cat(&[prev_idx, &k_new_idx], 2)?,
+                Tensor::cat(&[prev_scale, &k_new_scale], 2)?,
+                Tensor::cat(&[prev_zero, &k_new_zero], 2)?,
+            ),
+            _ => unreachable!(),
         };
-        let v_new = match &self.v_cache_t {
-            None => v.clone(),
-            Some(prev) => Tensor::cat(&[prev, v], 2)?,
+
+        let (v_idx, v_scale, v_zero) = match (&self.v_idx, &self.v_scale, &self.v_zero) {
+            (None, _, _) => (v_new_idx, v_new_scale, v_new_zero),
+            (Some(prev_idx), Some(prev_scale), Some(prev_zero)) => (
+                Tensor::cat(&[prev_idx, &v_new_idx], 2)?,
+                Tensor::cat(&[prev_scale, &v_new_scale], 2)?,
+                Tensor::cat(&[prev_zero, &v_new_zero], 2)?,
+            ),
+            _ => unreachable!(),
         };
-        self.k_cache_t = Some(k_new);
-        self.v_cache_t = Some(v_new);
+
+        self.k_idx = Some(k_idx);
+        self.k_scale = Some(k_scale);
+        self.k_zero = Some(k_zero);
+        self.v_idx = Some(v_idx);
+        self.v_scale = Some(v_scale);
+        self.v_zero = Some(v_zero);
+
         Ok(())
     }
 
@@ -116,25 +293,43 @@ impl TurboQuantKvCache {
     ///
     /// Output shapes: `[1, num_kv_heads, total_seq_len, head_dim]`
     ///
-    /// O(1): the device tensors are already up-to-date; this is just a pair of clones.
+    /// Reconstructs full-precision tensors from stored u8 indices + per-vector
+    /// scales/zeros, then applies the inverse rotation Π⊤.
     pub fn dequantize(&self) -> Result<(Tensor, Tensor)> {
-        let k_t = self
-            .k_cache_t
+        let k_idx = self
+            .k_idx
             .as_ref()
-            .expect("dequantize called on empty TurboQuantKvCache")
-            .clone();
-        let v_t = self
-            .v_cache_t
+            .expect("dequantize called on empty TurboQuantKvCache");
+        let k_scale = self.k_scale.as_ref().unwrap();
+        let k_zero = self.k_zero.as_ref().unwrap();
+        let v_idx = self
+            .v_idx
             .as_ref()
-            .expect("dequantize called on empty TurboQuantKvCache")
-            .clone();
-        Ok((k_t, v_t))
+            .expect("dequantize called on empty TurboQuantKvCache");
+        let v_scale = self.v_scale.as_ref().unwrap();
+        let v_zero = self.v_zero.as_ref().unwrap();
+
+        let rot_t = &self.codec.rotation_t; // [head_dim, head_dim]
+
+        // Reconstruct rotated tensors in f32.
+        let k_rot = dequantize_tensor(k_idx, k_scale, k_zero, DType::F32)?;
+        let v_rot = dequantize_tensor(v_idx, v_scale, v_zero, DType::F32)?;
+
+        // Apply inverse rotation Π⊤ and cast back to original dtype.
+        let k = k_rot.broadcast_matmul(rot_t)?.to_dtype(self.orig_dtype)?;
+        let v = v_rot.broadcast_matmul(rot_t)?.to_dtype(self.orig_dtype)?;
+
+        Ok((k, v))
     }
 
     /// Clear all cached tokens (start of a new sequence).
     pub fn clear(&mut self) {
-        self.k_cache_t = None;
-        self.v_cache_t = None;
+        self.k_idx = None;
+        self.k_scale = None;
+        self.k_zero = None;
+        self.v_idx = None;
+        self.v_scale = None;
+        self.v_zero = None;
     }
 }
 
@@ -143,6 +338,9 @@ impl TurboQuantKvCache {
 // ---------------------------------------------------------------------------
 
 /// Build a shared `TurboQuantCodec` from a `TurboQuantConfig`.
-pub fn build_codec(cfg: &TurboQuantConfig) -> std::sync::Arc<TurboQuantCodec> {
-    std::sync::Arc::new(TurboQuantCodec::new(cfg))
+pub fn build_codec(
+    cfg: &TurboQuantConfig,
+    device: &Device,
+) -> Result<std::sync::Arc<TurboQuantCodec>> {
+    Ok(std::sync::Arc::new(TurboQuantCodec::new(cfg, device)?))
 }


### PR DESCRIPTION
Replace the placeholder TurboQuantKvCache (which was doing plain concat with no compression) with a real implementation: append() now rotates incoming K/V vectors with a fixed random orthogonal matrix Π and quantizes to 4-bit indices using per-vector affine (min/max) scaling; dequantize() reconstructs full-precision tensors and applies Π⊤.

Also fix a trailing blank line in ServeArgs that was failing cargo fmt.