### PR TITLE
fix: set CUDA_COMPUTE_CAP to skip nvidia-smi probe in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Build CUDA backend plugin
         env:
           CUDA_PATH: /usr/local/cuda
+          # No GPU on CI runners; set a broadly-compatible compute capability
+          # so bindgen_cuda skips the nvidia-smi probe.
+          CUDA_COMPUTE_CAP: "80"
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu \
             -p inferrs-backend-cuda


### PR DESCRIPTION
bindgen_cuda calls nvidia-smi to detect the GPU compute capability when CUDA_COMPUTE_CAP is unset. CI runners have no GPU so nvidia-smi is absent. Setting CUDA_COMPUTE_CAP=80 (Ampere) bypasses the probe and allows candle-kernels to compile against headers/stubs only.