### PR TITLE
refactor: de-duplicate repeated constants, helpers, and logic

### DIFF
--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -15,6 +15,7 @@ use anyhow::Result;
 use crate::engine::load_engine;
 use crate::sampler::SamplingParams;
 use crate::tokenizer::Tokenizer;
+use crate::turbo_quant::GROUP_SIZE;
 use crate::util::format_bytes;
 use crate::ServeArgs;
 
@@ -176,7 +177,6 @@ pub fn run(args: BenchArgs) -> Result<()> {
     // ── KV cache memory estimate ─────────────────────────────────────────────
     let kv_mem_str = {
         let (num_kv_heads, head_dim, num_layers) = raw_config.kv_cache_params(&arch);
-        const GROUP_SIZE: usize = 32;
         // bytes consumed per token across all layers (K + V combined)
         let bytes_per_token: usize = if let Some(bits) = serve.turbo_quant.0 {
             // TurboQuant: nibble-packed indices + f32 per-group absmax scales

--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -107,6 +107,9 @@ pub struct RawConfig {
     pub text_config: Option<TextConfig>,
 }
 
+/// Default epsilon for RMS normalization layers across all model families.
+const RMS_NORM_EPS_DEFAULT: f64 = 1e-6;
+
 impl RawConfig {
     pub fn from_file(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path).context("Failed to read config.json")?;
@@ -171,7 +174,7 @@ impl RawConfig {
             max_window_layers: self.max_window_layers.unwrap_or(28),
             tie_word_embeddings: self.tie_word_embeddings.unwrap_or(true),
             rope_theta: self.rope_theta.unwrap_or(1000000.0),
-            rms_norm_eps: self.rms_norm_eps.unwrap_or(1e-6),
+            rms_norm_eps: self.rms_norm_eps.unwrap_or(RMS_NORM_EPS_DEFAULT),
             use_sliding_window: self.use_sliding_window.unwrap_or(false),
             hidden_act: candle_nn::Activation::Silu,
         }
@@ -193,7 +196,7 @@ impl RawConfig {
                     .as_deref()
                     .unwrap_or("gelu_pytorch_tanh"),
             ),
-            rms_norm_eps: self.rms_norm_eps.unwrap_or(1e-6),
+            rms_norm_eps: self.rms_norm_eps.unwrap_or(RMS_NORM_EPS_DEFAULT),
             rope_theta: self.rope_theta.unwrap_or(10000.0),
             attention_bias: self.attention_bias.unwrap_or(false),
             final_logit_softcapping: self.final_logit_softcapping,
@@ -220,7 +223,7 @@ impl RawConfig {
                     .as_deref()
                     .unwrap_or("gelu_pytorch_tanh"),
             ),
-            rms_norm_eps: self.rms_norm_eps.unwrap_or(1e-6),
+            rms_norm_eps: self.rms_norm_eps.unwrap_or(RMS_NORM_EPS_DEFAULT),
             rope_theta: self.rope_theta.unwrap_or(10000.0),
             attention_bias: self.attention_bias.unwrap_or(false),
             final_logit_softcapping: self.final_logit_softcapping,
@@ -251,7 +254,7 @@ impl RawConfig {
         let num_attention_heads = self.num_attention_heads.unwrap_or(16);
         let num_key_value_heads = self.num_key_value_heads.unwrap_or(8);
         let head_dim = self.head_dim.unwrap_or(hidden_size / num_attention_heads);
-        let rms_norm_eps = self.rms_norm_eps.unwrap_or(1e-6);
+        let rms_norm_eps = self.rms_norm_eps.unwrap_or(RMS_NORM_EPS_DEFAULT);
         let tie_word_embeddings = self.tie_word_embeddings.unwrap_or(true);
         let rope_theta = self.rope_theta.unwrap_or(1_000_000.0);
 
@@ -297,7 +300,9 @@ impl RawConfig {
         let hidden_size_per_layer_input = tc
             .and_then(|t| t.hidden_size_per_layer_input)
             .unwrap_or(256);
-        let rms_norm_eps = tc.and_then(|t| t.rms_norm_eps).unwrap_or(1e-6);
+        let rms_norm_eps = tc
+            .and_then(|t| t.rms_norm_eps)
+            .unwrap_or(RMS_NORM_EPS_DEFAULT);
         let sliding_window = tc.and_then(|t| t.sliding_window).unwrap_or(512);
         let sliding_window_pattern = tc.and_then(|t| t.sliding_window_pattern).unwrap_or(5);
         let max_position_embeddings = tc.and_then(|t| t.max_position_embeddings).unwrap_or(131072);
@@ -393,7 +398,9 @@ impl RawConfig {
         let num_attention_heads = tc.and_then(|t| t.num_attention_heads).unwrap_or(8);
         let num_key_value_heads = tc.and_then(|t| t.num_key_value_heads).unwrap_or(2);
         let head_dim = tc.and_then(|t| t.head_dim).unwrap_or(256);
-        let rms_norm_eps = tc.and_then(|t| t.rms_norm_eps).unwrap_or(1e-6);
+        let rms_norm_eps = tc
+            .and_then(|t| t.rms_norm_eps)
+            .unwrap_or(RMS_NORM_EPS_DEFAULT);
         let tie_word_embeddings = tc.and_then(|t| t.tie_word_embeddings).unwrap_or(true);
         let full_attention_interval = tc.and_then(|t| t.full_attention_interval).unwrap_or(4);
         let linear_conv_kernel_dim = tc.and_then(|t| t.linear_conv_kernel_dim).unwrap_or(4);

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -465,46 +465,17 @@ impl Engine {
             sampling_params.max_tokens
         );
 
-        let mut output_tokens: Vec<u32> = Vec::new();
-        let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
-
-        let logits = self.run_prefill(prompt_tokens)?;
-
-        let mut token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
-        output_tokens.push(token_id);
-        all_tokens.push(token_id);
-
-        let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
-
-        while finish_reason.is_none() {
-            let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
-            let logits = self.run_decode_step(token_id, seqlen_offset)?;
-
-            token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
-            output_tokens.push(token_id);
-            all_tokens.push(token_id);
-            finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
-        }
-
-        self.free_paged_blocks();
-
-        let finish_reason = finish_reason.unwrap_or_else(|| "length".to_string());
-        let output_text = self.tokenizer.decode(&output_tokens, true)?;
+        let (result, _prefill_ms, _decode_ms) =
+            self.bench_generate(request_id, prompt_tokens, sampling_params)?;
 
         tracing::debug!(
             "Request {} finished: {} output tokens, reason: {}",
             request_id,
-            output_tokens.len(),
-            finish_reason
+            result.completion_tokens,
+            result.finish_reason
         );
 
-        Ok(GenerationResult {
-            prompt_tokens: prompt_tokens.len(),
-            completion_tokens: output_tokens.len(),
-            output_token_ids: output_tokens,
-            output_text,
-            finish_reason,
-        })
+        Ok(result)
     }
 
     // ── Streaming generation ──────────────────────────────────────────────────

--- a/inferrs/src/models/attention_utils.rs
+++ b/inferrs/src/models/attention_utils.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::{linear_no_bias, ops, Linear, RmsNorm, VarBuilder};
+use candle_nn::{linear_no_bias, ops, rotary_emb, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 
@@ -106,6 +106,61 @@ impl Mlp {
         let hidden = (gate * up)?;
         self.down_proj.forward(&hidden).map_err(Into::into)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Shared RoPE application
+// ---------------------------------------------------------------------------
+
+/// Apply rotary embedding to a query or key tensor.
+///
+/// `x`       : `[batch, n_heads, seq_len, head_dim]`
+/// `cos`/`sin`: `[max_seq_len, rot_half]` — `rot_half = rot_dim / 2`
+///
+/// Both this implementation and candle's `rotary_emb::rope` use the **split**
+/// layout: the first half of the head dim is `x1`, the second half is `x2`,
+/// and the rotation is `[x1*cos - x2*sin, x1*sin + x2*cos]`.  This is
+/// identical to candle's `rotate_half` convention.
+///
+/// When `rot_dim == head_dim` (full rotation, e.g. Qwen3) the fast fused
+/// kernel (`rotary_emb::rope`) is used.  When `rot_dim < head_dim` (partial
+/// rotation, e.g. Qwen3.5) the manual path handles the pass-through suffix.
+pub fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let (_b, _h, t, d) = x.dims4()?;
+    let rot_half = cos.dim(1)?;
+    let rot_dim = rot_half * 2;
+
+    if rot_dim > d {
+        anyhow::bail!("rot_dim {rot_dim} > head_dim {d}");
+    }
+
+    // Fast path: full rotation — delegate to the fused candle kernel.
+    if rot_dim == d {
+        let cos = cos.narrow(0, 0, t)?.contiguous()?;
+        let sin = sin.narrow(0, 0, t)?.contiguous()?;
+        return rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Into::into);
+    }
+
+    // Partial rotation: split x into the rotated prefix and the pass-through suffix.
+    let x_rot = x.narrow(3, 0, rot_dim)?;
+    let x_pass = x.narrow(3, rot_dim, d - rot_dim)?;
+
+    let x1 = x_rot.narrow(3, 0, rot_half)?;
+    let x2 = x_rot.narrow(3, rot_half, rot_half)?;
+
+    // cos/sin broadcast: [1, 1, t, rot_half]
+    let cos = cos.narrow(0, 0, t)?.unsqueeze(0)?.unsqueeze(0)?;
+    let sin = sin.narrow(0, 0, t)?.unsqueeze(0)?.unsqueeze(0)?;
+
+    let rotated = Tensor::cat(
+        &[
+            (x1.broadcast_mul(&cos)? - x2.broadcast_mul(&sin)?)?,
+            (x1.broadcast_mul(&sin)? + x2.broadcast_mul(&cos)?)?,
+        ],
+        3,
+    )?;
+
+    Ok(Tensor::cat(&[rotated, x_pass], 3)?)
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -25,7 +25,7 @@ use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::{rms_norm, Activation, RmsNorm, VarBuilder};
 use std::sync::Arc;
 
-use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
+use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache, MIN_KV_BUFFER_CAP};
 
 // ---------------------------------------------------------------------------
 // QLinear: a Linear layer backed by either a standard Tensor or a QMatMul.
@@ -740,7 +740,10 @@ impl RetainingKvCache {
         // Starting from 0, the first allocation sizes to max(needed, 256) so a
         // single short conversation never allocates more than 256 tokens' worth.
         if needed > self.buf_cap {
-            let new_cap = needed.next_power_of_two().max(256).min(self.max_seq_len);
+            let new_cap = needed
+                .next_power_of_two()
+                .max(MIN_KV_BUFFER_CAP)
+                .min(self.max_seq_len);
 
             let mut k_shape = k.dims().to_vec();
             k_shape[2] = new_cap;

--- a/inferrs/src/models/qwen3.rs
+++ b/inferrs/src/models/qwen3.rs
@@ -11,14 +11,12 @@
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::{
-    embedding, linear_no_bias, rms_norm, rotary_emb, Embedding, Linear, RmsNorm, VarBuilder,
-};
+use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_rms_norm_heads, causal_mask, compute_logits, concat_kv_cache, paged_write_gather_sdpa,
-    precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
+    apply_rms_norm_heads, apply_rope, causal_mask, compute_logits, concat_kv_cache,
+    paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
 };
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
 
@@ -44,20 +42,6 @@ pub struct Qwen3Config {
     pub device: Device,
     /// When `Some(bits)`, KV cache vectors are quantized using TurboQuant at the given bit-width.
     pub turbo_quant_bits: Option<u8>,
-}
-
-// ---------------------------------------------------------------------------
-// RoPE utilities
-// ---------------------------------------------------------------------------
-
-/// Apply full rotary embedding to query/key tensors using candle's built-in kernel.
-/// x: [batch, n_heads, seq_len, head_dim]
-/// cos/sin: [seq_len, head_dim/2]
-fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
-    let (_b, _h, seq_len, _d) = x.dims4()?;
-    let cos = cos.narrow(0, 0, seq_len)?.contiguous()?;
-    let sin = sin.narrow(0, 0, seq_len)?.contiguous()?;
-    rotary_emb::rope(&x.contiguous()?, &cos, &sin).map_err(Into::into)
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -13,8 +13,8 @@ use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm,
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_output_gate, apply_rms_norm_heads, causal_mask, compute_logits, concat_kv_cache,
-    paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
+    apply_output_gate, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
+    concat_kv_cache, paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
 };
 
 // ---------------------------------------------------------------------------
@@ -51,53 +51,6 @@ pub struct Qwen35Config {
     pub tie_word_embeddings: bool,
     pub dtype: DType,
     pub device: Device,
-}
-
-// ---------------------------------------------------------------------------
-// RoPE utilities
-// ---------------------------------------------------------------------------
-
-/// Apply rotary embedding to query/key tensors.
-/// x: [batch, n_heads, seq_len, head_dim]
-/// cos/sin: [seq_len, rot_half]  (half of rot_dim)
-fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
-    let (_b, _h, t, d) = x.dims4()?;
-    let rot_half = cos.dim(1)?;
-    let rot_dim = rot_half * 2;
-
-    if rot_dim > d {
-        anyhow::bail!("rot_dim {rot_dim} > head_dim {d}");
-    }
-
-    // Split x into rotated and pass-through parts
-    let x_rot = x.narrow(3, 0, rot_dim)?;
-    let x_pass = if rot_dim < d {
-        Some(x.narrow(3, rot_dim, d - rot_dim)?)
-    } else {
-        None
-    };
-
-    // x_rot: [b, h, t, rot_dim] -> split into two halves along last dim
-    let x1 = x_rot.narrow(3, 0, rot_half)?;
-    let x2 = x_rot.narrow(3, rot_half, rot_half)?;
-
-    // cos/sin broadcast: [1, 1, t, rot_half]
-    let cos = cos.narrow(0, 0, t)?.unsqueeze(0)?.unsqueeze(0)?;
-    let sin = sin.narrow(0, 0, t)?.unsqueeze(0)?.unsqueeze(0)?;
-
-    // rotate_half: (x1, x2) -> (-x2, x1)
-    let rotated = Tensor::cat(
-        &[
-            (x1.broadcast_mul(&cos)? - x2.broadcast_mul(&sin)?)?,
-            (x1.broadcast_mul(&sin)? + x2.broadcast_mul(&cos)?)?,
-        ],
-        3,
-    )?;
-
-    match x_pass {
-        Some(pass) => Ok(Tensor::cat(&[rotated, pass], 3)?),
-        None => Ok(rotated),
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -130,6 +130,16 @@ pub struct ErrorDetail {
     pub r#type: String,
 }
 
+// ─── Time helpers ───────────────────────────────────────────────────────────
+
+/// Return the current Unix timestamp in seconds.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 // ─── Error helpers ──────────────────────────────────────────────────────────
 
 fn server_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
@@ -258,10 +268,7 @@ async fn chat_completions(
     Json(req): Json<ChatCompletionRequest>,
 ) -> impl IntoResponse {
     let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
-    let created = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let created = unix_now();
     let model_id = req.model.clone().unwrap_or_else(|| state.model_id.clone());
 
     // Apply chat template and tokenize
@@ -288,15 +295,14 @@ async fn chat_completions(
         .or(req.max_tokens)
         .unwrap_or(state.default_params.max_tokens);
     let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
-    let params = SamplingParams {
-        temperature: req.temperature.unwrap_or(state.default_params.temperature),
-        top_p: req.top_p.unwrap_or(state.default_params.top_p),
-        top_k: req.top_k.unwrap_or(state.default_params.top_k),
-        repetition_penalty: req
-            .repetition_penalty
-            .unwrap_or(state.default_params.repetition_penalty),
+    let params = build_sampling_params(
+        req.temperature,
+        req.top_p,
+        req.top_k,
+        req.repetition_penalty,
         max_tokens,
-    };
+        &state.default_params,
+    );
 
     let is_stream = req.stream.unwrap_or(false);
 
@@ -360,6 +366,17 @@ async fn chat_completions(
     }
 }
 
+/// Serialize `value` to a JSON SSE event.  Returns `None` and logs an error on failure.
+fn to_sse_event<T: serde::Serialize>(value: &T, label: &str) -> Option<Event> {
+    match serde_json::to_string(value) {
+        Ok(json) => Some(Event::default().data(json)),
+        Err(e) => {
+            tracing::error!("Failed to serialize {label}: {e}");
+            None
+        }
+    }
+}
+
 fn make_sse_stream(
     mut token_rx: mpsc::Receiver<StreamToken>,
     request_id: String,
@@ -382,12 +399,9 @@ fn make_sse_stream(
                 finish_reason: None,
             }],
         };
-        match serde_json::to_string(&first_chunk) {
-            Ok(json) => yield Ok(Event::default().data(json)),
-            Err(e) => {
-                tracing::error!("Failed to serialize chat stream role chunk: {e}");
-                return;
-            }
+        match to_sse_event(&first_chunk, "chat stream role chunk") {
+            Some(event) => yield Ok(event),
+            None => return,
         }
 
         // Token chunks
@@ -413,12 +427,9 @@ fn make_sse_stream(
                     finish_reason: token.finish_reason,
                 }],
             };
-            match serde_json::to_string(&chunk) {
-                Ok(json) => yield Ok(Event::default().data(json)),
-                Err(e) => {
-                    tracing::error!("Failed to serialize chat stream chunk: {e}");
-                    break;
-                }
+            match to_sse_event(&chunk, "chat stream chunk") {
+                Some(event) => yield Ok(event),
+                None => break,
             }
         }
 
@@ -483,10 +494,7 @@ async fn completions(
     Json(req): Json<CompletionRequest>,
 ) -> impl IntoResponse {
     let request_id = format!("cmpl-{}", uuid::Uuid::new_v4());
-    let created = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let created = unix_now();
     let model_id = req.model.clone().unwrap_or_else(|| state.model_id.clone());
 
     // Tokenize the prompt directly
@@ -499,15 +507,14 @@ async fn completions(
 
     let requested_max_tokens = req.max_tokens.unwrap_or(state.default_params.max_tokens);
     let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
-    let params = SamplingParams {
-        temperature: req.temperature.unwrap_or(state.default_params.temperature),
-        top_p: req.top_p.unwrap_or(state.default_params.top_p),
-        top_k: req.top_k.unwrap_or(state.default_params.top_k),
-        repetition_penalty: req
-            .repetition_penalty
-            .unwrap_or(state.default_params.repetition_penalty),
+    let params = build_sampling_params(
+        req.temperature,
+        req.top_p,
+        req.top_k,
+        req.repetition_penalty,
         max_tokens,
-    };
+        &state.default_params,
+    );
 
     let is_stream = req.stream.unwrap_or(false);
 
@@ -594,12 +601,9 @@ fn make_completion_sse_stream(
                     finish_reason: token.finish_reason,
                 }],
             };
-            match serde_json::to_string(&chunk) {
-                Ok(json) => yield Ok(Event::default().data(json)),
-                Err(e) => {
-                    tracing::error!("Failed to serialize completion stream chunk: {e}");
-                    break;
-                }
+            match to_sse_event(&chunk, "completion stream chunk") {
+                Some(event) => yield Ok(event),
+                None => break,
             }
         }
 
@@ -609,10 +613,7 @@ fn make_completion_sse_stream(
 }
 
 async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListResponse> {
-    let created = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let created = unix_now();
 
     Json(ModelListResponse {
         object: "list",
@@ -627,6 +628,25 @@ async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListRespon
 
 async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
+}
+
+/// Build [`SamplingParams`] by overlaying per-request values on top of the
+/// server's default params.  Any `None` field falls back to the default.
+fn build_sampling_params(
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<usize>,
+    repetition_penalty: Option<f64>,
+    max_tokens: usize,
+    defaults: &SamplingParams,
+) -> SamplingParams {
+    SamplingParams {
+        temperature: temperature.unwrap_or(defaults.temperature),
+        top_p: top_p.unwrap_or(defaults.top_p),
+        top_k: top_k.unwrap_or(defaults.top_k),
+        repetition_penalty: repetition_penalty.unwrap_or(defaults.repetition_penalty),
+        max_tokens,
+    }
 }
 
 /// Clamp `requested` so that `prompt_len + result <= max_seq_len`.

--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -159,7 +159,12 @@ pub struct TurboQuantConfig {
 // At head_dim=128, GROUP_SIZE=32: 4 f32 scales = 16 bytes/token vs 4 bytes
 // for per-vector. The packed indices are unchanged.
 
-const GROUP_SIZE: usize = 32;
+pub const GROUP_SIZE: usize = 32;
+
+/// Minimum pre-allocated capacity (in tokens) for growing KV cache buffers.
+/// Used by both `TurboQuantKvCache` and `RetainingKvCache` / `RetainingRotatingKvCache`
+/// to avoid excessive reallocations on short sequences.
+pub const MIN_KV_BUFFER_CAP: usize = 256;
 
 /// Quantize a flat CPU f32 slice `data` representing `[seq_len, head_dim]`
 /// using per-group absmax.  Used by `append` to avoid constructing per-head
@@ -642,7 +647,9 @@ impl TurboQuantKvCache {
         // On the first decode step this allocates a buffer sized to at least `seq_len` tokens.
         let needed_cap = self.seq_len;
         if self.kv_buffer_cap < needed_cap {
-            let new_cap = needed_cap.max(self.kv_buffer_cap * 2).max(256);
+            let new_cap = needed_cap
+                .max(self.kv_buffer_cap * 2)
+                .max(MIN_KV_BUFFER_CAP);
             let k_buf = Tensor::zeros(
                 (1, self.num_kv_heads, new_cap, self.head_dim),
                 self.orig_dtype,


### PR DESCRIPTION
- Extract unix_now(), build_sampling_params(), and to_sse_event() helpers in server.rs to eliminate three sets of copy-pasted blocks
- Add RMS_NORM_EPS_DEFAULT constant in config.rs (was inline 1e-6 six times)
- Export GROUP_SIZE and MIN_KV_BUFFER_CAP from turbo_quant.rs; use them in bench.rs and gemma4.rs instead of re-declaring the same magic numbers
- Move apply_rope to attention_utils.rs; remove the two per-file copies in qwen3.rs and qwen3_5.rs (general partial-rotation impl covers both)
- Collapse generate() into bench_generate() to remove the duplicate prefill+decode loop in engine.rs