### PR TITLE
Fix lib_path: use lib DSL method and rename shadowing block variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,8 @@ jobs:
                 libinferrs_backend_cuda.so
                 libinferrs_backend_rocm.so
                 libinferrs_backend_vulkan.so
-              ].each do |lib|
-                (lib_path / "inferrs" / lib).install lib if File.exist?(lib)
+              ].each do |plugin|
+                (lib / "inferrs" / plugin).install plugin if File.exist?(plugin)
               end
             end
 
@@ -272,7 +272,7 @@ jobs:
               # On Linux, also link into the standard search path.
               return unless OS.linux?
 
-              plugin_dir = lib_path / "inferrs"
+              plugin_dir = lib / "inferrs"
               bin_dir    = bin.realpath
               plugin_dir.children.select { |f| f.extname == ".so" }.each do |so|
                 (bin_dir / so.basename).make_symlink(so) unless (bin_dir / so.basename).exist?


### PR DESCRIPTION
Fix `lib_path` undefined method error on install on Linux.

```
$ brew install inferrs
==> Fetching downloads for: inferrs
✔︎ Formula inferrs (a3f4c277f5a67f7eb131bfa1db05353b2c2da4d9)                                                                                                                                                                     Verified      5.8MB/  5.8MB
==> Installing inferrs from ericcurtin/inferrs
Error: An exception occurred within a child process:
  NameError: undefined local variable or method 'lib_path' for an instance of Formulary::FormulaNamespace7a3e32032bc126e3f15cb497c271765ad667550d2589f8560310fb661fc4d0d2::Inferrs
```

`lib_path` is not a Homebrew DSL method. The correct method is `lib`.

Changes

- Replace `lib_path` with `lib` in both `install` and `post_install`
- Rename the `each` block variable from `lib` to `plugin` to avoid shadowing the `lib` DSL method, and update the existence guard accordingly (`File.exist?(plugin)`)