### PR TITLE
de-duplicate format_bytes, quant_dtype parsing

### DIFF
--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -12,10 +12,10 @@
 
 use anyhow::Result;
 
-use crate::config::RawConfig;
-use crate::engine::{attach_paged_kv_if_requested, Engine};
+use crate::engine::load_engine;
 use crate::sampler::SamplingParams;
 use crate::tokenizer::Tokenizer;
+use crate::util::format_bytes;
 use crate::ServeArgs;
 
 /// Extra options that only apply to the bench subcommand.
@@ -40,58 +40,18 @@ pub struct BenchArgs {
 
 pub fn run(args: BenchArgs) -> Result<()> {
     let serve = &args.serve;
-    let device = serve.resolve_device()?;
-    let dtype = serve.resolve_dtype()?;
 
-    // Parse --quantize format string if provided.
-    let quant_dtype = serve
-        .quantize
-        .as_deref()
-        .map(crate::quantize::parse_format)
-        .transpose()?;
+    // Load model, build engine, attach paged KV.
+    let ctx = load_engine(serve)?;
+    let mut engine = ctx.engine;
+    let raw_config = ctx.raw_config;
+    let arch = ctx.arch;
+    let dtype = ctx.dtype;
 
-    // Download / load model (same path as `serve`, quantize if requested).
-    let model_files =
-        crate::hub::download_and_maybe_quantize(&serve.model, &serve.revision, quant_dtype)?;
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
+    // Bench only needs a plain tokenizer (no chat template) for the BOS id.
     let tokenizer = Tokenizer::from_file(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-    )?;
-
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
-        model_files.gguf_path.as_deref(),
-        dtype,
-        &device,
-        serve.turbo_quant.0,
-    )?;
-
-    let mut engine = Engine::new(
-        model,
-        Tokenizer::from_file(
-            &model_files.tokenizer_path,
-            model_files.tokenizer_config_path.as_deref(),
-        )?,
-        device.clone(),
-        serve.max_batch_size,
-        serve.max_tokens_per_step,
-    );
-
-    // Wire up paged attention if requested (same logic as `serve`)
-    engine = attach_paged_kv_if_requested(
-        engine,
-        serve.paged_attention,
-        serve.block_size,
-        dtype,
-        &device,
-        &raw_config,
-        &arch,
+        &ctx.model_files.tokenizer_path,
+        ctx.model_files.tokenizer_config_path.as_deref(),
     )?;
 
     // Build a synthetic prompt of the requested length.
@@ -102,7 +62,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
     // Clamp max_tokens to the model's effective KV-cache capacity so that
     // models with a sliding-window limit (e.g. Gemma3 at 512 tokens) don't
     // crash mid-generation with an opaque tensor error.
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    let max_seq_len = ctx.max_seq_len;
     let max_tokens = {
         let available = if max_seq_len == usize::MAX {
             serve.max_tokens
@@ -242,7 +202,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
             max_seq_len
         };
         let total_bytes = bytes_per_token * effective_seq_len;
-        format_bytes(total_bytes)
+        format_bytes(total_bytes as u64)
     };
 
     println!();
@@ -262,18 +222,6 @@ pub fn run(args: BenchArgs) -> Result<()> {
     println!("  End-to-end p90          : {p90:.1} ms");
 
     Ok(())
-}
-
-fn format_bytes(bytes: usize) -> String {
-    if bytes >= 1024 * 1024 * 1024 {
-        format!("{:.2} GiB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    } else if bytes >= 1024 * 1024 {
-        format!("{:.1} MiB", bytes as f64 / (1024.0 * 1024.0))
-    } else if bytes >= 1024 {
-        format!("{:.1} KiB", bytes as f64 / 1024.0)
-    } else {
-        format!("{} B", bytes)
-    }
 }
 
 fn percentile(sorted: &[f64], p: f64) -> f64 {

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -5,10 +5,95 @@ use candle_core::{DType, Device, Tensor};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::config::{ModelArchitecture, RawConfig};
+use crate::hub::ModelFiles;
 use crate::kv_cache::{BlockPool, BlockTable, PagedCacheConfig, PagedKvStore};
 use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
+use crate::ServeArgs;
+
+// ---------------------------------------------------------------------------
+// Shared model-loading entry point
+// ---------------------------------------------------------------------------
+
+/// Everything produced by [`load_engine`] that callers may still need after
+/// the engine is constructed.
+pub struct EngineContext {
+    pub engine: Engine,
+    pub raw_config: RawConfig,
+    pub arch: ModelArchitecture,
+    pub model_files: ModelFiles,
+    pub dtype: DType,
+    pub max_seq_len: usize,
+}
+
+/// Build an [`Engine`] from [`ServeArgs`], handling the repeated sequence:
+/// parse quantize → download → load config → detect arch → load model →
+/// build engine tokenizer → construct Engine → attach paged KV.
+///
+/// The caller is responsible for building any *additional* tokenizer instances
+/// (e.g. the one used by the HTTP server / REPL) from the returned
+/// [`EngineContext::model_files`] and [`EngineContext::arch`].
+pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
+    let device = args.resolve_device()?;
+    let dtype = args.resolve_dtype()?;
+    let quant_dtype = args.resolve_quant_dtype()?;
+
+    let model_files =
+        crate::hub::download_and_maybe_quantize(&args.model, &args.revision, quant_dtype)?;
+
+    let raw_config = RawConfig::from_file(&model_files.config_path)?;
+    let arch = raw_config.detect_architecture()?;
+    tracing::info!("Detected architecture: {:?}", arch);
+
+    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    if max_seq_len < usize::MAX {
+        tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
+    }
+
+    let model = crate::models::load_model(
+        &raw_config,
+        &arch,
+        &model_files.weight_paths,
+        model_files.gguf_path.as_deref(),
+        dtype,
+        &device,
+        args.turbo_quant.0,
+    )?;
+
+    let engine_tokenizer = Tokenizer::from_file_with_arch(
+        &model_files.tokenizer_path,
+        model_files.tokenizer_config_path.as_deref(),
+        Some(&arch),
+    )?;
+
+    let mut engine = Engine::new(
+        model,
+        engine_tokenizer,
+        device.clone(),
+        args.max_batch_size,
+        args.max_tokens_per_step,
+    );
+
+    engine = attach_paged_kv_if_requested(
+        engine,
+        args.paged_attention,
+        args.block_size,
+        dtype,
+        &device,
+        &raw_config,
+        &arch,
+    )?;
+
+    Ok(EngineContext {
+        engine,
+        raw_config,
+        arch,
+        model_files,
+        dtype,
+        max_seq_len,
+    })
+}
 
 /// Abstraction over the two streaming channel flavours:
 /// - `tokio::sync::mpsc::Sender` (used by the HTTP server)

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -12,6 +12,7 @@ mod sampler;
 mod server;
 mod tokenizer;
 mod turbo_quant;
+mod util;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -241,6 +242,14 @@ impl ServeArgs {
             "bf16" => Ok(candle_core::DType::BF16),
             other => anyhow::bail!("Unknown dtype: {other}"),
         }
+    }
+
+    /// Parse the `--quantize` format string (if provided) into a `GgmlDType`.
+    pub fn resolve_quant_dtype(&self) -> Result<Option<candle_core::quantized::GgmlDType>> {
+        self.quantize
+            .as_deref()
+            .map(crate::quantize::parse_format)
+            .transpose()
     }
 }
 

--- a/inferrs/src/rm.rs
+++ b/inferrs/src/rm.rs
@@ -5,6 +5,8 @@ use clap::Parser;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use crate::util::format_bytes;
+
 #[derive(Parser, Clone)]
 pub struct RmArgs {
     /// HuggingFace model ID(s) to remove (e.g. google/gemma-3-1b-it)
@@ -34,7 +36,7 @@ pub fn run(args: RmArgs) -> Result<()> {
         let size = dir_size(&model_path).unwrap_or(0);
 
         if !args.force {
-            eprint!("Remove {} ({})? [y/N] ", model_id, human_size(size));
+            eprint!("Remove {} ({})? [y/N] ", model_id, format_bytes(size));
             std::io::stderr().flush()?;
             let mut input = String::new();
             std::io::stdin().read_line(&mut input)?;
@@ -45,7 +47,7 @@ pub fn run(args: RmArgs) -> Result<()> {
         }
 
         std::fs::remove_dir_all(&model_path)?;
-        println!("Removed {model_id} (freed {})", human_size(size));
+        println!("Removed {model_id} (freed {})", format_bytes(size));
     }
 
     Ok(())
@@ -87,19 +89,4 @@ fn dir_size(path: &Path) -> Result<u64> {
         }
     }
     Ok(total)
-}
-
-fn human_size(bytes: u64) -> String {
-    const GIB: u64 = 1 << 30;
-    const MIB: u64 = 1 << 20;
-    const KIB: u64 = 1 << 10;
-    if bytes >= GIB {
-        format!("{:.1} GiB", bytes as f64 / GIB as f64)
-    } else if bytes >= MIB {
-        format!("{:.1} MiB", bytes as f64 / MIB as f64)
-    } else if bytes >= KIB {
-        format!("{:.1} KiB", bytes as f64 / KIB as f64)
-    } else {
-        format!("{bytes} B")
-    }
 }

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -13,9 +13,7 @@ use crossterm::{
 use std::io::{self, Write};
 use std::sync::mpsc as stdmpsc;
 
-use crate::config::RawConfig;
-use crate::engine::{attach_paged_kv_if_requested, Engine, StreamToken, SyncEngineRequest};
-use crate::hub;
+use crate::engine::{load_engine, StreamToken, SyncEngineRequest};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
@@ -139,73 +137,22 @@ pub fn run(args: RunArgs) -> Result<()> {
 /// This runs on a plain OS thread, never inside the Tokio executor.
 fn run_blocking(args: RunArgs) -> Result<()> {
     let serve = args.to_serve_args();
-    let device = serve.resolve_device()?;
-    let dtype = serve.resolve_dtype()?;
 
-    // Parse --quantize format string if provided.
-    let quant_dtype = args
-        .quantize
-        .as_deref()
-        .map(crate::quantize::parse_format)
-        .transpose()?;
+    // Load model, build engine, attach paged KV.
+    let ctx = load_engine(&serve)?;
 
-    // Download / locate model files from HuggingFace Hub (and quantize if requested).
-    let model_files = hub::download_and_maybe_quantize(&args.model, &args.revision, quant_dtype)?;
-
-    // Load config and detect architecture
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
-
-    // Load tokenizer (used by the REPL to build prompts)
+    // REPL needs its own tokenizer for chat-template encoding.
     let tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
+        &ctx.model_files.tokenizer_path,
+        ctx.model_files.tokenizer_config_path.as_deref(),
+        Some(&ctx.arch),
     )?;
 
-    // Load model weights
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
-        model_files.gguf_path.as_deref(),
-        dtype,
-        &device,
-        args.turbo_quant.0,
-    )?;
-
-    // Engine tokenizer (separate instance — engine runs on its own thread)
-    let engine_tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
-    )?;
-
-    // Spawn engine on a dedicated OS thread.
-    // Use std::sync::mpsc (not tokio) so that sends/recvs are plain blocking
-    // calls with no Tokio runtime requirement.
+    // Spawn engine on a dedicated OS thread using stdlib channels (no Tokio).
     let (engine_tx, engine_rx) = stdmpsc::sync_channel::<SyncEngineRequest>(4);
-    let mut engine = Engine::new(model, engine_tokenizer, device.clone(), 1, 2048);
-
-    // Wire up paged attention if requested (same logic as `serve` and `bench`).
-    engine = attach_paged_kv_if_requested(
-        engine,
-        serve.paged_attention,
-        serve.block_size,
-        dtype,
-        &device,
-        &raw_config,
-        &arch,
-    )?;
-
-    let engine = engine;
-
     std::thread::Builder::new()
         .name("engine".to_string())
-        .spawn(move || engine.run_sync(engine_rx))
+        .spawn(move || ctx.engine.run_sync(engine_rx))
         .expect("Failed to spawn engine thread");
 
     let sampling_params = SamplingParams {
@@ -214,7 +161,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         top_k: args.top_k,
         max_tokens: args
             .max_tokens
-            .min(max_seq_len.saturating_sub(4096).max(256)),
+            .min(ctx.max_seq_len.saturating_sub(4096).max(256)),
         ..SamplingParams::default()
     };
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -18,8 +18,7 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::CorsLayer;
 
-use crate::config::RawConfig;
-use crate::engine::{attach_paged_kv_if_requested, EngineRequest, GenerationResult, StreamToken};
+use crate::engine::{load_engine, EngineRequest, GenerationResult, StreamToken};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Tokenizer};
 use crate::ServeArgs;
@@ -199,49 +198,15 @@ struct AppState {
 // ─── Server startup ─────────────────────────────────────────────────────────
 
 pub async fn run(args: ServeArgs) -> Result<()> {
-    let device = args.resolve_device()?;
-    let dtype = args.resolve_dtype()?;
+    // Load model, build engine, attach paged KV.
+    let ctx = load_engine(&args)?;
 
-    // Parse --quantize format string if provided.
-    let quant_dtype = args
-        .quantize
-        .as_deref()
-        .map(crate::quantize::parse_format)
-        .transpose()?;
-
-    // Download model (and quantize/cache as GGUF if requested).
-    let model_files =
-        crate::hub::download_and_maybe_quantize(&args.model, &args.revision, quant_dtype)?;
-
-    // Load config
-    let raw_config = RawConfig::from_file(&model_files.config_path)?;
-    let arch = raw_config.detect_architecture()?;
-    tracing::info!("Detected architecture: {:?}", arch);
-
-    // Load tokenizer
-    let tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
-    )?;
-    let tokenizer = Arc::new(tokenizer);
-
-    // Load model
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
-        model_files.gguf_path.as_deref(),
-        dtype,
-        &device,
-        args.turbo_quant.0,
-    )?;
-
-    // Effective sequence-length cap for this model.
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
-    if max_seq_len < usize::MAX {
-        tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
-    }
+    // The server needs its own tokenizer for chat-template encoding.
+    let tokenizer = Arc::new(Tokenizer::from_file_with_arch(
+        &ctx.model_files.tokenizer_path,
+        ctx.model_files.tokenizer_config_path.as_deref(),
+        Some(&ctx.arch),
+    )?);
 
     // Default sampling params from CLI args
     let default_params = SamplingParams {
@@ -252,36 +217,11 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         ..SamplingParams::default()
     };
 
-    // Create engine channel
+    // Create engine channel and spawn engine on a dedicated thread.
     let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
-
-    // Spawn engine on a dedicated thread
-    let mut engine = crate::engine::Engine::new(
-        model,
-        // The engine needs its own tokenizer for decoding
-        Tokenizer::from_file_with_arch(
-            &model_files.tokenizer_path,
-            model_files.tokenizer_config_path.as_deref(),
-            Some(&arch),
-        )?,
-        device.clone(),
-        args.max_batch_size,
-        args.max_tokens_per_step,
-    );
-
-    engine = attach_paged_kv_if_requested(
-        engine,
-        args.paged_attention,
-        args.block_size,
-        dtype,
-        &device,
-        &raw_config,
-        &arch,
-    )?;
-
     std::thread::Builder::new()
         .name("engine".to_string())
-        .spawn(move || engine.run(engine_rx))
+        .spawn(move || ctx.engine.run(engine_rx))
         .expect("Failed to spawn engine thread");
 
     // Build app state
@@ -290,7 +230,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         engine_tx,
         tokenizer,
         default_params,
-        max_seq_len,
+        max_seq_len: ctx.max_seq_len,
     });
 
     // Build router

--- a/inferrs/src/util.rs
+++ b/inferrs/src/util.rs
@@ -1,0 +1,17 @@
+//! Shared utility helpers.
+
+/// Format a byte count as a human-readable string (GiB / MiB / KiB / B).
+pub fn format_bytes(bytes: u64) -> String {
+    const GIB: u64 = 1 << 30;
+    const MIB: u64 = 1 << 20;
+    const KIB: u64 = 1 << 10;
+    if bytes >= GIB {
+        format!("{:.2} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}


### PR DESCRIPTION
- Add util::format_bytes(u64) shared helper; remove private format_bytes from bench.rs and human_size from rm.rs
- Add ServeArgs::resolve_quant_dtype() method; replace the identical 5-line quantize-parse block in server.rs, run.rs, and bench.rs with a single call
- Add engine::load_engine() / EngineContext; replace ~40-50 lines of repeated download → config → model → Engine → paged-KV boilerplate in all three command handlers with a single load_engine(&args) call