### PR TITLE
add MUSA (Moore Threads GPU) backend plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         with:
           components: rustfmt
       # Format-check only the packages that don't require GPU toolchains.
-      - run: cargo fmt --check -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+      # inferrs-backend-musa has no MUSA SDK dependency at compile time (it
+      # probes libmusart.so via dlopen at runtime) so it can be checked here.
+      - run: cargo fmt --check -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
 
   clippy:
     name: Clippy
@@ -43,7 +45,9 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends cuda-nvcc-12-6
           echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
-      - run: cargo clippy -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan -- -D warnings
+      # inferrs-backend-musa is included here for the same reason as fmt: it has
+      # no compile-time MUSA SDK dependency.
+      - run: cargo clippy -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan -- -D warnings
 
   build:
     name: Build (${{ matrix.target }})
@@ -125,7 +129,11 @@ jobs:
         shell: bash
         run: |
           if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
-            cargo test --no-run -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+            # --no-run: the test binary crashes at startup without nvcuda.dll
+            # on GPU-less CI runners; just verify compilation succeeds.
+            cargo test --no-run -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
           else
-            cargo test -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan
+            # inferrs-backend-musa has no compile-time MUSA SDK dependency, so
+            # it builds and runs (probe returns 1 = unavailable) on all runners.
+            cargo test -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,14 @@ jobs:
           cargo build --release --target x86_64-unknown-linux-gnu \
             -p inferrs-backend-rocm
 
+      # ── MUSA backend plugin (no GPU toolchain needed at compile time) ───
+      # The MUSA plugin probes libmusart.so via dlopen at runtime; building it
+      # only requires the Rust toolchain, so no MUSA SDK install is needed here.
+      - name: Build MUSA backend plugin
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu \
+            -p inferrs-backend-musa
+
       # ── Vulkan backend plugin (no GPU toolchain needed) ──────────────────
       - name: Build Vulkan backend plugin
         run: |
@@ -116,10 +124,11 @@ jobs:
           # Main binary
           cp "$RELEASE_DIR/inferrs" "$STAGE/"
 
-          # Backend plugins (ship all three; the binary picks the right one at
+          # Backend plugins (ship all; the binary picks the right one at
           # runtime via dlopen — missing plugins are silently skipped)
           for lib in \
             libinferrs_backend_cuda.so \
+            libinferrs_backend_musa.so \
             libinferrs_backend_rocm.so \
             libinferrs_backend_vulkan.so; do
             if [ -f "$RELEASE_DIR/$lib" ]; then
@@ -189,6 +198,12 @@ jobs:
           cargo build --release --target aarch64-unknown-linux-gnu \
             -p inferrs-backend-rocm
 
+      # ── MUSA backend plugin (aarch64: Moore Threads ships SDK for ARM) ──
+      - name: Build MUSA backend plugin
+        run: |
+          cargo build --release --target aarch64-unknown-linux-gnu \
+            -p inferrs-backend-musa
+
       # ── Vulkan backend plugin (arm64 systems can have Vulkan drivers) ────
       - name: Build Vulkan backend plugin
         run: |
@@ -204,6 +219,7 @@ jobs:
           cp "$RELEASE_DIR/inferrs" "$STAGE/"
           for lib in \
             libinferrs_backend_cuda.so \
+            libinferrs_backend_musa.so \
             libinferrs_backend_rocm.so \
             libinferrs_backend_vulkan.so; do
             [ -f "$RELEASE_DIR/$lib" ] && cp "$RELEASE_DIR/$lib" "$STAGE/"
@@ -290,6 +306,14 @@ jobs:
           cargo build --release --target x86_64-pc-windows-msvc `
             -p inferrs-backend-rocm
 
+      # ── MUSA backend plugin (no compile-time MUSA SDK dependency) ────────
+      # The MUSA plugin has no compile-time MUSA SDK dependency so it can be
+      # built with the standard MSVC toolchain that is already available here.
+      - name: Build MUSA backend plugin
+        run: |
+          cargo build --release --target x86_64-pc-windows-msvc `
+            -p inferrs-backend-musa
+
       # Note: inferrs-backend-vulkan is intentionally NOT built for Windows.
       # The Vulkan probe body is cfg(not(target_os = "linux")) → always returns
       # 1 (unavailable), so shipping the DLL would waste space with no benefit.
@@ -307,6 +331,7 @@ jobs:
           # LoadLibrary search (next to the executable) finds them automatically.
           foreach ($dll in @(
             "inferrs_backend_cuda.dll",
+            "inferrs_backend_musa.dll",
             "inferrs_backend_rocm.dll"
           )) {
             if (Test-Path "$releaseDir\$dll") {
@@ -449,19 +474,20 @@ jobs:
               end
             end
 
-            def install
-              bin.install "inferrs"
+             def install
+               bin.install "inferrs"
 
-              # Install GPU backend plugins alongside the binary so the
-              # inferrs binary can find them via dlopen at runtime.
-              %w[
-                libinferrs_backend_cuda.so
-                libinferrs_backend_rocm.so
-                libinferrs_backend_vulkan.so
-              ].each do |plugin|
-                bin.install plugin if File.exist?(plugin)
-              end
-            end
+               # Install GPU backend plugins alongside the binary so the
+               # inferrs binary can find them via dlopen at runtime.
+               %w[
+                 libinferrs_backend_cuda.so
+                 libinferrs_backend_musa.so
+                 libinferrs_backend_rocm.so
+                 libinferrs_backend_vulkan.so
+               ].each do |plugin|
+                 bin.install plugin if File.exist?(plugin)
+               end
+             end
 
             test do
               assert_match "inferrs", shell_output("#{bin}/inferrs --help")

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferrs-backend-musa"
+version = "0.1.0"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "inferrs-backend-rocm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "inferrs-benchmark",
     "backends/inferrs-backend-cann",
     "backends/inferrs-backend-cuda",
+    "backends/inferrs-backend-musa",
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
 ]
@@ -14,9 +15,12 @@ members = [
 #   cargo build -p inferrs-backend-rocm     (requires hipcc / ROCm)
 #   cargo build -p inferrs-backend-cann     (Linux/Android only; requires
 #                                            libascendcl.so from CANN SDK)
+# The MUSA backend has no compile-time SDK dependency (it probes libmusart.so
+# via dlopen at runtime) so it is included in default-members.
 default-members = [
     "inferrs",
     "inferrs-benchmark",
+    "backends/inferrs-backend-musa",
     "backends/inferrs-backend-vulkan",
 ]
 resolver = "2"

--- a/backends/inferrs-backend-musa/Cargo.toml
+++ b/backends/inferrs-backend-musa/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "inferrs-backend-musa"
+version = "0.1.0"
+edition = "2021"
+description = "MUSA (Moore Threads GPU) backend plugin for inferrs"
+license = "Apache-2.0"
+
+[lib]
+name = "inferrs_backend_musa"
+crate-type = ["cdylib"]
+
+[dependencies]
+# libloading wraps dlopen (Linux/macOS) and LoadLibraryW (Windows) behind a
+# safe Rust API.  We use it to open the MUSA runtime library at probe time
+# without linking it at compile time, so the plugin carries no build-time
+# dependency on the MUSA SDK.
+libloading = "0.8"

--- a/backends/inferrs-backend-musa/src/lib.rs
+++ b/backends/inferrs-backend-musa/src/lib.rs
@@ -1,0 +1,127 @@
+//! Probe whether a Moore Threads GPU (MUSA) device is available and
+//! functional on this system.
+//!
+//! # Design
+//!
+//! MUSA is the GPU compute platform from Moore Threads Technology.  It
+//! presents an API surface intentionally compatible with NVIDIA CUDA; the SDK
+//! ships a runtime library (`libmusart.so` on Linux, `musa.dll` on Windows)
+//! that exposes a `musaGetDeviceCount` symbol analogous to `cudaGetDeviceCount`.
+//!
+//! This plugin does **not** link against the MUSA SDK at compile time.
+//! Instead it opens the MUSA runtime library at probe time via `libloading`,
+//! which wraps `dlopen` on Linux and `LoadLibraryW` on Windows.  This means:
+//!
+//! * Building the plugin requires only the Rust toolchain — no MUSA SDK.
+//! * Shipping the plugin in release archives is safe on any host; a missing
+//!   MUSA driver simply causes the probe to return non-zero.
+//!
+//! The probe sequence is:
+//! 1. Try each candidate library name in priority order (versioned first).
+//! 2. Resolve `musaGetDeviceCount` from the opened library.
+//! 3. Call it; return 0 (available) only if the call succeeds and returns
+//!    at least one device.
+//!
+//! # Supported platforms
+//!
+//! Moore Threads currently ships the MUSA SDK for **Linux x86_64** and
+//! **Linux aarch64**.  Windows x86_64 support is included because Moore
+//! Threads has announced Windows drivers for the MTT S80 / S4000 / S5000
+//! series.
+//!
+//! Android and macOS are not supported by Moore Threads hardware.
+//! Windows aarch64 has no known MUSA SDK; the probe returns 1 there.
+
+/// Probe whether a MUSA device (Moore Threads GPU) is available.
+///
+/// Returns 0 if at least one MUSA device is usable, non-zero otherwise.
+///
+/// The `inferrs` binary `dlopen`s this plugin at runtime so the binary itself
+/// carries no compile-time dependency on the MUSA SDK.
+#[no_mangle]
+pub extern "C" fn inferrs_backend_probe() -> i32 {
+    // Linux x86_64 and aarch64: primary targets shipping the MUSA SDK.
+    // Windows x86_64: announced support from Moore Threads.
+    #[cfg(any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    ))]
+    {
+        probe_musa()
+    }
+
+    // macOS, Windows aarch64, Android, and all other platforms: not supported.
+    #[cfg(not(any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    )))]
+    {
+        1
+    }
+}
+
+/// Try candidate MUSA library names in order; for the first one that can be
+/// opened, attempt to resolve and call `musaGetDeviceCount`.
+#[cfg(any(
+    target_os = "linux",
+    all(target_os = "windows", target_arch = "x86_64")
+))]
+fn probe_musa() -> i32 {
+    // Candidate names searched in priority order.
+    //
+    // Linux:   versioned sonames are preferred (the linker chose them for the
+    //          installed ABI); unversioned names are fallbacks for custom installs
+    //          that lack symlinks.
+    //
+    //   libmusart.so — MUSA **runtime** library; exposes musaGetDeviceCount
+    //                  directly without requiring a separate musaInit() call.
+    //   libmusa.so   — MUSA **driver** API library (lower-level).
+    //
+    // Windows: Moore Threads DLLs follow the <name>.dll / <name>64.dll pattern
+    //          used by CUDA (nvcuda.dll → musa.dll, cudart64_*.dll → musa64.dll).
+    #[cfg(target_os = "linux")]
+    const CANDIDATES: &[&str] = &[
+        "libmusart.so.1",
+        "libmusart.so",
+        "libmusa.so.1",
+        "libmusa.so",
+    ];
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    const CANDIDATES: &[&str] = &["musa.dll", "musart.dll", "musa64.dll"];
+
+    type MusaGetDeviceCountFn = unsafe extern "C" fn(*mut i32) -> i32;
+
+    for lib_name in CANDIDATES {
+        // SAFETY: We are attempting to open a well-known system library by
+        // name.  libloading uses RTLD_LOCAL | RTLD_NOW on Linux and
+        // LoadLibraryW on Windows.
+        let lib = match unsafe { libloading::Library::new(lib_name) } {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        // SAFETY: We know the symbol name and its C ABI signature from the
+        // MUSA SDK.  The library is kept alive for the duration of the call.
+        let get_device_count: libloading::Symbol<MusaGetDeviceCountFn> =
+            match unsafe { lib.get(b"musaGetDeviceCount\0") } {
+                Ok(sym) => sym,
+                Err(_) => continue,
+            };
+
+        let mut count: i32 = 0;
+        // SAFETY: count is valid stack memory; musaGetDeviceCount writes
+        // exactly one i32 to the pointer.
+        let err = unsafe { get_device_count(&mut count) };
+
+        // musaSuccess == 0.  Only commit to a result when the call itself
+        // succeeded; a non-zero error code (driver mismatch, init failure,
+        // etc.) means this library is unusable — try the next candidate.
+        if err == 0 {
+            return if count > 0 { 0 } else { 1 };
+        }
+    }
+
+    // No MUSA library found on this system.
+    1
+}

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -38,16 +38,18 @@
 //!
 //! **Linux x86_64 / aarch64:**
 //!   1. CUDA   (`.so`)  → `Device::new_cuda(0)`
-//!   2. ROCm   (`.so`)  → `Device::new_cuda(0)` (HIP)
-//!   3. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
-//!   4. Vulkan (`.so`)  → CPU fallback with info log
-//!   5. CPU    (always available)
+//!   2. MUSA   (`.so`)  → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm   (`.so`)  → `Device::new_cuda(0)` (HIP)
+//!   4. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
+//!   5. Vulkan (`.so`)  → CPU fallback with info log
+//!   6. CPU    (always available)
 //!
 //! **Windows x86_64:**
 //!   1. CUDA   (`.dll`) → `Device::new_cuda(0)`
-//!   2. ROCm   (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
-//!   3. Vulkan (`.dll`) → CPU fallback with info log
-//!   4. CPU    (always available)
+//!   2. MUSA   (`.dll`) → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm   (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
+//!   4. Vulkan (`.dll`) → CPU fallback with info log
+//!   5. CPU    (always available)
 //!
 //! **Android aarch64:**
 //!   1. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
@@ -69,6 +71,10 @@ mod linux {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         Cuda,
+        /// Moore Threads GPU (MUSA SDK).  Uses the same `Device::new_cuda(0)`
+        /// path in candle-core as NVIDIA CUDA, because the MUSA SDK mirrors
+        /// the CUDA API.  The plugin probes for `libmusart.so` at runtime.
+        Musa,
         Rocm,
         /// Huawei Ascend NPU via CANN (Compute Architecture for Neural Networks).
         ///
@@ -93,18 +99,23 @@ mod linux {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → ROCm → CANN → Vulkan → CPU.
-        // Both x86_64 and aarch64 Linux support CUDA and ROCm.
+        // Priority order: CUDA → MUSA → ROCm → CANN → Vulkan → CPU.
+        // Both x86_64 and aarch64 Linux support CUDA, MUSA, and ROCm.
         //
-        // CANN (Huawei Ascend NPU) is placed after CUDA and ROCm so that a
-        // system with both an NVIDIA/AMD GPU and an Ascend NPU prefers the
-        // GPU.  CANN is placed before Vulkan because it represents dedicated
-        // neural-network silicon rather than a general graphics API.
+        // MUSA (Moore Threads) mirrors the CUDA API; its plugin probes
+        // `libmusart.so` without any compile-time dependency, so it is safe
+        // to ship on systems without a MUSA driver installed.
+        //
+        // CANN (Huawei Ascend NPU) is placed after CUDA/MUSA/ROCm so that a
+        // system with both a GPU and an Ascend NPU prefers the GPU.  CANN is
+        // placed before Vulkan because it represents dedicated neural-network
+        // silicon rather than a general graphics API.
         //
         // The CANN plugin is arch-gated at build time (x86_64 / aarch64 only)
         // so on unsupported architectures the `.so` simply won't exist.
         let candidates: &[(&str, BackendKind)] = &[
             ("libinferrs_backend_cuda.so", BackendKind::Cuda),
+            ("libinferrs_backend_musa.so", BackendKind::Musa),
             ("libinferrs_backend_rocm.so", BackendKind::Rocm),
             ("libinferrs_backend_cann.so", BackendKind::Cann),
             ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
@@ -303,6 +314,9 @@ mod windows {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         Cuda,
+        /// Moore Threads GPU (MUSA SDK).  Uses `Device::new_cuda(0)` because
+        /// MUSA mirrors the CUDA API.  The plugin probes `musa.dll` at runtime.
+        Musa,
         /// ROCm/HIP device (AMD GPU via ROCm 5.5+ HIP SDK for Windows).
         Rocm,
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
@@ -318,11 +332,13 @@ mod windows {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → ROCm → Vulkan → CPU.
+        // Priority order: CUDA → MUSA → ROCm → Vulkan → CPU.
         // ROCm on Windows x86_64 is supported via AMD's HIP SDK (ROCm 5.5+).
+        // MUSA Windows support is announced by Moore Threads.
         // CANN is not supported on Windows (Huawei SDK constraint).
         let candidates: &[(&str, BackendKind)] = &[
             ("inferrs_backend_cuda.dll", BackendKind::Cuda),
+            ("inferrs_backend_musa.dll", BackendKind::Musa),
             ("inferrs_backend_rocm.dll", BackendKind::Rocm),
             ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
         ];

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -254,6 +254,18 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
+                BackendKind::Musa => {
+                    // Moore Threads MUSA mirrors the CUDA API.  candle-core's
+                    // `cuda` feature covers MUSA when the binary is loaded in
+                    // an environment with the MUSA runtime libraries present.
+                    // `Device::new_cuda(0)` resolves through cudarc's
+                    // fallback-dynamic-loading, which at runtime binds to the
+                    // MUSA-compatible symbols instead of the NVIDIA ones.
+                    let device = candle_core::Device::new_cuda(0)?;
+                    tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
+                    disable_cuda_event_tracking(&device);
+                    return Ok(device);
+                }
                 BackendKind::Rocm => {
                     // ROCm uses the same HIP/CUDA device path in candle.
                     // Supported on Linux x86_64, Linux aarch64, and Windows


### PR DESCRIPTION
Add inferrs-backend-musa as a new cdylib probe plugin that detects Moore Threads GPUs via dlopen/LoadLibrary at runtime with no compile-time MUSA SDK dependency.

The plugin opens libmusart.so (Linux) or musa.dll (Windows) dynamically, resolves musaGetDeviceCount, and returns 0 only if at least one device is present. This mirrors the Vulkan plugin's compile-time-free approach.

Supported targets: Linux x86_64, Linux aarch64, Windows x86_64. macOS, Windows aarch64, and Android return 1 unconditionally as Moore Threads has no SDK for those platforms.

The probe chain priority is now CUDA > MUSA > ROCm > Vulkan > CPU on Linux, and CUDA > MUSA > Vulkan > CPU on Windows x86_64. On a MUSA system Device::new_cuda(0) is used, matching the same pattern as ROCm, since the MUSA SDK mirrors the CUDA API surface.

The plugin is added to default-members (alongside Vulkan) because it requires no GPU toolchain to build. CI fmt/clippy/test and the release packaging steps for all four relevant platform jobs are updated to include inferrs-backend-musa.