### PR TITLE
refactor: de-duplicate

### DIFF
--- a/src/bench.rs
+++ b/src/bench.rs
@@ -12,7 +12,6 @@
 
 use anyhow::Result;
 
-use crate::config::RawConfig;
 use crate::engine::{attach_paged_kv_if_requested, Engine};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::Tokenizer;
@@ -43,32 +42,31 @@ pub fn run(args: BenchArgs) -> Result<()> {
     let device = serve.resolve_device()?;
     let dtype = serve.resolve_dtype()?;
 
-    // Download / load model (same path as `serve`)
-    let model_files = crate::hub::download_model(&serve.model, &serve.revision)?;
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
-    let tokenizer = Tokenizer::from_file(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-    )?;
-
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
+    let loaded = crate::loader::load(
+        &serve.model,
+        &serve.revision,
         dtype,
         &device,
         serve.turbo_quant,
     )?;
+    let crate::loader::LoadedModel {
+        model_files,
+        raw_config,
+        arch,
+        tokenizer,
+        model,
+        max_seq_len,
+    } = loaded;
 
+    // The engine needs its own tokenizer instance for decoding.
+    let engine_tokenizer = Tokenizer::from_file_with_arch(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
+    )?;
     let mut engine = Engine::new(
         model,
-        Tokenizer::from_file(
-            &model_files.tokenizer_path,
-            model_files.tokenizer_config_path.as_deref(),
-        )?,
+        engine_tokenizer,
         device.clone(),
         serve.max_batch_size,
         serve.max_tokens_per_step,
@@ -93,7 +91,6 @@ pub fn run(args: BenchArgs) -> Result<()> {
     // Clamp max_tokens to the model's effective KV-cache capacity so that
     // models with a sliding-window limit (e.g. Gemma3 at 512 tokens) don't
     // crash mid-generation with an opaque tensor error.
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
     let max_tokens = {
         let available = if max_seq_len == usize::MAX {
             serve.max_tokens

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,71 @@
+//! Shared model-loading bootstrap used by `serve`, `bench`, and `run`.
+//!
+//! Downloading model files, parsing the config, detecting the architecture,
+//! and loading tokenizer + weights are identical across all three subcommands.
+//! This module centralises that logic so each caller only handles its own
+//! subcommand-specific setup (engine wiring, HTTP server, REPL, …).
+
+use anyhow::Result;
+use candle_core::{DType, Device};
+
+use crate::config::{ModelArchitecture, RawConfig};
+use crate::hub::ModelFiles;
+use crate::models::CausalLM;
+use crate::tokenizer::Tokenizer;
+
+/// Everything produced by the common model-loading sequence.
+pub struct LoadedModel {
+    pub model_files: ModelFiles,
+    pub raw_config: RawConfig,
+    pub arch: ModelArchitecture,
+    /// Tokenizer configured with the detected architecture's chat template.
+    pub tokenizer: Tokenizer,
+    /// Loaded model weights, ready for inference.
+    pub model: Box<dyn CausalLM>,
+    /// Hard upper bound on (prompt_tokens + output_tokens) for this model.
+    pub max_seq_len: usize,
+}
+
+/// Download model files, parse the config, detect the architecture, then
+/// load the tokenizer and model weights.
+///
+/// This is the common preamble shared by `serve`, `bench`, and `run`.
+pub fn load(
+    model_id: &str,
+    revision: &str,
+    dtype: DType,
+    device: &Device,
+    turbo_quant: Option<u8>,
+) -> Result<LoadedModel> {
+    let model_files = crate::hub::download_model(model_id, revision)?;
+
+    let raw_config = RawConfig::from_file(&model_files.config_path)?;
+    let arch = raw_config.detect_architecture()?;
+    tracing::info!("Detected architecture: {:?}", arch);
+
+    let tokenizer = Tokenizer::from_file_with_arch(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
+    )?;
+
+    let model = crate::models::load_model(
+        &raw_config,
+        &arch,
+        &model_files.weight_paths,
+        dtype,
+        device,
+        turbo_quant,
+    )?;
+
+    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+
+    Ok(LoadedModel {
+        model_files,
+        raw_config,
+        arch,
+        tokenizer,
+        model,
+        max_seq_len,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod engine;
 mod hub;
 mod kv_cache;
+mod loader;
 mod models;
 mod rm;
 mod run;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -62,64 +62,48 @@ macro_rules! impl_causal_lm_wrapper {
     };
 }
 
+/// Like `impl_causal_lm_wrapper!` but also wires up `forward_paged` for
+/// models that support paged attention.
+macro_rules! impl_causal_lm_wrapper_paged {
+    ($wrapper:ident, $inner_ty:ty) => {
+        struct $wrapper {
+            inner: $inner_ty,
+        }
+
+        impl CausalLM for $wrapper {
+            fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
+                self.inner
+                    .forward(input_ids, seqlen_offset)
+                    .map_err(Into::into)
+            }
+
+            fn forward_paged(
+                &mut self,
+                input_ids: &Tensor,
+                seqlen_offset: usize,
+                block_table: &BlockTable,
+                kv_store: &mut PagedKvStore,
+            ) -> Result<Tensor> {
+                self.inner
+                    .forward_paged(input_ids, seqlen_offset, block_table, kv_store)
+                    .map_err(Into::into)
+            }
+
+            fn clear_kv_cache(&mut self) {
+                self.inner.clear_kv_cache();
+            }
+        }
+    };
+}
+
 impl_causal_lm_wrapper!(
     Qwen2Model,
     candle_transformers::models::qwen2::ModelForCausalLM
 );
 impl_causal_lm_wrapper!(Gemma2Model, candle_transformers::models::gemma2::Model);
 impl_causal_lm_wrapper!(Gemma3Model, candle_transformers::models::gemma3::Model);
-
-/// A Qwen3 model wrapper.
-struct Qwen3ModelWrapper {
-    inner: qwen3::Qwen3Model,
-}
-
-impl CausalLM for Qwen3ModelWrapper {
-    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        self.inner.forward(input_ids, seqlen_offset)
-    }
-
-    fn forward_paged(
-        &mut self,
-        input_ids: &Tensor,
-        seqlen_offset: usize,
-        block_table: &BlockTable,
-        kv_store: &mut PagedKvStore,
-    ) -> Result<Tensor> {
-        self.inner
-            .forward_paged(input_ids, seqlen_offset, block_table, kv_store)
-    }
-
-    fn clear_kv_cache(&mut self) {
-        self.inner.clear_kv_cache();
-    }
-}
-
-/// A Qwen3.5 model wrapper.
-struct Qwen35ModelWrapper {
-    inner: qwen3_5::Qwen35Model,
-}
-
-impl CausalLM for Qwen35ModelWrapper {
-    fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        self.inner.forward(input_ids, seqlen_offset)
-    }
-
-    fn forward_paged(
-        &mut self,
-        input_ids: &Tensor,
-        seqlen_offset: usize,
-        block_table: &BlockTable,
-        kv_store: &mut PagedKvStore,
-    ) -> Result<Tensor> {
-        self.inner
-            .forward_paged(input_ids, seqlen_offset, block_table, kv_store)
-    }
-
-    fn clear_kv_cache(&mut self) {
-        self.inner.clear_kv_cache();
-    }
-}
+impl_causal_lm_wrapper_paged!(Qwen3ModelWrapper, qwen3::Qwen3Model);
+impl_causal_lm_wrapper_paged!(Qwen35ModelWrapper, qwen3_5::Qwen35Model);
 
 /// Load a model from weight files.
 pub fn load_model(

--- a/src/models/qwen3.rs
+++ b/src/models/qwen3.rs
@@ -275,6 +275,15 @@ impl DecoderLayer {
         })
     }
 
+    /// Shared post-attention residual: `x = x + attn_out`, then MLP block.
+    fn apply_residual_blocks(&self, x: &Tensor, attn_out: Tensor) -> Result<Tensor> {
+        let x = (x + attn_out)?;
+        let residual = x.clone();
+        let normed = self.post_attention_layernorm.forward(&x)?;
+        let mlp_out = self.mlp.forward(&normed)?;
+        (residual + mlp_out).map_err(Into::into)
+    }
+
     fn forward(
         &mut self,
         x: &Tensor,
@@ -285,11 +294,7 @@ impl DecoderLayer {
         let residual = x.clone();
         let normed = self.input_layernorm.forward(x)?;
         let attn_out = self.attn.forward(&normed, seqlen_offset, cos, sin)?;
-        let x = (residual + attn_out)?;
-        let residual = x.clone();
-        let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
-        (residual + mlp_out).map_err(Into::into)
+        self.apply_residual_blocks(&residual, attn_out)
     }
 
     fn forward_paged(
@@ -301,11 +306,7 @@ impl DecoderLayer {
         let residual = x.clone();
         let normed = self.input_layernorm.forward(x)?;
         let attn_out = self.attn.forward_paged(&normed, seqlen_offset, ctx)?;
-        let x = (residual + attn_out)?;
-        let residual = x.clone();
-        let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
-        (residual + mlp_out).map_err(Into::into)
+        self.apply_residual_blocks(&residual, attn_out)
     }
 
     fn clear_kv_cache(&mut self) {

--- a/src/models/qwen3_5.rs
+++ b/src/models/qwen3_5.rs
@@ -710,6 +710,15 @@ impl DecoderLayer {
         })
     }
 
+    /// Shared post-attention residual: `x = x + attn_out`, then MLP block.
+    fn apply_residual_blocks(&self, x: &Tensor, attn_out: Tensor) -> Result<Tensor> {
+        let x = (x + attn_out)?;
+        let residual = x.clone();
+        let normed = self.post_attention_layernorm.forward(&x)?;
+        let mlp_out = self.mlp.forward(&normed)?;
+        (residual + mlp_out).map_err(Into::into)
+    }
+
     fn forward(
         &mut self,
         x: &Tensor,
@@ -719,17 +728,11 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = x.clone();
         let normed = self.input_layernorm.forward(x)?;
-
         let attn_out = match &mut self.attn {
             LayerAttn::Full(a) => a.forward(&normed, seqlen_offset, cos, sin)?,
             LayerAttn::Linear(a) => a.forward(&normed)?,
         };
-
-        let x = (residual + attn_out)?;
-        let residual = x.clone();
-        let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
-        (residual + mlp_out).map_err(Into::into)
+        self.apply_residual_blocks(&residual, attn_out)
     }
 
     /// Paged-attention forward pass.
@@ -749,18 +752,12 @@ impl DecoderLayer {
     ) -> Result<Tensor> {
         let residual = x.clone();
         let normed = self.input_layernorm.forward(x)?;
-
         let attn_out = match &mut self.attn {
             LayerAttn::Full(a) => a.forward_paged(&normed, seqlen_offset, ctx)?,
             // SSM layers are not paged — use their standard recurrent path.
             LayerAttn::Linear(a) => a.forward(&normed)?,
         };
-
-        let x = (residual + attn_out)?;
-        let residual = x.clone();
-        let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
-        (residual + mlp_out).map_err(Into::into)
+        self.apply_residual_blocks(&residual, attn_out)
     }
 
     fn clear_cache(&mut self) {

--- a/src/run.rs
+++ b/src/run.rs
@@ -13,9 +13,7 @@ use crossterm::{
 use std::io::{self, Write};
 use std::sync::mpsc as stdmpsc;
 
-use crate::config::RawConfig;
 use crate::engine::{attach_paged_kv_if_requested, Engine, StreamToken, SyncEngineRequest};
-use crate::hub;
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
@@ -128,32 +126,21 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     let device = serve.resolve_device()?;
     let dtype = serve.resolve_dtype()?;
 
-    // Download / locate model files from HuggingFace Hub
-    let model_files = hub::download_model(&args.model, &args.revision)?;
-
-    // Load config and detect architecture
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
-
-    // Load tokenizer (used by the REPL to build prompts)
-    let tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
-    )?;
-
-    // Load model weights
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
+    let loaded = crate::loader::load(
+        &args.model,
+        &args.revision,
         dtype,
         &device,
         args.turbo_quant,
     )?;
+    let crate::loader::LoadedModel {
+        model_files,
+        raw_config,
+        arch,
+        tokenizer,
+        model,
+        max_seq_len,
+    } = loaded;
 
     // Engine tokenizer (separate instance — engine runs on its own thread)
     let engine_tokenizer = Tokenizer::from_file_with_arch(
@@ -574,32 +561,18 @@ fn read_line() -> Result<ReadResult> {
 
                     // ── Home / Ctrl+A ─────────────────────────────────────────
                     KeyCode::Home => {
-                        if cursor_pos > 0 {
-                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                            cursor_pos = 0;
-                        }
+                        move_to_bol(&mut stdout, &mut cursor_pos)?;
                     }
                     KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        if cursor_pos > 0 {
-                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                            cursor_pos = 0;
-                        }
+                        move_to_bol(&mut stdout, &mut cursor_pos)?;
                     }
 
                     // ── End / Ctrl+E ──────────────────────────────────────────
                     KeyCode::End => {
-                        let remaining = buf.len() - cursor_pos;
-                        if remaining > 0 {
-                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
-                            cursor_pos = buf.len();
-                        }
+                        move_to_eol(&mut stdout, &buf, &mut cursor_pos)?;
                     }
                     KeyCode::Char('e') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        let remaining = buf.len() - cursor_pos;
-                        if remaining > 0 {
-                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
-                            cursor_pos = buf.len();
-                        }
+                        move_to_eol(&mut stdout, &buf, &mut cursor_pos)?;
                     }
 
                     // ── Kill to EOL (Ctrl+K) ──────────────────────────────────
@@ -693,6 +666,25 @@ fn read_line() -> Result<ReadResult> {
             _ => {}
         }
     }
+}
+
+/// Move the terminal cursor to the beginning of the line (Home / Ctrl+A).
+fn move_to_bol(stdout: &mut io::Stdout, cursor_pos: &mut usize) -> Result<()> {
+    if *cursor_pos > 0 {
+        execute!(stdout, cursor::MoveLeft(*cursor_pos as u16))?;
+        *cursor_pos = 0;
+    }
+    Ok(())
+}
+
+/// Move the terminal cursor to the end of the line (End / Ctrl+E).
+fn move_to_eol(stdout: &mut io::Stdout, buf: &[char], cursor_pos: &mut usize) -> Result<()> {
+    let remaining = buf.len() - *cursor_pos;
+    if remaining > 0 {
+        execute!(stdout, cursor::MoveRight(remaining as u16))?;
+        *cursor_pos = buf.len();
+    }
+    Ok(())
 }
 
 /// Redraw the characters of `buf` starting at logical position `from`,

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::CorsLayer;
 
-use crate::config::RawConfig;
 use crate::engine::{attach_paged_kv_if_requested, EngineRequest, GenerationResult, StreamToken};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Tokenizer};
@@ -190,37 +189,27 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     let device = args.resolve_device()?;
     let dtype = args.resolve_dtype()?;
 
-    // Download model
-    let model_files = crate::hub::download_model(&args.model, &args.revision)?;
-
-    // Load config
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
-    // Load tokenizer
-    let tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
-    )?;
-    let tokenizer = Arc::new(tokenizer);
-
-    // Load model
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
+    let loaded = crate::loader::load(
+        &args.model,
+        &args.revision,
         dtype,
         &device,
         args.turbo_quant,
     )?;
+    let crate::loader::LoadedModel {
+        model_files,
+        raw_config,
+        arch,
+        tokenizer,
+        model,
+        max_seq_len,
+    } = loaded;
 
-    // Effective sequence-length cap for this model.
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
     if max_seq_len < usize::MAX {
         tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
     }
+
+    let tokenizer = Arc::new(tokenizer);
 
     // Default sampling params from CLI args
     let default_params = SamplingParams {
@@ -234,15 +223,15 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     // Create engine channel
     let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
 
-    // Spawn engine on a dedicated thread
+    // Spawn engine on a dedicated thread (needs its own tokenizer instance for decoding)
+    let engine_tokenizer = Tokenizer::from_file_with_arch(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
+    )?;
     let mut engine = crate::engine::Engine::new(
         model,
-        // The engine needs its own tokenizer for decoding
-        Tokenizer::from_file_with_arch(
-            &model_files.tokenizer_path,
-            model_files.tokenizer_config_path.as_deref(),
-            Some(&arch),
-        )?,
+        engine_tokenizer,
         device.clone(),
         args.max_batch_size,
         args.max_tokens_per_step,
@@ -409,15 +398,67 @@ async fn chat_completions(
     }
 }
 
-fn make_sse_stream(
+/// Build an SSE stream from a token channel.
+///
+/// `make_chunk` is called for each incoming [`StreamToken`] and returns the
+/// JSON string to send.  An optional `preamble_json` is emitted before the
+/// first token (used by chat completions to send the initial role chunk).
+fn make_sse_stream_inner(
     mut token_rx: mpsc::Receiver<StreamToken>,
+    preamble_json: Option<String>,
+    make_chunk: impl Fn(StreamToken) -> Option<String> + Send + 'static,
+) -> impl Stream<Item = Result<Event, Infallible>> {
+    async_stream::stream! {
+        if let Some(json) = preamble_json {
+            yield Ok(Event::default().data(json));
+        }
+
+        while let Some(token) = token_rx.recv().await {
+            if let Some(json) = make_chunk(token) {
+                yield Ok(Event::default().data(json));
+            }
+        }
+
+        yield Ok(Event::default().data("[DONE]"));
+    }
+}
+
+fn make_sse_stream(
+    token_rx: mpsc::Receiver<StreamToken>,
     request_id: String,
     model_id: String,
     created: u64,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
-    async_stream::stream! {
-        // First chunk: role
-        let first_chunk = ChatCompletionStreamResponse {
+    // Initial role chunk
+    let preamble = ChatCompletionStreamResponse {
+        id: request_id.clone(),
+        object: "chat.completion.chunk",
+        created,
+        model: model_id.clone(),
+        choices: vec![ChatCompletionStreamChoice {
+            index: 0,
+            delta: DeltaMessage {
+                role: Some("assistant".to_string()),
+                content: None,
+            },
+            finish_reason: None,
+        }],
+    };
+    let preamble_json = match serde_json::to_string(&preamble) {
+        Ok(j) => Some(j),
+        Err(e) => {
+            tracing::error!("Failed to serialize chat stream role chunk: {e}");
+            None
+        }
+    };
+
+    make_sse_stream_inner(token_rx, preamble_json, move |token| {
+        let content = if token.finish_reason.as_deref() == Some("stop") {
+            None
+        } else {
+            Some(token.text)
+        };
+        let chunk = ChatCompletionStreamResponse {
             id: request_id.clone(),
             object: "chat.completion.chunk",
             created,
@@ -425,55 +466,20 @@ fn make_sse_stream(
             choices: vec![ChatCompletionStreamChoice {
                 index: 0,
                 delta: DeltaMessage {
-                    role: Some("assistant".to_string()),
-                    content: None,
+                    role: None,
+                    content,
                 },
-                finish_reason: None,
+                finish_reason: token.finish_reason,
             }],
         };
-        match serde_json::to_string(&first_chunk) {
-            Ok(json) => yield Ok(Event::default().data(json)),
+        match serde_json::to_string(&chunk) {
+            Ok(j) => Some(j),
             Err(e) => {
-                tracing::error!("Failed to serialize chat stream role chunk: {e}");
-                return;
-            }
-        }
-
-        // Token chunks
-        while let Some(token) = token_rx.recv().await {
-            // Don't send EOS token text
-            let content = if token.finish_reason.as_deref() == Some("stop") {
+                tracing::error!("Failed to serialize chat stream chunk: {e}");
                 None
-            } else {
-                Some(token.text)
-            };
-
-            let chunk = ChatCompletionStreamResponse {
-                id: request_id.clone(),
-                object: "chat.completion.chunk",
-                created,
-                model: model_id.clone(),
-                choices: vec![ChatCompletionStreamChoice {
-                    index: 0,
-                    delta: DeltaMessage {
-                        role: None,
-                        content,
-                    },
-                    finish_reason: token.finish_reason,
-                }],
-            };
-            match serde_json::to_string(&chunk) {
-                Ok(json) => yield Ok(Event::default().data(json)),
-                Err(e) => {
-                    tracing::error!("Failed to serialize chat stream chunk: {e}");
-                    break;
-                }
             }
         }
-
-        // Final [DONE]
-        yield Ok(Event::default().data("[DONE]"));
-    }
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -628,43 +634,36 @@ async fn completions(
 }
 
 fn make_completion_sse_stream(
-    mut token_rx: mpsc::Receiver<StreamToken>,
+    token_rx: mpsc::Receiver<StreamToken>,
     request_id: String,
     model_id: String,
     created: u64,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
-    async_stream::stream! {
-        // Token chunks
-        while let Some(token) = token_rx.recv().await {
-            let text = if token.finish_reason.as_deref() == Some("stop") {
-                String::new()
-            } else {
-                token.text
-            };
-
-            let chunk = CompletionStreamResponse {
-                id: request_id.clone(),
-                object: "text_completion",
-                created,
-                model: model_id.clone(),
-                choices: vec![CompletionStreamChoice {
-                    index: 0,
-                    text,
-                    finish_reason: token.finish_reason,
-                }],
-            };
-            match serde_json::to_string(&chunk) {
-                Ok(json) => yield Ok(Event::default().data(json)),
-                Err(e) => {
-                    tracing::error!("Failed to serialize completion stream chunk: {e}");
-                    break;
-                }
+    make_sse_stream_inner(token_rx, None, move |token| {
+        let text = if token.finish_reason.as_deref() == Some("stop") {
+            String::new()
+        } else {
+            token.text
+        };
+        let chunk = CompletionStreamResponse {
+            id: request_id.clone(),
+            object: "text_completion",
+            created,
+            model: model_id.clone(),
+            choices: vec![CompletionStreamChoice {
+                index: 0,
+                text,
+                finish_reason: token.finish_reason,
+            }],
+        };
+        match serde_json::to_string(&chunk) {
+            Ok(j) => Some(j),
+            Err(e) => {
+                tracing::error!("Failed to serialize completion stream chunk: {e}");
+                None
             }
         }
-
-        // Final [DONE]
-        yield Ok(Event::default().data("[DONE]"));
-    }
+    })
 }
 
 async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListResponse> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -97,10 +97,6 @@ pub struct Tokenizer {
 }
 
 impl Tokenizer {
-    pub fn from_file(tokenizer_path: &Path, tokenizer_config_path: Option<&Path>) -> Result<Self> {
-        Self::from_file_with_arch(tokenizer_path, tokenizer_config_path, None)
-    }
-
     pub fn from_file_with_arch(
         tokenizer_path: &Path,
         tokenizer_config_path: Option<&Path>,

--- a/tests/server_integration.rs
+++ b/tests/server_integration.rs
@@ -38,23 +38,28 @@ fn free_port() -> u16 {
 /// `--device auto` is passed, which picks Metal on macOS (always compiled in
 /// via the `[target.cfg(macos)]` dependency block in `Cargo.toml`), CUDA on
 /// Linux/Windows when available, and falls back to CPU otherwise.
-fn spawn_server(model_id: &str, port: u16) -> Child {
+///
+/// Pass extra CLI arguments via `extra_args` (e.g. `&["--turbo-quant=4"]`).
+fn spawn_server(model_id: &str, port: u16, extra_args: &[&str]) -> Child {
     let bin = env!("CARGO_BIN_EXE_inferrs");
+    let port_str = port.to_string();
+    let mut args = vec![
+        "serve",
+        model_id,
+        "--port",
+        &port_str,
+        "--host",
+        "127.0.0.1",
+        "--max-tokens",
+        "128",
+        "--dtype",
+        "bf16",
+        "--device",
+        "auto",
+    ];
+    args.extend_from_slice(extra_args);
     Command::new(bin)
-        .args([
-            "serve",
-            model_id,
-            "--port",
-            &port.to_string(),
-            "--host",
-            "127.0.0.1",
-            "--max-tokens",
-            "128",
-            "--dtype",
-            "bf16",
-            "--device",
-            "auto",
-        ])
+        .args(&args)
         .stdout(Stdio::null())
         .stderr(Stdio::inherit())
         .spawn()
@@ -93,28 +98,8 @@ fn looks_intelligible(text: &str) -> bool {
 /// instead of the default full-precision cache.  Uses `require_equals` syntax
 /// as defined in the CLI (`--turbo-quant=4` for 4-bit).
 fn spawn_server_turbo(model_id: &str, port: u16, bits: u8) -> Child {
-    let bin = env!("CARGO_BIN_EXE_inferrs");
     let turbo_flag = format!("--turbo-quant={}", bits);
-    Command::new(bin)
-        .args([
-            "serve",
-            model_id,
-            "--port",
-            &port.to_string(),
-            "--host",
-            "127.0.0.1",
-            "--max-tokens",
-            "128",
-            "--dtype",
-            "bf16",
-            "--device",
-            "auto",
-            &turbo_flag,
-        ])
-        .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .expect("failed to spawn inferrs with TurboQuant")
+    spawn_server(model_id, port, &[turbo_flag.as_str()])
 }
 
 /// Send a single chat-completion request and return the assistant's text.


### PR DESCRIPTION
- Add impl_causal_lm_wrapper_paged! macro; replace hand-written Qwen3/Qwen35 wrapper impls
- Extract apply_residual_blocks helper in DecoderLayer (qwen3, qwen3_5)
- Add loader::load() to centralise model download/config/tokenizer/weights bootstrap used by serve, bench, and run
- Introduce make_sse_stream_inner; both SSE stream functions delegate to it
- Merge spawn_server/spawn_server_turbo in integration tests via extra_args slice
- Add move_to_bol/move_to_eol helpers to deduplicate Home/Ctrl+A and End/Ctrl+E key handlers