### PR TITLE
refactor: de-duplicate shared model code into attention_utils

### DIFF
--- a/src/kv_cache.rs
+++ b/src/kv_cache.rs
@@ -273,25 +273,6 @@ impl PagedKvStore {
         })
     }
 
-    /// Write key/value vectors for one token into the store at `slot_id`.
-    ///
-    /// `k` / `v`: tensors of shape `[num_kv_heads, head_dim]`.
-    pub fn write_slot(
-        &mut self,
-        layer_idx: usize,
-        slot_id: usize,
-        k: &Tensor,
-        v: &Tensor,
-    ) -> candle_core::Result<()> {
-        // index_add on dim 0: add k at position slot_id
-        let idx = Tensor::new(&[slot_id as u32], k.device())?;
-        self.key_caches[layer_idx] =
-            self.key_caches[layer_idx].index_add(&idx, &k.unsqueeze(0)?, 0)?;
-        self.value_caches[layer_idx] =
-            self.value_caches[layer_idx].index_add(&idx, &v.unsqueeze(0)?, 0)?;
-        Ok(())
-    }
-
     /// Gather key and value tensors for all slots in `slot_ids`.
     ///
     /// Returns `(k, v)` each of shape `[seq_len, num_kv_heads, head_dim]`.

--- a/src/models/attention_utils.rs
+++ b/src/models/attention_utils.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::RmsNorm;
+use candle_nn::{linear_no_bias, ops, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 
@@ -73,4 +73,175 @@ pub fn causal_mask(
         .reshape((1, 1, q_len, kv_len))?
         .to_dtype(dtype)?;
     Ok(mask)
+}
+
+// ---------------------------------------------------------------------------
+// Shared SwiGLU MLP
+// ---------------------------------------------------------------------------
+
+/// SwiGLU MLP: down_proj( silu(gate_proj(x)) * up_proj(x) ).
+/// Used by both Qwen3 and Qwen3.5 (and any future architecture with the same
+/// MLP topology).
+pub struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    pub fn new(hidden_size: usize, intermediate_size: usize, vb: VarBuilder) -> Result<Self> {
+        let gate_proj = linear_no_bias(hidden_size, intermediate_size, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(hidden_size, intermediate_size, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(intermediate_size, hidden_size, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward(x)?.silu()?;
+        let up = self.up_proj.forward(x)?;
+        let hidden = (gate * up)?;
+        self.down_proj.forward(&hidden).map_err(Into::into)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared RoPE precomputation
+// ---------------------------------------------------------------------------
+
+/// Precompute (cos, sin) tables for positions 0..max_seq_len.
+///
+/// `partial_factor` controls what fraction of `head_dim` is rotated:
+/// - Use `1.0` for full rotation (Qwen3).
+/// - Use a value like `0.25` for partial rotation (Qwen3.5).
+///
+/// The returned tensors have shape `[max_seq_len, rot_dim/2]`.
+pub fn precompute_rope(
+    head_dim: usize,
+    partial_factor: f64,
+    rope_theta: f64,
+    max_seq_len: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<(Tensor, Tensor)> {
+    let rot_dim = ((head_dim as f64 * partial_factor) as usize) & !1; // round down to even
+    let half = rot_dim / 2;
+
+    let freqs: Vec<f32> = (0..half)
+        .map(|i| {
+            let exp = 2.0 * i as f32 / rot_dim as f32;
+            1.0 / (rope_theta as f32).powf(exp)
+        })
+        .collect();
+    let freqs = Tensor::new(freqs.as_slice(), device)?;
+
+    let positions: Vec<f32> = (0..max_seq_len).map(|i| i as f32).collect();
+    let positions = Tensor::new(positions.as_slice(), device)?;
+
+    // outer product -> [max_seq_len, half]
+    let emb = positions
+        .unsqueeze(1)?
+        .broadcast_mul(&freqs.unsqueeze(0)?)?;
+
+    let cos = emb.cos()?.to_dtype(dtype)?;
+    let sin = emb.sin()?.to_dtype(dtype)?;
+    Ok((cos, sin))
+}
+
+// ---------------------------------------------------------------------------
+// Shared paged write / gather / SDPA
+// ---------------------------------------------------------------------------
+
+/// Attention head dimensions passed to [`paged_write_gather_sdpa`].
+pub struct AttnDims {
+    pub num_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    pub seqlen_offset: usize,
+}
+
+/// Write new K/V tokens into the paged store, then gather the full K/V context
+/// and run scaled dot-product attention.
+///
+/// `q`      : query,  `[b, num_heads,    t, head_dim]`
+/// `k` / `v`: key/value, `[b, num_kv_heads, t, head_dim]`
+///
+/// Returns the attention output `[b, t, num_heads * head_dim]` (already
+/// transposed/reshaped, ready for the output projection).
+pub fn paged_write_gather_sdpa(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    dims: &AttnDims,
+    ctx: &mut PagedCtx,
+) -> Result<Tensor> {
+    let AttnDims {
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        seqlen_offset,
+    } = *dims;
+    let (b, _nh, t, _hd) = q.dims4()?;
+
+    // Resolve slot IDs for the new tokens and for the full context in one pass.
+    let total_tokens = seqlen_offset + t;
+    let all_slot_ids: Vec<u32> = (0..total_tokens)
+        .map(|pos| {
+            ctx.block_table
+                .slot_for(pos)
+                .ok_or_else(|| anyhow::anyhow!("paged attention: no slot for position {}", pos))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Batch-write all new K/V tokens with a single index_add per tensor,
+    // reducing kernel launches from 2*t to 2.
+    // k/v: [b=1, num_kv_heads, t, head_dim] -> [t, num_kv_heads, head_dim]
+    let new_slot_ids = &all_slot_ids[seqlen_offset..];
+    let new_slots_tensor = Tensor::new(new_slot_ids, k.device())?;
+    let k_new = k.squeeze(0)?.transpose(0, 1)?.contiguous()?; // [t, num_kv_heads, head_dim]
+    let v_new = v.squeeze(0)?.transpose(0, 1)?.contiguous()?;
+    ctx.kv_store.key_caches[ctx.layer_idx] =
+        ctx.kv_store.key_caches[ctx.layer_idx].index_add(&new_slots_tensor, &k_new, 0)?;
+    ctx.kv_store.value_caches[ctx.layer_idx] =
+        ctx.kv_store.value_caches[ctx.layer_idx].index_add(&new_slots_tensor, &v_new, 0)?;
+
+    let (k_full, v_full) = ctx.kv_store.gather_slots(ctx.layer_idx, &all_slot_ids)?;
+
+    let kv_len = total_tokens;
+    let k_full = k_full
+        .reshape((b, kv_len, num_kv_heads, head_dim))?
+        .transpose(1, 2)?;
+    let v_full = v_full
+        .reshape((b, kv_len, num_kv_heads, head_dim))?
+        .transpose(1, 2)?;
+
+    // GQA expand
+    let groups = num_heads / num_kv_heads;
+    let k_full = repeat_kv(k_full, groups)?;
+    let v_full = repeat_kv(v_full, groups)?;
+
+    // Scaled dot-product attention
+    let scale = (head_dim as f64).sqrt();
+    let attn = q
+        .contiguous()?
+        .matmul(&k_full.transpose(2, 3)?.contiguous()?)?
+        .affine(1.0 / scale, 0.0)?;
+
+    let attn = if t > 1 {
+        let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
+        attn.broadcast_add(&mask)?
+    } else {
+        attn
+    };
+
+    let attn = ops::softmax_last_dim(&attn)?;
+    let out = attn.matmul(&v_full.contiguous()?)?; // [b, num_heads, t, head_dim]
+
+    out.transpose(1, 2)?
+        .reshape((b, t, num_heads * head_dim))?
+        .contiguous()
+        .map_err(Into::into)
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -170,7 +170,7 @@ pub fn load_model(
         }
     }
 
-    match arch {
+    let model: Box<dyn CausalLM> = match arch {
         ModelArchitecture::Qwen3 => {
             let config = raw_config.to_qwen3_config(dtype, device.clone(), turbo_quant_bits);
             tracing::info!(
@@ -181,9 +181,9 @@ pub fn load_model(
                 config.num_key_value_heads,
                 config.head_dim,
             );
-            let model = qwen3::Qwen3Model::new(&config, vb)?;
-            tracing::info!("Model loaded successfully");
-            Ok(Box::new(Qwen3ModelWrapper { inner: model }))
+            Box::new(Qwen3ModelWrapper {
+                inner: qwen3::Qwen3Model::new(&config, vb)?,
+            })
         }
         ModelArchitecture::Qwen2 => {
             let config = raw_config.to_qwen2_config();
@@ -194,9 +194,9 @@ pub fn load_model(
                 config.hidden_size,
                 config.num_key_value_heads
             );
-            let model = candle_transformers::models::qwen2::ModelForCausalLM::new(&config, vb)?;
-            tracing::info!("Model loaded successfully");
-            Ok(Box::new(Qwen2Model { inner: model }))
+            Box::new(Qwen2Model {
+                inner: candle_transformers::models::qwen2::ModelForCausalLM::new(&config, vb)?,
+            })
         }
         ModelArchitecture::Gemma2 => {
             let config = raw_config.to_gemma2_config();
@@ -207,9 +207,9 @@ pub fn load_model(
                 config.hidden_size,
                 config.head_dim
             );
-            let model = candle_transformers::models::gemma2::Model::new(false, &config, vb)?;
-            tracing::info!("Model loaded successfully");
-            Ok(Box::new(Gemma2Model { inner: model }))
+            Box::new(Gemma2Model {
+                inner: candle_transformers::models::gemma2::Model::new(false, &config, vb)?,
+            })
         }
         ModelArchitecture::Gemma3 => {
             let config = raw_config.to_gemma3_config();
@@ -220,9 +220,9 @@ pub fn load_model(
                 config.hidden_size,
                 config.head_dim
             );
-            let model = candle_transformers::models::gemma3::Model::new(false, &config, vb)?;
-            tracing::info!("Model loaded successfully");
-            Ok(Box::new(Gemma3Model { inner: model }))
+            Box::new(Gemma3Model {
+                inner: candle_transformers::models::gemma3::Model::new(false, &config, vb)?,
+            })
         }
         ModelArchitecture::Qwen35 => {
             let config = raw_config.to_qwen35_config(dtype, device.clone());
@@ -233,9 +233,11 @@ pub fn load_model(
                 config.hidden_size,
                 config.num_key_value_heads,
             );
-            let model = qwen3_5::Qwen35Model::new(&config, vb)?;
-            tracing::info!("Model loaded successfully");
-            Ok(Box::new(Qwen35ModelWrapper { inner: model }))
+            Box::new(Qwen35ModelWrapper {
+                inner: qwen3_5::Qwen35Model::new(&config, vb)?,
+            })
         }
-    }
+    };
+    tracing::info!("Model loaded successfully");
+    Ok(model)
 }

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -16,7 +16,10 @@ use candle_nn::{
 };
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
-use crate::models::attention_utils::{apply_rms_norm_heads, causal_mask, repeat_kv, PagedCtx};
+use crate::models::attention_utils::{
+    apply_rms_norm_heads, causal_mask, paged_write_gather_sdpa, precompute_rope, repeat_kv,
+    AttnDims, Mlp, PagedCtx,
+};
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
 
 // ---------------------------------------------------------------------------
@@ -47,40 +50,6 @@ pub struct Qwen3Config {
 // RoPE utilities
 // ---------------------------------------------------------------------------
 
-/// Precompute (cos, sin) for positions 0..max_seq_len.
-/// Qwen3 uses full-head-dim rotation (no partial factor).
-fn precompute_rope(
-    head_dim: usize,
-    rope_theta: f64,
-    max_seq_len: usize,
-    dtype: DType,
-    device: &Device,
-) -> Result<(Tensor, Tensor)> {
-    let half = head_dim / 2;
-
-    // freqs: [half]
-    let freqs: Vec<f32> = (0..half)
-        .map(|i| {
-            let exp = 2.0 * i as f32 / head_dim as f32;
-            1.0 / (rope_theta as f32).powf(exp)
-        })
-        .collect();
-    let freqs = Tensor::new(freqs.as_slice(), device)?;
-
-    // positions: [max_seq_len]
-    let positions: Vec<f32> = (0..max_seq_len).map(|i| i as f32).collect();
-    let positions = Tensor::new(positions.as_slice(), device)?;
-
-    // outer product -> [max_seq_len, half]
-    let emb = positions
-        .unsqueeze(1)?
-        .broadcast_mul(&freqs.unsqueeze(0)?)?;
-
-    let cos = emb.cos()?.to_dtype(dtype)?;
-    let sin = emb.sin()?.to_dtype(dtype)?;
-    Ok((cos, sin))
-}
-
 /// Apply full rotary embedding to query/key tensors using candle's built-in kernel.
 /// x: [batch, n_heads, seq_len, head_dim]
 /// cos/sin: [seq_len, head_dim/2]
@@ -92,34 +61,8 @@ fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
 }
 
 // ---------------------------------------------------------------------------
-// SwiGLU MLP
+// SwiGLU MLP (shared implementation in attention_utils::Mlp)
 // ---------------------------------------------------------------------------
-
-struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-}
-
-impl Mlp {
-    fn new(cfg: &Qwen3Config, vb: VarBuilder) -> Result<Self> {
-        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
-        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
-        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-        })
-    }
-
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(x)?.silu()?;
-        let up = self.up_proj.forward(x)?;
-        let hidden = (gate * up)?;
-        self.down_proj.forward(&hidden).map_err(Into::into)
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Attention layer (GQA + QK-norm + RoPE, no bias)
@@ -300,62 +243,18 @@ impl Attention {
         let q = apply_rope(&q, &cos_slice, &sin_slice)?;
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
-        // Write new K/V into paged store
-        for ti in 0..t {
-            let position = seqlen_offset + ti;
-            let slot_id = ctx.block_table.slot_for(position).ok_or_else(|| {
-                anyhow::anyhow!("paged attention: no slot for position {}", position)
-            })?;
-            let k_tok = k.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
-            let v_tok = v.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
-            ctx.kv_store
-                .write_slot(ctx.layer_idx, slot_id as usize, &k_tok, &v_tok)?;
-        }
-
-        // Gather full K/V context
-        let total_tokens = seqlen_offset + t;
-        let slot_ids: Vec<u32> = (0..total_tokens)
-            .map(|pos| {
-                ctx.block_table.slot_for(pos).ok_or_else(|| {
-                    anyhow::anyhow!("paged attention: missing slot for position {}", pos)
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let (k_full, v_full) = ctx.kv_store.gather_slots(ctx.layer_idx, &slot_ids)?;
-
-        let kv_len = total_tokens;
-        let k_full = k_full
-            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
-        let v_full = v_full
-            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
-
-        let groups = self.num_heads / self.num_kv_heads;
-        let k_full = repeat_kv(k_full, groups)?;
-        let v_full = repeat_kv(v_full, groups)?;
-
-        let scale = (self.head_dim as f64).sqrt();
-        let attn = q
-            .contiguous()?
-            .matmul(&k_full.transpose(2, 3)?.contiguous()?)?
-            .affine(1.0 / scale, 0.0)?;
-
-        let attn = if t > 1 {
-            let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
-            attn.broadcast_add(&mask)?
-        } else {
-            attn
-        };
-
-        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
-        let out = attn.matmul(&v_full.contiguous()?)?;
-
-        let out = out
-            .transpose(1, 2)?
-            .reshape((b, t, self.num_heads * self.head_dim))?
-            .contiguous()?;
+        let out = paged_write_gather_sdpa(
+            &q,
+            &k,
+            &v,
+            &AttnDims {
+                num_heads: self.num_heads,
+                num_kv_heads: self.num_kv_heads,
+                head_dim: self.head_dim,
+                seqlen_offset,
+            },
+            ctx,
+        )?;
 
         self.o_proj.forward(&out).map_err(Into::into)
     }
@@ -376,7 +275,7 @@ impl DecoderLayer {
     fn new(cfg: &Qwen3Config, vb: VarBuilder, tq_cfg: Option<&TurboQuantConfig>) -> Result<Self> {
         Ok(Self {
             attn: Attention::new(cfg, vb.pp("self_attn"), tq_cfg)?,
-            mlp: Mlp::new(cfg, vb.pp("mlp"))?,
+            mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
             input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: rms_norm(
                 cfg.hidden_size,
@@ -471,10 +370,12 @@ impl Qwen3Model {
             .get((cfg.vocab_size, cfg.hidden_size), "weight")
             .unwrap_or_else(|_| embed_tokens.embeddings().clone());
 
-        // Precompute RoPE tables (large enough for typical sequences)
+        // Precompute RoPE tables (large enough for typical sequences).
+        // Qwen3 uses full-head-dim rotation (partial_factor = 1.0).
         let max_seq = 65536;
         let (cos, sin) = precompute_rope(
             cfg.head_dim,
+            1.0,
             cfg.rope_theta,
             max_seq,
             cfg.dtype,

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -12,7 +12,10 @@ use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
-use crate::models::attention_utils::{apply_rms_norm_heads, causal_mask, repeat_kv, PagedCtx};
+use crate::models::attention_utils::{
+    apply_rms_norm_heads, causal_mask, paged_write_gather_sdpa, precompute_rope, repeat_kv,
+    AttnDims, Mlp, PagedCtx,
+};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -53,44 +56,6 @@ pub struct Qwen35Config {
 // ---------------------------------------------------------------------------
 // RoPE utilities
 // ---------------------------------------------------------------------------
-
-/// Precompute (cos, sin) for positions 0..max_seq_len with partial rotation.
-fn precompute_rope(
-    head_dim: usize,
-    partial_factor: f64,
-    rope_theta: f64,
-    max_seq_len: usize,
-    dtype: DType,
-    device: &Device,
-) -> Result<(Tensor, Tensor)> {
-    let rot_dim = (head_dim as f64 * partial_factor) as usize;
-    // round down to even
-    let rot_dim = rot_dim & !1;
-    let half = rot_dim / 2;
-
-    // freqs: [half]
-    let freqs: Vec<f32> = (0..half)
-        .map(|i| {
-            let exp = 2.0 * i as f32 / rot_dim as f32;
-            1.0 / (rope_theta as f32).powf(exp)
-        })
-        .collect();
-    let freqs = Tensor::new(freqs.as_slice(), device)?;
-
-    // positions: [max_seq_len]
-    let positions: Vec<f32> = (0..max_seq_len).map(|i| i as f32).collect();
-    let positions = Tensor::new(positions.as_slice(), device)?;
-
-    // outer product -> [max_seq_len, half]
-    let emb = positions
-        .unsqueeze(1)?
-        .broadcast_mul(&freqs.unsqueeze(0)?)?;
-
-    // cos/sin: [max_seq_len, half]
-    let cos = emb.cos()?.to_dtype(dtype)?;
-    let sin = emb.sin()?.to_dtype(dtype)?;
-    Ok((cos, sin))
-}
 
 /// Apply rotary embedding to query/key tensors.
 /// x: [batch, n_heads, seq_len, head_dim]
@@ -136,34 +101,8 @@ fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
 }
 
 // ---------------------------------------------------------------------------
-// SwiGLU MLP
+// SwiGLU MLP (shared implementation in attention_utils::Mlp)
 // ---------------------------------------------------------------------------
-
-struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-}
-
-impl Mlp {
-    fn new(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
-        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
-        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
-        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-        })
-    }
-
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(x)?.silu()?;
-        let up = self.up_proj.forward(x)?;
-        let hidden = (gate * up)?;
-        self.down_proj.forward(&hidden).map_err(Into::into)
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Full attention layer (GQA + QK-norm + RoPE, no bias)
@@ -364,68 +303,21 @@ impl FullAttention {
         let q = apply_rope(&q, &cos_slice, &sin_slice)?;
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
-        // ── Write new K/V into the paged store ───────────────────────────────
-        for ti in 0..t {
-            let position = seqlen_offset + ti;
-            let slot_id = ctx.block_table.slot_for(position).ok_or_else(|| {
-                anyhow::anyhow!(
-                    "paged attention: no slot allocated for position {}",
-                    position
-                )
-            })?;
-            let k_tok = k.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
-            let v_tok = v.narrow(2, ti, 1)?.squeeze(2)?.squeeze(0)?;
-            ctx.kv_store
-                .write_slot(ctx.layer_idx, slot_id as usize, &k_tok, &v_tok)?;
-        }
+        // ── Write/gather/SDPA ─────────────────────────────────────────────────
+        let out = paged_write_gather_sdpa(
+            &q,
+            &k,
+            &v,
+            &AttnDims {
+                num_heads: self.num_heads,
+                num_kv_heads: self.num_kv_heads,
+                head_dim: self.head_dim,
+                seqlen_offset,
+            },
+            ctx,
+        )?;
 
-        // ── Gather full K/V context for this sequence ─────────────────────────
-        let total_tokens = seqlen_offset + t;
-        let slot_ids: Vec<u32> = (0..total_tokens)
-            .map(|pos| {
-                ctx.block_table.slot_for(pos).ok_or_else(|| {
-                    anyhow::anyhow!("paged attention: missing slot for position {}", pos)
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let (k_full, v_full) = ctx.kv_store.gather_slots(ctx.layer_idx, &slot_ids)?;
-
-        // Reshape to [b, num_kv_heads, kv_len, head_dim]  (b == 1)
-        let kv_len = total_tokens;
-        let k_full = k_full
-            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
-        let v_full = v_full
-            .reshape((b, kv_len, self.num_kv_heads, self.head_dim))?
-            .transpose(1, 2)?;
-
-        // ── GQA expand ───────────────────────────────────────────────────────
-        let groups = self.num_heads / self.num_kv_heads;
-        let k_full = repeat_kv(k_full, groups)?;
-        let v_full = repeat_kv(v_full, groups)?;
-
-        // ── Scaled dot-product attention ─────────────────────────────────────
-        let scale = (self.head_dim as f64).sqrt();
-        let attn = q
-            .contiguous()?
-            .matmul(&k_full.transpose(2, 3)?.contiguous()?)?
-            .affine(1.0 / scale, 0.0)?;
-
-        let attn = if t > 1 {
-            let mask = causal_mask(t, kv_len, seqlen_offset, attn.device(), attn.dtype())?;
-            attn.broadcast_add(&mask)?
-        } else {
-            attn
-        };
-
-        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
-        let out = attn.matmul(&v_full.contiguous()?)?;
-
-        // ── Reshape + output gate ─────────────────────────────────────────────
-        let out = out
-            .transpose(1, 2)?
-            .reshape((b, t, self.num_heads * self.head_dim))?;
+        // ── Output gate ───────────────────────────────────────────────────────
         let gate_sig = (gate.neg()?.exp()? + 1.0)?.recip()?;
         let out = out.broadcast_mul(&gate_sig)?;
 
@@ -813,7 +705,7 @@ impl DecoderLayer {
     fn new_full(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             attn: LayerAttn::Full(FullAttention::new(cfg, vb.pp("self_attn"))?),
-            mlp: Mlp::new(cfg, vb.pp("mlp"))?,
+            mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
             input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: rms_norm(
                 cfg.hidden_size,
@@ -826,7 +718,7 @@ impl DecoderLayer {
     fn new_linear(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             attn: LayerAttn::Linear(LinearAttn::new(cfg, vb.pp("linear_attn"))?),
-            mlp: Mlp::new(cfg, vb.pp("mlp"))?,
+            mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
             input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: rms_norm(
                 cfg.hidden_size,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -232,7 +232,7 @@ fn detect_chat_template(config: &Option<TokenizerConfig>) -> ChatTemplate {
     ChatTemplate::ChatML
 }
 
-fn apply_chatml(messages: &[ChatMessage], _bos_token: &Option<String>) -> String {
+fn apply_chatml_inner(messages: &[ChatMessage], assistant_suffix: &str) -> String {
     let mut prompt = String::new();
     for msg in messages {
         prompt.push_str(&format!(
@@ -240,9 +240,13 @@ fn apply_chatml(messages: &[ChatMessage], _bos_token: &Option<String>) -> String
             msg.role, msg.content
         ));
     }
-    // Add the assistant turn marker
     prompt.push_str("<|im_start|>assistant\n");
+    prompt.push_str(assistant_suffix);
     prompt
+}
+
+fn apply_chatml(messages: &[ChatMessage], _bos_token: &Option<String>) -> String {
+    apply_chatml_inner(messages, "")
 }
 
 /// Qwen3.5 ChatML template with thinking disabled.
@@ -254,16 +258,7 @@ fn apply_chatml(messages: &[ChatMessage], _bos_token: &Option<String>) -> String
 /// the model enters thinking mode and prepends a long chain-of-thought before
 /// the actual reply.
 fn apply_qwen35(messages: &[ChatMessage]) -> String {
-    let mut prompt = String::new();
-    for msg in messages {
-        prompt.push_str(&format!(
-            "<|im_start|>{}\n{}<|im_end|>\n",
-            msg.role, msg.content
-        ));
-    }
-    // Add the assistant turn marker with the no-think prefix
-    prompt.push_str("<|im_start|>assistant\n<think>\n\n</think>\n\n");
-    prompt
+    apply_chatml_inner(messages, "<think>\n\n</think>\n\n")
 }
 
 fn apply_gemma(messages: &[ChatMessage], bos_token: &Option<String>) -> String {


### PR DESCRIPTION
- Extract shared SwiGLU Mlp struct (was identical in qwen3 and qwen3_5)
- Unify precompute_rope into a single function with a partial_factor param (qwen3 passes 1.0, qwen3_5 passes its partial_rotary_factor)
- Extract paged_write_gather_sdpa helper, eliminating the ~40-line write/gather/GQA-expand/SDPA block duplicated across both models
- Unify apply_chatml and apply_qwen35 via apply_chatml_inner(suffix)
- Consolidate the 5x repeated 'Model loaded successfully' log into one call after the architecture match block in mod.rs