### PR TITLE
ci: bump macOS runner from macos-15 to macos-26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            runner: macos-15
+            runner: macos-26
             rustflags: "-C target-feature=+fullfp16"
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   # ── macOS binary (Metal, linked directly) ─────────────────────────────────
   build-macos:
     name: Build (aarch64-apple-darwin)
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       RUSTFLAGS: "-C target-feature=+fullfp16"
     steps:


### PR DESCRIPTION
## Summary

- Bump macOS CI runner from macos-15 to macos-26 in both release.yml and ci.yml

The pre-built aarch64-apple-darwin binary from the macos-15 runner links against older framework versions (e.g. Metal.framework 368.12.0) which fail to initialize the Metal device on newer macOS with:

```
Error: Device not configured (os error 6)
```

Building from source on the same machine works fine. The root cause is a framework version mismatch between the CI build environment and the user system:

| Framework | macos-15 binary | Local build (newer macOS) |
|-----------|----------------|--------------------------|
| Metal.framework | 368.12.0 | 370.64.2 |
| CoreFoundation | 3502.1.255 | 4201.0.0 |
| libSystem | 1351.0.0 | 1356.0.0 |

Building on macos-26 (now GA for GitHub Actions) produces a binary compatible with current macOS releases.

## Test plan

- [ ] CI passes on macos-26 runner
- [ ] Release binary initializes Metal correctly on macOS 26