### PR TITLE
fix: contiguous() k/v in TurboQuantKvCache::append

### DIFF
--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -469,6 +469,16 @@ impl TurboQuantKvCache {
     /// Once the threshold is reached, the entire buffer is flushed to the
     /// quantized store in one shot.
     pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<()> {
+        // `slice_set` requires contiguous src tensors.  K/V arrive here as
+        // post-transpose views (non-contiguous) when the caller has not already
+        // materialised them into a fresh buffer (e.g. the prefill path, or
+        // value_states which never passes through the RoPE pre-alloc buffer).
+        // `.contiguous()` is a no-op when the tensor is already contiguous.
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+        let k = &k;
+        let v = &v;
+
         let new_seq = k.dim(2)?;
         let head_dim = self.head_dim;
 


### PR DESCRIPTION
K and V arrive as post-transpose non-contiguous views when coming from the prefill path or value_states (which never passes through the RoPE pre-alloc buffer). slice_set requires contiguous src tensors and was bailing with "slice-set only supports contiguous tensors" for nvidia/Gemma-4-31B-IT-NVFP4.

.contiguous() is a no-op when the tensor is already contiguous so there is no overhead on the decode fast-path.