### PR TITLE
refactor: de-duplicate generation helpers and model utilities

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -336,6 +336,38 @@ impl Engine {
         model.forward_paged(&input_ids, seqlen_offset, &ps.block_table, &mut ps.kv_store)
     }
 
+    // ── Shared generation helpers ─────────────────────────────────────────────
+
+    /// Run the prefill forward pass (paged or concat-KV) and return the logits.
+    /// Resets the KV cache and (if paged) the block table before running.
+    fn run_prefill(&mut self, prompt_tokens: &[u32]) -> Result<Tensor> {
+        self.model.clear_kv_cache();
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)
+        } else {
+            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, 0)
+        }
+    }
+
+    /// Run a single decode step (paged or concat-KV) and return the logits.
+    fn run_decode_step(&mut self, token_id: u32, seqlen_offset: usize) -> Result<Tensor> {
+        if let Some(ps) = &mut self.paged {
+            Self::paged_decode_step(&mut self.model, &self.device, token_id, seqlen_offset, ps)
+        } else {
+            let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
+            self.model.forward(&input_ids, seqlen_offset)
+        }
+    }
+
+    /// Free all paged KV blocks (no-op when paged attention is not active).
+    fn free_paged_blocks(&mut self) {
+        if let Some(ps) = &mut self.paged {
+            ps.block_table.free_all(&mut ps.block_pool);
+        }
+    }
+
     // ── Non-streaming generation ──────────────────────────────────────────────
 
     fn generate(
@@ -354,17 +386,7 @@ impl Engine {
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
-        let logits = if let Some(ps) = &mut self.paged {
-            // ── Paged path ────────────────────────────────────────────────────
-            ps.block_table.free_all(&mut ps.block_pool);
-            self.model.clear_kv_cache();
-            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
-        } else {
-            // ── Concat-KV path ────────────────────────────────────────────────
-            self.model.clear_kv_cache();
-            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-            self.model.forward(&input_ids, 0)?
-        };
+        let logits = self.run_prefill(prompt_tokens)?;
 
         let mut token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
@@ -374,12 +396,7 @@ impl Engine {
 
         while finish_reason.is_none() {
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-            let logits = if let Some(ps) = &mut self.paged {
-                Self::paged_decode_step(&mut self.model, &self.device, token_id, seqlen_offset, ps)?
-            } else {
-                let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
-                self.model.forward(&input_ids, seqlen_offset)?
-            };
+            let logits = self.run_decode_step(token_id, seqlen_offset)?;
 
             token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
@@ -387,9 +404,7 @@ impl Engine {
             finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
         }
 
-        if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-        }
+        self.free_paged_blocks();
 
         let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
         let output_text = self.tokenizer.decode(&output_tokens, true)?;
@@ -454,15 +469,7 @@ impl Engine {
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
         // Prefill
-        let logits = if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-            self.model.clear_kv_cache();
-            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
-        } else {
-            self.model.clear_kv_cache();
-            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-            self.model.forward(&input_ids, 0)?
-        };
+        let logits = self.run_prefill(prompt_tokens)?;
 
         let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
@@ -477,9 +484,7 @@ impl Engine {
             finish_reason: finish_reason.clone(),
         }) || finish_reason.is_some()
         {
-            if let Some(ps) = &mut self.paged {
-                ps.block_table.free_all(&mut ps.block_pool);
-            }
+            self.free_paged_blocks();
             return Ok(());
         }
 
@@ -488,18 +493,7 @@ impl Engine {
             let last_token = *output_tokens.last().unwrap();
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
 
-            let logits = if let Some(ps) = &mut self.paged {
-                Self::paged_decode_step(
-                    &mut self.model,
-                    &self.device,
-                    last_token,
-                    seqlen_offset,
-                    ps,
-                )?
-            } else {
-                let input_ids = Tensor::new(&[last_token], &self.device)?.unsqueeze(0)?;
-                self.model.forward(&input_ids, seqlen_offset)?
-            };
+            let logits = self.run_decode_step(last_token, seqlen_offset)?;
 
             let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
@@ -518,9 +512,7 @@ impl Engine {
             }
         }
 
-        if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-        }
+        self.free_paged_blocks();
 
         Ok(())
     }
@@ -545,15 +537,7 @@ impl Engine {
 
         let prefill_start = Instant::now();
 
-        let logits = if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-            self.model.clear_kv_cache();
-            Self::paged_prefill(&mut self.model, &self.device, prompt_tokens, ps)?
-        } else {
-            self.model.clear_kv_cache();
-            let input_ids = Tensor::new(prompt_tokens, &self.device)?.unsqueeze(0)?;
-            self.model.forward(&input_ids, 0)?
-        };
+        let logits = self.run_prefill(prompt_tokens)?;
 
         let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
 
@@ -566,12 +550,7 @@ impl Engine {
 
         while finish_reason.is_none() {
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-            let logits = if let Some(ps) = &mut self.paged {
-                Self::paged_decode_step(&mut self.model, &self.device, token_id, seqlen_offset, ps)?
-            } else {
-                let input_ids = Tensor::new(&[token_id], &self.device)?.unsqueeze(0)?;
-                self.model.forward(&input_ids, seqlen_offset)?
-            };
+            let logits = self.run_decode_step(token_id, seqlen_offset)?;
             token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
             all_tokens.push(token_id);
@@ -580,9 +559,7 @@ impl Engine {
 
         let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
 
-        if let Some(ps) = &mut self.paged {
-            ps.block_table.free_all(&mut ps.block_pool);
-        }
+        self.free_paged_blocks();
 
         let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
         let output_text = self.tokenizer.decode(&output_tokens, true)?;

--- a/src/models/attention_utils.rs
+++ b/src/models/attention_utils.rs
@@ -245,3 +245,63 @@ pub fn paged_write_gather_sdpa(
         .contiguous()
         .map_err(Into::into)
 }
+
+// ---------------------------------------------------------------------------
+// Shared final-logits extraction
+// ---------------------------------------------------------------------------
+
+/// Extract the last-token hidden state and project it through the LM head.
+///
+/// `x`              : `[b, t, hidden]` — hidden states after the final norm
+/// `lm_head_weight` : `[vocab, hidden]` — the unembedding weight matrix
+///
+/// Returns `[b, 1, vocab]`.
+pub fn compute_logits(x: &Tensor, lm_head_weight: &Tensor) -> Result<Tensor> {
+    let (_b, t, _h) = x.dims3()?;
+    let last = x.narrow(1, t - 1, 1)?; // [b, 1, hidden]
+    let last_2d = last.squeeze(1)?.contiguous()?; // [b, hidden]
+    let logits = last_2d.matmul(&lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
+    logits.unsqueeze(1).map_err(Into::into) // [b, 1, vocab]
+}
+
+// ---------------------------------------------------------------------------
+// Shared KV cache concat-append
+// ---------------------------------------------------------------------------
+
+/// Append new `k` / `v` tensors to `kv_cache` (standard concat strategy).
+///
+/// `k` / `v`  : `[b, num_kv_heads, t, head_dim]` — tensors for the current step
+/// `kv_cache` : mutable reference to the per-layer cache slot
+///
+/// Returns the (possibly extended) `(k, v)` pair to use for attention.
+pub fn concat_kv_cache(
+    k: Tensor,
+    v: Tensor,
+    kv_cache: &mut Option<(Tensor, Tensor)>,
+) -> Result<(Tensor, Tensor)> {
+    let (k, v) = match kv_cache {
+        None => (k, v),
+        Some((k_cache, v_cache)) => {
+            let k = Tensor::cat(&[k_cache as &Tensor, &k], 2)?;
+            let v = Tensor::cat(&[v_cache as &Tensor, &v], 2)?;
+            (k, v)
+        }
+    };
+    *kv_cache = Some((k.clone(), v.clone()));
+    Ok((k, v))
+}
+
+// ---------------------------------------------------------------------------
+// Shared output-gate sigmoid
+// ---------------------------------------------------------------------------
+
+/// Apply the attention output gate: `sigmoid(gate) * out`.
+///
+/// `gate` : `[b, t, num_heads * head_dim]`
+/// `out`  : `[b, t, num_heads * head_dim]`
+///
+/// Returns `[b, t, num_heads * head_dim]`.
+pub fn apply_output_gate(out: &Tensor, gate: &Tensor) -> Result<Tensor> {
+    let gate_sig = ops::sigmoid(gate)?;
+    out.broadcast_mul(&gate_sig).map_err(Into::into)
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -40,53 +40,34 @@ pub trait CausalLM: Send {
     fn clear_kv_cache(&mut self);
 }
 
-/// A Qwen2 model wrapper.
-struct Qwen2Model {
-    inner: candle_transformers::models::qwen2::ModelForCausalLM,
+/// Implement `CausalLM` for a simple newtype wrapper whose `inner` field
+/// exposes `.forward(input_ids, seqlen_offset)` and `.clear_kv_cache()`.
+macro_rules! impl_causal_lm_wrapper {
+    ($wrapper:ident, $inner_ty:ty) => {
+        struct $wrapper {
+            inner: $inner_ty,
+        }
+
+        impl CausalLM for $wrapper {
+            fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+                self.inner
+                    .forward(input_ids, seqlen_offset)
+                    .map_err(Into::into)
+            }
+
+            fn clear_kv_cache(&mut self) {
+                self.inner.clear_kv_cache();
+            }
+        }
+    };
 }
 
-impl CausalLM for Qwen2Model {
-    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let logits = self.inner.forward(input_ids, seqlen_offset)?;
-        Ok(logits)
-    }
-
-    fn clear_kv_cache(&mut self) {
-        self.inner.clear_kv_cache();
-    }
-}
-
-/// A Gemma2 model wrapper.
-struct Gemma2Model {
-    inner: candle_transformers::models::gemma2::Model,
-}
-
-impl CausalLM for Gemma2Model {
-    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let logits = self.inner.forward(input_ids, seqlen_offset)?;
-        Ok(logits)
-    }
-
-    fn clear_kv_cache(&mut self) {
-        self.inner.clear_kv_cache();
-    }
-}
-
-/// A Gemma3 model wrapper.
-struct Gemma3Model {
-    inner: candle_transformers::models::gemma3::Model,
-}
-
-impl CausalLM for Gemma3Model {
-    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let logits = self.inner.forward(input_ids, seqlen_offset)?;
-        Ok(logits)
-    }
-
-    fn clear_kv_cache(&mut self) {
-        self.inner.clear_kv_cache();
-    }
-}
+impl_causal_lm_wrapper!(
+    Qwen2Model,
+    candle_transformers::models::qwen2::ModelForCausalLM
+);
+impl_causal_lm_wrapper!(Gemma2Model, candle_transformers::models::gemma2::Model);
+impl_causal_lm_wrapper!(Gemma3Model, candle_transformers::models::gemma3::Model);
 
 /// A Qwen3 model wrapper.
 struct Qwen3ModelWrapper {

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -17,8 +17,8 @@ use candle_nn::{
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_rms_norm_heads, causal_mask, paged_write_gather_sdpa, precompute_rope, repeat_kv,
-    AttnDims, Mlp, PagedCtx,
+    apply_rms_norm_heads, causal_mask, compute_logits, concat_kv_cache, paged_write_gather_sdpa,
+    precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
 };
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
 
@@ -155,17 +155,7 @@ impl Attention {
             tq.append(&k, &v)?;
             tq.dequantize()?
         } else {
-            // Standard concat-based KV cache.
-            let (k, v) = match &self.kv_cache {
-                None => (k, v),
-                Some((k_cache, v_cache)) => {
-                    let k = Tensor::cat(&[k_cache, &k], 2)?;
-                    let v = Tensor::cat(&[v_cache, &v], 2)?;
-                    (k, v)
-                }
-            };
-            self.kv_cache = Some((k.clone(), v.clone()));
-            (k, v)
+            concat_kv_cache(k, v, &mut self.kv_cache)?
         };
 
         let kv_len = k.dim(2)?;
@@ -394,7 +384,7 @@ impl Qwen3Model {
 
     /// Forward pass. Returns logits for the last position: [batch, 1, vocab_size]
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let (_b, t) = input_ids.dims2()?;
+        let (_b, _t) = input_ids.dims2()?;
 
         let mut x = self.embed_tokens.forward(input_ids)?;
 
@@ -403,11 +393,7 @@ impl Qwen3Model {
         }
 
         x = self.norm.forward(&x)?;
-
-        let last = x.narrow(1, t - 1, 1)?; // [b, 1, hidden]
-        let last_2d = last.squeeze(1)?.contiguous()?; // [b, hidden]
-        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
-        logits.unsqueeze(1).map_err(Into::into) // [b, 1, vocab]
+        compute_logits(&x, &self.lm_head_weight)
     }
 
     /// Paged-attention forward pass.
@@ -418,7 +404,7 @@ impl Qwen3Model {
         block_table: &BlockTable,
         kv_store: &mut PagedKvStore,
     ) -> Result<Tensor> {
-        let (_b, t) = input_ids.dims2()?;
+        let (_b, _t) = input_ids.dims2()?;
 
         let mut x = self.embed_tokens.forward(input_ids)?;
 
@@ -434,11 +420,7 @@ impl Qwen3Model {
         }
 
         x = self.norm.forward(&x)?;
-
-        let last = x.narrow(1, t - 1, 1)?;
-        let last_2d = last.squeeze(1)?.contiguous()?;
-        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?;
-        logits.unsqueeze(1).map_err(Into::into)
+        compute_logits(&x, &self.lm_head_weight)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -13,8 +13,8 @@ use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm,
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_rms_norm_heads, causal_mask, paged_write_gather_sdpa, precompute_rope, repeat_kv,
-    AttnDims, Mlp, PagedCtx,
+    apply_output_gate, apply_rms_norm_heads, causal_mask, compute_logits, concat_kv_cache,
+    paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
 };
 
 // ---------------------------------------------------------------------------
@@ -197,15 +197,7 @@ impl FullAttention {
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
         // Append to KV cache
-        let (k, v) = match &self.kv_cache {
-            None => (k, v),
-            Some((k_cache, v_cache)) => {
-                let k = Tensor::cat(&[k_cache, &k], 2)?;
-                let v = Tensor::cat(&[v_cache, &v], 2)?;
-                (k, v)
-            }
-        };
-        self.kv_cache = Some((k.clone(), v.clone()));
+        let (k, v) = concat_kv_cache(k, v, &mut self.kv_cache)?;
 
         let kv_len = k.dim(2)?;
 
@@ -238,9 +230,8 @@ impl FullAttention {
             .transpose(1, 2)?
             .reshape((b, t, self.num_heads * self.head_dim))?;
 
-        // Apply output gate: sigmoid(gate) * out  (sigmoid = 1/(1+exp(-x)))
-        let gate_sig = (gate.neg()?.exp()? + 1.0)?.recip()?;
-        let out = out.broadcast_mul(&gate_sig)?;
+        // Apply output gate: sigmoid(gate) * out
+        let out = apply_output_gate(&out, &gate)?;
 
         let out = self.o_proj.forward(&out)?;
         Ok(out)
@@ -318,8 +309,7 @@ impl FullAttention {
         )?;
 
         // ── Output gate ───────────────────────────────────────────────────────
-        let gate_sig = (gate.neg()?.exp()? + 1.0)?.recip()?;
-        let out = out.broadcast_mul(&gate_sig)?;
+        let out = apply_output_gate(&out, &gate)?;
 
         self.o_proj.forward(&out).map_err(Into::into)
     }
@@ -702,22 +692,14 @@ struct DecoderLayer {
 }
 
 impl DecoderLayer {
-    fn new_full(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
+    fn new(cfg: &Qwen35Config, vb: VarBuilder, is_full_attention: bool) -> Result<Self> {
+        let attn = if is_full_attention {
+            LayerAttn::Full(FullAttention::new(cfg, vb.pp("self_attn"))?)
+        } else {
+            LayerAttn::Linear(LinearAttn::new(cfg, vb.pp("linear_attn"))?)
+        };
         Ok(Self {
-            attn: LayerAttn::Full(FullAttention::new(cfg, vb.pp("self_attn"))?),
-            mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
-            input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
-            post_attention_layernorm: rms_norm(
-                cfg.hidden_size,
-                cfg.rms_norm_eps,
-                vb.pp("post_attention_layernorm"),
-            )?,
-        })
-    }
-
-    fn new_linear(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
-        Ok(Self {
-            attn: LayerAttn::Linear(LinearAttn::new(cfg, vb.pp("linear_attn"))?),
+            attn,
             mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
             input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: rms_norm(
@@ -813,12 +795,8 @@ impl Qwen35Model {
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for (i, layer_type) in cfg.layer_types.iter().enumerate() {
             let layer_vb = lm_vb.pp("layers").pp(i.to_string());
-            let layer = if layer_type.is_full_attention {
-                DecoderLayer::new_full(cfg, layer_vb)
-            } else {
-                DecoderLayer::new_linear(cfg, layer_vb)
-            }
-            .with_context(|| format!("loading layer {}", i))?;
+            let layer = DecoderLayer::new(cfg, layer_vb, layer_type.is_full_attention)
+                .with_context(|| format!("loading layer {}", i))?;
             layers.push(layer);
         }
 
@@ -852,8 +830,6 @@ impl Qwen35Model {
     /// input_ids: [batch, seq_len]
     /// Returns logits for the last position: [batch, 1, vocab_size]
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        let (_b, t) = input_ids.dims2()?;
-
         let mut x = self.embed_tokens.forward(input_ids)?; // [b, t, hidden]
 
         for layer in &mut self.layers {
@@ -861,18 +837,7 @@ impl Qwen35Model {
         }
 
         x = self.norm.forward(&x)?;
-
-        // Take last position only
-        let last = x.narrow(1, t - 1, 1)?; // [b, 1, hidden]
-
-        // Tied embedding: matmul with embed_tokens weight [vocab, hidden]
-        // last is [b, 1, hidden]; flatten to [b, hidden] for 2D matmul then restore
-        // Both operands must be contiguous for Metal matmul.
-        let last_2d = last.squeeze(1)?.contiguous()?; // [b, hidden]
-        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
-
-        let logits = logits.unsqueeze(1)?; // [b, 1, vocab]
-        Ok(logits)
+        compute_logits(&x, &self.lm_head_weight)
     }
 
     /// Paged-attention forward pass.
@@ -891,7 +856,7 @@ impl Qwen35Model {
         block_table: &BlockTable,
         kv_store: &mut PagedKvStore,
     ) -> Result<Tensor> {
-        let (_b, t) = input_ids.dims2()?;
+        let (_b, _t) = input_ids.dims2()?;
 
         let mut x = self.embed_tokens.forward(input_ids)?; // [b, t, hidden]
 
@@ -914,11 +879,7 @@ impl Qwen35Model {
         }
 
         x = self.norm.forward(&x)?;
-
-        let last = x.narrow(1, t - 1, 1)?;
-        let last_2d = last.squeeze(1)?.contiguous()?;
-        let logits = last_2d.matmul(&self.lm_head_weight.t()?.contiguous()?)?;
-        logits.unsqueeze(1).map_err(Into::into)
+        compute_logits(&x, &self.lm_head_weight)
     }
 
     pub fn clear_kv_cache(&mut self) {


### PR DESCRIPTION
- engine.rs: extract run_prefill, run_decode_step, free_paged_blocks to eliminate three identical paged/concat-KV blocks in generate, generate_stream_inner, and bench_generate
- attention_utils.rs: add compute_logits, concat_kv_cache, apply_output_gate shared helpers used by both qwen3 and qwen3_5
- qwen3.rs / qwen3_5.rs: replace inline KV concat, output-gate sigmoid, and final-logits blocks with the new shared helpers
- qwen3_5.rs: merge new_full/new_linear constructors into a single new()
- mod.rs: replace Qwen2/Gemma2/Gemma3 CausalLM newtype boilerplate with an impl_causal_lm_wrapper! macro