### PR TITLE
feat(audio): Gemma 4 audio input support via Conformer encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1659,6 +1659,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
+ "base64 0.22.1",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -1669,6 +1670,7 @@ dependencies = [
  "hf-hub",
  "indicatif",
  "libloading 0.8.9",
+ "rustfft",
  "serde",
  "serde_json",
  "tokenizers",
@@ -2342,6 +2344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2608,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -2935,6 +2960,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
@@ -3316,6 +3347,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -56,6 +56,8 @@ async-stream = "0.3"
 anyhow = { workspace = true }
 crossterm = "0.28"
 indicatif = "0.17"
+rustfft = "6"
+base64 = "0.22"
 
 # Linux: dynamic backend loading + CUDA device support.
 # Enable the cuda feature so Device::new_cuda() is available at runtime.

--- a/inferrs/src/audio.rs
+++ b/inferrs/src/audio.rs
@@ -1,0 +1,336 @@
+//! Audio preprocessing: log-mel spectrogram computation.
+//!
+//! Implements the `Gemma4AudioFeatureExtractor` algorithm:
+//!  - 16 kHz input (mono f32)
+//!  - 20 ms frames (320 samples), 10 ms hop (160 samples)
+//!  - 512-point RFFT → 257 magnitude bins
+//!  - 128 HTK-scale mel filters (0–8 kHz)
+//!  - log(mel + 1e-3)
+//!  - Semicausal padding: prepend frame_length/2 = 160 zeros
+//!
+//! Output shape: [T, 128] as a row-major `Vec<f32>` plus the frame count T.
+
+use anyhow::{bail, Result};
+use rustfft::num_complex::Complex32;
+use rustfft::FftPlanner;
+use std::f32::consts::PI;
+
+/// Mel spectrogram parameters.
+pub const SAMPLE_RATE: u32 = 16_000;
+pub const FRAME_LEN: usize = 320;
+pub const HOP_LEN: usize = 160;
+pub const FFT_LEN: usize = 512;
+pub const N_FFT_BINS: usize = FFT_LEN / 2 + 1; // 257
+pub const N_MEL: usize = 128;
+pub const MEL_FLOOR: f32 = 1e-3;
+pub const MIN_FREQ: f32 = 0.0;
+pub const MAX_FREQ: f32 = 8000.0;
+
+// ---------------------------------------------------------------------------
+// Mel filter bank (computed once)
+// ---------------------------------------------------------------------------
+
+/// Precomputed HTK mel filterbank matrix: shape [N_FFT_BINS, N_MEL].
+///
+/// Element `[f, m]` is the weight applied to FFT bin `f` when computing mel
+/// band `m`.  Matches the `transformers.audio_utils.mel_filter_bank` output
+/// with `norm=None, mel_scale="htk"`.
+pub fn build_mel_filterbank() -> Vec<f32> {
+    let n_bins = N_FFT_BINS;
+    let n_mel = N_MEL;
+
+    // Convert Hz to HTK mel.
+    let hz_to_mel = |f: f32| -> f32 { 2595.0 * (1.0 + f / 700.0).log10() };
+    let mel_to_hz = |m: f32| -> f32 { 700.0 * (10.0_f32.powf(m / 2595.0) - 1.0) };
+
+    let mel_min = hz_to_mel(MIN_FREQ);
+    let mel_max = hz_to_mel(MAX_FREQ);
+
+    // N_MEL + 2 linearly-spaced mel points (includes two boundary points).
+    let mel_points: Vec<f32> = (0..=n_mel + 1)
+        .map(|i| mel_min + (mel_max - mel_min) * i as f32 / (n_mel + 1) as f32)
+        .collect();
+
+    // Convert mel points back to Hz, then to FFT bin indices.
+    let bin_freqs: Vec<f32> = (0..n_bins)
+        .map(|k| k as f32 * SAMPLE_RATE as f32 / FFT_LEN as f32)
+        .collect();
+
+    let mel_hz: Vec<f32> = mel_points.iter().map(|&m| mel_to_hz(m)).collect();
+
+    // Build filterbank: [n_bins, n_mel] in row-major order.
+    let mut fb = vec![0.0f32; n_bins * n_mel];
+
+    for m in 0..n_mel {
+        let lower = mel_hz[m];
+        let center = mel_hz[m + 1];
+        let upper = mel_hz[m + 2];
+
+        for (f, &freq) in bin_freqs.iter().enumerate() {
+            let w = if freq >= lower && freq <= center {
+                if center > lower {
+                    (freq - lower) / (center - lower)
+                } else {
+                    0.0
+                }
+            } else if freq > center && freq <= upper {
+                if upper > center {
+                    (upper - freq) / (upper - center)
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            };
+            fb[f * n_mel + m] = w;
+        }
+    }
+    fb
+}
+
+// ---------------------------------------------------------------------------
+// Periodic Hann window
+// ---------------------------------------------------------------------------
+
+fn hann_window(n: usize) -> Vec<f32> {
+    // Periodic (DFT-even) Hann: w[k] = 0.5 - 0.5 * cos(2π k / n)
+    (0..n)
+        .map(|k| 0.5 - 0.5 * (2.0 * PI * k as f32 / n as f32).cos())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/// Compute a log-mel spectrogram from mono 16 kHz PCM samples.
+///
+/// Returns `(data, num_frames)` where `data` is row-major `[num_frames, N_MEL]`.
+/// Panics or errors if `samples` is empty.
+pub fn compute_log_mel(samples: &[f32]) -> Result<(Vec<f32>, usize)> {
+    if samples.is_empty() {
+        bail!("audio input is empty");
+    }
+
+    let fb = build_mel_filterbank();
+    let window = hann_window(FRAME_LEN);
+
+    // Semicausal padding: prepend HOP_LEN zeros so the first frame is centred
+    // at t=0, matching sl.STFT(time_padding='semicausal').
+    let pad = HOP_LEN; // 160
+    let total_len = samples.len() + pad;
+
+    // frame_size_for_unfold = FRAME_LEN + 1 = 321
+    let frame_size_for_unfold = FRAME_LEN + 1;
+    let num_frames = if total_len >= frame_size_for_unfold {
+        (total_len - frame_size_for_unfold) / HOP_LEN + 1
+    } else {
+        0
+    };
+
+    if num_frames == 0 {
+        bail!("audio too short to produce any frames");
+    }
+
+    // Set up FFT planner for real-valued FFTs (we use complex FFT + take first
+    // FFT_LEN/2+1 bins).
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(FFT_LEN);
+
+    let mut out = vec![0.0f32; num_frames * N_MEL];
+
+    let padded_get = |i: usize| -> f32 {
+        if i < pad {
+            0.0
+        } else {
+            samples[i - pad]
+        }
+    };
+
+    for t in 0..num_frames {
+        let start = t * HOP_LEN;
+
+        // Extract frame of length FRAME_LEN (= frame_size_for_unfold - 1 = 320).
+        // The Python code uses frames_to_process[..., :-1] after unfolding with
+        // size=321 — i.e., it discards the last sample of each 321-sample window.
+        let mut frame: Vec<Complex32> = (0..FRAME_LEN)
+            .map(|i| {
+                let sample = padded_get(start + i);
+                Complex32::new(sample * window[i], 0.0)
+            })
+            .collect();
+
+        // Zero-pad from FRAME_LEN to FFT_LEN.
+        frame.resize(FFT_LEN, Complex32::new(0.0, 0.0));
+
+        // In-place FFT.
+        fft.process(&mut frame);
+
+        // Magnitude of first N_FFT_BINS = 257 bins.
+        // Then multiply by mel filterbank to get mel energies.
+        // out[t, m] = sum_f |X[f]| * fb[f, m]
+        let row = &mut out[t * N_MEL..(t + 1) * N_MEL];
+
+        for f in 0..N_FFT_BINS {
+            let mag = frame[f].norm(); // |complex|
+                                       // Dot into mel bins.
+            let fb_row = &fb[f * N_MEL..(f + 1) * N_MEL];
+            for (m, w) in fb_row.iter().enumerate() {
+                row[m] += mag * w;
+            }
+        }
+
+        // log(mel + floor)
+        for v in row.iter_mut() {
+            *v = (*v + MEL_FLOOR).ln();
+        }
+    }
+
+    Ok((out, num_frames))
+}
+
+/// Decode audio from bytes (WAV file or raw interleaved f32 PCM).
+///
+/// `format` should be `"wav"` or `"pcm_f32"`.
+/// WAV files are decoded via a minimal parser (supports 16-bit PCM and 32-bit float WAV).
+/// For `pcm_f32`, the bytes are interpreted directly as little-endian f32 samples.
+pub fn decode_audio(data: &[u8], format: &str) -> Result<Vec<f32>> {
+    match format {
+        "wav" => decode_wav(data),
+        "pcm_f32" => {
+            if !data.len().is_multiple_of(4) {
+                bail!("pcm_f32 data length is not a multiple of 4");
+            }
+            Ok(data
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect())
+        }
+        other => bail!("unsupported audio format: {other}; expected 'wav' or 'pcm_f32'"),
+    }
+}
+
+/// Minimal WAV decoder supporting 16-bit PCM and 32-bit IEEE float, mono or
+/// stereo (downmixed to mono by averaging).
+fn decode_wav(data: &[u8]) -> Result<Vec<f32>> {
+    if data.len() < 44 {
+        bail!("WAV too short");
+    }
+    if &data[0..4] != b"RIFF" || &data[8..12] != b"WAVE" {
+        bail!("not a RIFF/WAVE file");
+    }
+
+    // Walk chunks.
+    let mut pos = 12usize;
+    let mut fmt_channels = 1u16;
+    let mut fmt_sample_rate = 16000u32;
+    let mut fmt_audio_format = 1u16; // 1=PCM, 3=IEEE float
+    let mut fmt_bits_per_sample = 16u16;
+    let mut pcm_data: &[u8] = &[];
+
+    while pos + 8 <= data.len() {
+        let chunk_id = &data[pos..pos + 4];
+        let chunk_size = u32::from_le_bytes(data[pos + 4..pos + 8].try_into().unwrap()) as usize;
+        let chunk_data = if pos + 8 + chunk_size <= data.len() {
+            &data[pos + 8..pos + 8 + chunk_size]
+        } else {
+            &data[pos + 8..]
+        };
+
+        if chunk_id == b"fmt " && chunk_data.len() >= 16 {
+            fmt_audio_format = u16::from_le_bytes(chunk_data[0..2].try_into().unwrap());
+            fmt_channels = u16::from_le_bytes(chunk_data[2..4].try_into().unwrap());
+            fmt_sample_rate = u32::from_le_bytes(chunk_data[4..8].try_into().unwrap());
+            fmt_bits_per_sample = u16::from_le_bytes(chunk_data[14..16].try_into().unwrap());
+        } else if chunk_id == b"data" {
+            pcm_data = chunk_data;
+        }
+
+        pos = match 8usize
+            .checked_add(chunk_size)
+            .and_then(|n| pos.checked_add(n))
+        {
+            Some(p) => p,
+            None => break,
+        };
+    }
+
+    if fmt_sample_rate != SAMPLE_RATE {
+        // We just warn and proceed; the encoder will run at whatever rate the
+        // data actually is — callers should resample to 16 kHz beforehand.
+        tracing::warn!(
+            "WAV sample rate is {}, expected {}. Resample to 16 kHz for best results.",
+            fmt_sample_rate,
+            SAMPLE_RATE
+        );
+    }
+
+    let ch = fmt_channels as usize;
+
+    let samples: Vec<f32> = match (fmt_audio_format, fmt_bits_per_sample) {
+        (1, 16) => pcm_data
+            .chunks_exact(2 * ch)
+            .map(|frame| {
+                let sum: f32 = (0..ch)
+                    .map(|c| {
+                        let s = i16::from_le_bytes([frame[c * 2], frame[c * 2 + 1]]);
+                        s as f32 / 32768.0
+                    })
+                    .sum();
+                sum / ch as f32
+            })
+            .collect(),
+        (3, 32) => pcm_data
+            .chunks_exact(4 * ch)
+            .map(|frame| {
+                let sum: f32 = (0..ch)
+                    .map(|c| f32::from_le_bytes(frame[c * 4..c * 4 + 4].try_into().unwrap()))
+                    .sum();
+                sum / ch as f32
+            })
+            .collect(),
+        (fmt, bits) => {
+            bail!("unsupported WAV format: audio_format={fmt}, bits_per_sample={bits}; only 16-bit PCM and 32-bit float are supported");
+        }
+    };
+
+    Ok(samples)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mel_filterbank_shape() {
+        let fb = build_mel_filterbank();
+        assert_eq!(fb.len(), N_FFT_BINS * N_MEL);
+    }
+
+    #[test]
+    fn mel_filterbank_non_negative() {
+        let fb = build_mel_filterbank();
+        assert!(fb.iter().all(|&v| v >= 0.0));
+    }
+
+    #[test]
+    fn compute_log_mel_short_audio() {
+        // 2 seconds of silence at 16kHz → should produce ~199 frames.
+        let samples = vec![0.0f32; 32000];
+        let (mel, n_frames) = compute_log_mel(&samples).unwrap();
+        assert_eq!(n_frames, 199);
+        assert_eq!(mel.len(), 199 * N_MEL);
+        // Silence → all mel bins ≈ log(0 + 1e-3) = -6.908
+        let expected = MEL_FLOOR.ln();
+        for &v in &mel {
+            assert!((v - expected).abs() < 1e-4, "expected {expected}, got {v}");
+        }
+    }
+
+    #[test]
+    fn hann_window_shape() {
+        let w = hann_window(FRAME_LEN);
+        assert_eq!(w.len(), FRAME_LEN);
+        assert!((w[0]).abs() < 1e-6); // window starts at 0
+    }
+}

--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -65,6 +65,58 @@ pub struct TextConfig {
     pub attention_k_eq_v: Option<bool>,
 }
 
+/// Audio encoder configuration from `audio_config` in `config.json`.
+#[derive(Debug, Deserialize, Clone)]
+pub struct AudioConfig {
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub output_proj_dims: usize,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    pub subsampling_conv_channels: Vec<usize>,
+    #[serde(default = "default_conv_kernel_size")]
+    pub conv_kernel_size: usize,
+    pub attention_chunk_size: usize,
+    pub attention_context_left: usize,
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub attention_context_right: usize,
+    #[serde(default = "default_logit_cap")]
+    pub attention_logit_cap: f64,
+    #[serde(default = "default_invalid_logit")]
+    pub attention_invalid_logits_value: f64,
+    #[serde(default = "default_residual_weight")]
+    pub residual_weight: f64,
+    #[serde(default = "default_gradient_clipping")]
+    pub gradient_clipping: f64,
+    #[allow(dead_code)]
+    #[serde(default = "default_hidden_act")]
+    pub hidden_act: String,
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-6
+}
+fn default_conv_kernel_size() -> usize {
+    5
+}
+fn default_logit_cap() -> f64 {
+    50.0
+}
+fn default_invalid_logit() -> f64 {
+    -1e9
+}
+fn default_residual_weight() -> f64 {
+    0.5
+}
+fn default_gradient_clipping() -> f64 {
+    1e10
+}
+fn default_hidden_act() -> String {
+    "silu".to_string()
+}
+
 /// Raw config.json from HuggingFace.
 #[derive(Debug, Deserialize)]
 pub struct RawConfig {
@@ -106,6 +158,10 @@ pub struct RawConfig {
 
     // Qwen3.5/Gemma4-specific (nested text_config)
     pub text_config: Option<TextConfig>,
+
+    // Gemma4 multimodal
+    pub audio_config: Option<AudioConfig>,
+    pub audio_token_id: Option<u32>,
 }
 
 /// Default epsilon for RMS normalization layers across all model families.
@@ -624,6 +680,8 @@ mod tests {
             sliding_window_pattern: None,
             layer_types: None,
             text_config: None,
+            audio_config: None,
+            audio_token_id: None,
         }
     }
 

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -223,6 +223,7 @@ pub enum SyncEngineRequest {
     GenerateStream {
         request_id: String,
         prompt_tokens: Vec<u32>,
+        audio: Option<AudioEmbedContext>,
         sampling_params: SamplingParams,
         token_tx: std::sync::mpsc::SyncSender<StreamToken>,
     },
@@ -902,12 +903,14 @@ impl Engine {
                 SyncEngineRequest::GenerateStream {
                     request_id,
                     prompt_tokens,
+                    audio,
                     sampling_params,
                     token_tx,
                 } => {
                     if let Err(e) = self.generate_stream_sync(
                         &request_id,
                         &prompt_tokens,
+                        audio,
                         &sampling_params,
                         &token_tx,
                     ) {
@@ -1009,9 +1012,13 @@ impl Engine {
         &mut self,
         request_id: &str,
         prompt_tokens: &[u32],
+        audio: Option<AudioEmbedContext>,
         sampling_params: &SamplingParams,
         token_tx: &std::sync::mpsc::SyncSender<StreamToken>,
     ) -> Result<()> {
+        if let Some(audio_ctx) = audio {
+            Self::cb_prepare_audio(&mut self.model, &self.device, prompt_tokens, audio_ctx)?;
+        }
         self.generate_stream_inner(request_id, prompt_tokens, sampling_params, token_tx)
     }
 

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -183,12 +183,23 @@ impl TokenSender for std::sync::mpsc::SyncSender<StreamToken> {
     }
 }
 
+/// Audio input pending encoding on the engine thread.
+pub struct AudioEmbedContext {
+    /// Log-mel spectrogram: shape `[1, T, 128]` on CPU (f32).
+    /// The engine thread calls `model.encode_audio(mel)` before prefill.
+    pub mel: candle_core::Tensor,
+    /// Token ID for `<|audio|>` soft tokens; used to locate positions in
+    /// `prompt_tokens` where audio embeddings should be injected.
+    pub audio_token_id: u32,
+}
+
 /// Request to the engine (async/tokio version, used by the HTTP server).
 pub enum EngineRequest {
     /// Generate tokens for a chat completion.
     Generate {
         request_id: String,
         prompt_tokens: Vec<u32>,
+        audio: Option<AudioEmbedContext>,
         sampling_params: SamplingParams,
         response_tx: oneshot::Sender<GenerationResult>,
     },
@@ -200,6 +211,7 @@ pub enum EngineRequest {
     GenerateStream {
         request_id: String,
         prompt_tokens: Vec<u32>,
+        audio: Option<AudioEmbedContext>,
         sampling_params: SamplingParams,
         output_buf: OutputBuffer,
     },
@@ -321,6 +333,8 @@ struct ActiveSequence {
     all_tokens: Vec<u32>,
     sampling_params: SamplingParams,
     sink: TokenSink,
+    /// Pending audio context to be prepared before the first prefill.
+    audio: Option<AudioEmbedContext>,
     /// Per-sequence block table for paged attention.
     /// `None` when running without paged attention.
     block_table: Option<BlockTable>,
@@ -342,6 +356,7 @@ impl ActiveSequence {
             EngineRequest::Generate {
                 request_id,
                 prompt_tokens,
+                audio,
                 sampling_params,
                 response_tx,
             } => {
@@ -352,6 +367,7 @@ impl ActiveSequence {
                     output_tokens: Vec::new(),
                     all_tokens,
                     sampling_params,
+                    audio,
                     sink: TokenSink::OneShot(Some(response_tx)),
                     block_table: block_size.map(BlockTable::new),
                     prefilled: false,
@@ -361,6 +377,7 @@ impl ActiveSequence {
             EngineRequest::GenerateStream {
                 request_id,
                 prompt_tokens,
+                audio,
                 sampling_params,
                 output_buf,
             } => {
@@ -371,6 +388,7 @@ impl ActiveSequence {
                     output_tokens: Vec::new(),
                     all_tokens,
                     sampling_params,
+                    audio,
                     sink: TokenSink::Streaming {
                         request_id,
                         output_buf,
@@ -674,6 +692,21 @@ impl Engine {
                     continue;
                 }
 
+                // Prepare audio embeddings before the first prefill.
+                if !seq.prefilled {
+                    if let Some(audio_ctx) = seq.audio.take() {
+                        if let Err(e) = Self::cb_prepare_audio(
+                            &mut model,
+                            &device,
+                            &seq.prompt_tokens,
+                            audio_ctx,
+                        ) {
+                            seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
+                            continue;
+                        }
+                    }
+                }
+
                 let logits_result = if !seq.prefilled {
                     // Prefill: run all prompt tokens through the model.
                     Self::cb_prefill(
@@ -767,6 +800,46 @@ impl Engine {
     // ── Continuous-batching helpers ────────────────────────────────────────
 
     /// Run a prefill forward pass for a single sequence (continuous batching).
+    /// Encode audio and register embeddings with the model before prefill.
+    ///
+    /// Finds all positions in `prompt_tokens` that match `ctx.audio_token_id`,
+    /// encodes the mel spectrogram via the model's audio tower, then stores
+    /// (embeddings, positions) so that the next `forward()` call injects them.
+    fn cb_prepare_audio(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        prompt_tokens: &[u32],
+        ctx: AudioEmbedContext,
+    ) -> Result<()> {
+        let mel = ctx.mel.to_device(device)?;
+        let embeds = model.encode_audio(&mel)?;
+        let positions: Vec<usize> = prompt_tokens
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &id)| {
+                if id == ctx.audio_token_id {
+                    Some(i)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if positions.is_empty() {
+            tracing::warn!(
+                "Audio encoder produced {} embeddings but no <|audio|> tokens found in prompt",
+                embeds.dim(0)?
+            );
+        }
+        tracing::info!(
+            "Audio: encoded {} embeddings, found {} <|audio|> positions (token_id={})",
+            embeds.dim(0).unwrap_or(0),
+            positions.len(),
+            ctx.audio_token_id,
+        );
+        model.set_pending_audio(embeds, positions);
+        Ok(())
+    }
+
     ///
     /// When paged attention is active, allocates blocks and calls
     /// `forward_paged`.  Otherwise clears the model's internal KV cache and
@@ -850,6 +923,8 @@ impl Engine {
 
         tracing::info!("Engine loop stopped (sync)");
     }
+
+    // ── Audio helpers ─────────────────────────────────────────────────────────
 
     // ── Paged-attention helpers ───────────────────────────────────────────────
 

--- a/inferrs/src/hub.rs
+++ b/inferrs/src/hub.rs
@@ -18,8 +18,73 @@ pub struct ModelFiles {
     pub gguf_path: Option<PathBuf>,
 }
 
+/// Load model files from a local directory (no network required).
+pub fn load_local_model(path: &std::path::Path) -> Result<ModelFiles> {
+    tracing::info!("Loading model from local path: {}", path.display());
+
+    let config_path = path.join("config.json");
+    anyhow::ensure!(
+        config_path.exists(),
+        "config.json not found in {}",
+        path.display()
+    );
+
+    let tokenizer_path = path.join("tokenizer.json");
+    anyhow::ensure!(
+        tokenizer_path.exists(),
+        "tokenizer.json not found in {}",
+        path.display()
+    );
+
+    let tokenizer_config_path = {
+        let p = path.join("tokenizer_config.json");
+        if p.exists() {
+            Some(p)
+        } else {
+            None
+        }
+    };
+
+    // Prefer model.safetensors, then scan for shards
+    let weight_paths = if path.join("model.safetensors").exists() {
+        vec![path.join("model.safetensors")]
+    } else {
+        let mut shards: Vec<PathBuf> = std::fs::read_dir(path)
+            .with_context(|| format!("Cannot read {}", path.display()))?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map(|e| e == "safetensors").unwrap_or(false))
+            .collect();
+        shards.sort();
+        anyhow::ensure!(
+            !shards.is_empty(),
+            "No safetensors files found in {}",
+            path.display()
+        );
+        shards
+    };
+
+    Ok(ModelFiles {
+        config_path,
+        tokenizer_path,
+        tokenizer_config_path,
+        weight_paths,
+        gguf_path: None,
+    })
+}
+
 /// Download model files from HuggingFace Hub.
 pub fn download_model(model_id: &str, revision: &str) -> Result<ModelFiles> {
+    // If the model_id looks like a local path, load directly without network.
+    let as_path = std::path::Path::new(model_id);
+    if as_path.is_absolute()
+        || model_id.starts_with("./")
+        || model_id.starts_with("../")
+        || as_path.exists()
+    {
+        return load_local_model(as_path);
+    }
+
     tracing::info!("Downloading model {} (revision: {})", model_id, revision);
 
     let api = Api::new().context("Failed to create HuggingFace API client")?;

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod backend;
 mod bench;
 mod config;

--- a/inferrs/src/models/audio_encoder.rs
+++ b/inferrs/src/models/audio_encoder.rs
@@ -1,0 +1,690 @@
+//! Gemma 4 audio encoder (Conformer / Universal Speech Model).
+//!
+//! Architecture (per layer):
+//!   1. FeedForward1 (macaron, residual_weight=0.5)
+//!   2. norm_pre_attn → chunked local self-attention → norm_post_attn + residual
+//!   3. LightConv1d (GLU + depthwise conv)
+//!   4. FeedForward2 (macaron, residual_weight=0.5)
+//!   5. norm_out
+//!
+//! After N layers: output_proj (hidden_size → output_proj_dims).
+//!
+//! Weight prefix: `model.audio_tower.*`
+//! Projection prefix: `model.embed_audio.*`
+//!
+//! # Attention
+//! Uses chunked local attention with chunk_size=12 and context_left=13.
+//! For inference we implement this as full attention with a band mask — each
+//! query attends only to itself and the preceding 12 keys.  This is correct
+//! (same mathematical result as the blocked implementation) and fast enough
+//! given typical audio lengths after 4× subsampling (≤ ~750 frames for 30 s).
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Device, Module, Tensor, D};
+use candle_nn::{
+    layer_norm_no_bias, linear_no_bias, rms_norm, LayerNorm, Linear, RmsNorm, VarBuilder,
+};
+
+use crate::config::AudioConfig;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Clamp a tensor element-wise to `[-clip, clip]`.
+fn grad_clip(xs: &Tensor, clip: f32) -> Result<Tensor> {
+    Ok(xs.clamp(-clip as f64, clip as f64)?)
+}
+
+// ---------------------------------------------------------------------------
+// ClippableLinear — weights stored under `.linear.weight`.
+// ---------------------------------------------------------------------------
+
+/// A linear layer whose weights are stored under `.linear.weight`.
+///
+/// Applies QAT clipping bounds (input_min/max, output_min/max) from the checkpoint.
+/// The model was trained with quantization-aware training and stores per-layer
+/// saturation bounds that must be applied at inference time to match the reference.
+struct ClipLinear {
+    inner: Linear,
+    /// Clamp input to [input_min, input_max] before the linear (if stored).
+    input_min: Option<f32>,
+    input_max: Option<f32>,
+    /// Clamp output to [output_min, output_max] after the linear (if stored).
+    output_min: Option<f32>,
+    output_max: Option<f32>,
+}
+
+impl ClipLinear {
+    fn load(vb: VarBuilder, in_dim: usize, out_dim: usize) -> Result<Self> {
+        let inner = linear_no_bias(in_dim, out_dim, vb.pp("linear"))?;
+        // Load optional QAT clipping bounds.  These are 0-dim scalar tensors (shape []).
+        // If absent (e.g. non-QAT checkpoint) the clamping step is skipped.
+        let load_scalar = |name: &str| -> Option<f32> {
+            // Candle represents a 0-dim tensor as shape `()`.
+            vb.get((), name).ok().and_then(|t| {
+                t.to_dtype(candle_core::DType::F32)
+                    .ok()?
+                    .to_scalar::<f32>()
+                    .ok()
+            })
+        };
+        Ok(Self {
+            inner,
+            input_min: load_scalar("input_min"),
+            input_max: load_scalar("input_max"),
+            output_min: load_scalar("output_min"),
+            output_max: load_scalar("output_max"),
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        // Pre-linear input clamp
+        let xs = match (self.input_min, self.input_max) {
+            (Some(lo), Some(hi)) => xs.clamp(lo as f64, hi as f64)?,
+            _ => xs.clone(),
+        };
+        let xs = self.inner.forward(&xs)?;
+        // Post-linear output clamp
+        let xs = match (self.output_min, self.output_max) {
+            (Some(lo), Some(hi)) => xs.clamp(lo as f64, hi as f64)?,
+            _ => xs,
+        };
+        Ok(xs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SubSampleConvProjection
+// ---------------------------------------------------------------------------
+
+struct ConvProjLayer {
+    conv: candle_nn::Conv2d,
+    norm: LayerNorm,
+    out_channels: usize,
+}
+
+impl ConvProjLayer {
+    fn load(vb: VarBuilder, in_ch: usize, out_ch: usize, eps: f64) -> Result<Self> {
+        let conv = candle_nn::conv2d_no_bias(
+            in_ch,
+            out_ch,
+            3,
+            candle_nn::Conv2dConfig {
+                stride: 2,
+                padding: 1,
+                dilation: 1,
+                groups: 1,
+                cudnn_fwd_algo: None,
+            },
+            vb.pp("conv"),
+        )?;
+        let norm = layer_norm_no_bias(out_ch, eps, vb.pp("norm"))?;
+        Ok(Self {
+            conv,
+            norm,
+            out_channels: out_ch,
+        })
+    }
+
+    /// Input: `[batch, in_ch, T, freq]` → Output: `[batch, out_ch, T/2, freq/2]`
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let xs = self.conv.forward(xs)?;
+        // Move channels last for LayerNorm: [batch, T/2, freq/2, out_ch]
+        let xs = xs.permute((0, 2, 3, 1))?;
+        let xs = self.norm.forward(&xs)?;
+        let xs = xs.relu()?;
+        // Restore channel-first: [batch, out_ch, T/2, freq/2]
+        Ok(xs.permute((0, 3, 1, 2))?)
+    }
+}
+
+struct SubSampleConvProjection {
+    layer0: ConvProjLayer,
+    layer1: ConvProjLayer,
+    input_proj: Linear,
+}
+
+impl SubSampleConvProjection {
+    fn load(vb: VarBuilder, cfg: &AudioConfig) -> Result<Self> {
+        let layer0 = ConvProjLayer::load(
+            vb.pp("layer0"),
+            1,
+            cfg.subsampling_conv_channels[0],
+            cfg.rms_norm_eps,
+        )?;
+        let layer1 = ConvProjLayer::load(
+            vb.pp("layer1"),
+            cfg.subsampling_conv_channels[0],
+            cfg.subsampling_conv_channels[1],
+            cfg.rms_norm_eps,
+        )?;
+        // proj_input_dim = (N_MEL / 4) * ch1  (128 mel bins halved twice by stride-2 convs)
+        let proj_input_dim = (crate::audio::N_MEL / 4) * cfg.subsampling_conv_channels[1];
+        let input_proj =
+            linear_no_bias(proj_input_dim, cfg.hidden_size, vb.pp("input_proj_linear"))?;
+        Ok(Self {
+            layer0,
+            layer1,
+            input_proj,
+        })
+    }
+
+    /// Input: `[1, T, 128]` log-mel → Output: `[1, T/4, hidden_size]`
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        // Add channel dim: [1, 1, T, 128]
+        let xs = xs.unsqueeze(1)?;
+        let xs = self.layer0.forward(&xs)?;
+        let xs = self.layer1.forward(&xs)?;
+
+        let (batch, _ch, t4, freq4) = xs.dims4()?;
+        // [batch, ch=32, T/4, 32] → [batch, T/4, 32, 32]
+        let xs = xs.permute((0, 2, 3, 1))?;
+        // → [batch, T/4, 32*32=1024]
+        let xs = xs.reshape((batch, t4, freq4 * self.layer1.out_channels))?;
+        // Project: [batch, T/4, hidden_size]
+        Ok(self.input_proj.forward(&xs)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Relative positional encoding
+// ---------------------------------------------------------------------------
+
+/// Relative position embeddings matching the reference Gemma4 audio encoder.
+///
+/// Shape: `[context_left, hidden_size]` = `[13, 1024]`.
+///
+/// Reference: `position_ids = torch.arange(12, -1, -1)` → 13 decreasing values [12..0].
+/// Standard sinusoidal encoding: `inv_timescales[j] = 1 / 10000^(2j/d)`.
+/// `pos_embed[n] = [sin(pos[n] * inv_ts), cos(pos[n] * inv_ts)]`.
+///
+/// Indexing: for full-sequence attention (query i, key j):
+///   embed_idx = max_pos - clamp(i - j, 0, max_pos)
+///   = max_pos for j == i  (current position, relative pos = 0)
+///   = 0 for i - j >= 12  (furthest past, clamped)
+struct RelPositionalEncoding {
+    embeddings: Tensor,
+}
+
+impl RelPositionalEncoding {
+    fn new(cfg: &AudioConfig, device: &Device, dtype: DType) -> Result<Self> {
+        // 13 positions: [12, 11, ..., 0] (context_left = 13)
+        let n_pos = cfg.attention_context_left; // 13
+        let h = cfg.hidden_size;
+        let half = h / 2;
+
+        // inv_timescales[j] = 1 / 10000^(2j/h)  (standard sinusoidal PE)
+        let mut data = vec![0.0f32; n_pos * h];
+        for n in 0..n_pos {
+            let pos = (n_pos - 1 - n) as f32; // 12, 11, ..., 0
+            for j in 0..half {
+                let inv_ts = f32::exp(-2.0 * j as f32 * (10000f32).ln() / h as f32);
+                let angle = pos * inv_ts;
+                data[n * h + j] = angle.sin();
+                data[n * h + half + j] = angle.cos();
+            }
+        }
+        // Shape: [13, hidden_size]
+        let embeddings = Tensor::from_vec(data, (n_pos, h), device)?.to_dtype(dtype)?;
+        Ok(Self { embeddings })
+    }
+
+    fn get(&self) -> &Tensor {
+        &self.embeddings
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Audio attention (band-masked full attention with relative position bias)
+// ---------------------------------------------------------------------------
+
+struct AudioAttention {
+    q_proj: ClipLinear,
+    k_proj: ClipLinear,
+    v_proj: ClipLinear,
+    post: ClipLinear,
+    relative_k_proj: Tensor, // [num_heads * head_dim, hidden_size]
+    per_dim_scale: Tensor,   // [head_dim]
+    num_heads: usize,
+    head_dim: usize,
+    q_scale: f32,
+    k_scale: f32,
+    logit_cap: f32,
+    invalid_logit: f32,
+    #[allow(dead_code)]
+    chunk_size: usize, // attention_chunk_size (12) — block boundary step
+    context_left: usize, // attention_context_left (13) — lookback includes current
+}
+
+impl AudioAttention {
+    fn load(vb: VarBuilder, cfg: &AudioConfig) -> Result<Self> {
+        let head_dim = cfg.hidden_size / cfg.num_attention_heads;
+        let q_scale = ((head_dim as f64).powf(-0.5) / 2.0_f64.ln()) as f32;
+        let k_scale = ((1.0 + std::f64::consts::E).ln() / 2.0_f64.ln()) as f32;
+        let attn = vb.pp("self_attn");
+        Ok(Self {
+            q_proj: ClipLinear::load(attn.pp("q_proj"), cfg.hidden_size, cfg.hidden_size)?,
+            k_proj: ClipLinear::load(attn.pp("k_proj"), cfg.hidden_size, cfg.hidden_size)?,
+            v_proj: ClipLinear::load(attn.pp("v_proj"), cfg.hidden_size, cfg.hidden_size)?,
+            post: ClipLinear::load(attn.pp("post"), cfg.hidden_size, cfg.hidden_size)?,
+            relative_k_proj: attn.get(
+                (cfg.num_attention_heads * head_dim, cfg.hidden_size),
+                "relative_k_proj.weight",
+            )?,
+            per_dim_scale: attn.get((head_dim,), "per_dim_scale")?,
+            num_heads: cfg.num_attention_heads,
+            head_dim,
+            q_scale,
+            k_scale,
+            logit_cap: cfg.attention_logit_cap as f32,
+            invalid_logit: cfg.attention_invalid_logits_value as f32,
+            chunk_size: cfg.attention_chunk_size,
+            context_left: cfg.attention_context_left,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, pos_emb: &Tensor) -> Result<Tensor> {
+        let (batch, t, _) = xs.dims3()?;
+        let h = self.num_heads;
+        let d = self.head_dim;
+
+        // Projections and cast to f32 for attention (matches PyTorch .float()).
+        let q = self
+            .q_proj
+            .forward(xs)?
+            .reshape((batch, t, h, d))?
+            .to_dtype(DType::F32)?;
+        let k = self
+            .k_proj
+            .forward(xs)?
+            .reshape((batch, t, h, d))?
+            .to_dtype(DType::F32)?;
+        let v = self
+            .v_proj
+            .forward(xs)?
+            .reshape((batch, t, h, d))?
+            .to_dtype(DType::F32)?;
+
+        // Scale Q by q_scale * softplus(per_dim_scale)
+        let pds = self.per_dim_scale.to_dtype(DType::F32)?;
+        // softplus(x) = log(1 + exp(x))
+        let pds_sp = (pds.exp()? + 1.0_f64)?.log()?;
+        let q = (q.broadcast_mul(&pds_sp)? * self.q_scale as f64)?;
+
+        // Scale K
+        let k = (k * self.k_scale as f64)?;
+
+        // [batch, H, T, D] — make contiguous after permute for Metal
+        let q = q.permute((0, 2, 1, 3))?.contiguous()?;
+        let k = k.permute((0, 2, 1, 3))?.contiguous()?;
+        let v = v.permute((0, 2, 1, 3))?.contiguous()?;
+
+        // Content-content scores: [batch, H, T, T]
+        let matrix_ac = q.matmul(&k.transpose(2, 3)?.contiguous()?)?;
+
+        // Relative position bias (matrix_bd).
+        //
+        // pos_emb: [13, hidden_size]  (context_left = 13, positions [12..0] decreasing)
+        // relative_k_proj: [H*D, hidden_size] — standard nn.Linear weight layout
+        //
+        // Step 1: rel_k = pos_emb @ relative_k_proj.T  →  [13, H*D]
+        let rel_kp = self.relative_k_proj.to_dtype(DType::F32)?; // [H*D, hidden_size]
+        let pos_emb_f32 = pos_emb.to_dtype(DType::F32)?; // [13, hidden_size]
+        let rel_k_flat = pos_emb_f32.matmul(&rel_kp.t()?.contiguous()?)?; // [13, H*D]
+
+        // Step 2: reshape to [13, H, D], then permute to [H, D, 13]
+        let n_pos = rel_k_flat.dim(0)?; // 13
+        let rel_k = rel_k_flat.reshape((n_pos, h, d))?; // [13, H, D]
+        let rel_k = rel_k.permute((1, 2, 0))?.contiguous()?; // [H, D, 13]
+
+        // Step 3: qr = q @ rel_k  →  [batch, H, T, 13]
+        let qr = q.matmul(&rel_k.unsqueeze(0)?.broadcast_as((batch, h, d, n_pos))?)?;
+
+        // Step 4: gather indices.
+        // For (query i, key j): embed_idx = max_pos - clamp(i - j, 0, max_pos)
+        //   where max_pos = 12 (index of embedding for relative position 0).
+        // Equivalently: pos_emb[0] = embedding for distance 12 (furthest past),
+        //               pos_emb[12] = embedding for distance 0 (current position).
+        // Distances beyond 12 are clamped (all share the pos_emb[0] embedding).
+        let max_pos = (n_pos - 1) as i64; // 12
+        let mut idx_data = vec![0u32; t * t];
+        for i in 0..t {
+            for j in 0..t {
+                let dist = (i as i64 - j as i64).clamp(0, max_pos);
+                idx_data[i * t + j] = (max_pos - dist) as u32;
+            }
+        }
+        let idx = Tensor::from_vec(idx_data, (t, t), xs.device())?; // [T, T]
+
+        // Step 5: broadcast idx to [B, H, T, T] and gather from qr [B, H, T, 13]
+        let idx = idx
+            .unsqueeze(0)?
+            .unsqueeze(0)?
+            .broadcast_as((batch, h, t, t))?
+            .contiguous()?;
+        let matrix_bd = qr.contiguous()?.gather(&idx, 3)?; // [B, H, T, T]
+
+        // Step 6: combine content-content and position bias
+        let mut attn = (matrix_ac + matrix_bd)?;
+
+        // Softcap: tanh(attn / cap) * cap
+        attn = ((attn / self.logit_cap as f64)?.tanh()? * self.logit_cap as f64)?;
+
+        // Causal band mask: apply invalid_logit where mask=0
+        let mask = self.build_band_mask(t, xs.device())?; // u8: [1, 1, T, T]
+        let mask_f32 = mask.to_dtype(DType::F32)?.broadcast_as(attn.shape())?;
+        let fill =
+            Tensor::full(self.invalid_logit, attn.shape(), attn.device())?.to_dtype(DType::F32)?;
+        // attended positions: attn, masked positions: invalid_logit
+        attn = ((&attn * &mask_f32)? + (&fill * (1.0_f64 - &mask_f32)?)?)?;
+
+        // Softmax + weighted sum
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        let out = attn
+            .contiguous()?
+            .matmul(&v)?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?
+            .reshape((batch, t, h * d))?;
+
+        // Cast back and output projection
+        let out = out.to_dtype(xs.dtype())?;
+        self.post.forward(&out)
+    }
+
+    /// Causal sliding-window mask: u8 `[1, 1, T, T]`, `1` where query i may attend to key j.
+    ///
+    /// Each query attends to itself and the `max_past` = `context_left - 2` = 11 preceding
+    /// keys: j ∈ [i-11, i], giving a window of 12 positions.
+    /// This is mathematically equivalent to the reference blocked chunked attention
+    /// (chunk_size=12, context_left=13) when implemented as full T×T attention —
+    /// both produce the same attended key sets for every query position.
+    fn build_band_mask(&self, t: usize, device: &Device) -> Result<Tensor> {
+        // Causal sliding window: query i attends to keys j in [i - max_past, i].
+        // Reference: sliding_window_mask_function((chunk_size=12, 0)) → 12 positions.
+        // context_left=13 → max_past = context_left - 2 = 11 → window [i-11, i] = 12 keys.
+        // (Query 74 → [63..74], query 12 → [1..12], query 0 → [0..0])
+        let max_past = self.context_left - 2; // 11
+        let mut data = vec![0u8; t * t];
+        for i in 0..t {
+            let lo = i.saturating_sub(max_past);
+            for j in lo..=i {
+                data[i * t + j] = 1;
+            }
+        }
+        Ok(Tensor::from_vec(data, (1usize, 1usize, t, t), device)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FeedForward
+// ---------------------------------------------------------------------------
+
+struct AudioFeedForward {
+    layer1: ClipLinear,
+    layer2: ClipLinear,
+    pre_norm: RmsNorm,
+    post_norm: RmsNorm,
+    grad_clip: f32,
+    residual_weight: f32,
+}
+
+impl AudioFeedForward {
+    fn load(vb: VarBuilder, cfg: &AudioConfig) -> Result<Self> {
+        Ok(Self {
+            layer1: ClipLinear::load(vb.pp("ffw_layer_1"), cfg.hidden_size, cfg.hidden_size * 4)?,
+            layer2: ClipLinear::load(vb.pp("ffw_layer_2"), cfg.hidden_size * 4, cfg.hidden_size)?,
+            pre_norm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            post_norm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("post_layer_norm"))?,
+            grad_clip: cfg.gradient_clipping as f32,
+            residual_weight: cfg.residual_weight as f32,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let residual = xs.clone();
+        let xs = grad_clip(xs, self.grad_clip)?;
+        let xs = self.pre_norm.forward(&xs)?;
+        let xs = candle_nn::ops::silu(&self.layer1.forward(&xs)?)?;
+        let xs = self.layer2.forward(&xs)?;
+        let xs = grad_clip(&xs, self.grad_clip)?;
+        let xs = self.post_norm.forward(&xs)?;
+        let scaled = (xs * self.residual_weight as f64)?;
+        (scaled + residual).context("FFN residual add")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LightConv1d
+// ---------------------------------------------------------------------------
+
+struct LightConv1d {
+    linear_start: ClipLinear,
+    linear_end: ClipLinear,
+    conv_weight: Tensor, // [hidden, 1, kernel_size]
+    pre_norm: RmsNorm,
+    conv_norm: RmsNorm,
+    kernel_size: usize,
+    grad_clip: f32,
+}
+
+impl LightConv1d {
+    fn load(vb: VarBuilder, cfg: &AudioConfig) -> Result<Self> {
+        let h = cfg.hidden_size;
+        let k = cfg.conv_kernel_size;
+        Ok(Self {
+            linear_start: ClipLinear::load(vb.pp("linear_start"), h, h * 2)?,
+            linear_end: ClipLinear::load(vb.pp("linear_end"), h, h)?,
+            conv_weight: vb.get((h, 1, k), "depthwise_conv1d.weight")?,
+            pre_norm: rms_norm(h, cfg.rms_norm_eps, vb.pp("pre_layer_norm"))?,
+            conv_norm: rms_norm(h, cfg.rms_norm_eps, vb.pp("conv_norm"))?,
+            kernel_size: k,
+            grad_clip: cfg.gradient_clipping as f32,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let residual = xs.clone();
+        let (batch, _t, h) = xs.dims3()?;
+
+        let xs = self.pre_norm.forward(xs)?;
+        // GLU: linear_start → [batch, T, 2H] → split → gate
+        let xs2h = self.linear_start.forward(&xs)?; // [batch, T, 2H]
+        let xa = xs2h.narrow(D::Minus1, 0, h)?;
+        let xb = xs2h.narrow(D::Minus1, h, h)?;
+        let xs = (xa * candle_nn::ops::sigmoid(&xb)?)?; // [batch, T, H]
+
+        // Causal depthwise conv1d: left-pad by (kernel_size-1).
+        let left_pad = self.kernel_size - 1;
+        let pad = Tensor::zeros((batch, left_pad, h), xs.dtype(), xs.device())?;
+        let xs_padded = Tensor::cat(&[&pad, &xs], 1)?; // [batch, T+pad, H]
+
+        // Conv1d expects [batch, C, T]: transpose to [batch, H, T+pad]
+        // Metal conv1d only supports F32; cast to F32, conv, cast back.
+        let orig_dtype = xs.dtype();
+        let xs_t = xs_padded.to_dtype(DType::F32)?.permute((0, 2, 1))?;
+        let cw = self.conv_weight.to_dtype(DType::F32)?;
+        // Depthwise: groups = H, so each channel has its own filter of size k.
+        let xs_conv = xs_t.conv1d(&cw, 0, 1, 1, h)?.to_dtype(orig_dtype)?;
+        let xs = xs_conv.permute((0, 2, 1))?; // [batch, T, H]
+
+        let xs = grad_clip(&xs, self.grad_clip)?;
+        let xs = self.conv_norm.forward(&xs)?;
+        let xs = candle_nn::ops::silu(&xs)?;
+        let xs = self.linear_end.forward(&xs)?;
+        Ok((xs + residual)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full Conformer layer
+// ---------------------------------------------------------------------------
+
+struct AudioLayer {
+    ff1: AudioFeedForward,
+    ff2: AudioFeedForward,
+    attn: AudioAttention,
+    lconv: LightConv1d,
+    norm_pre_attn: RmsNorm,
+    norm_post_attn: RmsNorm,
+    norm_out: RmsNorm,
+    grad_clip: f32,
+}
+
+impl AudioLayer {
+    fn load(vb: VarBuilder, cfg: &AudioConfig) -> Result<Self> {
+        Ok(Self {
+            ff1: AudioFeedForward::load(vb.pp("feed_forward1"), cfg)?,
+            ff2: AudioFeedForward::load(vb.pp("feed_forward2"), cfg)?,
+            attn: AudioAttention::load(vb.clone(), cfg)?,
+            lconv: LightConv1d::load(vb.pp("lconv1d"), cfg)?,
+            norm_pre_attn: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm_pre_attn"))?,
+            norm_post_attn: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm_post_attn"))?,
+            norm_out: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("norm_out"))?,
+            grad_clip: cfg.gradient_clipping as f32,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, pos_emb: &Tensor) -> Result<Tensor> {
+        // Macaron FFN1
+        let xs = self.ff1.forward(xs)?;
+
+        // Local attention
+        let residual = xs.clone();
+        let xs_norm = self
+            .norm_pre_attn
+            .forward(&grad_clip(&xs, self.grad_clip)?)?;
+        let attn_out = self.attn.forward(&xs_norm, pos_emb)?;
+        let xs = (self
+            .norm_post_attn
+            .forward(&grad_clip(&attn_out, self.grad_clip)?)?
+            + residual)?;
+
+        // LightConv1d
+        let xs = self.lconv.forward(&xs)?;
+
+        // Macaron FFN2
+        let xs = self.ff2.forward(&xs)?;
+
+        // Final norm
+        Ok(self.norm_out.forward(&grad_clip(&xs, self.grad_clip)?)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public: AudioEncoder
+// ---------------------------------------------------------------------------
+
+/// Full Gemma 4 audio encoder.
+///
+/// Input: `[1, T, 128]` log-mel spectrogram on the model device.
+/// Output: `[T/4, lm_hidden_size]` embeddings ready for LM injection.
+pub struct AudioEncoder {
+    subsample: SubSampleConvProjection,
+    rel_pos: RelPositionalEncoding,
+    layers: Vec<AudioLayer>,
+    output_proj: Linear,      // hidden_size → output_proj_dims (with bias)
+    output_proj_bias: Tensor, // [output_proj_dims]
+    embed_proj: Linear,       // output_proj_dims → lm_hidden_size
+    rms_norm_eps: f64,
+    dtype: DType,
+}
+
+impl AudioEncoder {
+    /// Load from a VarBuilder rooted at `model.`
+    pub fn load(
+        vb: VarBuilder,
+        cfg: &AudioConfig,
+        lm_hidden_size: usize,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<Self> {
+        let at = vb.pp("audio_tower");
+        let subsample = SubSampleConvProjection::load(at.pp("subsample_conv_projection"), cfg)?;
+        let rel_pos = RelPositionalEncoding::new(cfg, device, dtype)?;
+
+        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
+        for i in 0..cfg.num_hidden_layers {
+            layers.push(AudioLayer::load(at.pp(format!("layers.{i}")), cfg)?);
+        }
+
+        let output_proj =
+            linear_no_bias(cfg.hidden_size, cfg.output_proj_dims, at.pp("output_proj"))?;
+        let output_proj_bias = at.get((cfg.output_proj_dims,), "output_proj.bias")?;
+
+        let embed_proj = linear_no_bias(
+            cfg.output_proj_dims,
+            lm_hidden_size,
+            vb.pp("embed_audio").pp("embedding_projection"),
+        )?;
+
+        Ok(Self {
+            subsample,
+            rel_pos,
+            layers,
+            output_proj,
+            output_proj_bias,
+            embed_proj,
+            rms_norm_eps: cfg.rms_norm_eps,
+            dtype,
+        })
+    }
+
+    /// Encode a log-mel spectrogram to LM-space embeddings.
+    ///
+    /// `mel`: f32 Tensor `[1, T, 128]` (on model device, or CPU — will be moved).
+    /// Returns: `[T/4, output_proj_dims]`.
+    /// Maximum mel frames to process (15s × 100fps = 1500 frames → 375 after 4× subsampling).
+    /// Full T×T attention on Metal is stable up to ~375 frames; larger inputs produce degenerate
+    /// output. TODO: implement blocked chunked attention (chunk_size=12) to lift this limit.
+    pub const MAX_MEL_FRAMES: usize = 1500;
+
+    pub fn encode(&self, mel: &Tensor) -> Result<Tensor> {
+        let pos_emb = self.rel_pos.get();
+
+        // Cast mel to the model's dtype (mel is always computed as F32)
+        let mel = mel.to_dtype(self.dtype)?;
+
+        // Truncate to MAX_MEL_FRAMES to stay within full-attention memory limits.
+        let t = mel.dim(1)?;
+        let mel = if t > Self::MAX_MEL_FRAMES {
+            mel.narrow(1, 0, Self::MAX_MEL_FRAMES)?
+        } else {
+            mel
+        };
+
+        // Subsampling: [1, T, 128] → [1, T/4, hidden_size]
+        let xs = self.subsample.forward(&mel)?;
+
+        // Conformer layers
+        let mut xs = xs;
+        for layer in &self.layers {
+            xs = layer.forward(&xs, pos_emb)?;
+        }
+
+        // Output projection: linear + bias
+        let xs = self.output_proj.forward(&xs)?;
+        let bias = self
+            .output_proj_bias
+            .to_dtype(xs.dtype())?
+            .unsqueeze(0)?
+            .unsqueeze(0)?;
+        let xs = xs.broadcast_add(&bias)?;
+
+        // embed_audio: RMSNorm (no learnable scale) then linear projection
+        let xs = rms_norm_no_scale(&xs, self.rms_norm_eps)?;
+        let xs = self.embed_proj.forward(&xs)?;
+
+        // Remove batch dim: [T/4, output_proj_dims]
+        Ok(xs.squeeze(0)?)
+    }
+}
+
+/// RMSNorm without a learnable scale: `x / rms(x)`.
+fn rms_norm_no_scale(xs: &Tensor, eps: f64) -> Result<Tensor> {
+    let x2 = xs.sqr()?;
+    let mean = x2.mean_keepdim(D::Minus1)?;
+    let rms = (mean + eps)?.sqrt()?;
+    Ok(xs.broadcast_div(&rms)?)
+}

--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -1965,14 +1965,102 @@ impl Gemma4Model {
         mask_1.expand((b_size, 1, tgt_len, kv_len))
     }
 
+    /// Forward pass with pre-computed audio embeddings.
+    ///
+    /// `audio_embeds`:   `[N, hidden_size]` — output of the audio encoder in LM space
+    /// `audio_positions`: positions in `input_ids` that are `<|audio|>` soft tokens
+    ///
+    /// Audio embeddings are in the unscaled token embedding space; they are
+    /// inserted before the `sqrt(hidden_size)` scale is applied, exactly as in
+    /// the reference `Gemma4ForConditionalGeneration.forward`.
+    pub fn forward_with_audio(
+        &mut self,
+        input_ids: &Tensor,
+        seqlen_offset: usize,
+        audio_embeds: Tensor,
+        audio_positions: Vec<usize>,
+    ) -> Result<Tensor> {
+        let (b_size, seq_len) = input_ids.dims2()?;
+
+        // Replace audio soft token IDs with 0 (pad) to avoid OOB embedding lookup.
+        let safe_ids = {
+            let ids_data = input_ids.to_vec2::<u32>()?;
+            let mut safe: Vec<u32> = ids_data.into_iter().flatten().collect();
+            for &pos in &audio_positions {
+                if pos < safe.len() {
+                    safe[pos] = 0;
+                }
+            }
+            Tensor::from_vec(safe, (b_size, seq_len), input_ids.device())?
+        };
+
+        // Embed tokens and scale by sqrt(hidden_size) — same as in forward().
+        // This matches the reference Gemma4TextScaledWordEmbedding which bakes
+        // the scale into the embedding lookup.
+        let xs = self.embed_tokens.forward(&safe_ids)?;
+        let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
+
+        // Inject audio embeddings into the already-scaled embedding tensor.
+        // Audio features from embedding_projection are trained to live in the
+        // scaled embedding space (the reference injects them after embed_tokens,
+        // which includes the sqrt scale).
+        //
+        // Save text-only xs (PAD at audio positions) for PLI computation.
+        // The reference uses llm_inputs_embeds (PAD at audio) for per_layer_model_projection,
+        // not the audio-injected embeddings.  Cloning before injection preserves that.
+        let xs_for_pli = xs.clone();
+        let audio_embeds = audio_embeds.to_device(xs.device())?.to_dtype(xs.dtype())?;
+        let h = self.hidden_size;
+        tracing::info!(
+            "forward_with_audio: injecting {} audio embeddings at {} positions",
+            audio_embeds.dim(0).unwrap_or(0),
+            audio_positions.len()
+        );
+        for (audio_idx, &pos) in audio_positions.iter().enumerate() {
+            if audio_idx >= audio_embeds.dim(0)? {
+                break;
+            }
+            let emb = audio_embeds.narrow(0, audio_idx, 1)?.unsqueeze(0)?; // [1, 1, H]
+            xs = xs.slice_assign(&[0..b_size, pos..pos + 1, 0..h], &emb)?;
+        }
+
+        self.forward_transformer(
+            b_size,
+            seq_len,
+            seqlen_offset,
+            &safe_ids,
+            Some(&xs_for_pli),
+            xs,
+        )
+    }
+
     pub fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
         let (b_size, seq_len) = input_ids.dims2()?;
 
         // Main token embeddings (scaled by sqrt(hidden_size) via embed_tokens convention)
         // Note: the Gemma embedding is raw; we scale here as in Gemma3.
         let xs = self.embed_tokens.forward(input_ids)?;
-        let mut xs = (xs * (self.hidden_size as f64).sqrt())?;
+        let xs = (xs * (self.hidden_size as f64).sqrt())?;
 
+        self.forward_transformer(b_size, seq_len, seqlen_offset, input_ids, None, xs)
+    }
+
+    /// Shared transformer body — runs PLI, attention layers, and lm_head.
+    ///
+    /// `ids_for_pli`: the token IDs used for PLI embedding lookup.  For the
+    /// audio path this is the safe (audio positions zeroed) IDs tensor.
+    fn forward_transformer(
+        &mut self,
+        b_size: usize,
+        seq_len: usize,
+        seqlen_offset: usize,
+        ids_for_pli: &Tensor,
+        // Text-only embeddings for PLI projection (PAD at audio positions).
+        // When Some, used for per_layer_model_projection instead of xs.
+        // Matches reference behavior: PLI uses llm_inputs_embeds (PAD at audio).
+        xs_for_pli: Option<&Tensor>,
+        mut xs: Tensor,
+    ) -> Result<Tensor> {
         // Per-layer inputs (PLI) — only for efficient variants.
         //
         // `pli_all` has shape [b, seq_len, num_hidden_layers, pli_dim].
@@ -1987,7 +2075,7 @@ impl Gemma4Model {
         let pli_per_layer: Vec<Option<Tensor>> = if let Some(model_pli) = &self.pli {
             // Embedding lookup on CPU, then transfer result to GPU.
             // The full table is CPU-resident to avoid exhausting VRAM.
-            let ids_cpu = input_ids.to_device(&Device::Cpu)?;
+            let ids_cpu = ids_for_pli.to_device(&Device::Cpu)?;
             let embed_dim = model_pli.embed_tokens_per_layer_cpu.dim(1)?;
             let mut out_dims = ids_cpu.dims().to_vec();
             out_dims.push(embed_dim);
@@ -1998,7 +2086,11 @@ impl Gemma4Model {
                 .reshape(out_dims)?;
             let pli_embed = pli_embed_cpu.to_device(&model_pli.gpu_device)?;
             let pli_embed = (pli_embed * model_pli.embed_combined_scale)?;
-            let pli_proj = xs.apply(&model_pli.per_layer_model_projection)?;
+            // For the audio path, per_layer_model_projection must use text-only embeddings
+            // (PAD at audio positions), matching the reference Gemma4Model.forward() which
+            // computes per_layer_inputs from llm_inputs_embeds (not the audio-injected ones).
+            let proj_input = xs_for_pli.unwrap_or(&xs);
+            let pli_proj = proj_input.apply(&model_pli.per_layer_model_projection)?;
             let pli_proj =
                 pli_proj.reshape((b_size, seq_len, self.num_hidden_layers, model_pli.pli_dim))?;
             let pli_proj = model_pli.per_layer_projection_norm.forward(&pli_proj)?;

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -4,6 +4,7 @@
 //! with a unified trait for the engine to use.
 
 pub mod attention_utils;
+pub mod audio_encoder;
 pub mod gemma4;
 pub mod qwen3;
 pub mod qwen3_5;
@@ -40,6 +41,28 @@ pub trait CausalLM: Send {
 
     /// Clear all KV caches (for starting a new sequence).
     fn clear_kv_cache(&mut self);
+
+    // ── Audio ────────────────────────────────────────────────────────────────
+
+    /// Returns `true` if this model has an audio encoder.
+    #[allow(dead_code)]
+    fn has_audio_tower(&self) -> bool {
+        false
+    }
+
+    /// Encode a log-mel spectrogram (f32, shape `[1, T, 128]`) to LM-space
+    /// embeddings of shape `[T/4, lm_hidden_size]`.
+    ///
+    /// Returns an error for models without an audio encoder.
+    fn encode_audio(&mut self, _mel: &Tensor) -> Result<Tensor> {
+        anyhow::bail!("this model does not have an audio encoder")
+    }
+
+    /// Store audio embeddings to be injected during the next `forward()` call.
+    ///
+    /// `embeds`:    `[N, lm_hidden_size]` — output of `encode_audio`
+    /// `positions`: indices in the upcoming `input_ids` that hold audio soft tokens
+    fn set_pending_audio(&mut self, _embeds: Tensor, _positions: Vec<usize>) {}
 }
 
 /// Implement `CausalLM` for a simple newtype wrapper whose `inner` field
@@ -97,18 +120,43 @@ impl CausalLM for Qwen3ModelWrapper {
     }
 }
 
-/// A Gemma4 model wrapper.
+/// A Gemma4 model wrapper (with optional audio encoder).
 struct Gemma4ModelWrapper {
     inner: gemma4::Gemma4Model,
+    audio_encoder: Option<crate::models::audio_encoder::AudioEncoder>,
+    /// Pending audio: embeddings + positions of audio soft tokens in input_ids.
+    pending_audio: Option<(Tensor, Vec<usize>)>,
 }
 
 impl CausalLM for Gemma4ModelWrapper {
     fn forward(&mut self, input_ids: &Tensor, seqlen_offset: usize) -> Result<Tensor> {
-        Ok(self.inner.forward(input_ids, seqlen_offset)?)
+        if let Some((audio_embeds, positions)) = self.pending_audio.take() {
+            Ok(self
+                .inner
+                .forward_with_audio(input_ids, seqlen_offset, audio_embeds, positions)?)
+        } else {
+            Ok(self.inner.forward(input_ids, seqlen_offset)?)
+        }
     }
 
     fn clear_kv_cache(&mut self) {
         self.inner.clear_kv_cache();
+    }
+
+    fn has_audio_tower(&self) -> bool {
+        self.audio_encoder.is_some()
+    }
+
+    fn encode_audio(&mut self, mel: &Tensor) -> Result<Tensor> {
+        let enc = self
+            .audio_encoder
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Gemma4 model was loaded without an audio tower"))?;
+        enc.encode(mel)
+    }
+
+    fn set_pending_audio(&mut self, embeds: Tensor, positions: Vec<usize>) {
+        self.pending_audio = Some((embeds, positions));
     }
 }
 
@@ -390,8 +438,34 @@ pub fn load_model(
                 config.hidden_size,
                 config.num_key_value_heads,
             );
+            let inner = gemma4::Gemma4Model::new(&config, vb.clone(), gemma4_qvb.as_ref())?;
+
+            // Load audio encoder if audio_config is present in the model config.
+            let audio_encoder = if let Some(audio_cfg) = &raw_config.audio_config {
+                tracing::info!(
+                    "Gemma4 audio encoder: {} layers, hidden={}, output_dims={}",
+                    audio_cfg.num_hidden_layers,
+                    audio_cfg.hidden_size,
+                    audio_cfg.output_proj_dims,
+                );
+                let enc = audio_encoder::AudioEncoder::load(
+                    vb.pp("model"),
+                    audio_cfg,
+                    config.hidden_size,
+                    device,
+                    dtype,
+                )
+                .context("Failed to load Gemma4 audio encoder")?;
+                tracing::info!("Audio encoder loaded successfully");
+                Some(enc)
+            } else {
+                None
+            };
+
             Box::new(Gemma4ModelWrapper {
-                inner: gemma4::Gemma4Model::new(&config, vb, gemma4_qvb.as_ref())?,
+                inner,
+                audio_encoder,
+                pending_audio: None,
             })
         }
     };

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -13,9 +13,9 @@ use crossterm::{
 use std::io::{self, Write};
 use std::sync::mpsc as stdmpsc;
 
-use crate::engine::{load_engine, StreamToken, SyncEngineRequest};
+use crate::engine::{load_engine, AudioEmbedContext, StreamToken, SyncEngineRequest};
 use crate::sampler::SamplingParams;
-use crate::tokenizer::{ChatMessage, Role, Tokenizer};
+use crate::tokenizer::{apply_gemma4_with_audio, AudioInput, ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
 
 // ─── CLI args ────────────────────────────────────────────────────────────────
@@ -87,6 +87,10 @@ pub struct RunArgs {
     #[arg(long, num_args(0..=1), default_missing_value("Q4K"), require_equals(true),
           value_name = "FORMAT")]
     pub quantize: Option<String>,
+
+    /// Path to a WAV audio file to attach to the prompt (Gemma 4 audio models).
+    #[arg(long)]
+    pub audio: Option<std::path::PathBuf>,
 }
 
 impl RunArgs {
@@ -141,6 +145,10 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     // Load model, build engine, attach paged KV.
     let ctx = load_engine(&serve)?;
 
+    // Extract fields needed before ctx is partially moved.
+    let audio_token_id = ctx.raw_config.audio_token_id;
+    let max_seq_len = ctx.max_seq_len;
+
     // REPL needs its own tokenizer for chat-template encoding.
     let tokenizer = Tokenizer::from_file_with_arch(
         &ctx.model_files.tokenizer_path,
@@ -161,7 +169,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         top_k: args.top_k,
         max_tokens: args
             .max_tokens
-            .min(ctx.max_seq_len.saturating_sub(4096).max(256)),
+            .min(max_seq_len.saturating_sub(4096).max(256)),
         ..SamplingParams::default()
     };
 
@@ -177,13 +185,51 @@ fn run_blocking(args: RunArgs) -> Result<()> {
 
     // Non-interactive: single prompt then exit
     if let Some(prompt) = args.prompt {
+        // Build audio context if --audio was given.
+        let audio_ctx = if let Some(audio_path) = &args.audio {
+            let token_id = audio_token_id.ok_or_else(|| {
+                anyhow::anyhow!("This model does not support audio (no audio_token_id in config)")
+            })?;
+            let raw_bytes = std::fs::read(audio_path)?;
+            let samples = crate::audio::decode_audio(&raw_bytes, "wav")?;
+            let (mel_data, n_mel_frames) = crate::audio::compute_log_mel(&samples)?;
+            let effective_mel =
+                n_mel_frames.min(crate::models::audio_encoder::AudioEncoder::MAX_MEL_FRAMES);
+            let after_pass1 = (effective_mel.saturating_sub(1)) / 2 + 1;
+            let n_audio_tokens = (after_pass1.saturating_sub(1)) / 2 + 1;
+            let mel_tensor = candle_core::Tensor::from_vec(
+                mel_data,
+                (1, n_mel_frames, crate::audio::N_MEL),
+                &candle_core::Device::Cpu,
+            )?;
+            messages.push(ChatMessage {
+                role: Role::User,
+                audio: Some(AudioInput {
+                    data: String::new(),
+                    format: "wav".to_string(),
+                }),
+                content: prompt,
+            });
+            let prompt_str = apply_gemma4_with_audio(&messages, &[n_audio_tokens]);
+            let prompt_tokens = tokenizer.encode(&prompt_str, false)?;
+            let ctx = AudioEmbedContext {
+                mel: mel_tensor,
+                audio_token_id: token_id,
+            };
+            stream_response_collect(&engine_tx, prompt_tokens, Some(ctx), &sampling_params)?;
+            println!();
+            return Ok(());
+        } else {
+            None
+        };
+
         messages.push(ChatMessage {
             role: Role::User,
             audio: None,
             content: prompt,
         });
         let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
-        stream_response_collect(&engine_tx, prompt_tokens, &sampling_params)?;
+        stream_response_collect(&engine_tx, prompt_tokens, audio_ctx, &sampling_params)?;
         println!();
         return Ok(());
     }
@@ -305,7 +351,7 @@ fn repl(
 
         // Stream the response and collect the full text for history
         let assistant_text =
-            match stream_response_collect(&engine_tx, prompt_tokens, &sampling_params) {
+            match stream_response_collect(&engine_tx, prompt_tokens, None, &sampling_params) {
                 Ok(t) => t,
                 Err(e) => {
                     eprintln!("Generation error: {e}");
@@ -403,6 +449,7 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
 fn stream_response_collect(
     engine_tx: &stdmpsc::SyncSender<SyncEngineRequest>,
     prompt_tokens: Vec<u32>,
+    audio: Option<AudioEmbedContext>,
     sampling_params: &SamplingParams,
 ) -> Result<String> {
     let (token_tx, token_rx) = stdmpsc::sync_channel::<StreamToken>(256);
@@ -411,6 +458,7 @@ fn stream_response_collect(
     engine_tx.send(SyncEngineRequest::GenerateStream {
         request_id,
         prompt_tokens,
+        audio,
         sampling_params: sampling_params.clone(),
         token_tx,
     })?;

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -170,6 +170,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     if let Some(sys) = &args.system {
         messages.push(ChatMessage {
             role: Role::System,
+            audio: None,
             content: sys.clone(),
         });
     }
@@ -178,6 +179,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
     if let Some(prompt) = args.prompt {
         messages.push(ChatMessage {
             role: Role::User,
+            audio: None,
             content: prompt,
         });
         let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
@@ -288,6 +290,7 @@ fn repl(
         messages.push(ChatMessage {
             role: Role::User,
             content: user_content,
+            audio: None,
         });
 
         // Encode the full conversation with the chat template
@@ -316,6 +319,7 @@ fn repl(
         // Append assistant turn to history
         messages.push(ChatMessage {
             role: Role::Assistant,
+            audio: None,
             content: assistant_text,
         });
     }
@@ -350,6 +354,7 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
                         ChatMessage {
                             role: Role::System,
                             content: parts[2].to_string(),
+                            audio: None,
                         },
                     );
                     println!("System prompt set.");

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use axum::{
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     response::{
         sse::{Event, Sse},
@@ -19,9 +19,11 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tower_http::cors::CorsLayer;
 
-use crate::engine::{load_engine, EngineRequest, GenerationResult, OutputBuffer, StreamToken};
+use crate::engine::{
+    load_engine, AudioEmbedContext, EngineRequest, GenerationResult, OutputBuffer, StreamToken,
+};
 use crate::sampler::SamplingParams;
-use crate::tokenizer::{ChatMessage, Role, Tokenizer};
+use crate::tokenizer::{apply_gemma4_with_audio, AudioInput, ChatMessage, Role, Tokenizer};
 use crate::ServeArgs;
 
 // ---------------------------------------------------------------------------
@@ -442,6 +444,7 @@ fn anthropic_messages_to_chat(
         chat_messages.push(ChatMessage {
             role: Role::System,
             content: sys.to_string(),
+            audio: None,
         });
     }
     for msg in messages {
@@ -452,6 +455,7 @@ fn anthropic_messages_to_chat(
         chat_messages.push(ChatMessage {
             role,
             content: msg.content.clone(),
+            audio: None,
         });
     }
     chat_messages
@@ -470,6 +474,20 @@ struct AppState {
     output_buf: OutputBuffer,
     /// Maps request_id → per-client SSE channel.
     stream_registry: StreamRegistry,
+    /// Token ID for `<|audio|>` soft tokens, present when model supports audio.
+    audio_token_id: Option<u32>,
+}
+
+fn audio_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: ErrorDetail {
+                message: message.into(),
+                r#type: "invalid_request_error".to_string(),
+            },
+        }),
+    )
 }
 
 // ─── Server startup ─────────────────────────────────────────────────────────
@@ -494,6 +512,10 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         ..SamplingParams::default()
     };
 
+    // Extract values from ctx before it is moved into the engine thread.
+    let max_seq_len = ctx.max_seq_len;
+    let audio_token_id = ctx.raw_config.audio_token_id;
+
     // Create the shared output buffer and per-request stream registry.
     let output_buf = OutputBuffer::new();
     let stream_registry: StreamRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -514,9 +536,10 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         engine_tx,
         tokenizer,
         default_params,
-        max_seq_len: ctx.max_seq_len,
+        max_seq_len,
         output_buf,
         stream_registry,
+        audio_token_id,
     });
 
     // Build router
@@ -526,6 +549,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/models", get(list_models))
         .route("/health", get(health))
+        .layer(DefaultBodyLimit::max(64 * 1024 * 1024)) // 64 MiB for audio payloads
         .layer(CorsLayer::permissive())
         .with_state(state);
 
@@ -548,20 +572,97 @@ async fn chat_completions(
     let created = unix_now();
     let model_id = req.model.clone().unwrap_or_else(|| state.model_id.clone());
 
-    // Apply chat template and tokenize
-    let prompt_tokens = match state
-        .tokenizer
-        .apply_chat_template_and_encode(&req.messages)
-    {
-        Ok(tokens) => tokens,
-        Err(e) => return Err(tokenization_error(e)),
+    // ── Audio preprocessing ──────────────────────────────────────────────────
+    // If any message has an audio attachment:
+    //   1. Decode audio bytes → PCM samples
+    //   2. Compute log-mel spectrogram → Tensor [1, T, 128]
+    //   3. Determine N = T / 4 (audio soft tokens after 4× subsampling)
+    //   4. Tokenize the prompt with N audio soft-token placeholders
+    //   5. Build AudioEmbedContext carrying the mel tensor (encoding happens on
+    //      the engine thread which owns the model weights)
+    let has_audio = req.messages.iter().any(|m| m.audio.is_some());
+
+    let (prompt_tokens, audio_ctx) = if has_audio {
+        let audio_token_id = state.audio_token_id.ok_or_else(|| {
+            audio_error("This model does not support audio input (no audio_token_id in config)")
+        })?;
+
+        // Collect audio inputs in message order.
+        let audio_inputs: Vec<&AudioInput> = req
+            .messages
+            .iter()
+            .filter_map(|m| m.audio.as_ref())
+            .collect();
+
+        if audio_inputs.len() > 1 {
+            return Err(audio_error(
+                "Only one audio input per request is currently supported",
+            ));
+        }
+        let audio_in = audio_inputs[0];
+
+        let raw_bytes =
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, &audio_in.data)
+                .map_err(|e| audio_error(format!("Base64 decode failed: {e}")))?;
+
+        let samples = crate::audio::decode_audio(&raw_bytes, &audio_in.format)
+            .map_err(|e| audio_error(format!("Audio decode failed: {e}")))?;
+
+        let (mel_data, n_mel_frames) = crate::audio::compute_log_mel(&samples)
+            .map_err(|e| audio_error(format!("Mel spectrogram failed: {e}")))?;
+
+        // Number of audio soft tokens after two stride-2 conv layers (kernel=3, padding=1).
+        // Each pass: out = floor((in - 1) / 2) + 1  (= ceil(in / 2)).
+        // Cap to AudioEncoder::MAX_MEL_FRAMES to match encoder truncation.
+        let effective_mel_frames =
+            n_mel_frames.min(crate::models::audio_encoder::AudioEncoder::MAX_MEL_FRAMES);
+        let after_pass1 = (effective_mel_frames.saturating_sub(1)) / 2 + 1;
+        let n_audio_tokens = (after_pass1.saturating_sub(1)) / 2 + 1;
+
+        // Tokenize with audio soft-token placeholders.
+        let prompt = apply_gemma4_with_audio(&req.messages, &[n_audio_tokens]);
+        let tokens = state
+            .tokenizer
+            .encode(&prompt, false)
+            .map_err(tokenization_error)?;
+
+        // Build mel tensor on CPU (engine thread moves it to device).
+        let mel_tensor = candle_core::Tensor::from_vec(
+            mel_data,
+            (1, n_mel_frames, crate::audio::N_MEL),
+            &candle_core::Device::Cpu,
+        )
+        .map_err(|e| server_error(format!("Mel tensor creation failed: {e}")))?
+        .to_dtype(candle_core::DType::F32)
+        .map_err(|e| server_error(format!("Mel dtype conversion failed: {e}")))?;
+
+        let audio_ctx = AudioEmbedContext {
+            mel: mel_tensor,
+            audio_token_id,
+        };
+
+        (tokens, Some(audio_ctx))
+    } else {
+        let tokens = match state
+            .tokenizer
+            .apply_chat_template_and_encode(&req.messages)
+        {
+            Ok(t) => t,
+            Err(e) => return Err(tokenization_error(e)),
+        };
+        (tokens, None)
     };
 
     tracing::info!(
-        "Request {}: {} messages, {} prompt tokens",
+        "Request {}: {} messages, {} prompt tokens{}",
         request_id,
         req.messages.len(),
-        prompt_tokens.len()
+        prompt_tokens.len(),
+        if audio_ctx.is_some() {
+            " (with audio)"
+        } else {
+            ""
+        }
     );
 
     check_prompt_length(prompt_tokens.len(), state.max_seq_len)?;
@@ -595,6 +696,7 @@ async fn chat_completions(
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
+            audio: audio_ctx,
             sampling_params: params,
             output_buf: state.output_buf.clone(),
         };
@@ -613,6 +715,7 @@ async fn chat_completions(
         let engine_req = EngineRequest::Generate {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
+            audio: audio_ctx,
             sampling_params: params,
             response_tx,
         };
@@ -813,6 +916,7 @@ async fn completions(
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens,
+            audio: None,
             sampling_params: params,
             output_buf: state.output_buf.clone(),
         };
@@ -831,6 +935,7 @@ async fn completions(
         let engine_req = EngineRequest::Generate {
             request_id: request_id.clone(),
             prompt_tokens,
+            audio: None,
             sampling_params: params,
             response_tx,
         };
@@ -971,6 +1076,7 @@ async fn anthropic_messages(
         let engine_req = EngineRequest::GenerateStream {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
+            audio: None,
             sampling_params: params,
             output_buf: state.output_buf.clone(),
         };
@@ -992,6 +1098,7 @@ async fn anthropic_messages(
         let engine_req = EngineRequest::Generate {
             request_id: request_id.clone(),
             prompt_tokens: prompt_tokens.clone(),
+            audio: None,
             sampling_params: params,
             response_tx,
         };

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -23,11 +23,28 @@ impl std::fmt::Display for Role {
     }
 }
 
-/// A chat message.
+/// Audio attachment on a chat message.
+///
+/// `data` is a base64-encoded audio file.  `format` should be `"wav"` (default)
+/// or `"pcm_f32"` (raw little-endian f32 samples at 16 kHz).
+#[derive(Debug, Clone, serde::Serialize, Deserialize)]
+pub struct AudioInput {
+    pub data: String,
+    #[serde(default = "default_audio_format")]
+    pub format: String,
+}
+
+fn default_audio_format() -> String {
+    "wav".to_string()
+}
+
+/// A chat message (text + optional audio attachment).
 #[derive(Debug, Clone, serde::Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub audio: Option<AudioInput>,
 }
 
 /// Chat template format detected from the model.
@@ -328,26 +345,54 @@ fn apply_gemma3(messages: &[ChatMessage]) -> String {
     )
 }
 
-/// Gemma4 chat template.
+/// Gemma4 chat template (text-only, no audio).
 ///
 /// Format: `<bos>\n<|turn>role\ncontent<turn|>\n`
 /// The assistant turn uses "model" as the role label.
 fn apply_gemma4(messages: &[ChatMessage]) -> String {
-    // The Gemma4 jinja template emits `{{ bos_token }}\n` — there is a literal
-    // newline directly after the bos token before the first turn marker.
-    apply_gemma_family(
-        messages,
-        "<bos>\n",
-        "<|turn>",
-        "<turn|>\n",
-        "<|turn>model\n",
-        |role| match role {
+    apply_gemma4_inner(messages, &[])
+}
+
+/// Gemma4 template with audio soft-token placeholders.
+///
+/// For each message that has an `audio` field, `n_audio_tokens` audio soft
+/// token placeholders are inserted between `<boa>` and `<eoa>`.
+/// `audio_token_counts[i]` is the number of soft tokens for the i-th audio
+/// message (in encounter order across all messages).
+pub fn apply_gemma4_with_audio(messages: &[ChatMessage], audio_token_counts: &[usize]) -> String {
+    apply_gemma4_inner(messages, audio_token_counts)
+}
+
+fn apply_gemma4_inner(messages: &[ChatMessage], audio_token_counts: &[usize]) -> String {
+    // Reference format (from AutoProcessor.apply_chat_template):
+    //   <bos><|turn>user\n<|audio><|audio|>×N<audio|>text<turn|>\n<|turn>model\n
+    // No \n after <bos>, no \n between <audio|> and text.
+    let mut prompt = String::from("<bos>");
+    let mut audio_idx = 0usize;
+    for msg in messages {
+        let role = match msg.role {
             Role::System => "system",
             Role::User => "user",
             Role::Assistant => "model",
-        },
-        str::trim,
-    )
+        };
+        // Build the content, inserting audio tokens if this message has audio.
+        // Token strings from the Gemma4 tokenizer:
+        //   <|audio>   = begin-of-audio  (id 256000)
+        //   <|audio|>  = audio soft token (id 258881), repeated N times
+        //   <audio|>   = end-of-audio    (id 258883)
+        let content = if msg.audio.is_some() {
+            let n = audio_token_counts.get(audio_idx).copied().unwrap_or(0);
+            audio_idx += 1;
+            let soft_tokens = "<|audio|>".repeat(n);
+            // No newline between <audio|> and text — matches reference template.
+            format!("<|audio>{soft_tokens}<audio|>{}", msg.content.trim())
+        } else {
+            msg.content.trim().to_string()
+        };
+        prompt.push_str(&format!("<|turn>{}\n{}<turn|>\n", role, content));
+    }
+    prompt.push_str("<|turn>model\n");
+    prompt
 }
 
 fn apply_generic(messages: &[ChatMessage]) -> String {
@@ -366,6 +411,7 @@ mod tests {
     fn user_msg(content: &str) -> ChatMessage {
         ChatMessage {
             role: Role::User,
+            audio: None,
             content: content.to_string(),
         }
     }
@@ -373,6 +419,7 @@ mod tests {
     fn system_msg(content: &str) -> ChatMessage {
         ChatMessage {
             role: Role::System,
+            audio: None,
             content: content.to_string(),
         }
     }
@@ -380,6 +427,7 @@ mod tests {
     fn assistant_msg(content: &str) -> ChatMessage {
         ChatMessage {
             role: Role::Assistant,
+            audio: None,
             content: content.to_string(),
         }
     }


### PR DESCRIPTION
Adds end-to-end audio inference for Gemma 4 models: mel spectrogram extraction, USM/Conformer audio encoder (12 layers, chunked local attention), and injection of audio embeddings into the LM embedding space before the transformer layers.

1. Record a WAV file

Open **QuickTime Player** → File → New Audio Recording. Click the red button to record, then stop and save.

This records 16 kHz mono 16-bit PCM, the ideal format. Press Ctrl+C to stop early.

2. Convert to the required format (if needed)

If you recorded via QuickTime or have an existing file, convert it with ffmpeg:

```
brew install ffmpeg
ffmpeg -i input.m4a -ar 16000 -ac 1 -sample_fmt s16 /tmp/my_audio.wav
```

Requirements: 16 kHz sample rate, mono, 16-bit PCM or 32-bit float. Files longer than 15 seconds are truncated.

3. Build and start the server

```
cargo build --release
./target/release/inferrs serve /path/to/gemma-4-E2B-it --port 8080
```

4. Encode the audio and send the request
```
$ curl -X POST http://localhost:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d "$(python3 -c "
  import json, base64
  audio = open('/tmp/my_audio.wav', 'rb').read()
  b64 = base64.b64encode(audio).decode()
  payload = {
    'model': 'gemma-4',
    'messages': [{
      'role': 'user',
      'content': 'what is my name? i say it in the audio recording',
      'audio': {'data': b64, 'format': 'wav'}
    }],
    'max_tokens': 200,
    'temperature': 0.1
  }
  print(json.dumps(payload))
  ")"
{"id":"chatcmpl-844fe3b9-3347-483c-bb2d-3bb98378e36e","object":"chat.completion","created":1775476869,"model":"gemma-4","choices":[{"index":0,"message":{"role":"assistant","content":"Your name is Dorothy."},"finish_reason":"stop"}],"usage":{"prompt_tokens":172,"completion_tokens":6,"total_tokens":178}}
```