### PR TITLE
add inferrs pull subcommand

### DIFF
--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -6,6 +6,7 @@ mod engine;
 mod hub;
 mod kv_cache;
 mod models;
+mod pull;
 mod quantize;
 mod rm;
 mod run;
@@ -65,6 +66,8 @@ enum Commands {
     Run(run::RunArgs),
     /// Benchmark inference throughput and latency
     Bench(bench::BenchArgs),
+    /// Download a model to the local cache without serving it
+    Pull(pull::PullArgs),
     /// Remove a cached model from local disk
     Rm(rm::RmArgs),
 }
@@ -264,7 +267,7 @@ async fn main() -> Result<()> {
     // Users can still get logs by setting RUST_LOG explicitly (e.g. RUST_LOG=debug).
     let default_log_level = match &cli.command {
         Commands::Run(_) | Commands::Bench(_) | Commands::Rm(_) => "error",
-        _ => "info",
+        _ => "info", // Pull and Serve both benefit from info-level progress log
     };
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -283,6 +286,9 @@ async fn main() -> Result<()> {
         Commands::Bench(args) => {
             tracing::info!("Running benchmark for model: {}", args.serve.model);
             bench::run(args)?;
+        }
+        Commands::Pull(args) => {
+            pull::run(args)?;
         }
         Commands::Rm(args) => {
             rm::run(args)?;

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -1,0 +1,46 @@
+//! `inferrs pull` — pre-download a HuggingFace model to the local cache.
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser, Clone)]
+pub struct PullArgs {
+    /// HuggingFace model ID (e.g. Qwen/Qwen3.5-0.8B)
+    pub model: String,
+
+    /// Git branch or tag on HuggingFace Hub
+    #[arg(long, default_value = "main")]
+    pub revision: String,
+
+    /// Quantize weights and cache the result as a GGUF file.
+    ///
+    /// Accepted formats (case-insensitive): Q4_0, Q4_1, Q5_0, Q5_1, Q8_0,
+    /// Q2K, Q3K, Q4K (Q4_K_M), Q5K, Q6K.
+    ///
+    /// When used as a plain flag (`--quantize`) the default Q4_K_M (= Q4K) is used.
+    #[arg(long, num_args(0..=1), default_missing_value("Q4K"), require_equals(true),
+          value_name = "FORMAT")]
+    pub quantize: Option<String>,
+}
+
+pub fn run(args: PullArgs) -> Result<()> {
+    let quant_dtype = args
+        .quantize
+        .as_deref()
+        .map(crate::quantize::parse_format)
+        .transpose()?;
+
+    let files = crate::hub::download_and_maybe_quantize(&args.model, &args.revision, quant_dtype)?;
+
+    println!("Pulled {}", args.model);
+    println!("  config:    {}", files.config_path.display());
+    println!("  tokenizer: {}", files.tokenizer_path.display());
+    for w in &files.weight_paths {
+        println!("  weights:   {}", w.display());
+    }
+    if let Some(gguf) = &files.gguf_path {
+        println!("  gguf:      {}", gguf.display());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Pre-download a HuggingFace model to the local cache without starting the server. Supports --revision and --quantize (same semantics as inferrs serve) so users can warm the cache and optionally convert weights to GGUF in one step.