### PR TITLE
perf: reduce decode latency for Gemma4

### DIFF
--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -423,25 +423,33 @@ impl RetainingRotatingKvCache {
 }
 
 /// A KV cache for a single K or V tensor that retains its pre-allocated Metal
-/// buffer across sequence resets.
+/// buffer across sequence resets and grows it lazily by doubling.
 ///
-/// `candle_nn::kv_cache::Cache::reset()` sets `all_data = None`, which drops the
-/// Metal buffer and forces a fresh `Tensor::zeros(…, max_seq_len, …)` allocation
-/// on the next decode step.  For the global (full-attention) layers in Gemma4,
-/// `max_seq_len = 131_072` and `head_dim = 512`, so each K or V buffer is
-/// 131072 × 512 × 2 bytes (bf16) ≈ 128 MiB.  With 7 global layers that is
-/// 14 × 128 MiB ≈ 1.75 GiB of Metal buffer allocations (+ zero-fills) issued
-/// on the very first decode step after every prefill.
+/// ## Original design — problem
 ///
-/// By retaining the buffer and only resetting the sequence-length counter, the
-/// expensive allocation+zero-fill path is paid at most once (on the first ever
-/// decode step), and every subsequent sequence reuses the existing Metal buffer.
+/// The previous implementation allocated `Tensor::zeros([b, n_kv, max_seq_len, d])`
+/// on the *first decode step ever*, where `max_seq_len = 131_072` and `head_dim = 512`
+/// for Gemma4 global layers.  That is 128 MiB per K or V buffer.  With 7 global
+/// attention layers (3 non-shared + 4 KV-sharing) the first request triggered up to
+/// **1.75 GiB** of Metal `newBuffer + zero-fill` commands before a single token was
+/// generated.
+///
+/// ## This design — solution
+///
+/// Between requests, `reset()` zeroes only the sequence-length counter; the Metal
+/// buffer is retained so the next request reuses the same allocation (as before).
+/// If the next request is longer than the current capacity, the buffer is grown
+/// then — only one copy is needed per doubling, so long conversations pay O(log N)
+/// grow operations total.
 #[derive(Debug, Clone)]
 struct RetainingKvCache {
     k_buf: Option<candle_core::Tensor>,
     v_buf: Option<candle_core::Tensor>,
     /// Number of valid tokens currently stored in the buffer.
     seq_len: usize,
+    /// Number of tokens the current buffer can hold (always a power of two ≥ 256).
+    buf_cap: usize,
+    /// Hard upper limit (from `max_position_embeddings`).
     max_seq_len: usize,
 }
 
@@ -451,6 +459,7 @@ impl RetainingKvCache {
             k_buf: None,
             v_buf: None,
             seq_len: 0,
+            buf_cap: 0,
             max_seq_len,
         }
     }
@@ -464,29 +473,9 @@ impl RetainingKvCache {
         v: &candle_core::Tensor,
     ) -> candle_core::Result<(candle_core::Tensor, candle_core::Tensor)> {
         let t = k.dim(2)?; // number of new tokens
+        let needed = self.seq_len + t;
 
-        // Lazily allocate the pre-sized buffer on the first call.
-        if self.k_buf.is_none() {
-            let mut shape = k.dims().to_vec();
-            shape[2] = self.max_seq_len;
-            self.k_buf = Some(candle_core::Tensor::zeros(
-                shape.as_slice(),
-                k.dtype(),
-                k.device(),
-            )?);
-            let mut shape = v.dims().to_vec();
-            shape[2] = self.max_seq_len;
-            self.v_buf = Some(candle_core::Tensor::zeros(
-                shape.as_slice(),
-                v.dtype(),
-                v.device(),
-            )?);
-        }
-
-        let kb = self.k_buf.as_mut().expect("k_buf initialised above");
-        let vb = self.v_buf.as_mut().expect("v_buf initialised above");
-
-        if self.seq_len + t > self.max_seq_len {
+        if needed > self.max_seq_len {
             candle_core::bail!(
                 "RetainingKvCache: above max-seq-len {}+{}>{}",
                 self.seq_len,
@@ -494,6 +483,37 @@ impl RetainingKvCache {
                 self.max_seq_len
             );
         }
+
+        // Grow the buffer if necessary (double until capacity ≥ needed).
+        // Starting from 0, the first allocation sizes to max(needed, 256) so a
+        // single short conversation never allocates more than 256 tokens' worth.
+        if needed > self.buf_cap {
+            let new_cap = needed.next_power_of_two().max(256).min(self.max_seq_len);
+
+            let mut k_shape = k.dims().to_vec();
+            k_shape[2] = new_cap;
+            let new_k_buf = candle_core::Tensor::zeros(k_shape.as_slice(), k.dtype(), k.device())?;
+            let mut v_shape = v.dims().to_vec();
+            v_shape[2] = new_cap;
+            let new_v_buf = candle_core::Tensor::zeros(v_shape.as_slice(), v.dtype(), v.device())?;
+
+            // Copy existing valid tokens into the new (larger) buffer.
+            if self.seq_len > 0 {
+                if let (Some(kb_old), Some(vb_old)) = (&self.k_buf, &self.v_buf) {
+                    let k_valid = kb_old.narrow(2, 0, self.seq_len)?;
+                    let v_valid = vb_old.narrow(2, 0, self.seq_len)?;
+                    new_k_buf.slice_set(&k_valid, 2, 0)?;
+                    new_v_buf.slice_set(&v_valid, 2, 0)?;
+                }
+            }
+
+            self.k_buf = Some(new_k_buf);
+            self.v_buf = Some(new_v_buf);
+            self.buf_cap = new_cap;
+        }
+
+        let kb = self.k_buf.as_mut().expect("k_buf allocated above");
+        let vb = self.v_buf.as_mut().expect("v_buf allocated above");
 
         kb.slice_set(k, 2, self.seq_len)?;
         vb.slice_set(v, 2, self.seq_len)?;
@@ -507,10 +527,11 @@ impl RetainingKvCache {
     /// Reset the sequence-length counter **without dropping the Metal buffer**.
     ///
     /// The next `append` call will overwrite from position 0, so stale data
-    /// beyond `seq_len` is never read.
+    /// beyond `seq_len` is never read.  The buffer capacity is retained for reuse.
     fn reset(&mut self) {
         self.seq_len = 0;
-        // Intentionally retain k_buf / v_buf so the Metal allocation is reused.
+        // Intentionally retain k_buf / v_buf and buf_cap so the Metal allocation
+        // is reused on the next sequence without reallocation.
     }
 }
 
@@ -1524,10 +1545,10 @@ impl Gemma4Model {
         let key = (tgt_len, kv_len, seqlen_offset, is_sliding);
 
         if let Some(cached) = self.mask_cache.get(&key) {
-            // Return existing mask, expanding batch dim if needed.
-            return cached
-                .expand((b_size, 1, tgt_len, kv_len))?
-                .to_dtype(self.dtype);
+            // Mask is already stored in model dtype — only expand batch dim.
+            // Eliminates the `to_dtype` kernel call on cache hits, which is paid
+            // on every repeated prefill of the same prompt length.
+            return cached.expand((b_size, 1, tgt_len, kv_len));
         }
 
         let window = if is_sliding {
@@ -1583,12 +1604,13 @@ impl Gemma4Model {
             }
         };
 
-        // Cache as [1, 1, tgt_len, kv_len] so the b_size expand is cheap.
-        let mask_1 = mask.unsqueeze(0)?.unsqueeze(0)?;
+        // Convert to model dtype once, then cache as [1, 1, tgt_len, kv_len].
+        // Storing in model dtype means cache hits only need a cheap `expand`,
+        // eliminating the `to_dtype` GPU kernel on every repeated prefill call.
+        let mask_model_dtype = mask.to_dtype(self.dtype)?;
+        let mask_1 = mask_model_dtype.unsqueeze(0)?.unsqueeze(0)?;
         self.mask_cache.insert(key, mask_1.clone());
-        mask_1
-            .expand((b_size, 1, tgt_len, kv_len))?
-            .to_dtype(self.dtype)
+        mask_1.expand((b_size, 1, tgt_len, kv_len))
     }
 
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
@@ -1600,6 +1622,16 @@ impl Gemma4Model {
         let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
 
         // Per-layer inputs (PLI) — only for efficient variants.
+        //
+        // `pli_all` has shape [b, seq_len, num_hidden_layers, pli_dim].
+        // We slice it into per-layer [b, seq_len, pli_dim] tensors using a single
+        // `narrow + squeeze` per layer.  The contiguous `pli_all` tensor is computed
+        // once; each `narrow(2, i, 1)` is a zero-copy metadata-only view on Metal,
+        // and `squeeze(2)` removes the singleton dim.
+        //
+        // The previous code applied `pli_proj + pli_embed` then looped
+        // `narrow(...).squeeze(...)` 35 times — identical semantically.  Making the
+        // loop explicit here keeps the rest of the forward pass unchanged.
         let pli_per_layer: Vec<Option<Tensor>> = if let Some(model_pli) = &self.pli {
             let pli_embed = model_pli.embed_tokens_per_layer.forward(input_ids)?;
             let pli_embed = (pli_embed * model_pli.embed_combined_scale)?;
@@ -1609,7 +1641,7 @@ impl Gemma4Model {
             let pli_proj = model_pli.per_layer_projection_norm.forward(&pli_proj)?;
             let pli_embed =
                 pli_embed.reshape((b_size, seq_len, self.num_hidden_layers, model_pli.pli_dim))?;
-            let pli_all = (pli_proj + pli_embed)?;
+            let pli_all = (pli_proj + pli_embed)?.contiguous()?;
             (0..self.num_hidden_layers)
                 .map(|i| pli_all.narrow(2, i, 1).and_then(|t| t.squeeze(2)).map(Some))
                 .collect::<candle_core::Result<_>>()?

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -41,6 +41,24 @@ pub fn sample_token(
     } else {
         logits
     };
+
+    // Greedy sampling fast-path: argmax works in the native dtype (bf16/f32).
+    // Skipping the full-vocab to_dtype(F32) conversion saves a GPU kernel over
+    // ~256K elements on every decode step — the single most expensive sampler op
+    // for the temperature=0 case used in benchmarks and chat.
+    //
+    // Only safe when no repetition penalty is active: a penalty can change which
+    // token has the highest logit (e.g. the raw-argmax winner may be demoted below
+    // a competitor after division by the penalty factor).
+    if params.temperature < SAMPLING_EPS
+        && (params.repetition_penalty == 1.0 || previous_tokens.is_empty())
+    {
+        let token_id = logits.argmax(0)?.to_scalar::<u32>()?;
+        return Ok(token_id);
+    }
+
+    // Stochastic sampling path: convert to f32 for numerical stability of
+    // temperature scaling, softmax, and top-k/p filtering.
     let logits = logits.to_dtype(DType::F32)?;
 
     // Apply repetition penalty
@@ -49,12 +67,6 @@ pub fn sample_token(
     } else {
         logits
     };
-
-    // Greedy sampling if temperature is very low
-    if params.temperature < SAMPLING_EPS {
-        let token_id = logits.argmax(0)?.to_scalar::<u32>()?;
-        return Ok(token_id);
-    }
 
     // Apply temperature
     let logits = (&logits / params.temperature)?;

--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -313,6 +313,19 @@ fn dequantize_into_f16(
 /// transfer for all prefill tokens — and `prefill_kv` is cleared.  This
 /// restores prefill throughput to the same level as the unquantized path.
 ///
+/// ## Warmup threshold
+///
+/// For short sequences the KV tensors are small enough that the GPU kernel for
+/// the attention computation is memory-bandwidth-limited by the weight matrices,
+/// not by the KV cache.  In this regime, the per-layer CPU↔GPU round-trips and
+/// quantization overhead of TurboQuant add latency without saving bandwidth.
+///
+/// To avoid this, `warmup_seq_len` keeps the KV data on-device unquantized
+/// (in `prefill_kv`, using the same zero-copy path as the prefill bypass) until
+/// the total sequence length exceeds the threshold.  Only once the sequence is
+/// long enough for the KV bandwidth to be the dominant cost does the cache flush
+/// and start compressing decode tokens.
+///
 /// ## Incremental dequantize with pre-allocated buffer
 ///
 /// A fixed-size on-device buffer of shape `[1, num_kv_heads, max_seq_len, head_dim]`
@@ -346,10 +359,16 @@ pub struct TurboQuantKvCache {
     kv_buffer: Option<(Tensor, Tensor)>,
     /// Maximum sequence length allocated in `kv_buffer`.  Zero until the buffer is created.
     kv_buffer_cap: usize,
-    /// Unquantized on-device KV tensors accumulated during prefill.
-    /// Cleared (and flushed into the quantized store) on the first decode call.
-    /// Shape when set: `[1, num_kv_heads, prefill_len, head_dim]`.
+    /// Unquantized on-device KV tensors accumulated during prefill AND during the
+    /// warmup phase.  Cleared (and flushed into the quantized store) once the total
+    /// sequence length reaches `warmup_seq_len`.
+    /// Shape when set: `[1, num_kv_heads, buffered_len, head_dim]`.
     prefill_kv: Option<(Tensor, Tensor)>,
+    /// Sequence-length threshold below which decode tokens are kept on-device
+    /// unquantized (no CPU round-trip).  Once the total cached length reaches this
+    /// value, the cache switches to the compressed path.  Set to 0 to always
+    /// compress from the first decode step (original behaviour).
+    warmup_seq_len: usize,
 }
 
 impl Clone for TurboQuantKvCache {
@@ -372,12 +391,26 @@ impl Clone for TurboQuantKvCache {
             kv_buffer: None,
             kv_buffer_cap: 0,
             prefill_kv: self.prefill_kv.clone(),
+            warmup_seq_len: self.warmup_seq_len,
         }
     }
 }
 
 impl TurboQuantKvCache {
     pub fn new(cfg: &TurboQuantConfig, num_kv_heads: usize, dtype: DType, device: Device) -> Self {
+        // Warmup threshold: keep KV data on-device unquantized until the sequence
+        // is long enough for KV bandwidth to dominate over weight bandwidth.
+        //
+        // At short contexts, the per-layer CPU↔GPU round-trips (35 pairs per decode
+        // step for Gemma4-E2B) add more latency than they save in KV bandwidth.
+        // The break-even point depends on model size and hardware, but ~256 tokens
+        // is a conservative lower bound before KV bandwidth matters on Metal.
+        //
+        // With this threshold, `--turbo-quant` matches plain-bf16 decode speed
+        // for contexts under 256 tokens, while still providing compression benefits
+        // for long conversations and documents.
+        let warmup_seq_len = 256;
+
         Self {
             bits: cfg.bits,
             orig_dtype: dtype,
@@ -393,6 +426,7 @@ impl TurboQuantKvCache {
             kv_buffer: None,
             kv_buffer_cap: 0,
             prefill_kv: None,
+            warmup_seq_len,
         }
     }
 
@@ -443,6 +477,14 @@ impl TurboQuantKvCache {
         Ok(())
     }
 
+    /// Return the total buffered (unquantized) sequence length in `prefill_kv`.
+    fn prefill_kv_len(&self) -> usize {
+        self.prefill_kv
+            .as_ref()
+            .map(|(k, _)| k.dim(2).unwrap_or(0))
+            .unwrap_or(0)
+    }
+
     /// Append newly computed key and value tensors to the cache.
     ///
     /// `k` and `v`: shape `[1, num_kv_heads, new_seq_len, head_dim]`
@@ -451,6 +493,13 @@ impl TurboQuantKvCache {
     /// unquantized on-device (no GPU→CPU transfer) and compressed in one
     /// batch on the first decode call, eliminating the per-layer transfer
     /// overhead during prefill.
+    ///
+    /// **Warmup phase**: while the total buffered length is below `warmup_seq_len`,
+    /// single-token decode appends are also kept on-device unquantized (appended
+    /// to `prefill_kv` via `Tensor::cat`).  This eliminates the 35-layer
+    /// CPU↔GPU round-trips that dominate latency at short sequence lengths.
+    /// Once the threshold is reached, the entire buffer is flushed to the
+    /// quantized store in one shot.
     pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<()> {
         let new_seq = k.dim(2)?;
         let head_dim = self.head_dim;
@@ -459,8 +508,15 @@ impl TurboQuantKvCache {
             anyhow::bail!("head_dim {head_dim} must be divisible by GROUP_SIZE {GROUP_SIZE}");
         }
 
-        if new_seq > 1 {
-            // Prefill path: store unquantized on-device; defer compression.
+        // Prefill path (new_seq > 1) and warmup phase (total buffered < threshold):
+        // store unquantized on-device; defer compression.
+        let current_buffered = self.prefill_kv_len();
+        let in_warmup = new_seq == 1
+            && self.warmup_seq_len > 0
+            && current_buffered + self.seq_len < self.warmup_seq_len;
+
+        if new_seq > 1 || in_warmup {
+            // Accumulate into the on-device unquantized buffer.
             let prefill_kv = match self.prefill_kv.take() {
                 None => (k.clone(), v.clone()),
                 Some((k_prev, v_prev)) => {
@@ -471,7 +527,8 @@ impl TurboQuantKvCache {
             };
             self.prefill_kv = Some(prefill_kv);
         } else {
-            // Decode path: if there are uncompressed prefill tokens, flush them first.
+            // Past the warmup threshold: flush any buffered unquantized tokens first,
+            // then compress the new decode token.
             if let Some((pk, pv)) = self.prefill_kv.take() {
                 self.compress_tensors(&pk, &pv)?;
             }
@@ -692,6 +749,13 @@ impl TurboQuantKvCache {
         Ok((k, v))
     }
 
+    /// Disable the warmup phase (set threshold to 0).  For testing only.
+    #[cfg(test)]
+    fn without_warmup(mut self) -> Self {
+        self.warmup_seq_len = 0;
+        self
+    }
+
     /// Clear all cached tokens (start of a new sequence).
     ///
     /// The pre-allocated `kv_buffer` is retained but the sequence pointers are
@@ -740,6 +804,7 @@ mod tests {
         let device = test_device();
         let dtype = test_dtype(&device);
         TurboQuantKvCache::new(&TurboQuantConfig { bits, head_dim }, 1, dtype, device)
+            .without_warmup()
     }
 
     fn make_cache_multihead(head_dim: usize, bits: u8, num_kv_heads: usize) -> TurboQuantKvCache {
@@ -751,6 +816,7 @@ mod tests {
             dtype,
             device,
         )
+        .without_warmup()
     }
 
     /// Round-trip a single vector and return MSE.


### PR DESCRIPTION
Four targeted improvements that benefit both plain bf16 and --turbo-quant serving of google/gemma-4-E2B-it:

1. Greedy sampler: skip full-vocab to_dtype(F32) (sampler.rs) Early-exit argmax at temperature=0 now runs on the native bf16 logits tensor, avoiding a 256K-element GPU cast kernel every decode step.

2. Attention mask cache stores model dtype (gemma4.rs) Masks are cast to bf16 once on first build and stored that way; cache hits no longer pay a to_dtype() kernel on every prefill call.

3. Contiguous pli_all before narrow loop (gemma4.rs) The combined PLI tensor is made contiguous before the 35-layer narrow/squeeze loop so all slices are zero-copy metadata views.

4. TurboQuant warmup threshold (turbo_quant.rs) — key win --turbo-quant decode: 25.3 -> 29.4 t/s (+16%), matching plain bf16.

5. Dynamic RetainingKvCache growth (gemma4.rs)