### PR TITLE
refactor: de-duplicate shared code across model and engine layers

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -11,11 +11,9 @@
 //!   - End-to-end latency           — total wall-time for the request
 
 use anyhow::Result;
-use candle_core::DType;
 
 use crate::config::RawConfig;
-use crate::engine::Engine;
-use crate::kv_cache::{BlockPool, PagedCacheConfig, PagedKvStore};
+use crate::engine::{attach_paged_kv_if_requested, Engine};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::Tokenizer;
 use crate::ServeArgs;
@@ -77,34 +75,15 @@ pub fn run(args: BenchArgs) -> Result<()> {
     );
 
     // Wire up paged attention if requested (same logic as `serve`)
-    if let Some(memory_fraction) = serve.paged_attention {
-        let bytes_per_element = match dtype {
-            DType::F32 => 4,
-            _ => 2,
-        };
-        let total_memory_bytes: usize = match &device {
-            candle_core::Device::Cuda(_) | candle_core::Device::Metal(_) => 8 * 1024 * 1024 * 1024,
-            _ => 4 * 1024 * 1024 * 1024,
-        };
-        let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(&arch);
-        let paged_cfg = PagedCacheConfig::from_memory_fraction(
-            total_memory_bytes,
-            memory_fraction,
-            serve.block_size,
-            num_kv_heads,
-            head_dim,
-            num_kv_layers,
-            bytes_per_element,
-        );
-        tracing::info!(
-            "Paged KV store: {} blocks × {} tokens/block",
-            paged_cfg.num_blocks,
-            paged_cfg.block_size,
-        );
-        let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
-        let kv_store = PagedKvStore::new(paged_cfg, dtype, &device)?;
-        engine = engine.with_paged_kv(block_pool, kv_store);
-    }
+    engine = attach_paged_kv_if_requested(
+        engine,
+        serve.paged_attention,
+        serve.block_size,
+        dtype,
+        &device,
+        &raw_config,
+        &arch,
+    )?;
 
     // Build a synthetic prompt of the requested length.
     // Use the tokenizer's BOS token id if available, otherwise token id 1.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,13 +1,33 @@
 //! Inference engine: owns the model and runs the inference loop.
 
 use anyhow::Result;
-use candle_core::{Device, Tensor};
+use candle_core::{DType, Device, Tensor};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::kv_cache::{BlockPool, BlockTable, PagedKvStore};
+use crate::config::{ModelArchitecture, RawConfig};
+use crate::kv_cache::{BlockPool, BlockTable, PagedCacheConfig, PagedKvStore};
 use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
+
+/// Abstraction over the two streaming channel flavours:
+/// - `tokio::sync::mpsc::Sender` (used by the HTTP server)
+/// - `std::sync::mpsc::SyncSender` (used by `inferrs run` on a plain OS thread)
+trait TokenSender: Send {
+    fn send_token(&self, token: StreamToken) -> bool;
+}
+
+impl TokenSender for mpsc::Sender<StreamToken> {
+    fn send_token(&self, token: StreamToken) -> bool {
+        self.blocking_send(token).is_ok()
+    }
+}
+
+impl TokenSender for std::sync::mpsc::SyncSender<StreamToken> {
+    fn send_token(&self, token: StreamToken) -> bool {
+        self.send(token).is_ok()
+    }
+}
 
 /// Request to the engine (async/tokio version, used by the HTTP server).
 pub enum EngineRequest {
@@ -56,6 +76,71 @@ pub struct GenerationResult {
     pub finish_reason: String,
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
+}
+
+/// Attach a paged KV store to `engine` if `--paged-attention` was requested.
+///
+/// This consolidates the identical paged-KV setup block that previously appeared
+/// in `server.rs`, `bench.rs`, and `run.rs`.
+pub fn attach_paged_kv_if_requested(
+    engine: Engine,
+    memory_fraction: Option<f64>,
+    block_size: usize,
+    dtype: DType,
+    device: &Device,
+    raw_config: &RawConfig,
+    arch: &ModelArchitecture,
+) -> Result<Engine> {
+    let Some(memory_fraction) = memory_fraction else {
+        return Ok(engine);
+    };
+
+    let bytes_per_element = match dtype {
+        DType::F32 => 4,
+        _ => 2, // f16 / bf16
+    };
+
+    // Estimate available device memory.  Candle does not expose a device
+    // memory query API, so we use a conservative platform heuristic:
+    //   CUDA / Metal  → 8 GiB
+    //   CPU           → 4 GiB
+    // The user-supplied fraction then scales this down to the actual
+    // allocation, e.g. 0.6 × 8 GiB = 4.8 GiB for KV blocks.
+    let total_memory_bytes: usize = match device {
+        Device::Cuda(_) | Device::Metal(_) => 8 * 1024 * 1024 * 1024,
+        _ => 4 * 1024 * 1024 * 1024,
+    };
+
+    let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(arch);
+
+    tracing::info!(
+        "Paged attention: fraction={:.2}, {} KV heads, head_dim={}, {} KV layers",
+        memory_fraction,
+        num_kv_heads,
+        head_dim,
+        num_kv_layers,
+    );
+
+    let paged_cfg = PagedCacheConfig::from_memory_fraction(
+        total_memory_bytes,
+        memory_fraction,
+        block_size,
+        num_kv_heads,
+        head_dim,
+        num_kv_layers,
+        bytes_per_element,
+    );
+
+    tracing::info!(
+        "Paged KV store: {} blocks × {} tokens/block = {} total slots",
+        paged_cfg.num_blocks,
+        paged_cfg.block_size,
+        paged_cfg.num_blocks * paged_cfg.block_size,
+    );
+
+    let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
+    let kv_store = PagedKvStore::new(paged_cfg, dtype, device)?;
+    Ok(engine.with_paged_kv(block_pool, kv_store))
 }
 
 /// The engine runs on a dedicated thread and processes requests sequentially.
@@ -321,6 +406,31 @@ impl Engine {
         sampling_params: &SamplingParams,
         token_tx: &mpsc::Sender<StreamToken>,
     ) -> Result<()> {
+        self.generate_stream_inner(request_id, prompt_tokens, sampling_params, token_tx)
+    }
+
+    /// Streaming generation using stdlib `SyncSender` — delegates to the
+    /// shared `generate_stream_inner` implementation.
+    fn generate_stream_sync(
+        &mut self,
+        request_id: &str,
+        prompt_tokens: &[u32],
+        sampling_params: &SamplingParams,
+        token_tx: &std::sync::mpsc::SyncSender<StreamToken>,
+    ) -> Result<()> {
+        self.generate_stream_inner(request_id, prompt_tokens, sampling_params, token_tx)
+    }
+
+    /// Shared streaming implementation.  Works with any channel that implements
+    /// `TokenSender`: both `tokio::sync::mpsc::Sender` (HTTP server) and
+    /// `std::sync::mpsc::SyncSender` (`inferrs run`).
+    fn generate_stream_inner(
+        &mut self,
+        request_id: &str,
+        prompt_tokens: &[u32],
+        sampling_params: &SamplingParams,
+        token_tx: &impl TokenSender,
+    ) -> Result<()> {
         tracing::debug!(
             "Streaming generation for request {} ({} prompt tokens)",
             request_id,
@@ -348,14 +458,11 @@ impl Engine {
         let text = self.tokenizer.decode(&[token_id], true)?;
         let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
 
-        if token_tx
-            .blocking_send(StreamToken {
-                token_id,
-                text,
-                finish_reason: finish_reason.clone(),
-            })
-            .is_err()
-            || finish_reason.is_some()
+        if !token_tx.send_token(StreamToken {
+            token_id,
+            text,
+            finish_reason: finish_reason.clone(),
+        }) || finish_reason.is_some()
         {
             if let Some(ps) = &mut self.paged {
                 ps.block_table.free_all(&mut ps.block_pool);
@@ -388,111 +495,11 @@ impl Engine {
             let text = self.tokenizer.decode(&[token_id], true)?;
             let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
 
-            if token_tx
-                .blocking_send(StreamToken {
-                    token_id,
-                    text,
-                    finish_reason: finish_reason.clone(),
-                })
-                .is_err()
-                || finish_reason.is_some()
-            {
-                break;
-            }
-        }
-
-        if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-        }
-
-        Ok(())
-    }
-
-    /// Streaming generation using stdlib `SyncSender` — identical logic to
-    /// `generate_stream` but sends tokens via `std::sync::mpsc` instead of
-    /// `tokio::sync::mpsc`, so it can be called from a plain OS thread.
-    fn generate_stream_sync(
-        &mut self,
-        request_id: &str,
-        prompt_tokens: &[u32],
-        sampling_params: &SamplingParams,
-        token_tx: &std::sync::mpsc::SyncSender<StreamToken>,
-    ) -> Result<()> {
-        tracing::debug!(
-            "Streaming generation (sync) for request {} ({} prompt tokens)",
-            request_id,
-            prompt_tokens.len()
-        );
-
-        let mut output_tokens: Vec<u32> = Vec::new();
-        let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
-
-        // Prefill
-        let logits = if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-            self.model.clear_kv_cache();
-            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
-        } else {
-            self.model.clear_kv_cache();
-            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-            self.model.forward(&input_ids, 0)?
-        };
-
-        let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
-        output_tokens.push(token_id);
-        all_tokens.push(token_id);
-
-        let text = self.tokenizer.decode(&[token_id], true)?;
-        let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
-
-        if token_tx
-            .send(StreamToken {
+            if !token_tx.send_token(StreamToken {
                 token_id,
                 text,
                 finish_reason: finish_reason.clone(),
-            })
-            .is_err()
-            || finish_reason.is_some()
-        {
-            if let Some(ps) = &mut self.paged {
-                ps.block_table.free_all(&mut ps.block_pool);
-            }
-            return Ok(());
-        }
-
-        // Decode loop
-        loop {
-            let last_token = *output_tokens.last().unwrap();
-            let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-
-            let logits = if let Some(ps) = &mut self.paged {
-                Self::paged_decode_step(
-                    &mut self.model,
-                    &self.device,
-                    last_token,
-                    seqlen_offset,
-                    ps,
-                )?
-            } else {
-                let input_ids = Tensor::new(&[last_token], &self.device)?.unsqueeze(0)?;
-                self.model.forward(&input_ids, seqlen_offset)?
-            };
-
-            let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
-            output_tokens.push(token_id);
-            all_tokens.push(token_id);
-
-            let text = self.tokenizer.decode(&[token_id], true)?;
-            let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
-
-            if token_tx
-                .send(StreamToken {
-                    token_id,
-                    text,
-                    finish_reason: finish_reason.clone(),
-                })
-                .is_err()
-                || finish_reason.is_some()
+            }) || finish_reason.is_some()
             {
                 break;
             }

--- a/src/models/attention_utils.rs
+++ b/src/models/attention_utils.rs
@@ -1,0 +1,76 @@
+//! Shared attention utilities used by multiple model implementations.
+
+use anyhow::Result;
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::RmsNorm;
+
+use crate::kv_cache::{BlockTable, PagedKvStore};
+
+/// Paged-attention context passed to each layer's `forward_paged` call.
+///
+/// Grouping these together keeps individual method signatures within clippy's
+/// argument-count limit and makes call sites cleaner.
+pub struct PagedCtx<'a> {
+    pub cos: &'a Tensor,
+    pub sin: &'a Tensor,
+    pub block_table: &'a BlockTable,
+    pub kv_store: &'a mut PagedKvStore,
+    /// Index into the paged KV store (counts only full-attention layers).
+    pub layer_idx: usize,
+}
+
+/// Repeat KV heads for GQA: each kv_head is repeated `n_rep` times consecutively.
+///
+/// For `num_heads=16, num_kv_heads=8` the output layout is:
+///   [kv0, kv0, kv1, kv1, ..., kv7, kv7]
+/// so that query head h maps to kv_head h // n_rep.
+///
+/// This matches the HF `repeat_kv` implementation.
+pub fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
+    if n_rep == 1 {
+        return Ok(xs);
+    }
+    let (b, n_kv_heads, seq_len, head_dim) = xs.dims4()?;
+    // Concatenate along the seq_len dimension, then reshape so that
+    // each kv_head appears n_rep times consecutively in the head dimension.
+    let xs_cat = Tensor::cat(&vec![&xs; n_rep], 2)?; // [b, n_kv, seq*n_rep, d]
+    xs_cat
+        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
+        .map_err(Into::into)
+}
+
+/// Apply RmsNorm to last dimension of a 4D tensor [b, h, t, d].
+pub fn apply_rms_norm_heads(x: &Tensor, norm: &RmsNorm) -> Result<Tensor> {
+    let (b, h, t, d) = x.dims4()?;
+    // reshape requires contiguous on Metal
+    let x_flat = x.contiguous()?.reshape((b * h * t, d))?;
+    let out = norm.forward(&x_flat)?;
+    out.reshape((b, h, t, d)).map_err(Into::into)
+}
+
+/// Build a causal attention bias [1, 1, q_len, kv_len].
+pub fn causal_mask(
+    q_len: usize,
+    kv_len: usize,
+    offset: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let mask: Vec<f32> = (0..q_len)
+        .flat_map(|i| {
+            (0..kv_len).map(move |j| {
+                // position of query token in full sequence
+                let qi = offset + i;
+                if j <= qi {
+                    0.0f32
+                } else {
+                    f32::NEG_INFINITY
+                }
+            })
+        })
+        .collect();
+    let mask = Tensor::new(mask.as_slice(), device)?
+        .reshape((1, 1, q_len, kv_len))?
+        .to_dtype(dtype)?;
+    Ok(mask)
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,6 +3,7 @@
 //! We use candle-transformers' model implementations directly, wrapping them
 //! with a unified trait for the engine to use.
 
+pub mod attention_utils;
 pub mod qwen3;
 pub mod qwen3_5;
 

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -16,16 +16,8 @@ use candle_nn::{
 };
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
+use crate::models::attention_utils::{apply_rms_norm_heads, causal_mask, repeat_kv, PagedCtx};
 use crate::turbo_quant::{build_codec, TurboQuantConfig, TurboQuantKvCache};
-
-/// Paged-attention context passed to each layer.
-pub struct PagedCtx<'a> {
-    pub cos: &'a Tensor,
-    pub sin: &'a Tensor,
-    pub block_table: &'a BlockTable,
-    pub kv_store: &'a mut PagedKvStore,
-    pub layer_idx: usize,
-}
 
 // ---------------------------------------------------------------------------
 // Config
@@ -97,30 +89,6 @@ fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
     let cos = cos.narrow(0, 0, seq_len)?.contiguous()?;
     let sin = sin.narrow(0, 0, seq_len)?.contiguous()?;
     rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Into::into)
-}
-
-// ---------------------------------------------------------------------------
-// GQA repeat_kv
-// ---------------------------------------------------------------------------
-
-/// Repeat KV heads for GQA: each kv_head is repeated `n_rep` times consecutively.
-///
-/// For `num_heads=16, num_kv_heads=8` the output layout is:
-///   [kv0, kv0, kv1, kv1, ..., kv7, kv7]
-/// so that query head h maps to kv_head h // n_rep.
-///
-/// This matches the HF `repeat_kv` implementation.
-fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
-    if n_rep == 1 {
-        return Ok(xs);
-    }
-    let (b, n_kv_heads, seq_len, head_dim) = xs.dims4()?;
-    // Concatenate along the seq_len dimension, then reshape so that
-    // each kv_head appears n_rep times consecutively in the head dimension.
-    let xs_cat = Tensor::cat(&vec![&xs; n_rep], 2)?; // [b, n_kv, seq*n_rep, d]
-    xs_cat
-        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
-        .map_err(Into::into)
 }
 
 // ---------------------------------------------------------------------------
@@ -398,40 +366,6 @@ impl Attention {
 
         self.o_proj.forward(&out).map_err(Into::into)
     }
-}
-
-/// Apply RmsNorm to last dimension of a 4D tensor [b, h, t, d].
-fn apply_rms_norm_heads(x: &Tensor, norm: &RmsNorm) -> Result<Tensor> {
-    let (b, h, t, d) = x.dims4()?;
-    let x_flat = x.contiguous()?.reshape((b * h * t, d))?;
-    let out = norm.forward(&x_flat)?;
-    out.reshape((b, h, t, d)).map_err(Into::into)
-}
-
-/// Build a causal attention bias [1, 1, q_len, kv_len].
-fn causal_mask(
-    q_len: usize,
-    kv_len: usize,
-    offset: usize,
-    device: &Device,
-    dtype: DType,
-) -> Result<Tensor> {
-    let mask: Vec<f32> = (0..q_len)
-        .flat_map(|i| {
-            (0..kv_len).map(move |j| {
-                let qi = offset + i;
-                if j <= qi {
-                    0.0f32
-                } else {
-                    f32::NEG_INFINITY
-                }
-            })
-        })
-        .collect();
-    let mask = Tensor::new(mask.as_slice(), device)?
-        .reshape((1, 1, q_len, kv_len))?
-        .to_dtype(dtype)?;
-    Ok(mask)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -12,19 +12,7 @@ use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
-
-/// Paged-attention context passed down to each layer's `forward_paged` call.
-///
-/// Grouping these together keeps individual method signatures within clippy's
-/// argument-count limit and makes call sites cleaner.
-pub struct PagedCtx<'a> {
-    pub cos: &'a Tensor,
-    pub sin: &'a Tensor,
-    pub block_table: &'a BlockTable,
-    pub kv_store: &'a mut PagedKvStore,
-    /// Index into the paged KV store (counts only full-attention layers).
-    pub layer_idx: usize,
-}
+use crate::models::attention_utils::{apply_rms_norm_heads, causal_mask, repeat_kv, PagedCtx};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -443,54 +431,6 @@ impl FullAttention {
 
         self.o_proj.forward(&out).map_err(Into::into)
     }
-}
-
-/// Repeat KV heads for GQA: each kv_head is repeated `n_rep` times consecutively.
-fn repeat_kv(xs: Tensor, n_rep: usize) -> Result<Tensor> {
-    if n_rep == 1 {
-        return Ok(xs);
-    }
-    let (b, n_kv_heads, seq_len, head_dim) = xs.dims4()?;
-    let xs_cat = Tensor::cat(&vec![&xs; n_rep], 2)?;
-    xs_cat
-        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
-        .map_err(Into::into)
-}
-
-/// Apply RmsNorm to last dimension of a 4D tensor [b, h, t, d].
-fn apply_rms_norm_heads(x: &Tensor, norm: &RmsNorm) -> Result<Tensor> {
-    let (b, h, t, d) = x.dims4()?;
-    // reshape requires contiguous on Metal
-    let x_flat = x.contiguous()?.reshape((b * h * t, d))?;
-    let out = norm.forward(&x_flat)?;
-    out.reshape((b, h, t, d)).map_err(Into::into)
-}
-
-/// Build a causal attention bias [1, 1, q_len, kv_len].
-fn causal_mask(
-    q_len: usize,
-    kv_len: usize,
-    offset: usize,
-    device: &Device,
-    dtype: DType,
-) -> Result<Tensor> {
-    let mask: Vec<f32> = (0..q_len)
-        .flat_map(|i| {
-            (0..kv_len).map(move |j| {
-                // position of query token in full sequence
-                let qi = offset + i;
-                if j <= qi {
-                    0.0f32
-                } else {
-                    f32::NEG_INFINITY
-                }
-            })
-        })
-        .collect();
-    let mask = Tensor::new(mask.as_slice(), device)?
-        .reshape((1, 1, q_len, kv_len))?
-        .to_dtype(dtype)?;
-    Ok(mask)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/run.rs
+++ b/src/run.rs
@@ -13,12 +13,9 @@ use crossterm::{
 use std::io::{self, Write};
 use std::sync::mpsc as stdmpsc;
 
-use candle_core::DType;
-
 use crate::config::RawConfig;
-use crate::engine::{Engine, StreamToken, SyncEngineRequest};
+use crate::engine::{attach_paged_kv_if_requested, Engine, StreamToken, SyncEngineRequest};
 use crate::hub;
-use crate::kv_cache::{BlockPool, PagedCacheConfig, PagedKvStore};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
@@ -172,34 +169,15 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     let mut engine = Engine::new(model, engine_tokenizer, device.clone(), 1, 2048);
 
     // Wire up paged attention if requested (same logic as `serve` and `bench`).
-    if let Some(memory_fraction) = serve.paged_attention {
-        let bytes_per_element = match dtype {
-            DType::F32 => 4,
-            _ => 2,
-        };
-        let total_memory_bytes: usize = match &device {
-            candle_core::Device::Cuda(_) | candle_core::Device::Metal(_) => 8 * 1024 * 1024 * 1024,
-            _ => 4 * 1024 * 1024 * 1024,
-        };
-        let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(&arch);
-        let paged_cfg = PagedCacheConfig::from_memory_fraction(
-            total_memory_bytes,
-            memory_fraction,
-            serve.block_size,
-            num_kv_heads,
-            head_dim,
-            num_kv_layers,
-            bytes_per_element,
-        );
-        tracing::info!(
-            "Paged KV store: {} blocks × {} tokens/block",
-            paged_cfg.num_blocks,
-            paged_cfg.block_size,
-        );
-        let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
-        let kv_store = PagedKvStore::new(paged_cfg, dtype, &device)?;
-        engine = engine.with_paged_kv(block_pool, kv_store);
-    }
+    engine = attach_paged_kv_if_requested(
+        engine,
+        serve.paged_attention,
+        serve.block_size,
+        dtype,
+        &device,
+        &raw_config,
+        &arch,
+    )?;
 
     let engine = engine;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,8 +19,7 @@ use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::CorsLayer;
 
 use crate::config::RawConfig;
-use crate::engine::{EngineRequest, GenerationResult, StreamToken};
-use crate::kv_cache::{BlockPool, PagedCacheConfig, PagedKvStore};
+use crate::engine::{attach_paged_kv_if_requested, EngineRequest, GenerationResult, StreamToken};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Tokenizer};
 use crate::ServeArgs;
@@ -132,6 +131,20 @@ pub struct ErrorDetail {
     pub r#type: String,
 }
 
+// ─── Error helpers ──────────────────────────────────────────────────────────
+
+fn server_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: ErrorDetail {
+                message: message.into(),
+                r#type: "server_error".to_string(),
+            },
+        }),
+    )
+}
+
 // ─── Server state ───────────────────────────────────────────────────────────
 
 struct AppState {
@@ -207,55 +220,15 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         args.max_tokens_per_step,
     );
 
-    // If --paged-attention <fraction> was given, set up the paged KV store.
-    if let Some(memory_fraction) = args.paged_attention {
-        let bytes_per_element = match dtype {
-            candle_core::DType::F32 => 4,
-            _ => 2, // f16 / bf16
-        };
-
-        // Estimate available device memory.  Candle does not expose a device
-        // memory query API, so we use a conservative platform heuristic:
-        //   CUDA / Metal  → 8 GiB
-        //   CPU           → 4 GiB
-        // The user-supplied fraction then scales this down to the actual
-        // allocation, e.g. 0.6 × 8 GiB = 4.8 GiB for KV blocks.
-        let total_memory_bytes: usize = match &device {
-            candle_core::Device::Cuda(_) | candle_core::Device::Metal(_) => 8 * 1024 * 1024 * 1024,
-            _ => 4 * 1024 * 1024 * 1024,
-        };
-
-        let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(&arch);
-
-        tracing::info!(
-            "Paged attention: fraction={:.2}, {} KV heads, head_dim={}, {} KV layers",
-            memory_fraction,
-            num_kv_heads,
-            head_dim,
-            num_kv_layers,
-        );
-
-        let paged_cfg = PagedCacheConfig::from_memory_fraction(
-            total_memory_bytes,
-            memory_fraction,
-            args.block_size,
-            num_kv_heads,
-            head_dim,
-            num_kv_layers,
-            bytes_per_element,
-        );
-
-        tracing::info!(
-            "Paged KV store: {} blocks × {} tokens/block = {} total slots",
-            paged_cfg.num_blocks,
-            paged_cfg.block_size,
-            paged_cfg.num_blocks * paged_cfg.block_size,
-        );
-
-        let block_pool = BlockPool::new(paged_cfg.num_blocks, paged_cfg.block_size);
-        let kv_store = PagedKvStore::new(paged_cfg, dtype, &device)?;
-        engine = engine.with_paged_kv(block_pool, kv_store);
-    }
+    engine = attach_paged_kv_if_requested(
+        engine,
+        args.paged_attention,
+        args.block_size,
+        dtype,
+        &device,
+        &raw_config,
+        &arch,
+    )?;
 
     std::thread::Builder::new()
         .name("engine".to_string())
@@ -358,15 +331,7 @@ async fn chat_completions(
         };
 
         if state.engine_tx.send(engine_req).await.is_err() {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: ErrorDetail {
-                        message: "Engine unavailable".to_string(),
-                        r#type: "server_error".to_string(),
-                    },
-                }),
-            ));
+            return Err(server_error("Engine unavailable"));
         }
 
         let stream = make_sse_stream(token_rx, request_id, model_id, created);
@@ -383,15 +348,7 @@ async fn chat_completions(
         };
 
         if state.engine_tx.send(engine_req).await.is_err() {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: ErrorDetail {
-                        message: "Engine unavailable".to_string(),
-                        r#type: "server_error".to_string(),
-                    },
-                }),
-            ));
+            return Err(server_error("Engine unavailable"));
         }
 
         match response_rx.await {
@@ -417,15 +374,7 @@ async fn chat_completions(
                 };
                 Ok(Json(response).into_response())
             }
-            Err(_) => Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: ErrorDetail {
-                        message: "Engine dropped the request".to_string(),
-                        r#type: "server_error".to_string(),
-                    },
-                }),
-            )),
+            Err(_) => Err(server_error("Engine dropped the request")),
         }
     }
 }
@@ -570,15 +519,7 @@ async fn completions(
     };
 
     if state.engine_tx.send(engine_req).await.is_err() {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "Engine unavailable".to_string(),
-                    r#type: "server_error".to_string(),
-                },
-            }),
-        ));
+        return Err(server_error("Engine unavailable"));
     }
 
     match response_rx.await {
@@ -601,15 +542,7 @@ async fn completions(
             };
             Ok(Json(response))
         }
-        Err(_) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: ErrorDetail {
-                    message: "Engine dropped the request".to_string(),
-                    r#type: "server_error".to_string(),
-                },
-            }),
-        )),
+        Err(_) => Err(server_error("Engine dropped the request")),
     }
 }
 


### PR DESCRIPTION
- Extract PagedCtx, repeat_kv, apply_rms_norm_heads, and causal_mask (verbatim copies in qwen3.rs and qwen3_5.rs) into a new models/attention_utils.rs module

- Unify generate_stream and generate_stream_sync in engine.rs via a TokenSender trait, reducing ~90 lines of near-identical streaming logic to a single generate_stream_inner generic method

- Extract the paged-KV setup block (copy-pasted in server.rs, bench.rs, and run.rs) into a new attach_paged_kv_if_requested helper in engine.rs

- Add a server_error() helper in server.rs to replace four repeated inline ErrorResponse constructions