### PR TITLE
Add NVFP4 dequantization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "hf-hub",
  "indicatif",
  "libloading 0.8.9",
+ "rayon",
  "rustfft",
  "serde",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
 .DEFAULT_GOAL := build
 
+# Detect OS for conditional package inclusion.
+UNAME_S := $(shell uname -s)
+
+# inferrs-backend-cuda is only built on Linux or Windows (not macOS).
+ifeq ($(UNAME_S),Darwin)
+  CUDA_PKG :=
+else
+  CUDA_PKG := -p inferrs-backend-cuda
+endif
+
 # Packages that can be built/tested without GPU toolchains (CUDA, ROCm).
-NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan $(CUDA_PKG)
 
 .PHONY: all build release fmt clippy test
 

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -54,6 +54,7 @@ uuid = { version = "1", features = ["v4"] }
 futures = "0.3"
 async-stream = "0.3"
 anyhow = { workspace = true }
+rayon = "1"
 crossterm = "0.28"
 indicatif = "0.17"
 rustfft = "6"

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -105,7 +105,24 @@ pub struct EngineContext {
 /// [`EngineContext::model_files`] and [`EngineContext::arch`].
 pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
     let device = args.resolve_device()?;
-    let dtype = args.resolve_dtype()?;
+    let dtype = {
+        let requested = args.resolve_dtype()?;
+        // CPU matmul does not support BF16 or F16 — fall back to F32 automatically.
+        if matches!(device, candle_core::Device::Cpu)
+            && matches!(
+                requested,
+                candle_core::DType::BF16 | candle_core::DType::F16
+            )
+        {
+            tracing::warn!(
+                "CPU device does not support {requested:?} matmul — using F32 instead. \
+                 Pass --dtype f32 to suppress this warning."
+            );
+            candle_core::DType::F32
+        } else {
+            requested
+        }
+    };
     let quant_dtype = args.resolve_quant_dtype()?;
 
     let model_files =
@@ -238,6 +255,92 @@ pub struct StreamToken {
     pub finish_reason: Option<String>,
 }
 
+/// Suppresses thinking-block tokens from the output stream.
+///
+/// Some models (e.g. Gemma4, Qwen3.5) emit a `<think>…</think>` reasoning
+/// block before the actual response.  The block is delimited by a dedicated
+/// special token (e.g. `<|think|>` = ID 98 for Gemma4, `<think>` for Qwen).
+/// The filter tracks whether we are currently inside a thinking block and
+/// returns `false` (suppress) for tokens that should not reach the client.
+///
+/// The block delimiter acts as a toggle: the first occurrence opens the block,
+/// the second occurrence closes it.  Both delimiter tokens are suppressed.
+#[derive(Debug, Default)]
+pub struct ThinkFilter {
+    /// Token ID(s) that open a thinking block.  Empty = disabled.
+    think_token_ids: Vec<u32>,
+    /// Token ID(s) that close a thinking block.
+    close_ids: Vec<u32>,
+    /// Whether we are currently inside a thinking block.
+    pub in_think: bool,
+}
+
+impl ThinkFilter {
+    /// Build a filter from the tokenizer's vocabulary.
+    ///
+    /// Looks up common thinking-block delimiter tokens by their string
+    /// representation and records their IDs.  Returns a no-op filter when
+    /// none are found.
+    pub fn from_tokenizer(tokenizer: &Tokenizer) -> Self {
+        // Thinking block delimiters used by different model families:
+        //
+        //   Gemma4 (google):  <|think|> opens and closes (toggle)
+        //   Qwen3/3.5:        <think> opens, </think> closes
+        //   NVIDIA NVFP4:     <|channel> opens, <channel|> closes
+        //
+        // We collect the open and close token IDs separately.
+        // For toggle-style tokens the same ID appears in both lists.
+        let open_candidates = ["<|think|>", "<think>", "<|channel>"];
+        let close_candidates = ["<|think|>", "</think>", "<channel|>"];
+
+        let mut open_ids = Vec::new();
+        let mut close_ids = Vec::new();
+        for name in &open_candidates {
+            if let Some(id) = tokenizer.token_to_id(name) {
+                open_ids.push(id);
+            }
+        }
+        for name in &close_candidates {
+            if let Some(id) = tokenizer.token_to_id(name) {
+                close_ids.push(id);
+            }
+        }
+        // Deduplicate
+        open_ids.dedup();
+        close_ids.dedup();
+
+        if !open_ids.is_empty() {
+            tracing::debug!(
+                "ThinkFilter: open_ids={:?} close_ids={:?}",
+                open_ids,
+                close_ids
+            );
+        }
+        Self {
+            think_token_ids: open_ids, // reused as open_ids
+            in_think: false,
+            close_ids,
+        }
+    }
+
+    /// Process one token.  Returns `true` if the token should be sent to the
+    /// client, or `false` if it is part of the thinking block and should be
+    /// suppressed.
+    pub fn keep(&mut self, token_id: u32) -> bool {
+        // Check close first so toggle-style tokens (same ID in both lists)
+        // correctly exit the thinking block on their second occurrence.
+        if self.in_think && self.close_ids.contains(&token_id) {
+            self.in_think = false;
+            return false;
+        }
+        if !self.in_think && self.think_token_ids.contains(&token_id) {
+            self.in_think = true;
+            return false;
+        }
+        !self.in_think
+    }
+}
+
 /// Result of a non-streaming generation.
 #[derive(Debug)]
 pub struct GenerationResult {
@@ -344,6 +447,8 @@ struct ActiveSequence {
     /// `true` once the sequence is done (stop token, max length, error, or
     /// client disconnect).
     finished: bool,
+    /// Suppresses thinking-block tokens before they reach the client.
+    think_filter: ThinkFilter,
 }
 
 impl ActiveSequence {
@@ -373,6 +478,7 @@ impl ActiveSequence {
                     block_table: block_size.map(BlockTable::new),
                     prefilled: false,
                     finished: false,
+                    think_filter: ThinkFilter::default(),
                 }
             }
             EngineRequest::GenerateStream {
@@ -397,6 +503,7 @@ impl ActiveSequence {
                     block_table: block_size.map(BlockTable::new),
                     prefilled: false,
                     finished: false,
+                    think_filter: ThinkFilter::default(),
                 }
             }
         }
@@ -658,7 +765,8 @@ impl Engine {
             while active.len() < effective_batch_size {
                 match rx.try_recv() {
                     Ok(req) => {
-                        let seq = ActiveSequence::from_engine_request(req, block_size);
+                        let mut seq = ActiveSequence::from_engine_request(req, block_size);
+                        seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         tracing::debug!(
                             "Accepted request {} ({} prompt tokens, batch_size={})",
                             seq.request_id,
@@ -675,7 +783,8 @@ impl Engine {
             if active.is_empty() {
                 match rx.blocking_recv() {
                     Some(req) => {
-                        let seq = ActiveSequence::from_engine_request(req, block_size);
+                        let mut seq = ActiveSequence::from_engine_request(req, block_size);
+                        seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         tracing::debug!(
                             "Accepted request {} ({} prompt tokens)",
                             seq.request_id,
@@ -767,7 +876,6 @@ impl Engine {
                     seq.prefilled = true;
                 }
 
-                let text = tokenizer.decode(&[token_id], true).unwrap_or_default();
                 let finish_reason = check_stop(
                     token_id,
                     seq.output_tokens.len(),
@@ -775,11 +883,16 @@ impl Engine {
                     &stop_token_ids,
                 );
 
-                let client_gone = !seq.sink.send_token(StreamToken {
-                    token_id,
-                    text,
-                    finish_reason: finish_reason.clone(),
-                });
+                let client_gone = if seq.think_filter.keep(token_id) {
+                    let text = tokenizer.decode(&[token_id], true).unwrap_or_default();
+                    !seq.sink.send_token(StreamToken {
+                        token_id,
+                        text,
+                        finish_reason: finish_reason.clone(),
+                    })
+                } else {
+                    false
+                };
 
                 if finish_reason.is_some() || client_gone {
                     let reason = finish_reason.unwrap_or_else(|| "cancelled".to_string());
@@ -1040,6 +1153,7 @@ impl Engine {
 
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
+        let mut think_filter = ThinkFilter::from_tokenizer(&self.tokenizer);
 
         // Prefill
         let logits = self.run_prefill(prompt_tokens)?;
@@ -1048,15 +1162,20 @@ impl Engine {
         output_tokens.push(token_id);
         all_tokens.push(token_id);
 
-        let text = self.tokenizer.decode(&[token_id], true)?;
         let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
 
-        if !token_tx.send_token(StreamToken {
-            token_id,
-            text,
-            finish_reason: finish_reason.clone(),
-        }) || finish_reason.is_some()
-        {
+        if think_filter.keep(token_id) {
+            let text = self.tokenizer.decode(&[token_id], true)?;
+            if !token_tx.send_token(StreamToken {
+                token_id,
+                text,
+                finish_reason: finish_reason.clone(),
+            }) {
+                self.free_paged_blocks();
+                return Ok(());
+            }
+        }
+        if finish_reason.is_some() {
             self.free_paged_blocks();
             return Ok(());
         }
@@ -1072,15 +1191,19 @@ impl Engine {
             output_tokens.push(token_id);
             all_tokens.push(token_id);
 
-            let text = self.tokenizer.decode(&[token_id], true)?;
             let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
 
-            if !token_tx.send_token(StreamToken {
-                token_id,
-                text,
-                finish_reason: finish_reason.clone(),
-            }) || finish_reason.is_some()
-            {
+            if think_filter.keep(token_id) {
+                let text = self.tokenizer.decode(&[token_id], true)?;
+                if !token_tx.send_token(StreamToken {
+                    token_id,
+                    text,
+                    finish_reason: finish_reason.clone(),
+                }) {
+                    break;
+                }
+            }
+            if finish_reason.is_some() {
                 break;
             }
         }

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -6,6 +6,7 @@ mod engine;
 mod hub;
 mod kv_cache;
 mod models;
+mod nvfp4;
 mod pull;
 mod quantize;
 mod rm;

--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -130,6 +130,8 @@ impl Module for QLinear {
     }
 }
 
+// NVFP4 dequantization is implemented in crate::nvfp4 (shared with quantize.rs).
+
 // ---------------------------------------------------------------------------
 // QGgufVarBuilder: a VarBuilder for quantized GGUF tensors.
 //
@@ -232,7 +234,8 @@ impl QGgufVarBuilder {
 /// Build a bias-free QLinear layer.
 ///
 /// If `qvb` is `Some`, keeps the weight as QTensor (quantized GGUF path).
-/// If `qvb` is `None`, loads the dequantized tensor from `vb`.
+/// If `qvb` is `None`, loads the dequantized tensor from `vb`, with NVFP4
+/// dequantization applied automatically when the weight is stored in that format.
 ///
 /// Both `vb` and `qvb` are already `.pp("layer_name")` scoped.
 fn qlinear_b(
@@ -254,7 +257,16 @@ fn qlinear_b(
         ql.bias = b;
         Ok(ql)
     } else {
-        let weight = vb.get((out_dim, in_dim), "weight")?;
+        // Check for NVFP4 quantized weight (U8 packed FP4 + F8E4M3 block scales).
+        let dtype = vb.dtype();
+        let device = vb.device().clone();
+        let weight = if let Some(w) =
+            crate::nvfp4::try_load_from_varbuilder(&vb, out_dim, in_dim, dtype, &device)?
+        {
+            w
+        } else {
+            vb.get((out_dim, in_dim), "weight")?
+        };
         Ok(QLinear::from_tensor(weight, b))
     }
 }

--- a/inferrs/src/nvfp4.rs
+++ b/inferrs/src/nvfp4.rs
@@ -1,0 +1,203 @@
+//! NVIDIA NVFP4 weight dequantization.
+//!
+//! NVFP4 stores MLP projection weights in a block-wise FP4 format spread
+//! across four tensors per layer:
+//!
+//! | Suffix          | DType    | Shape              | Meaning                          |
+//! |-----------------|----------|--------------------|----------------------------------|
+//! | `weight`        | U8       | `[out, in/2]`      | Two FP4 E2M1 nibbles per byte    |
+//! | `weight_scale`  | F8E4M3   | `[out, in/16]`     | One FP8 scale per 16 FP4 values  |
+//! | `weight_scale_2`| F32      | `[]` (scalar)      | Global scale for `weight_scale`  |
+//! | `input_scale`   | F32      | `[]` (scalar)      | Activation scale (unused here)   |
+//!
+//! Dequantization formula (element at logical row `r`, column `c`):
+//! ```text
+//! nibble     = low or high 4 bits of weight[r, c/2]
+//! fp4_val    = FP4_E2M1_LUT[nibble]
+//! block_scale = f8e4m3_to_f32(weight_scale[r, c/16]) * weight_scale_2
+//! W[r, c]    = fp4_val * block_scale
+//! ```
+//!
+//! `input_scale` is intentionally ignored: it quantizes activations, not
+//! weights, and is irrelevant for weight-only dequantization with standard
+//! BF16/F32 matmul.
+
+use candle_core::{DType, Device, Result, Tensor};
+use rayon::prelude::*;
+
+/// FP4 E2M1 look-up table: index = 4-bit nibble (0..15), value = f32.
+///
+/// Encoding: `bit3=sign, bits[2:1]=exponent (bias 1), bit0=mantissa`.
+pub const FP4_E2M1_LUT: [f32; 16] = [
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, // positive (nibbles 0–7)
+    0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0, // negative (nibbles 8–15)
+];
+
+/// Tensor name suffixes that are auxiliary NVFP4 scale tensors (dot-prefixed).
+///
+/// These siblings of a packed-FP4 weight tensor carry quantization metadata
+/// and must be consumed during dequantization rather than written verbatim
+/// into a GGUF file or used as independent model parameters.
+pub const NVFP4_AUX_SUFFIXES: &[&str] = &[".weight_scale", ".weight_scale_2", ".input_scale"];
+
+/// Return `true` when `name` is an NVFP4 auxiliary scale tensor that should
+/// be skipped during GGUF conversion (consumed by dequantization instead).
+pub fn is_nvfp4_aux(name: &str) -> bool {
+    NVFP4_AUX_SUFFIXES
+        .iter()
+        .any(|&suffix| name.ends_with(suffix))
+}
+
+/// Dequantize an NVFP4 weight from raw CPU buffers.
+///
+/// Returns a `[out_dim, in_dim]` row-major `Vec<f32>`.
+///
+/// Parallelized across rows with rayon; the inner loop (8 bytes → 16 floats)
+/// is structured to allow LLVM to auto-vectorize.
+///
+/// # Arguments
+/// * `packed`  — raw packed bytes, length `out_dim * in_dim / 2`
+/// * `scales`  — combined per-block F32 scales, length `out_dim * (in_dim / 16)`
+///   (i.e. `weight_scale_f32 * weight_scale_2` already applied)
+pub fn dequantize_raw(packed: &[u8], scales: &[f32], out_dim: usize, in_dim: usize) -> Vec<f32> {
+    let half_in = in_dim / 2;
+    let num_blocks = in_dim / 16; // 16 FP4 values per scale block = 8 bytes
+
+    let mut out = vec![0f32; out_dim * in_dim];
+
+    out.par_chunks_mut(in_dim)
+        .enumerate()
+        .for_each(|(r, row_out)| {
+            let packed_row = &packed[r * half_in..(r + 1) * half_in];
+            let scale_row = &scales[r * num_blocks..(r + 1) * num_blocks];
+
+            for (b, &scale) in scale_row.iter().enumerate() {
+                let byte_start = b * 8; // 16 FP4 = 8 bytes
+                let col_start = b * 16;
+                for i in 0..8usize {
+                    let byte = packed_row[byte_start + i];
+                    let lo = (byte & 0x0F) as usize;
+                    let hi = ((byte >> 4) & 0x0F) as usize;
+                    row_out[col_start + i * 2] = FP4_E2M1_LUT[lo] * scale;
+                    row_out[col_start + i * 2 + 1] = FP4_E2M1_LUT[hi] * scale;
+                }
+            }
+        });
+
+    out
+}
+
+/// Dequantize an NVFP4 weight tensor to a candle [`Tensor`].
+///
+/// All inputs must reside on CPU.
+///
+/// # Arguments
+/// * `packed`    — U8 tensor `[out_dim, in_dim/2]`
+/// * `scale_f32` — F32 tensor `[out_dim, in_dim/16]` (already × `weight_scale_2`)
+/// * `out_dim`, `in_dim` — logical weight shape
+/// * `dtype`     — target dtype for the output (F32 or BF16)
+/// * `device`    — target device
+pub fn dequantize_tensor(
+    packed: &Tensor,
+    scale_f32: &Tensor,
+    out_dim: usize,
+    in_dim: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<Tensor> {
+    let packed_data = packed.flatten_all()?.to_vec1::<u8>()?;
+    let scale_data = scale_f32.flatten_all()?.to_vec1::<f32>()?;
+
+    let out = dequantize_raw(&packed_data, &scale_data, out_dim, in_dim);
+
+    Tensor::from_vec(out, (out_dim, in_dim), &Device::Cpu)?
+        .to_dtype(dtype)?
+        .to_device(device)
+}
+
+/// Load and dequantize an NVFP4 weight from a [`candle_nn::VarBuilder`].
+///
+/// Returns `Some(tensor)` when `weight_scale` is present (indicating NVFP4
+/// format), or `None` when the weight is a standard float tensor.
+///
+/// The returned tensor has shape `[out_dim, in_dim]` in `dtype` on `device`.
+pub fn try_load_from_varbuilder(
+    vb: &candle_nn::VarBuilder,
+    out_dim: usize,
+    in_dim: usize,
+    dtype: DType,
+    device: &Device,
+) -> Result<Option<Tensor>> {
+    if !vb.contains_tensor("weight_scale") {
+        return Ok(None);
+    }
+
+    // Load packed FP4 bytes; bring to CPU before any dtype cast.
+    let packed = vb
+        .get_unchecked_dtype("weight", DType::U8)?
+        .to_device(&Device::Cpu)?;
+    let expected = candle_core::Shape::from((out_dim, in_dim / 2));
+    if packed.shape() != &expected {
+        candle_core::bail!(
+            "NVFP4: unexpected packed shape {:?}, want {:?}",
+            packed.shape(),
+            expected
+        );
+    }
+
+    // F8E4M3 → F32 is supported on CPU; cast before touching CUDA.
+    let scale_f8 = vb
+        .get_unchecked_dtype("weight_scale", DType::F8E4M3)?
+        .to_device(&Device::Cpu)?;
+    let scale_f32_raw = scale_f8.to_dtype(DType::F32)?;
+
+    let scale2_t = vb
+        .get_unchecked_dtype("weight_scale_2", DType::F32)?
+        .to_device(&Device::Cpu)?;
+    let scale2 = scale2_t.to_vec0::<f32>()?;
+    let scale_f32 = scale_f32_raw.affine(scale2 as f64, 0.0)?;
+
+    let w = dequantize_tensor(&packed, &scale_f32, out_dim, in_dim, dtype, device)?;
+    Ok(Some(w))
+}
+
+/// Load and dequantize an NVFP4 weight directly from a
+/// [`candle_core::safetensors::MmapedSafetensors`] handle.
+///
+/// `base_name` is the full tensor name without the suffix, e.g.
+/// `"model.language_model.layers.0.mlp.gate_proj"`.
+/// The function appends `".weight"`, `".weight_scale"`, and
+/// `".weight_scale_2"` to form the actual tensor names.
+///
+/// Returns the dequantized `[out_dim, in_dim]` F32 tensor on CPU.
+pub fn load_from_safetensors(
+    st: &candle_core::safetensors::MmapedSafetensors,
+    base_name: &str,
+) -> Result<Tensor> {
+    let packed = st
+        .load(&format!("{base_name}.weight"), &Device::Cpu)?
+        .to_dtype(DType::U8)?;
+    let (out_dim, half_in) = packed.dims2()?;
+    let in_dim = half_in * 2;
+
+    // F8E4M3 → F32 on CPU.
+    let scale_f8 = st
+        .load(&format!("{base_name}.weight_scale"), &Device::Cpu)?
+        .to_dtype(DType::F8E4M3)?;
+    let scale_f32_raw = scale_f8.to_dtype(DType::F32)?;
+
+    let scale2 = st
+        .load(&format!("{base_name}.weight_scale_2"), &Device::Cpu)?
+        .to_dtype(DType::F32)?
+        .to_vec0::<f32>()?;
+    let scale_f32 = scale_f32_raw.affine(scale2 as f64, 0.0)?;
+
+    dequantize_tensor(
+        &packed,
+        &scale_f32,
+        out_dim,
+        in_dim,
+        DType::F32,
+        &Device::Cpu,
+    )
+}

--- a/inferrs/src/quantize.rs
+++ b/inferrs/src/quantize.rs
@@ -177,9 +177,33 @@ pub fn convert_to_gguf(
     // Build (name, QTensor) pairs — collected eagerly to pass a slice to the writer.
     let mut qtensors: Vec<(String, QTensor)> = Vec::with_capacity(n as usize);
 
+    // Build a set of all tensor names for NVFP4 detection.
+    // An NVFP4 weight tensor is one whose ".weight" sibling has a ".weight_scale"
+    // present in the file.  We detect this by checking the full name set.
+    let name_set: std::collections::HashSet<&str> =
+        tensor_names.iter().map(|s| s.as_str()).collect();
+
     for name in &tensor_names {
-        // Load tensor on CPU in f32 — quantization requires f32 input.
-        let tensor = st.load(name, &Device::Cpu)?.to_dtype(DType::F32)?;
+        // Skip NVFP4 auxiliary tensors — they are consumed when dequantizing the
+        // corresponding weight tensor and must not appear as independent entries.
+        if crate::nvfp4::is_nvfp4_aux(name) {
+            bar.inc(1);
+            continue;
+        }
+
+        // Detect NVFP4 weight tensors: a ".weight" whose sibling ".weight_scale"
+        // exists in the file.  Dequantize them via the nvfp4 module so that the
+        // resulting GGUF stores the correct full-width float matrix.
+        let tensor = if name.ends_with(".weight")
+            && name_set.contains(format!("{}.weight_scale", &name[..name.len() - 7]).as_str())
+        {
+            let base = &name[..name.len() - 7]; // strip trailing ".weight"
+            tracing::info!("NVFP4 dequantizing {name}");
+            crate::nvfp4::load_from_safetensors(&st, base)?
+        } else {
+            // Load tensor on CPU in f32 — quantization requires f32 input.
+            st.load(name, &Device::Cpu)?.to_dtype(DType::F32)?
+        };
 
         // All GGML quantization formats require a non-scalar shape and a last
         // dimension that is a multiple of the block size (32 for Q8_0, 256 for

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -181,6 +181,11 @@ impl Tokenizer {
             .and_then(|t| self.inner.token_to_id(t))
     }
 
+    /// Look up a token string and return its ID, or `None` if not in vocabulary.
+    pub fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.inner.token_to_id(token)
+    }
+
     /// Encode text to token IDs.
     pub fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
         let encoding = self


### PR DESCRIPTION
- Add nvfp4.rs module: dequantizes NVIDIA FP4 weights (U8 packed nibbles
  + F8E4M3 per-block scales + F32 global scale) using rayon-parallelized row loops; shared between the safetensors load path and GGUF conversion
- Fix gemma4.rs MLP loading: detect NVFP4 by probing for weight_scale, dequantize to full-width BF16/F32 before matmul
- Fix quantize.rs --quantize path: dequantize NVFP4 weights before GGUF quantization, skip auxiliary scale tensors (weight_scale, weight_scale_2, input_scale) from the GGUF output
- Fix CPU BF16 fallback in engine.rs: auto-downcast BF16/F16 to F32 on CPU
- Add ThinkFilter in engine.rs: suppresses thinking-block tokens from the output stream; handles <|channel>/<channel|> (NVIDIA), <|think|> (Gemma4), and <think>/</think> (Qwen) delimiter families
- Add token_to_id() to Tokenizer wrapper for reliable special-token lookup