### PR TITLE
fix: mount huggingface cache volume as read-write

### DIFF
--- a/inferrs-benchmark/src/main.rs
+++ b/inferrs-benchmark/src/main.rs
@@ -771,7 +771,7 @@ fn start_vllm_server(model: &str, port: u16) -> Result<Child> {
     // PeakMemoryTracker will therefore report near-zero memory for vllm groups;
     // the benchmark output notes this explicitly.
     let hf_hub_cache = hf_hub_cache_dir();
-    let volume = format!("{hf_hub_cache}:/root/.cache/huggingface/hub:ro");
+    let volume = format!("{hf_hub_cache}:/root/.cache/huggingface/hub");
 
     let port_mapping = format!("{port}:8000");
     let child = Command::new("docker")


### PR DESCRIPTION
Remove :ro flag from the HF hub cache volume mount so vllm can
write to the cache directory inside the container as needed.