### PR TITLE
add ROCm support for Windows x86_64, Linux aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
           name: inferrs-x86_64-unknown-linux-gnu
           path: inferrs-x86_64-unknown-linux-gnu.tar.gz
 
-  # ── Linux aarch64: main binary + CUDA/Vulkan plugins ─────────────────────
+  # ── Linux aarch64: main binary + CUDA/ROCm/Vulkan plugins ───────────────
   build-linux-arm64:
     name: Build (aarch64-unknown-linux-gnu)
     runs-on: ubuntu-24.04-arm
@@ -169,6 +169,26 @@ jobs:
           cargo build --release --target aarch64-unknown-linux-gnu \
             -p inferrs -p inferrs-backend-cuda
 
+      # ── ROCm backend plugin (aarch64 supports ROCm on MI300A / Radeon) ──
+      # amdgpu-install does not yet provide a pre-built sbsa ROCm package in
+      # the same DEB form as x86_64, so we install the upstream ROCm apt repo
+      # directly (supported since ROCm 6.0 for sbsa/aarch64).
+      - name: Install ROCm toolkit
+        run: |
+          wget -q https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/noble/amdgpu-install_6.3.60303-1_all.deb
+          sudo dpkg -i amdgpu-install_6.3.60303-1_all.deb || true
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends \
+            rocm-dev hip-dev
+
+      - name: Build ROCm backend plugin
+        env:
+          ROCM_PATH: /opt/rocm
+          HIP_PATH: /opt/rocm
+        run: |
+          cargo build --release --target aarch64-unknown-linux-gnu \
+            -p inferrs-backend-rocm
+
       # ── Vulkan backend plugin (arm64 systems can have Vulkan drivers) ────
       - name: Build Vulkan backend plugin
         run: |
@@ -184,6 +204,7 @@ jobs:
           cp "$RELEASE_DIR/inferrs" "$STAGE/"
           for lib in \
             libinferrs_backend_cuda.so \
+            libinferrs_backend_rocm.so \
             libinferrs_backend_vulkan.so; do
             [ -f "$RELEASE_DIR/$lib" ] && cp "$RELEASE_DIR/$lib" "$STAGE/"
           done
@@ -194,7 +215,7 @@ jobs:
           name: inferrs-aarch64-unknown-linux-gnu
           path: inferrs-aarch64-unknown-linux-gnu.tar.gz
 
-  # ── Windows x86_64 binary (with CUDA support) ────────────────────────────
+  # ── Windows x86_64 binary (with CUDA + ROCm support) ────────────────────
   build-windows-x86:
     name: Build (x86_64-pc-windows-msvc)
     runs-on: windows-2022
@@ -236,6 +257,45 @@ jobs:
           cargo build --release --target x86_64-pc-windows-msvc `
             -p inferrs -p inferrs-backend-cuda
 
+      # ── ROCm backend plugin (Windows x86_64, ROCm 5.5+ HIP SDK) ─────────
+      # AMD provides a native HIP SDK installer for Windows. The choco package
+      # `amd-hip-sdk` wraps the official AMD HIP SDK installer.  The plugin is
+      # built separately from the CUDA steps because hipcc sets conflicting
+      # environment variables (ROCM_PATH vs CUDA_PATH).
+      #
+      # The resulting DLL uses the same `inferrs_backend_probe` ABI as the
+      # Linux .so, so the Windows runtime LoadLibrary probe finds it using
+      # the same logic as on Linux.
+      - name: Install AMD HIP SDK (Windows)
+        shell: pwsh
+        run: choco install --no-progress -y amd-hip-sdk
+
+      - name: Build ROCm backend plugin
+        shell: pwsh
+        run: |
+          # Resolve the versioned ROCm install path dynamically so the build
+          # does not break when Chocolatey installs a newer HIP SDK version.
+          $rocmRoot = "C:\Program Files\AMD\ROCm"
+          $rocmPath = Get-ChildItem $rocmRoot -Directory |
+                        Sort-Object Name -Descending |
+                        Select-Object -First 1 -ExpandProperty FullName
+          if (-not $rocmPath) {
+            Write-Error "No ROCm installation found under $rocmRoot"
+            exit 1
+          }
+          Write-Host "Using ROCm at: $rocmPath"
+          $env:ROCM_PATH = $rocmPath
+          $env:HIP_PATH   = $rocmPath
+          $env:PATH = "$rocmPath\bin;$env:PATH"
+          cargo build --release --target x86_64-pc-windows-msvc `
+            -p inferrs-backend-rocm
+
+      # Note: inferrs-backend-vulkan is intentionally NOT built for Windows.
+      # The Vulkan probe body is cfg(not(target_os = "linux")) → always returns
+      # 1 (unavailable), so shipping the DLL would waste space with no benefit.
+      # When candle gains wgpu support and the Vulkan probe is extended to
+      # Windows, add a build step and DLL entry here.
+
       - name: Package
         shell: pwsh
         run: |
@@ -243,10 +303,15 @@ jobs:
           $stage = "inferrs-windows-x86_64"
           New-Item -ItemType Directory -Force $stage | Out-Null
           Copy-Item "$releaseDir\inferrs.exe" "$stage\"
-          # Ship the CUDA plugin alongside the binary so the runtime dlopen
-          # search (next to the executable) finds it automatically.
-          if (Test-Path "$releaseDir\inferrs_backend_cuda.dll") {
-            Copy-Item "$releaseDir\inferrs_backend_cuda.dll" "$stage\"
+          # Ship all GPU backend plugins alongside the binary so the runtime
+          # LoadLibrary search (next to the executable) finds them automatically.
+          foreach ($dll in @(
+            "inferrs_backend_cuda.dll",
+            "inferrs_backend_rocm.dll"
+          )) {
+            if (Test-Path "$releaseDir\$dll") {
+              Copy-Item "$releaseDir\$dll" "$stage\"
+            }
           }
           Compress-Archive -Path "$stage\*" -DestinationPath "inferrs-x86_64-pc-windows-msvc.zip"
 

--- a/backends/inferrs-backend-vulkan/src/lib.rs
+++ b/backends/inferrs-backend-vulkan/src/lib.rs
@@ -10,6 +10,10 @@
 /// available and will accelerate inference once candle gains wgpu support.
 /// Until then the binary falls back to CPU after logging the detection.
 ///
+/// Platform coverage: Linux only. The probe always returns 1 (unavailable) on
+/// Windows and macOS. When candle gains wgpu support and the Vulkan probe is
+/// extended to Windows, update the cfg guard below and the release workflow.
+///
 /// Returns 0 if `libvulkan.so.1` can be opened, 1 otherwise.
 #[no_mangle]
 pub extern "C" fn inferrs_backend_probe() -> i32 {

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -18,9 +18,24 @@
 //! If a probe succeeds the matching `candle_core::Device` variant is returned.
 //! The caller (`resolve_device`) uses this to construct the actual device.
 //!
+//! ## Platform support matrix
+//!
+//! | Platform                  | CUDA | ROCm | Vulkan |
+//! |---------------------------|------|------|--------|
+//! | Linux x86_64              | ✓    | ✓    | ✓      |
+//! | Linux aarch64             | ✓    | ✓    | ✓      |
+//! | Windows x86_64            | ✓    | ✓    | ✓      |
+//! | Windows aarch64           | —    | —    | —      |
+//! | macOS aarch64             | —    | —    | —      |
+//! | Android                   | —    | —    | —      |
+//!
+//! ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for Windows).
+//! ROCm on Linux aarch64 is supported on hardware such as AMD MI300A APUs
+//! and Radeon-equipped AArch64 platforms.
+//!
 //! Plugin search order (highest priority first):
 //!   1. CUDA   (`.so` / `.dll`)  → `Device::new_cuda(0)`
-//!   2. ROCm   (`.so`)           → `Device::new_cuda(0)` (HIP, Linux only)
+//!   2. ROCm   (`.so` / `.dll`)  → `Device::new_cuda(0)` (HIP)
 //!   3. Vulkan (`.so` / `.dll`)  → CPU fallback with warning
 //!   4. CPU    (always available)
 
@@ -51,7 +66,8 @@ mod linux {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → ROCm → Vulkan → CPU
+        // Priority order: CUDA → ROCm → Vulkan → CPU.
+        // Both x86_64 and aarch64 Linux support CUDA and ROCm.
         let candidates: &[(&str, BackendKind)] = &[
             ("libinferrs_backend_cuda.so", BackendKind::Cuda),
             ("libinferrs_backend_rocm.so", BackendKind::Rocm),
@@ -137,7 +153,10 @@ mod linux {
 pub use linux::{detect_backend, BackendKind};
 
 // ── Windows x86_64 ───────────────────────────────────────────────────────────
-// CUDA is not available on Windows ARM, so the plugin system is x86_64-only.
+// CUDA and ROCm are not available on Windows ARM, so the plugin system is
+// x86_64-only.  ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for
+// Windows); the plugin DLL is named `inferrs_backend_rocm.dll` and follows
+// the same ABI as the Linux `.so`.
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod windows {
@@ -149,6 +168,8 @@ mod windows {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         Cuda,
+        /// ROCm/HIP device (AMD GPU via ROCm 5.5+ HIP SDK for Windows).
+        Rocm,
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
         /// Falls back to CPU while logging the detection.
         Vulkan,
@@ -162,9 +183,11 @@ mod windows {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → Vulkan → CPU  (ROCm is Linux-only)
+        // Priority order: CUDA → ROCm → Vulkan → CPU.
+        // ROCm on Windows x86_64 is supported via AMD's HIP SDK (ROCm 5.5+).
         let candidates: &[(&str, BackendKind)] = &[
             ("inferrs_backend_cuda.dll", BackendKind::Cuda),
+            ("inferrs_backend_rocm.dll", BackendKind::Rocm),
             ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
         ];
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -254,9 +254,10 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
-                #[cfg(target_os = "linux")]
                 BackendKind::Rocm => {
                     // ROCm uses the same HIP/CUDA device path in candle.
+                    // Supported on Linux x86_64, Linux aarch64, and Windows
+                    // x86_64 (via AMD HIP SDK / ROCm 5.5+).
                     let device = candle_core::Device::new_cuda(0)?;
                     tracing::info!("Using ROCm device (via plugin)");
                     disable_cuda_event_tracking(&device);


### PR DESCRIPTION
Extend the existing ROCm plugin system beyond Linux x86_64 to cover all architectures and OSes where ROCm/HIP is available:

- backend.rs: add BackendKind::Rocm to the Windows x86_64 module and probe inferrs_backend_rocm.dll via LoadLibrary, matching the Linux dlopen path; remove the Linux-only cfg guard on the Rocm match arm in main.rs so it compiles on both platforms
- release.yml: build inferrs-backend-rocm on Linux aarch64 (ROCm 6.x sbsa packages via amdgpu-install) and include libinferrs_backend_rocm.so in the aarch64 tarball
- release.yml: install AMD HIP SDK via Chocolatey on Windows x86_64, build inferrs-backend-rocm.dll, and ship it in the Windows zip

macOS, Windows aarch64, and Android are left unchanged — ROCm has no support on those platforms.