### PR TITLE
ci: handle idempotent winget API calls to fix exit code 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,13 +454,15 @@ jobs:
             "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/ref/heads/master" \
             | jq -r '.object.sha')
 
-          # 422 means branch already exists; that is fine
-          curl -sf -X POST \
+          # 201 = created, 422 = branch already exists — both are acceptable
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg ref "refs/heads/${BRANCH}" --arg sha "$FORK_SHA" \
                  '{ref: $ref, sha: $sha}')" \
-            "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/refs" || true
+            "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/refs")
+          [[ "$HTTP_STATUS" == "201" || "$HTTP_STATUS" == "422" ]] || \
+            { echo "Branch creation failed with HTTP ${HTTP_STATUS}"; exit 1; }
 
           # ── push manifest files to the fork branch ────────────────────────
           for FILE in \
@@ -492,8 +494,8 @@ jobs:
           done
 
           # ── open PR from fork branch → microsoft/winget-pkgs ─────────────
-          # 422 means a PR already exists for this branch; that is fine
-          curl -sf -X POST \
+          # 201 = created, 422 = PR already exists — both are acceptable
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "$(jq -n \
@@ -502,4 +504,6 @@ jobs:
               --arg head "${PUBLISHER}:${BRANCH}" \
               --arg base "master" \
               '{title: $title, body: $body, head: $head, base: $base}')" \
-            "https://api.github.com/repos/microsoft/winget-pkgs/pulls" || true
+            "https://api.github.com/repos/microsoft/winget-pkgs/pulls")
+          [[ "$HTTP_STATUS" == "201" || "$HTTP_STATUS" == "422" ]] || \
+            { echo "PR creation failed with HTTP ${HTTP_STATUS}"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,12 +454,13 @@ jobs:
             "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/ref/heads/master" \
             | jq -r '.object.sha')
 
+          # 422 means branch already exists; that is fine
           curl -sf -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "$(jq -n --arg ref "refs/heads/${BRANCH}" --arg sha "$FORK_SHA" \
                  '{ref: $ref, sha: $sha}')" \
-            "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/refs"
+            "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/git/refs" || true
 
           # ── push manifest files to the fork branch ────────────────────────
           for FILE in \
@@ -469,11 +470,19 @@ jobs:
 
             CONTENT=$(base64 -w0 "manifests/${FILE}")
 
+            # Fetch existing file SHA in case the file already exists on the branch
+            FILE_SHA=$(curl -sf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              "https://api.github.com/repos/${PUBLISHER}/winget-pkgs/contents/${DEST_DIR}/${FILE}?ref=${BRANCH}" \
+              | jq -r '.sha // empty' || true)
+
             PAYLOAD=$(jq -n \
               --arg message "Add inferrs ${VERSION}" \
               --arg content "$CONTENT" \
               --arg branch "$BRANCH" \
-              '{message: $message, content: $content, branch: $branch}')
+              --arg sha "$FILE_SHA" \
+              'if $sha != "" then {message: $message, content: $content, branch: $branch, sha: $sha}
+               else {message: $message, content: $content, branch: $branch} end')
 
             curl -sf -X PUT \
               -H "Authorization: Bearer ${GH_TOKEN}" \
@@ -483,6 +492,7 @@ jobs:
           done
 
           # ── open PR from fork branch → microsoft/winget-pkgs ─────────────
+          # 422 means a PR already exists for this branch; that is fine
           curl -sf -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Content-Type: application/json" \
@@ -492,4 +502,4 @@ jobs:
               --arg head "${PUBLISHER}:${BRANCH}" \
               --arg base "master" \
               '{title: $title, body: $body, head: $head, base: $base}')" \
-            "https://api.github.com/repos/microsoft/winget-pkgs/pulls"
+            "https://api.github.com/repos/microsoft/winget-pkgs/pulls" || true


### PR DESCRIPTION
Branch creation and PR creation now use || true to tolerate 422 responses when the branch or PR already exists. File uploads now fetch the existing file SHA first so updates don't fail with 422.