### PR TITLE
feat: default --turbo-quant to 8-bit on

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ brew install inferrs
 ### Run
 
 ```bash
-inferrs run --turbo-quant google/gemma-4-E2B-it
+inferrs run google/gemma-4-E2B-it
 ```
 
 ## Architecture

--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -69,7 +69,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
         model_files.gguf_path.as_deref(),
         dtype,
         &device,
-        serve.turbo_quant,
+        serve.turbo_quant.0,
     )?;
 
     let mut engine = Engine::new(
@@ -218,7 +218,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
         let (num_kv_heads, head_dim, num_layers) = raw_config.kv_cache_params(&arch);
         const GROUP_SIZE: usize = 32;
         // bytes consumed per token across all layers (K + V combined)
-        let bytes_per_token: usize = if let Some(bits) = serve.turbo_quant {
+        let bytes_per_token: usize = if let Some(bits) = serve.turbo_quant.0 {
             // TurboQuant: nibble-packed indices + f32 per-group absmax scales
             let index_bytes = if bits <= 4 {
                 // two indices packed per byte

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -17,6 +17,37 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
+/// CLI argument for `--turbo-quant`.
+///
+/// Parses as either a bit-width (1–8) or the literal string `"false"` to
+/// explicitly disable TurboQuant.  The default value is `"8"` (8-bit), so
+/// TurboQuant is **on by default** — pass `--turbo-quant=false` to turn it off.
+#[derive(Clone, Debug)]
+pub struct TurboQuantArg(pub Option<u8>);
+
+impl std::str::FromStr for TurboQuantArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("false") {
+            return Ok(TurboQuantArg(None));
+        }
+        match s.parse::<u8>() {
+            Ok(n) if (1..=8).contains(&n) => Ok(TurboQuantArg(Some(n))),
+            _ => Err(format!("expected a bit-width (1–8) or 'false', got '{s}'")),
+        }
+    }
+}
+
+impl std::fmt::Display for TurboQuantArg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(n) => write!(f, "{n}"),
+            None => write!(f, "false"),
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "inferrs", about = "A TurboQuant inference engine")]
 struct Cli {
@@ -108,13 +139,13 @@ pub struct ServeArgs {
     #[arg(long)]
     pub paged_attention: Option<f64>,
 
-    /// Enable TurboQuant KV cache compression (Qwen3 only).
-    /// Use as a flag (`--turbo-quant`) for the default 8-bit compression, or with an explicit
-    /// bit-width (`--turbo-quant=N`) for 1–8 bits.  Indices are nibble-packed for bits ≤ 4.
-    /// 8-bit (the default) gives ~2× compression vs bf16 with near-lossless quality.
+    /// TurboQuant KV cache compression bit-width (Qwen3/Gemma4).
+    /// Enabled by default at 8 bits (~2× KV memory reduction, near-lossless quality).
+    /// Pass an explicit bit-width (`--turbo-quant=N`, 1–8) to change the compression level.
     /// 4-bit gives ~3.5× but may produce poor output on models with large QK-norm values.
-    #[arg(long, num_args(0..=1), default_missing_value("8"), require_equals(true))]
-    pub turbo_quant: Option<u8>,
+    /// Disable entirely with `--turbo-quant=false`.
+    #[arg(long, default_value = "8", require_equals(true))]
+    pub turbo_quant: TurboQuantArg,
 
     /// Quantize model weights and cache the result on disk as a GGUF file.
     /// On first use the weights are quantized and saved next to the HuggingFace cache;

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -272,14 +272,15 @@ pub fn load_model(
         None
     };
 
-    // Warn if --turbo-quant was requested but this architecture doesn't support it.
+    // TurboQuant is on by default; warn if this architecture doesn't support it.
     if turbo_quant_bits.is_some() {
         match arch {
             ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4 => {} // supported
             other => {
                 tracing::warn!(
                     "--turbo-quant is not supported for {:?} and will be ignored. \
-                     TurboQuant KV cache compression is currently only available for Qwen3 and Gemma4.",
+                     TurboQuant KV cache compression is currently only available for Qwen3 and Gemma4. \
+                     Pass --turbo-quant=false to suppress this warning.",
                     other
                 );
             }

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -69,13 +69,13 @@ pub struct RunArgs {
     #[arg(long)]
     pub paged_attention: Option<f64>,
 
-    /// Enable TurboQuant KV cache compression (Qwen3 only).
-    /// Use as a flag (`--turbo-quant`) for the default 8-bit compression, or with an explicit
-    /// bit-width (`--turbo-quant=N`) for 1–8 bits.  Indices are nibble-packed for bits ≤ 4.
-    /// 8-bit (the default) gives ~2× compression vs bf16 with near-lossless quality.
+    /// TurboQuant KV cache compression bit-width (Qwen3/Gemma4).
+    /// Enabled by default at 8 bits (~2× KV memory reduction, near-lossless quality).
+    /// Pass an explicit bit-width (`--turbo-quant=N`, 1–8) to change the compression level.
     /// 4-bit gives ~3.5× but may produce poor output on models with large QK-norm values.
-    #[arg(long, num_args(0..=1), default_missing_value("8"), require_equals(true))]
-    pub turbo_quant: Option<u8>,
+    /// Disable entirely with `--turbo-quant=false`.
+    #[arg(long, default_value = "8", require_equals(true))]
+    pub turbo_quant: crate::TurboQuantArg,
 
     /// Quantize model weights and cache the result on disk as a GGUF file.
     /// On first use the weights are quantized and saved next to the HuggingFace cache;
@@ -111,7 +111,7 @@ impl RunArgs {
             top_k: self.top_k,
             max_tokens: self.max_tokens,
             paged_attention: self.paged_attention,
-            turbo_quant: self.turbo_quant,
+            turbo_quant: self.turbo_quant.clone(),
             quantize: self.quantize.clone(),
         }
     }
@@ -174,7 +174,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         model_files.gguf_path.as_deref(),
         dtype,
         &device,
-        args.turbo_quant,
+        args.turbo_quant.0,
     )?;
 
     // Engine tokenizer (separate instance — engine runs on its own thread)

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -234,7 +234,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         model_files.gguf_path.as_deref(),
         dtype,
         &device,
-        args.turbo_quant,
+        args.turbo_quant.0,
     )?;
 
     // Effective sequence-length cap for this model.

--- a/inferrs/tests/server_integration.rs
+++ b/inferrs/tests/server_integration.rs
@@ -87,11 +87,11 @@ fn looks_intelligible(text: &str) -> bool {
     text.chars().any(|c| c.is_ascii_alphabetic())
 }
 
-/// Starts `inferrs serve <model_id>` with TurboQuant KV-cache compression enabled.
+/// Starts `inferrs serve <model_id>` with an explicit TurboQuant bit-width.
 ///
-/// Passes `--turbo-quant=<bits>` to enable the TurboQuant quantized KV cache
-/// instead of the default full-precision cache.  Uses `require_equals` syntax
-/// as defined in the CLI (`--turbo-quant=4` for 4-bit).
+/// TurboQuant is on by default (8-bit); this helper overrides the bit-width via
+/// `--turbo-quant=<bits>`.  Uses `require_equals` syntax as defined in the CLI
+/// (`--turbo-quant=4` for 4-bit).
 fn spawn_server_turbo(model_id: &str, port: u16, bits: u8) -> Child {
     let bin = env!("CARGO_BIN_EXE_inferrs");
     let turbo_flag = format!("--turbo-quant={}", bits);


### PR DESCRIPTION
TurboQuant KV cache compression is now enabled by default (8-bit) for all serve/run/bench commands. Users must explicitly opt out by passing --turbo-quant=false. A new TurboQuantArg newtype handles parsing of both numeric bit-widths and the 'false' opt-out string.