### PR TITLE
Implement continuous batching

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1,8 +1,25 @@
-//! Inference engine: owns the model and runs the inference loop.
+//! Inference engine: owns the model and runs the continuous-batching loop.
+//!
+//! The engine always uses **continuous batching**: new requests are accepted
+//! between decode steps so that arriving work does not have to wait for
+//! earlier sequences to complete.
+//!
+//! When paged attention is active, multiple in-flight sequences share the
+//! paged KV store and are truly interleaved at the token level (up to
+//! `max_batch_size` concurrent sequences).
+//!
+//! Without paged attention the model's internal concat-KV cache is
+//! single-sequence, so the effective batch size is capped at 1.  The
+//! continuous-batching loop structure is still used so that the engine
+//! thread can accept and queue new requests between decode steps of the
+//! active sequence.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 
 use crate::config::{ModelArchitecture, RawConfig};
 use crate::hub::ModelFiles;
@@ -11,6 +28,58 @@ use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
 use crate::ServeArgs;
+
+// ---------------------------------------------------------------------------
+// Output buffer — decouples the engine thread from per-client channels
+// ---------------------------------------------------------------------------
+
+/// A pending token that the engine has produced but that has not yet been
+/// routed to the HTTP client.
+pub struct PendingToken {
+    pub request_id: String,
+    pub token: StreamToken,
+}
+
+/// Shared, lock-protected buffer through which the engine thread delivers
+/// tokens without ever blocking on a slow client.
+///
+/// The engine pushes `(request_id, token)` pairs here; a separate async
+/// drain task in the HTTP server routes each entry to the correct per-request
+/// `mpsc::Sender`.
+#[derive(Clone)]
+pub struct OutputBuffer {
+    inner: Arc<Mutex<VecDeque<PendingToken>>>,
+    notify: Arc<Notify>,
+}
+
+impl OutputBuffer {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Push a token (called from the engine thread).
+    pub fn push(&self, request_id: String, token: StreamToken) {
+        self.inner
+            .lock()
+            .expect("output buffer poisoned")
+            .push_back(PendingToken { request_id, token });
+        self.notify.notify_one();
+    }
+
+    /// Drain all pending tokens (called from the async drain task).
+    pub fn drain(&self) -> Vec<PendingToken> {
+        let mut guard = self.inner.lock().expect("output buffer poisoned");
+        guard.drain(..).collect()
+    }
+
+    /// Returns a reference to the [`Notify`] so the drain task can `await` it.
+    pub fn notified(&self) -> tokio::sync::futures::Notified<'_> {
+        self.notify.notified()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Shared model-loading entry point
@@ -124,11 +193,15 @@ pub enum EngineRequest {
         response_tx: oneshot::Sender<GenerationResult>,
     },
     /// Generate tokens with streaming.
+    ///
+    /// The engine pushes produced tokens into `output_buf` keyed by
+    /// `request_id`.  A separate async drain task routes them to the
+    /// per-request HTTP channel so the engine never blocks on a slow client.
     GenerateStream {
         request_id: String,
         prompt_tokens: Vec<u32>,
         sampling_params: SamplingParams,
-        token_tx: mpsc::Sender<StreamToken>,
+        output_buf: OutputBuffer,
     },
 }
 
@@ -161,6 +234,210 @@ pub struct GenerationResult {
     pub finish_reason: String,
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Continuous batching: per-sequence state
+// ---------------------------------------------------------------------------
+
+/// Abstraction over the response channel for an active sequence.
+///
+/// For streaming requests, tokens are pushed into the shared [`OutputBuffer`]
+/// (the engine never blocks on a slow client).  For non-streaming requests,
+/// the tokens are accumulated and the final result is sent when the sequence
+/// completes.
+enum TokenSink {
+    /// Streaming: push tokens into the shared output buffer.
+    Streaming {
+        request_id: String,
+        output_buf: OutputBuffer,
+    },
+    /// Non-streaming: send the final result via a oneshot channel.
+    OneShot(Option<oneshot::Sender<GenerationResult>>),
+}
+
+impl TokenSink {
+    /// Deliver a streamed token.  Always returns `true` (the engine never
+    /// blocks — the drain task handles client-side back-pressure).
+    fn send_token(&self, token: StreamToken) -> bool {
+        match self {
+            TokenSink::Streaming {
+                request_id,
+                output_buf,
+            } => {
+                output_buf.push(request_id.clone(), token);
+                true
+            }
+            // For non-streaming, tokens are accumulated in ActiveSequence.
+            TokenSink::OneShot(_) => true,
+        }
+    }
+
+    /// Send the final [`GenerationResult`] (non-streaming only).
+    fn send_result(&mut self, result: GenerationResult) {
+        if let TokenSink::OneShot(tx) = self {
+            if let Some(tx) = tx.take() {
+                let _ = tx.send(result);
+            }
+        }
+    }
+
+    /// Send an error response appropriate to the channel type.
+    fn send_error(&mut self, error: &anyhow::Error, prompt_len: usize) {
+        match self {
+            TokenSink::Streaming {
+                request_id,
+                output_buf,
+            } => {
+                output_buf.push(
+                    request_id.clone(),
+                    StreamToken {
+                        token_id: 0,
+                        text: format!("Error: {error}"),
+                        finish_reason: Some("error".to_string()),
+                    },
+                );
+            }
+            TokenSink::OneShot(tx) => {
+                if let Some(tx) = tx.take() {
+                    let _ = tx.send(GenerationResult {
+                        output_token_ids: vec![],
+                        output_text: format!("Error: {error}"),
+                        finish_reason: "error".to_string(),
+                        prompt_tokens: prompt_len,
+                        completion_tokens: 0,
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// State for a single in-flight sequence in the continuous batching scheduler.
+struct ActiveSequence {
+    request_id: String,
+    prompt_tokens: Vec<u32>,
+    output_tokens: Vec<u32>,
+    all_tokens: Vec<u32>,
+    sampling_params: SamplingParams,
+    sink: TokenSink,
+    /// Per-sequence block table for paged attention.
+    /// `None` when running without paged attention.
+    block_table: Option<BlockTable>,
+    /// `true` once the prefill phase has completed.
+    prefilled: bool,
+    /// `true` once the sequence is done (stop token, max length, error, or
+    /// client disconnect).
+    finished: bool,
+}
+
+impl ActiveSequence {
+    /// Create an [`ActiveSequence`] from an [`EngineRequest`].
+    ///
+    /// When `block_size` is `Some`, a per-sequence [`BlockTable`] is created
+    /// for paged attention.  When `None`, no block table is allocated (the
+    /// non-paged path uses the model's internal concat-KV cache).
+    fn from_engine_request(req: EngineRequest, block_size: Option<usize>) -> Self {
+        match req {
+            EngineRequest::Generate {
+                request_id,
+                prompt_tokens,
+                sampling_params,
+                response_tx,
+            } => {
+                let all_tokens = prompt_tokens.clone();
+                Self {
+                    request_id,
+                    prompt_tokens,
+                    output_tokens: Vec::new(),
+                    all_tokens,
+                    sampling_params,
+                    sink: TokenSink::OneShot(Some(response_tx)),
+                    block_table: block_size.map(BlockTable::new),
+                    prefilled: false,
+                    finished: false,
+                }
+            }
+            EngineRequest::GenerateStream {
+                request_id,
+                prompt_tokens,
+                sampling_params,
+                output_buf,
+            } => {
+                let all_tokens = prompt_tokens.clone();
+                Self {
+                    request_id: request_id.clone(),
+                    prompt_tokens,
+                    output_tokens: Vec::new(),
+                    all_tokens,
+                    sampling_params,
+                    sink: TokenSink::Streaming {
+                        request_id,
+                        output_buf,
+                    },
+                    block_table: block_size.map(BlockTable::new),
+                    prefilled: false,
+                    finished: false,
+                }
+            }
+        }
+    }
+
+    /// Mark the sequence as successfully finished and send the final result
+    /// (for non-streaming requests).
+    fn finish_ok(
+        &mut self,
+        finish_reason: &str,
+        tokenizer: &Tokenizer,
+        block_pool: Option<&mut BlockPool>,
+    ) {
+        tracing::debug!(
+            "Request {} finished: {} output tokens, reason: {}",
+            self.request_id,
+            self.output_tokens.len(),
+            finish_reason,
+        );
+        if let (Some(bt), Some(pool)) = (&mut self.block_table, block_pool) {
+            bt.free_all(pool);
+        }
+        self.sink.send_result(GenerationResult {
+            output_token_ids: self.output_tokens.clone(),
+            output_text: tokenizer
+                .decode(&self.output_tokens, true)
+                .unwrap_or_default(),
+            finish_reason: finish_reason.to_string(),
+            prompt_tokens: self.prompt_tokens.len(),
+            completion_tokens: self.output_tokens.len(),
+        });
+        self.finished = true;
+    }
+
+    /// Mark the sequence as failed, free its blocks, and send an error.
+    fn finish_error(&mut self, error: anyhow::Error, block_pool: Option<&mut BlockPool>) {
+        tracing::warn!("Request {} failed: {}", self.request_id, error);
+        if let (Some(bt), Some(pool)) = (&mut self.block_table, block_pool) {
+            bt.free_all(pool);
+        }
+        self.sink.send_error(&error, self.prompt_tokens.len());
+        self.finished = true;
+    }
+}
+
+/// Check whether generation should stop (free-standing helper for use by the
+/// continuous batching loop where `self` is destructured).
+fn check_stop(
+    token_id: u32,
+    num_output_tokens: usize,
+    params: &SamplingParams,
+    stop_token_ids: &[u32],
+) -> Option<String> {
+    if stop_token_ids.contains(&token_id) {
+        return Some("stop".to_string());
+    }
+    if num_output_tokens >= params.max_tokens {
+        return Some("length".to_string());
+    }
+    None
 }
 
 /// Attach a paged KV store to `engine` if `--paged-attention` was requested.
@@ -241,13 +518,19 @@ pub fn attach_paged_kv_if_requested(
     Ok(engine.with_paged_kv(block_pool, kv_store))
 }
 
-/// The engine runs on a dedicated thread and processes requests sequentially.
+/// The engine runs on a dedicated thread and processes requests using
+/// continuous batching.
+///
+/// With paged attention, multiple sequences share the paged KV store and
+/// run concurrently (up to `max_batch_size`).  Without paged attention the
+/// model's internal concat-KV cache is single-sequence so the effective
+/// batch size is 1, but the continuous-batching loop structure is still
+/// used to accept and queue requests between decode steps.
 pub struct Engine {
     model: Box<dyn CausalLM>,
     tokenizer: Tokenizer,
     device: Device,
     stop_token_ids: Vec<u32>,
-    #[allow(dead_code)]
     max_batch_size: usize,
     #[allow(dead_code)]
     max_tokens_per_step: usize,
@@ -255,11 +538,18 @@ pub struct Engine {
     paged: Option<PagedState>,
 }
 
-/// State needed for paged-attention mode.
+/// Shared state for paged-attention mode.
+///
+/// The block pool and KV store are shared across all in-flight sequences.
+/// Each sequence maintains its own [`BlockTable`] that maps logical blocks
+/// to physical block IDs in the shared pool.
 struct PagedState {
     block_pool: BlockPool,
     kv_store: PagedKvStore,
-    /// Per-request block table, reset at the start of each request.
+    /// Standalone block table used by the non-batching code paths
+    /// (`bench_generate`, `run_sync`) which process a single request at a
+    /// time.  The continuous-batching loop maintains per-sequence block
+    /// tables instead.
     block_table: BlockTable,
 }
 
@@ -295,52 +585,238 @@ impl Engine {
     }
 
     /// Run the engine loop, processing requests from the channel.
-    pub fn run(mut self, mut rx: mpsc::Receiver<EngineRequest>) {
-        tracing::info!("Engine loop started");
+    ///
+    /// Always uses continuous batching.  When paged attention is active,
+    /// multiple sequences can run concurrently.  Without paged attention the
+    /// effective batch size is 1 (the model's internal KV cache is
+    /// single-sequence).
+    pub fn run(self, rx: mpsc::Receiver<EngineRequest>) {
+        self.run_continuous_batching(rx);
+    }
 
-        while let Some(request) = rx.blocking_recv() {
-            match request {
-                EngineRequest::Generate {
-                    request_id,
-                    prompt_tokens,
-                    sampling_params,
-                    response_tx,
-                } => {
-                    let result = self.generate(&request_id, &prompt_tokens, &sampling_params);
-                    let _ = response_tx.send(match result {
-                        Ok(r) => r,
-                        Err(e) => GenerationResult {
-                            output_token_ids: vec![],
-                            output_text: format!("Error: {e}"),
-                            finish_reason: "error".to_string(),
-                            prompt_tokens: prompt_tokens.len(),
-                            completion_tokens: 0,
-                        },
-                    });
-                }
-                EngineRequest::GenerateStream {
-                    request_id,
-                    prompt_tokens,
-                    sampling_params,
-                    token_tx,
-                } => {
-                    if let Err(e) = self.generate_stream(
-                        &request_id,
-                        &prompt_tokens,
-                        &sampling_params,
-                        &token_tx,
-                    ) {
-                        let _ = token_tx.blocking_send(StreamToken {
-                            token_id: 0,
-                            text: format!("Error: {e}"),
-                            finish_reason: Some("error".to_string()),
-                        });
+    /// Continuous batching engine loop.
+    ///
+    /// Each iteration:
+    /// 1. Accept all pending requests from the channel (non-blocking).
+    /// 2. If no sequences are active, block until a request arrives.
+    /// 3. For each active sequence, run one step (prefill or decode).
+    /// 4. Remove completed sequences and free their KV blocks.
+    ///
+    /// Without paged attention the model's concat-KV cache is
+    /// single-sequence, so only one sequence is processed at a time.
+    fn run_continuous_batching(self, mut rx: mpsc::Receiver<EngineRequest>) {
+        // Destructure self so the borrow checker can track disjoint field
+        // borrows (model, paged.block_pool, paged.kv_store, etc.).
+        let Engine {
+            mut model,
+            tokenizer,
+            device,
+            stop_token_ids,
+            max_batch_size,
+            max_tokens_per_step: _,
+            paged,
+        } = self;
+
+        let mut paged = paged;
+        let is_paged = paged.is_some();
+
+        // Without paged attention the model's internal concat-KV cache
+        // supports only one sequence at a time.
+        let effective_batch_size = if is_paged { max_batch_size } else { 1 };
+        // block_size is only needed for creating per-sequence BlockTables.
+        let block_size = paged.as_ref().map(|ps| ps.block_pool.block_size);
+
+        tracing::info!(
+            "Engine loop started (continuous batching, max_batch_size={}, paged={})",
+            effective_batch_size,
+            is_paged,
+        );
+
+        let mut active: VecDeque<ActiveSequence> = VecDeque::new();
+
+        loop {
+            // ── 1. Accept new requests (non-blocking) ─────────────────────
+            while active.len() < effective_batch_size {
+                match rx.try_recv() {
+                    Ok(req) => {
+                        let seq = ActiveSequence::from_engine_request(req, block_size);
+                        tracing::debug!(
+                            "Accepted request {} ({} prompt tokens, batch_size={})",
+                            seq.request_id,
+                            seq.prompt_tokens.len(),
+                            active.len() + 1,
+                        );
+                        active.push_back(seq);
                     }
+                    Err(_) => break,
                 }
             }
+
+            // ── 2. If idle, block until the next request arrives ──────────
+            if active.is_empty() {
+                match rx.blocking_recv() {
+                    Some(req) => {
+                        let seq = ActiveSequence::from_engine_request(req, block_size);
+                        tracing::debug!(
+                            "Accepted request {} ({} prompt tokens)",
+                            seq.request_id,
+                            seq.prompt_tokens.len(),
+                        );
+                        active.push_back(seq);
+                    }
+                    None => break, // channel closed
+                }
+            }
+
+            // ── 3. Process one step per active sequence ───────────────────
+            for seq in active.iter_mut() {
+                if seq.finished {
+                    continue;
+                }
+
+                let logits_result = if !seq.prefilled {
+                    // Prefill: run all prompt tokens through the model.
+                    Self::cb_prefill(
+                        &mut model,
+                        &device,
+                        &seq.prompt_tokens,
+                        seq.block_table.as_mut(),
+                        paged.as_mut(),
+                    )
+                } else {
+                    // Decode: generate the next token.
+                    // `output_tokens` should be non-empty here (`prefilled` is
+                    // set only after the first token is pushed), but we handle
+                    // `None` defensively to avoid a panic on internal bugs.
+                    let last_token = match seq.output_tokens.last() {
+                        Some(&t) => t,
+                        None => {
+                            seq.finish_error(
+                                anyhow::anyhow!("internal error: decode before prefill"),
+                                paged.as_mut().map(|ps| &mut ps.block_pool),
+                            );
+                            continue;
+                        }
+                    };
+                    let seqlen_offset = seq.prompt_tokens.len() + seq.output_tokens.len() - 1;
+                    Self::cb_decode_step(
+                        &mut model,
+                        &device,
+                        last_token,
+                        seqlen_offset,
+                        seq.block_table.as_mut(),
+                        paged.as_mut(),
+                    )
+                };
+
+                let logits = match logits_result {
+                    Ok(l) => l,
+                    Err(e) => {
+                        seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
+                        continue;
+                    }
+                };
+
+                let token_id =
+                    match sampler::sample_token(&logits, &seq.sampling_params, &seq.all_tokens) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
+                            continue;
+                        }
+                    };
+
+                seq.output_tokens.push(token_id);
+                seq.all_tokens.push(token_id);
+
+                if !seq.prefilled {
+                    seq.prefilled = true;
+                }
+
+                let text = tokenizer.decode(&[token_id], true).unwrap_or_default();
+                let finish_reason = check_stop(
+                    token_id,
+                    seq.output_tokens.len(),
+                    &seq.sampling_params,
+                    &stop_token_ids,
+                );
+
+                let client_gone = !seq.sink.send_token(StreamToken {
+                    token_id,
+                    text,
+                    finish_reason: finish_reason.clone(),
+                });
+
+                if finish_reason.is_some() || client_gone {
+                    let reason = finish_reason.unwrap_or_else(|| "cancelled".to_string());
+                    seq.finish_ok(
+                        &reason,
+                        &tokenizer,
+                        paged.as_mut().map(|ps| &mut ps.block_pool),
+                    );
+                }
+            }
+
+            // ── 4. Remove completed sequences ─────────────────────────────
+            active.retain(|s| !s.finished);
         }
 
-        tracing::info!("Engine loop stopped");
+        tracing::info!("Engine loop stopped (continuous batching)");
+    }
+
+    // ── Continuous-batching helpers ────────────────────────────────────────
+
+    /// Run a prefill forward pass for a single sequence (continuous batching).
+    ///
+    /// When paged attention is active, allocates blocks and calls
+    /// `forward_paged`.  Otherwise clears the model's internal KV cache and
+    /// calls `forward`.
+    fn cb_prefill(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        prompt_tokens: &[u32],
+        block_table: Option<&mut BlockTable>,
+        paged: Option<&mut PagedState>,
+    ) -> Result<Tensor> {
+        let input_ids = Tensor::new(prompt_tokens, device)?.unsqueeze(0)?;
+        match (block_table, paged) {
+            (Some(bt), Some(ps)) => {
+                for pos in 0..prompt_tokens.len() {
+                    if !bt.ensure_allocated(pos, &mut ps.block_pool) {
+                        anyhow::bail!("paged attention: out of KV blocks at position {pos}");
+                    }
+                }
+                model.forward_paged(&input_ids, 0, bt, &mut ps.kv_store)
+            }
+            _ => {
+                model.clear_kv_cache();
+                model.forward(&input_ids, 0)
+            }
+        }
+    }
+
+    /// Run a single decode step for one sequence (continuous batching).
+    ///
+    /// When paged attention is active, allocates the next block (if needed)
+    /// and calls `forward_paged`.  Otherwise calls `forward`.
+    fn cb_decode_step(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        token_id: u32,
+        seqlen_offset: usize,
+        block_table: Option<&mut BlockTable>,
+        paged: Option<&mut PagedState>,
+    ) -> Result<Tensor> {
+        let input_ids = Tensor::new(&[token_id], device)?.unsqueeze(0)?;
+        match (block_table, paged) {
+            (Some(bt), Some(ps)) => {
+                if !bt.ensure_allocated(seqlen_offset, &mut ps.block_pool) {
+                    anyhow::bail!("paged attention: out of KV blocks at position {seqlen_offset}");
+                }
+                model.forward_paged(&input_ids, seqlen_offset, bt, &mut ps.kv_store)
+            }
+            _ => model.forward(&input_ids, seqlen_offset),
+        }
     }
 
     /// Run the engine loop using only stdlib channels — no Tokio runtime required.
@@ -450,45 +926,7 @@ impl Engine {
         }
     }
 
-    // ── Non-streaming generation ──────────────────────────────────────────────
-
-    fn generate(
-        &mut self,
-        request_id: &str,
-        prompt_tokens: &[u32],
-        sampling_params: &SamplingParams,
-    ) -> Result<GenerationResult> {
-        tracing::debug!(
-            "Generating for request {} ({} prompt tokens, max {} output tokens)",
-            request_id,
-            prompt_tokens.len(),
-            sampling_params.max_tokens
-        );
-
-        let (result, _prefill_ms, _decode_ms) =
-            self.bench_generate(request_id, prompt_tokens, sampling_params)?;
-
-        tracing::debug!(
-            "Request {} finished: {} output tokens, reason: {}",
-            request_id,
-            result.completion_tokens,
-            result.finish_reason
-        );
-
-        Ok(result)
-    }
-
     // ── Streaming generation ──────────────────────────────────────────────────
-
-    fn generate_stream(
-        &mut self,
-        request_id: &str,
-        prompt_tokens: &[u32],
-        sampling_params: &SamplingParams,
-        token_tx: &mpsc::Sender<StreamToken>,
-    ) -> Result<()> {
-        self.generate_stream_inner(request_id, prompt_tokens, sampling_params, token_tx)
-    }
 
     /// Streaming generation using stdlib `SyncSender` — delegates to the
     /// shared `generate_stream_inner` implementation.

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -13,15 +13,54 @@ use axum::{
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tower_http::cors::CorsLayer;
 
-use crate::engine::{load_engine, EngineRequest, GenerationResult, StreamToken};
+use crate::engine::{load_engine, EngineRequest, GenerationResult, OutputBuffer, StreamToken};
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
+
+// ---------------------------------------------------------------------------
+// Per-request stream registry
+// ---------------------------------------------------------------------------
+
+/// Maps `request_id` → the `mpsc::Sender` that delivers tokens to the HTTP
+/// SSE handler for that request.  Entries are inserted just before the engine
+/// request is sent and removed once the final token (or an error) is routed.
+type StreamRegistry = Arc<Mutex<HashMap<String, mpsc::Sender<StreamToken>>>>;
+
+/// Spawn a background task that drains the shared [`OutputBuffer`] and routes
+/// each token to the correct per-request channel.
+///
+/// This is the equivalent of vLLM's `output_handler` task: the engine thread
+/// never touches per-client channels, so a slow client cannot stall the
+/// batching loop.
+fn spawn_drain_task(output_buf: OutputBuffer, registry: StreamRegistry) {
+    tokio::spawn(async move {
+        loop {
+            // Wait until the engine signals that new tokens are available.
+            output_buf.notified().await;
+
+            let pending = output_buf.drain();
+            let mut reg = registry.lock().await;
+            for pt in pending {
+                if let Some(tx) = reg.get(&pt.request_id) {
+                    let is_final = pt.token.finish_reason.is_some();
+                    // try_send: if the client channel is full or gone, drop
+                    // the token rather than stalling the drain task.
+                    let _ = tx.try_send(pt.token);
+                    if is_final {
+                        reg.remove(&pt.request_id);
+                    }
+                }
+            }
+        }
+    });
+}
 
 // ─── OpenAI API types ───────────────────────────────────────────────────────
 
@@ -427,6 +466,10 @@ struct AppState {
     default_params: SamplingParams,
     /// Hard upper bound on (prompt_tokens + output_tokens) for this model.
     max_seq_len: usize,
+    /// Shared buffer that the engine writes tokens into.
+    output_buf: OutputBuffer,
+    /// Maps request_id → per-client SSE channel.
+    stream_registry: StreamRegistry,
 }
 
 // ─── Server startup ─────────────────────────────────────────────────────────
@@ -451,6 +494,13 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         ..SamplingParams::default()
     };
 
+    // Create the shared output buffer and per-request stream registry.
+    let output_buf = OutputBuffer::new();
+    let stream_registry: StreamRegistry = Arc::new(Mutex::new(HashMap::new()));
+
+    // Spawn the drain task: wakes on Notify, drains the buffer, routes tokens.
+    spawn_drain_task(output_buf.clone(), stream_registry.clone());
+
     // Create engine channel and spawn engine on a dedicated thread.
     let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
     std::thread::Builder::new()
@@ -465,6 +515,8 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         tokenizer,
         default_params,
         max_seq_len: ctx.max_seq_len,
+        output_buf,
+        stream_registry,
     });
 
     // Build router
@@ -532,17 +584,23 @@ async fn chat_completions(
     let is_stream = req.stream.unwrap_or(false);
 
     if is_stream {
-        // Streaming response
+        // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
+        state
+            .stream_registry
+            .lock()
+            .await
+            .insert(request_id.clone(), token_tx);
 
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
             sampling_params: params,
-            token_tx,
+            output_buf: state.output_buf.clone(),
         };
 
         if state.engine_tx.send(engine_req).await.is_err() {
+            state.stream_registry.lock().await.remove(&request_id);
             return Err(server_error("Engine unavailable"));
         }
 
@@ -744,17 +802,23 @@ async fn completions(
     let is_stream = req.stream.unwrap_or(false);
 
     if is_stream {
-        // Streaming response — send tokens as SSE events.
+        // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
+        state
+            .stream_registry
+            .lock()
+            .await
+            .insert(request_id.clone(), token_tx);
 
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens,
             sampling_params: params,
-            token_tx,
+            output_buf: state.output_buf.clone(),
         };
 
         if state.engine_tx.send(engine_req).await.is_err() {
+            state.stream_registry.lock().await.remove(&request_id);
             return Err(server_error("Engine unavailable"));
         }
 
@@ -896,16 +960,23 @@ async fn anthropic_messages(
     let is_stream = req.stream.unwrap_or(false);
 
     if is_stream {
+        // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
+        state
+            .stream_registry
+            .lock()
+            .await
+            .insert(request_id.clone(), token_tx);
 
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
             sampling_params: params,
-            token_tx,
+            output_buf: state.output_buf.clone(),
         };
 
         if state.engine_tx.send(engine_req).await.is_err() {
+            state.stream_registry.lock().await.remove(&request_id);
             return Err(anthropic_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "api_error",


### PR DESCRIPTION
- Engine::run() always calls run_continuous_batching() — removed the run_sequential() path entirely.
- run_continuous_batching() computes effective_batch_size based on whether paged attention is active (max_batch_size vs 1).
- cb_prefill/cb_decode_step now handle both paged and non-paged paths: paged → forward_paged with block allocation; non-paged → clear_kv_cache + forward.
- ActiveSequence.block_table is now Option<BlockTable> (None when non-paged).
- finish_ok/finish_error accept Option<&mut BlockPool>.
- Removed dead generate() and generate_stream() methods that were only used by the old sequential path.