### PR TITLE
fix: add CUDA bin dir to PATH after toolkit install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends \
             cuda-toolkit-12-6
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
 
       - name: Build CUDA backend plugin
         env:


### PR DESCRIPTION
nvcc is installed to /usr/local/cuda/bin by cuda-toolkit-12-6 but that directory is not in the runner's default PATH, causing the cudarc build script to fail with ENOENT when invoking nvcc.