### PR TITLE
add inferrs list subcommand

### DIFF
--- a/inferrs/src/list.rs
+++ b/inferrs/src/list.rs
@@ -1,0 +1,63 @@
+//! `inferrs list` — show locally cached HuggingFace models.
+
+use anyhow::Result;
+use clap::Parser;
+
+use crate::util::{cache_root, dir_size, format_bytes};
+
+#[derive(Parser, Clone)]
+pub struct ListArgs {}
+
+pub fn run(_args: ListArgs) -> Result<()> {
+    let cache_dir = cache_root();
+
+    if !cache_dir.exists() {
+        println!(
+            "No models cached (cache directory does not exist: {})",
+            cache_dir.display()
+        );
+        return Ok(());
+    }
+
+    let mut entries: Vec<(String, u64)> = std::fs::read_dir(&cache_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().map(|t| t.is_dir()).unwrap_or(false)
+                && e.file_name().to_string_lossy().starts_with("models--")
+        })
+        .map(|e| {
+            let folder = e.file_name().to_string_lossy().into_owned();
+            let model_id = folder_to_model_id(&folder);
+            let size = dir_size(&e.path()).unwrap_or(0);
+            (model_id, size)
+        })
+        .collect();
+
+    if entries.is_empty() {
+        println!("No models cached.");
+        return Ok(());
+    }
+
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let name_width = entries.iter().map(|(id, _)| id.len()).max().unwrap_or(0);
+
+    for (model_id, size) in &entries {
+        println!(
+            "{:<width$}  {}",
+            model_id,
+            format_bytes(*size),
+            width = name_width
+        );
+    }
+
+    Ok(())
+}
+
+/// Convert "models--Org--Name" back to "Org/Name".
+fn folder_to_model_id(folder: &str) -> String {
+    folder
+        .strip_prefix("models--")
+        .unwrap_or(folder)
+        .replace("--", "/")
+}

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod engine;
 mod hub;
 mod kv_cache;
+mod list;
 mod models;
 mod pull;
 mod quantize;
@@ -70,6 +71,8 @@ enum Commands {
     Pull(pull::PullArgs),
     /// Remove a cached model from local disk
     Rm(rm::RmArgs),
+    /// List locally cached models
+    List(list::ListArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -262,11 +265,11 @@ impl ServeArgs {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    // For `run`, `bench`, and `rm`, suppress info-level logging by default — the interactive REPL
-    // writes to stdout and log lines would corrupt the prompt display.
+    // For `run`, `bench`, `rm`, and `list`, suppress info-level logging by default — the
+    // interactive REPL writes to stdout and log lines would corrupt the prompt display.
     // Users can still get logs by setting RUST_LOG explicitly (e.g. RUST_LOG=debug).
     let default_log_level = match &cli.command {
-        Commands::Run(_) | Commands::Bench(_) | Commands::Rm(_) => "error",
+        Commands::Run(_) | Commands::Bench(_) | Commands::Rm(_) | Commands::List(_) => "error",
         _ => "info", // Pull and Serve both benefit from info-level progress log
     };
     tracing_subscriber::fmt()
@@ -292,6 +295,9 @@ async fn main() -> Result<()> {
         }
         Commands::Rm(args) => {
             rm::run(args)?;
+        }
+        Commands::List(args) => {
+            list::run(args)?;
         }
     }
 

--- a/inferrs/src/rm.rs
+++ b/inferrs/src/rm.rs
@@ -3,9 +3,8 @@
 use anyhow::Result;
 use clap::Parser;
 use std::io::Write;
-use std::path::{Path, PathBuf};
 
-use crate::util::format_bytes;
+use crate::util::{cache_root, dir_size, format_bytes};
 
 #[derive(Parser, Clone)]
 pub struct RmArgs {
@@ -53,40 +52,7 @@ pub fn run(args: RmArgs) -> Result<()> {
     Ok(())
 }
 
-/// Resolve the hf-hub cache root: `$HF_HOME/hub` or `~/.cache/huggingface/hub`.
-fn cache_root() -> PathBuf {
-    if let Ok(hf_home) = std::env::var("HF_HOME") {
-        PathBuf::from(hf_home).join("hub")
-    } else if let Ok(xdg_cache) = std::env::var("XDG_CACHE_HOME") {
-        PathBuf::from(xdg_cache).join("huggingface/hub")
-    } else {
-        dirs_home().join(".cache/huggingface/hub")
-    }
-}
-
-/// Portable home directory without pulling in the `dirs` crate.
-fn dirs_home() -> PathBuf {
-    std::env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("/"))
-}
-
 /// Convert "Org/Name" → "models--Org--Name" (mirrors hf-hub's `Repo::folder_name`).
 fn model_folder_name(model_id: &str) -> String {
     format!("models--{model_id}").replace('/', "--")
-}
-
-/// Recursively sum the size of all files under `path`.
-fn dir_size(path: &Path) -> Result<u64> {
-    let mut total = 0u64;
-    for entry in std::fs::read_dir(path)? {
-        let entry = entry?;
-        let metadata = entry.metadata()?;
-        if metadata.is_dir() {
-            total += dir_size(&entry.path()).unwrap_or(0);
-        } else {
-            total += metadata.len();
-        }
-    }
-    Ok(total)
 }

--- a/inferrs/src/util.rs
+++ b/inferrs/src/util.rs
@@ -1,5 +1,9 @@
 //! Shared utility helpers.
 
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
 /// Format a byte count as a human-readable string (GiB / MiB / KiB / B).
 pub fn format_bytes(bytes: u64) -> String {
     const GIB: u64 = 1 << 30;
@@ -14,4 +18,44 @@ pub fn format_bytes(bytes: u64) -> String {
     } else {
         format!("{bytes} B")
     }
+}
+
+/// Resolve the hf-hub cache root: `$HF_HOME/hub` or `~/.cache/huggingface/hub`.
+pub fn cache_root() -> PathBuf {
+    if let Ok(hf_home) = std::env::var("HF_HOME") {
+        PathBuf::from(hf_home).join("hub")
+    } else if let Ok(xdg_cache) = std::env::var("XDG_CACHE_HOME") {
+        PathBuf::from(xdg_cache).join("huggingface/hub")
+    } else {
+        home_dir().join(".cache/huggingface/hub")
+    }
+}
+
+/// Portable home directory without pulling in the `dirs` crate.
+///
+/// Checks `HOME` (Unix) then `USERPROFILE` (Windows), falling back to `/`.
+pub fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/"))
+}
+
+/// Recursively sum the size of all files under `path`.
+///
+/// Uses `symlink_metadata` so that symbolic links (e.g. the HuggingFace
+/// `snapshots/` → `blobs/` indirection) are not followed and their targets
+/// are not double-counted.
+pub fn dir_size(path: &Path) -> Result<u64> {
+    let mut total = 0u64;
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        let metadata = entry.path().symlink_metadata()?;
+        if metadata.is_dir() {
+            total += dir_size(&entry.path()).unwrap_or(0);
+        } else if metadata.is_file() {
+            total += metadata.len();
+        }
+    }
+    Ok(total)
 }


### PR DESCRIPTION
Scan the local HuggingFace cache and print each cached model ID alongside its total disk usage, sorted alphabetically and column-aligned for readability.