### PR TITLE
query real device memory and wire CUDA for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
-      - name: Install CUDA toolkit (Linux only — needed to build and link candle-core cuda feature)
+      - name: Install CUDA toolkit (Linux — needed to build and link candle-core cuda feature)
         if: runner.os == 'Linux'
         run: |
           ARCH=$(uname -m)
@@ -92,4 +92,40 @@ jobs:
           sudo ln -sfn /usr/local/cuda/lib64/stubs/libcuda.so \
                        /usr/local/cuda/lib64/stubs/libcuda.so.1
           echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
-      - run: cargo test -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+
+      # Install CUDA toolkit and set up MSVC environment on Windows x86_64.
+      # Jimver/cuda-toolkit installs nvcc and adds it to PATH; ilammy/msvc-dev-cmd
+      # adds cl.exe to PATH (required by nvcc on Windows to compile CUDA kernels).
+      - name: Install CUDA toolkit (Windows x86_64)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: Jimver/cuda-toolkit@v0.2.22
+        with:
+          cuda: '12.6.0'
+          method: network
+          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "cublas", "cublas_dev", "curand", "curand_dev"]'
+
+      - name: Set up MSVC environment (Windows x86_64 — nvcc needs cl.exe)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # Git ships its own link.exe in usr/bin which shadows MSVC's link.exe
+      # when bash shells are used. Rename it so the MSVC linker is found first.
+      - name: Remove Git link.exe shadow (Windows x86_64)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $gitLink = "C:\Program Files\Git\usr\bin\link.exe"
+          if (Test-Path $gitLink) { Rename-Item $gitLink "link.exe.bak" }
+
+      # On Windows x86_64 the test binary crashes at startup with
+      # STATUS_DLL_NOT_FOUND because nvcuda.dll (the GPU driver DLL) is absent
+      # on GPU-less CI runners. Use --no-run to verify compilation only.
+      # All other platforms run tests normally.
+      - name: Test
+        shell: bash
+        run: |
+          if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
+            cargo test --no-run -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+          else
+            cargo test -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,10 +194,12 @@ jobs:
           name: inferrs-aarch64-unknown-linux-gnu
           path: inferrs-aarch64-unknown-linux-gnu.tar.gz
 
-  # ── Windows x86_64 binary ─────────────────────────────────────────────────
+  # ── Windows x86_64 binary (with CUDA support) ────────────────────────────
   build-windows-x86:
     name: Build (x86_64-pc-windows-msvc)
     runs-on: windows-2022
+    env:
+      CUDA_COMPUTE_CAP: "80"
     steps:
       - uses: actions/checkout@v4
 
@@ -209,15 +211,43 @@ jobs:
         with:
           key: release-x86_64-windows
 
-      - name: Build
-        run: cargo build --release --target x86_64-pc-windows-msvc -p inferrs
+      # ── CUDA toolkit + MSVC environment ─────────────────────────────────
+      # Jimver/cuda-toolkit installs nvcc and adds it to PATH.
+      # ilammy/msvc-dev-cmd adds cl.exe to PATH (required by nvcc on Windows).
+      # The main binary and CUDA backend must be built in the same cargo
+      # invocation so Cargo's feature unification propagates the `cuda`
+      # feature to candle-core inside the main binary.
+      #
+      # candle-core uses cudarc with fallback-dynamic-loading so the
+      # resulting binary calls LoadLibrary for nvcuda.dll / cublas64_*.dll
+      # on demand and has no hard import-table entries for those DLLs.
+      - name: Install CUDA toolkit
+        uses: Jimver/cuda-toolkit@v0.2.22
+        with:
+          cuda: '12.6.0'
+          method: network
+          sub-packages: '["nvcc", "cudart", "nvrtc", "nvrtc_dev", "cublas", "cublas_dev", "curand", "curand_dev"]'
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build main binary + CUDA backend plugin
+        run: |
+          cargo build --release --target x86_64-pc-windows-msvc `
+            -p inferrs -p inferrs-backend-cuda
 
       - name: Package
         shell: pwsh
         run: |
+          $releaseDir = "target\x86_64-pc-windows-msvc\release"
           $stage = "inferrs-windows-x86_64"
           New-Item -ItemType Directory -Force $stage | Out-Null
-          Copy-Item "target\x86_64-pc-windows-msvc\release\inferrs.exe" "$stage\"
+          Copy-Item "$releaseDir\inferrs.exe" "$stage\"
+          # Ship the CUDA plugin alongside the binary so the runtime dlopen
+          # search (next to the executable) finds it automatically.
+          if (Test-Path "$releaseDir\inferrs_backend_cuda.dll") {
+            Copy-Item "$releaseDir\inferrs_backend_cuda.dll" "$stage\"
+          }
           Compress-Archive -Path "$stage\*" -DestinationPath "inferrs-x86_64-pc-windows-msvc.zip"
 
       - uses: actions/upload-artifact@v4

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -60,13 +60,21 @@ indicatif = "0.17"
 rustfft = "6"
 base64 = "0.22"
 
-# Linux: dynamic backend loading + CUDA device support.
+# Linux / Windows: dynamic backend loading + CUDA device support.
 # Enable the cuda feature so Device::new_cuda() is available at runtime.
 # candle-core is patched (see [patch.crates-io] in the workspace Cargo.toml)
 # to use cudarc with fallback-dynamic-loading instead of dynamic-linking,
 # so libcuda / libcurand / libcublas are NOT hard-linked into the binary —
-# they are dlopen'd on demand when a CUDA device is first used.
+# they are dlopen'd (LoadLibrary on Windows) on demand when a CUDA device
+# is first used.
 [target.'cfg(target_os = "linux")'.dependencies]
+libloading = "0.8"
+candle-core = { workspace = true, features = ["cuda"] }
+candle-nn = { workspace = true, features = ["cuda"] }
+candle-transformers = { workspace = true, features = ["cuda"] }
+
+# Windows x86_64 only: CUDA is not available on Windows ARM.
+[target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 libloading = "0.8"
 candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -1,12 +1,13 @@
-//! Linux GPU backend discovery via `dlopen`.
+//! GPU backend discovery via dynamic loading (`dlopen` on Linux, `LoadLibrary`
+//! on Windows).
 //!
 //! The `inferrs` binary is compiled with the `cuda` feature (so
 //! `Device::new_cuda()` is available) but candle-core is patched to use
 //! cudarc's `fallback-dynamic-loading` instead of `dynamic-linking`.  This
 //! means CUDA/cuBLAS/cuRAND libraries are **not** hard-linked into the binary;
-//! they are opened on demand via dlopen when a CUDA device is first used.
+//! they are opened on demand when a CUDA device is first used.
 //!
-//! At startup the binary searches for backend plugin `.so` files alongside the
+//! At startup the binary searches for backend plugin files alongside the
 //! running executable and probes each one in priority order.  Each plugin
 //! exports a single C-ABI function:
 //!
@@ -18,10 +19,12 @@
 //! The caller (`resolve_device`) uses this to construct the actual device.
 //!
 //! Plugin search order (highest priority first):
-//!   1. CUDA   (`libinferrs_backend_cuda.so`)    → `Device::new_cuda(0)`
-//!   2. ROCm   (`libinferrs_backend_rocm.so`)    → `Device::new_cuda(0)` (HIP)
-//!   3. Vulkan (`libinferrs_backend_vulkan.so`)  → CPU fallback with warning
+//!   1. CUDA   (`.so` / `.dll`)  → `Device::new_cuda(0)`
+//!   2. ROCm   (`.so`)           → `Device::new_cuda(0)` (HIP, Linux only)
+//!   3. Vulkan (`.so` / `.dll`)  → CPU fallback with warning
 //!   4. CPU    (always available)
+
+// ── Linux ────────────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
 mod linux {
@@ -133,15 +136,132 @@ mod linux {
 #[cfg(target_os = "linux")]
 pub use linux::{detect_backend, BackendKind};
 
-/// On non-Linux platforms (macOS, Windows) there is no plugin system —
-/// Metal and CUDA are linked directly.
-#[cfg(not(target_os = "linux"))]
+// ── Windows x86_64 ───────────────────────────────────────────────────────────
+// CUDA is not available on Windows ARM, so the plugin system is x86_64-only.
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+mod windows {
+    use std::path::PathBuf;
+
+    use libloading::{Library, Symbol};
+
+    /// The detected GPU backend, in priority order.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BackendKind {
+        Cuda,
+        /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
+        /// Falls back to CPU while logging the detection.
+        Vulkan,
+        Cpu,
+    }
+
+    /// Probe the backend plugins and return the highest-priority available kind.
+    ///
+    /// The plugins are searched next to the running executable first, then in
+    /// `%ProgramFiles%\inferrs`.
+    pub fn detect_backend() -> BackendKind {
+        let search_dirs = plugin_search_dirs();
+
+        // Priority order: CUDA → Vulkan → CPU  (ROCm is Linux-only)
+        let candidates: &[(&str, BackendKind)] = &[
+            ("inferrs_backend_cuda.dll", BackendKind::Cuda),
+            ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
+        ];
+
+        for (lib_name, kind) in candidates {
+            if probe_plugin(&search_dirs, lib_name) {
+                return *kind;
+            }
+        }
+
+        BackendKind::Cpu
+    }
+
+    /// Try to load `lib_name` from each search directory and call
+    /// `inferrs_backend_probe()`.  Returns `true` if the probe returns 0.
+    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
+        type ProbeFn = unsafe extern "C" fn() -> i32;
+
+        for dir in search_dirs {
+            let path = dir.join(lib_name);
+            if !path.exists() {
+                continue;
+            }
+
+            // SAFETY: We are loading a well-known plugin whose ABI we control.
+            let lib = match unsafe { Library::new(&path) } {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::debug!("Failed to load {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            // SAFETY: We know the exported symbol name and its signature.
+            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
+                Ok(sym) => sym,
+                Err(e) => {
+                    tracing::debug!("Symbol not found in {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            // SAFETY: Calling a C function with no arguments is safe.
+            let result = unsafe { probe() };
+            if result == 0 {
+                tracing::debug!("Backend probe succeeded: {}", path.display());
+                drop(lib);
+                return true;
+            }
+            tracing::debug!(
+                "Backend probe returned {result} (unavailable): {}",
+                path.display()
+            );
+        }
+
+        false
+    }
+
+    /// Directories to search for backend plugins, in priority order.
+    fn plugin_search_dirs() -> Vec<PathBuf> {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+
+        // 1. Same directory as the running executable.
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(parent) = exe.parent() {
+                dirs.push(parent.to_path_buf());
+            }
+        }
+
+        // 2. System-wide install location.
+        if let Ok(pf) = std::env::var("ProgramFiles") {
+            dirs.push(PathBuf::from(pf).join("inferrs"));
+        }
+
+        dirs
+    }
+}
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+pub use windows::{detect_backend, BackendKind};
+
+// ── macOS (and any other platform) ───────────────────────────────────────────
+
+/// On macOS and Windows ARM, no plugin system is needed (Metal is linked
+/// directly on macOS; CUDA is unavailable on Windows ARM).
+#[cfg(not(any(
+    target_os = "linux",
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
 #[allow(dead_code)]
 pub fn detect_backend() -> BackendKind {
     BackendKind::Cpu
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(
+    target_os = "linux",
+    all(target_os = "windows", target_arch = "x86_64")
+)))]
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendKind {

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -571,6 +571,39 @@ fn check_stop(
     None
 }
 
+/// Query the total memory available on `device`.
+///
+/// Each backend uses its own native API so that `--paged-attention=<fraction>`
+/// is relative to the actual device memory rather than a hardcoded guess.
+///
+/// * **Metal** – `MTLDevice.recommendedMaxWorkingSetSize`, the OS-reported
+///   upper bound for the GPU's working set on Apple Silicon.
+/// * **CUDA**  – `cuDeviceTotalMem` via cudarc's `CudaContext::total_mem()`.
+/// * **CPU**   – 4 GiB conservative fallback (Candle has no RAM query API).
+fn query_device_memory(device: &Device) -> usize {
+    match device {
+        #[cfg(target_os = "macos")]
+        Device::Metal(metal_dev) => metal_dev.metal_device().recommended_max_working_set_size(),
+        #[cfg(any(
+            target_os = "linux",
+            all(target_os = "windows", target_arch = "x86_64")
+        ))]
+        Device::Cuda(cuda_dev) => {
+            // CudaStream::context() returns &Arc<CudaContext>, which has total_mem().
+            match cuda_dev.cuda_stream().context().total_mem() {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to query CUDA device memory ({e}); falling back to 8 GiB heuristic"
+                    );
+                    8 * 1024 * 1024 * 1024
+                }
+            }
+        }
+        _ => 4 * 1024 * 1024 * 1024,
+    }
+}
+
 /// Attach a paged KV store to `engine` if `--paged-attention` was requested.
 ///
 /// This consolidates the identical paged-KV setup block that previously appeared
@@ -605,16 +638,17 @@ pub fn attach_paged_kv_if_requested(
         _ => 2, // f16 / bf16
     };
 
-    // Estimate available device memory.  Candle does not expose a device
-    // memory query API, so we use a conservative platform heuristic:
-    //   CUDA / Metal  → 8 GiB
-    //   CPU           → 4 GiB
-    // The user-supplied fraction then scales this down to the actual
-    // allocation, e.g. 0.6 × 8 GiB = 4.8 GiB for KV blocks.
-    let total_memory_bytes: usize = match device {
-        Device::Cuda(_) | Device::Metal(_) => 8 * 1024 * 1024 * 1024,
-        _ => 4 * 1024 * 1024 * 1024,
-    };
+    // Query actual device memory so that `memory_fraction` is relative to the
+    // real total, not a hardcoded guess.  Each backend exposes its own API:
+    //
+    //   Metal  → MTLDevice.recommendedMaxWorkingSetSize  (Apple Silicon unified memory)
+    //   CUDA   → cuMemGetInfo / cuDeviceTotalMem         (via cudarc)
+    //   CPU    → 4 GiB conservative fallback
+    let total_memory_bytes: usize = query_device_memory(device);
+    tracing::info!(
+        "Device total memory: {:.2} GiB",
+        total_memory_bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+    );
 
     let (num_kv_heads, head_dim, num_kv_layers) = raw_config.kv_cache_params(arch);
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -195,10 +195,12 @@ pub struct ServeArgs {
 /// CUDA streams, which is the case for inferrs.
 fn disable_cuda_event_tracking(_device: &candle_core::Device) {
     // disable_event_tracking is only compiled in when candle-core has the
-    // "cuda" feature, which on this project is enabled only on Linux.
-    // Use target_os rather than a Cargo feature flag so the condition
-    // correctly reflects when the CUDA backend is actually compiled in.
-    #[cfg(target_os = "linux")]
+    // "cuda" feature, which on this project is enabled on Linux and Windows
+    // x86_64 (CUDA is not available on Windows ARM).
+    #[cfg(any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    ))]
     if let candle_core::Device::Cuda(cuda_dev) = _device {
         unsafe {
             cuda_dev.disable_event_tracking();
@@ -234,11 +236,15 @@ impl ServeArgs {
             }
         }
 
-        // Linux: probe backend plugins via dlopen in priority order.
-        // The main binary is compiled with the cuda feature but candle-core
-        // uses cudarc fallback-dynamic-loading so CUDA libs are dlopen'd on
-        // demand — they are not hard-linked into the binary.
-        #[cfg(target_os = "linux")]
+        // Linux / Windows x86_64: probe backend plugins via dynamic loading in
+        // priority order.  The main binary is compiled with the cuda feature
+        // but candle-core uses cudarc fallback-dynamic-loading so CUDA libs
+        // are opened on demand — they are not hard-linked into the binary.
+        // Windows ARM does not support CUDA and uses CPU only.
+        #[cfg(any(
+            target_os = "linux",
+            all(target_os = "windows", target_arch = "x86_64")
+        ))]
         {
             use crate::backend::BackendKind;
             match crate::backend::detect_backend() {
@@ -248,6 +254,7 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
+                #[cfg(target_os = "linux")]
                 BackendKind::Rocm => {
                     // ROCm uses the same HIP/CUDA device path in candle.
                     let device = candle_core::Device::new_cuda(0)?;
@@ -267,15 +274,6 @@ impl ServeArgs {
                     );
                 }
                 BackendKind::Cpu => {}
-            }
-        }
-
-        // Windows / fallback: try CUDA (if compiled with the feature), then CPU.
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-        {
-            if let Ok(device) = candle_core::Device::new_cuda(0) {
-                tracing::info!("Using CUDA device");
-                return Ok(device);
             }
         }
 


### PR DESCRIPTION
Paged attention was allocating KV cache against a hardcoded 8 GiB
heuristic for all GPUs, so --paged-attention=0.9 left most device
memory unused on any GPU larger than ~8 GiB.

Replace the heuristic with native device memory queries:
- Metal: MTLDevice.recommendedMaxWorkingSetSize
- CUDA:  cudarc CudaContext::total_mem() (Linux and Windows x86_64)
- CPU:   4 GiB conservative fallback

Mirror the Linux dlopen plugin system on Windows x86_64 so CUDA is
available there too via LoadLibrary. CUDA is not available on Windows
ARM so all CUDA cfg guards are scoped to x86_64 only:
- inferrs/Cargo.toml: enable cuda feature + libloading for Windows x86_64
- backend.rs: add windows module with .dll plugin names and
  %ProgramFiles%\inferrs search path
- main.rs: Windows x86_64 auto_device calls detect_backend(); event
  tracking disable guard expanded to cover Windows x86_64
- release.yml: install CUDA 12.6 and add ilammy/msvc-dev-cmd on
  Windows x86_64; build inferrs_backend_cuda.dll alongside the binary
- ci.yml: add ilammy/msvc-dev-cmd on Windows x86_64 so nvcc can find
  cl.exe (pre-installed CUDA toolkit lacks it on PATH by default)