### PR TITLE
Fix inference on CUDA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "candle-core",
+ "candle-nn",
+ "candle-transformers",
 ]
 
 [[package]]

--- a/backends/inferrs-backend-cuda/Cargo.toml
+++ b/backends/inferrs-backend-cuda/Cargo.toml
@@ -11,4 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 candle-core = { workspace = true, features = ["cuda"] }
+candle-nn = { workspace = true, features = ["cuda"] }
+candle-transformers = { workspace = true, features = ["cuda"] }
 anyhow = { workspace = true }


### PR DESCRIPTION
Add candle-nn and candle-transformers with the cuda feature to the CUDA backend so custom ops (rope, softmax) are available via Cargo feature unification when building the CUDA backend.