### PR TITLE
fix: contiguous() on all slice_set src tensors

### DIFF
--- a/candle-nn/src/kv_cache.rs
+++ b/candle-nn/src/kv_cache.rs
@@ -73,7 +73,7 @@ impl Cache {
             *ad = Tensor::cat(&[&*ad, &next_ad], self.dim)?;
             self.max_seq_len += self.grow_by;
         }
-        ad.slice_set(src, self.dim, self.current_seq_len)?;
+        ad.slice_set(&src.contiguous()?, self.dim, self.current_seq_len)?;
         self.current_seq_len += seq_len;
         Ok(())
     }

--- a/inferrs-benchmark/src/main.rs
+++ b/inferrs-benchmark/src/main.rs
@@ -76,7 +76,7 @@ struct BenchmarkArgs {
     llama_model: String,
 
     /// Seconds to wait for a server to become healthy.
-    #[arg(long, default_value_t = 120)]
+    #[arg(long, default_value_t = 600)]
     server_ready_timeout: u64,
 
     /// Override path to the inferrs binary.

--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -1072,8 +1072,8 @@ impl RetainingKvCache {
                 if let (Some(kb_old), Some(vb_old)) = (&self.k_buf, &self.v_buf) {
                     let k_valid = kb_old.narrow(2, 0, self.seq_len)?;
                     let v_valid = vb_old.narrow(2, 0, self.seq_len)?;
-                    new_k_buf.slice_set(&k_valid, 2, 0)?;
-                    new_v_buf.slice_set(&v_valid, 2, 0)?;
+                    new_k_buf.slice_set(&k_valid.contiguous()?, 2, 0)?;
+                    new_v_buf.slice_set(&v_valid.contiguous()?, 2, 0)?;
                 }
             }
 
@@ -1085,8 +1085,8 @@ impl RetainingKvCache {
         let kb = self.k_buf.as_mut().expect("k_buf allocated above");
         let vb = self.v_buf.as_mut().expect("v_buf allocated above");
 
-        kb.slice_set(k, 2, self.seq_len)?;
-        vb.slice_set(v, 2, self.seq_len)?;
+        kb.slice_set(&k.contiguous()?, 2, self.seq_len)?;
+        vb.slice_set(&v.contiguous()?, 2, self.seq_len)?;
         self.seq_len += t;
 
         let k_out = kb.narrow(2, 0, self.seq_len)?;


### PR DESCRIPTION
Three KV cache slice_set sites were receiving non-contiguous post-transpose tensors, causing 'slice-set only supports contiguous tensors' on nvidia/Gemma-4-31B-IT-NVFP4:

- candle-nn/src/kv_cache.rs Cache::append: plain KvCache path (turbo-quant=false)
- inferrs/src/models/gemma4.rs normal KV buffer append (lines 1075/1076 narrow() results, lines 1088/1089 raw k/v)

Also bumps --server-ready-timeout default from 120s to 600s so 31B model loads don't time out on the health check.