### PR TITLE
fix: replace panic asserts with Result errors and fix bench BOS token

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -87,7 +87,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
 
     // Build a synthetic prompt of the requested length.
     // Use the tokenizer's BOS token id if available, otherwise token id 1.
-    let bos_id = tokenizer.stop_token_ids.first().copied().unwrap_or(1);
+    let bos_id = tokenizer.bos_token_id().unwrap_or(1);
     let prompt_tokens: Vec<u32> = std::iter::repeat_n(bos_id, args.prompt_len).collect();
 
     // Clamp max_tokens to the model's effective KV-cache capacity so that

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -152,6 +152,13 @@ impl Tokenizer {
         })
     }
 
+    /// Return the BOS token ID, if the tokenizer config declares one.
+    pub fn bos_token_id(&self) -> Option<u32> {
+        self.bos_token
+            .as_deref()
+            .and_then(|t| self.inner.token_to_id(t))
+    }
+
     /// Encode text to token IDs.
     pub fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
         let encoding = self

--- a/src/turbo_quant.rs
+++ b/src/turbo_quant.rs
@@ -124,11 +124,9 @@ const GROUP_SIZE: usize = 32;
 /// - `n_elems` — `seq_len * head_dim`
 fn quantize(x: &Tensor, bits: u8) -> Result<(Vec<u8>, Vec<f32>, usize)> {
     let (seq_len, head_dim) = x.dims2()?;
-    assert_eq!(
-        head_dim % GROUP_SIZE,
-        0,
-        "head_dim {head_dim} must be divisible by GROUP_SIZE {GROUP_SIZE}"
-    );
+    if head_dim % GROUP_SIZE != 0 {
+        anyhow::bail!("head_dim {head_dim} must be divisible by GROUP_SIZE {GROUP_SIZE}");
+    }
     let n_groups = head_dim / GROUP_SIZE;
     let n_levels = 1usize << bits;
     let levels = (n_levels - 1) as f32;
@@ -283,10 +281,9 @@ impl TurboQuantKvCache {
 
     /// Return dequantized `(k, v)` tensors of shape `[1, num_kv_heads, seq_len, head_dim]`.
     pub fn dequantize(&self) -> Result<(Tensor, Tensor)> {
-        assert!(
-            self.seq_len > 0,
-            "dequantize called on empty TurboQuantKvCache"
-        );
+        if self.seq_len == 0 {
+            anyhow::bail!("dequantize called on empty TurboQuantKvCache");
+        }
 
         let mut k_heads = Vec::with_capacity(self.num_kv_heads);
         let mut v_heads = Vec::with_capacity(self.num_kv_heads);


### PR DESCRIPTION
Convert assert!/assert_eq! in turbo_quant.rs to anyhow::bail! so misuse returns a propagatable error instead of crashing the engine thread. Add Tokenizer::bos_token_id() and use it in bench.rs to build synthetic prompts from the actual BOS token rather than the EOS/stop token.