### PR TITLE
Set default-members to exclude CUDA/ROCm backends from bare cargo build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,14 @@ members = [
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
 ]
+# Default members exclude the CUDA/ROCm backends, which require the CUDA/ROCm
+# toolchain (nvcc, nvidia-smi, hipcc) and only make sense on Linux with a GPU.
+# `cargo build` (no -p flag) will only build these. To build a GPU backend
+# explicitly: `cargo build -p inferrs-backend-cuda`
+default-members = [
+    "inferrs",
+    "backends/inferrs-backend-vulkan",
+]
 resolver = "2"
 
 [workspace.dependencies]


### PR DESCRIPTION
The GPU backends require nvcc/nvidia-smi/hipcc which are not available on macOS or systems without a GPU toolchain. Using default-members means `cargo build` skips them while they remain buildable explicitly with -p.