### PR TITLE
add OpenVINO backend probe for x86_64/aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferrs-backend-openvino"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "inferrs-backend-rocm"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
     "backends/inferrs-backend-hexagon",
+    "backends/inferrs-backend-openvino",
 ]
 # Default members exclude GPU/NPU backends that require vendor-specific toolchains.
 # `cargo build` (no -p flag) builds only the listed members.
@@ -26,6 +27,7 @@ default-members = [
     "backends/inferrs-backend-musa",
     "backends/inferrs-backend-vulkan",
     "backends/inferrs-backend-hexagon",
+    "backends/inferrs-backend-openvino",
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ endif
 HEXAGON_PKG := -p inferrs-backend-hexagon
 
 # Packages that can be built/tested without GPU toolchains (CUDA, ROCm).
-# The Hexagon backend is included because it has no exotic toolchain requirement.
-NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan $(HEXAGON_PKG) $(CUDA_PKG)
+# Both the Hexagon and OpenVINO backends have no exotic toolchain requirement
+# and can be built anywhere (they probe at runtime via dlopen/LoadLibrary).
+NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan $(HEXAGON_PKG) -p inferrs-backend-openvino $(CUDA_PKG)
 
 .PHONY: all build release fmt clippy test
 

--- a/backends/inferrs-backend-openvino/Cargo.toml
+++ b/backends/inferrs-backend-openvino/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "inferrs-backend-openvino"
+version = "0.1.0"
+edition = "2021"
+description = "OpenVINO backend plugin for inferrs (probe-only; detection via dlopen/LoadLibrary)"
+license = "Apache-2.0"
+
+[lib]
+name = "inferrs_backend_openvino"
+crate-type = ["cdylib"]
+
+[dependencies]
+# libc is used for low-level dlopen on Linux/Android to probe libopenvino
+# without linking against it at compile time.
+libc = "0.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+# windows-sys is used for LoadLibrary / FreeLibrary on Windows.
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_LibraryLoader"] }

--- a/backends/inferrs-backend-openvino/src/lib.rs
+++ b/backends/inferrs-backend-openvino/src/lib.rs
@@ -1,0 +1,270 @@
+//! Probe whether an OpenVINO runtime is available on this system.
+//!
+//! This plugin is a pure probe — it does **not** link against OpenVINO at
+//! compile time.  Instead it uses `dlopen` (Linux/Android/macOS) or
+//! `LoadLibraryW` (Windows) to discover the OpenVINO runtime library at
+//! runtime, mirroring the pattern used by `inferrs-backend-vulkan`.
+//!
+//! # Library names probed per platform
+//!
+//! | Platform          | Library name(s)                                        |
+//! |-------------------|--------------------------------------------------------|
+//! | Linux x86_64      | `libopenvino.so.2025.2`, `libopenvino.so.2024.6`, `libopenvino.so` |
+//! | Linux aarch64     | same as x86_64                                         |
+//! | Android aarch64   | `libopenvino.so`                                       |
+//! | macOS x86_64      | `libopenvino.dylib`, `libopenvino.2025.2.dylib`        |
+//! | macOS aarch64     | same as macOS x86_64                                   |
+//! | Windows x86_64    | `openvino.dll`                                         |
+//! | Windows aarch64   | `openvino.dll`                                         |
+//!
+//! OpenVINO supports x86_64 and aarch64; no other CPU architectures are
+//! targeted by Intel.  The probe returns non-zero (unavailable) on any other
+//! architecture or OS.
+//!
+//! # Return value
+//!
+//! `0`  — OpenVINO runtime library was found and loaded successfully.
+//! `1`  — Library not found or failed to load.
+
+// ── Linux ─────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+mod linux_probe {
+    use std::ffi::CString;
+
+    /// Versioned and unversioned candidate library names for Linux x86_64/aarch64.
+    ///
+    /// Versioned names are tried first so that the probe binds to a specific,
+    /// known-good release rather than whatever symlink `libopenvino.so`
+    /// happens to point to.  The list matches the versions OpenVINO ships in
+    /// its official installers and pip wheels as of 2025.
+    ///
+    /// The naming convention is identical on x86_64 and aarch64 Linux.
+    const CANDIDATES: &[&str] = &[
+        "libopenvino.so.2025.2",
+        "libopenvino.so.2025.1",
+        "libopenvino.so.2024.6",
+        "libopenvino.so.2024.5",
+        "libopenvino.so",
+    ];
+
+    /// Try to open any of the candidate library names via `dlopen`.
+    /// Returns `true` if at least one name succeeded.
+    pub fn probe() -> bool {
+        for name in CANDIDATES {
+            let Ok(cname) = CString::new(*name) else {
+                continue;
+            };
+            // SAFETY: `dlopen` is safe to call with a valid C string and
+            // standard flags.  We immediately `dlclose` the handle — we only
+            // need to know whether the library can be found.
+            let handle =
+                unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+            if !handle.is_null() {
+                unsafe { libc::dlclose(handle) };
+                return true;
+            }
+        }
+        false
+    }
+}
+
+// ── Android ───────────────────────────────────────────────────────────────────
+//
+// OpenVINO for Android targets aarch64 devices only.  The library is packaged
+// as an unversioned `.so` — the versioned symlink convention used on Linux
+// desktop distributions does not apply in the Android ecosystem.
+
+#[cfg(target_os = "android")]
+mod android_probe {
+    use std::ffi::CString;
+
+    /// Android packages OpenVINO as a plain unversioned shared library.
+    const CANDIDATES: &[&str] = &["libopenvino.so"];
+
+    pub fn probe() -> bool {
+        for name in CANDIDATES {
+            let Ok(cname) = CString::new(*name) else {
+                continue;
+            };
+            // SAFETY: same as the Linux case above.
+            let handle =
+                unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+            if !handle.is_null() {
+                unsafe { libc::dlclose(handle) };
+                return true;
+            }
+        }
+        false
+    }
+}
+
+// ── macOS ─────────────────────────────────────────────────────────────────────
+//
+// OpenVINO provides a macOS distribution for both x86_64 and Apple Silicon
+// (aarch64).  The official installer places the runtime as a `.dylib` in
+// the chosen prefix, e.g. `/opt/intel/openvino/lib/libopenvino.dylib`.
+
+#[cfg(target_os = "macos")]
+mod macos_probe {
+    use std::ffi::CString;
+
+    /// macOS ships both versioned and unversioned dylibs.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    const CANDIDATES: &[&str] = &[
+        "libopenvino.2025.2.dylib",
+        "libopenvino.2025.1.dylib",
+        "libopenvino.2024.6.dylib",
+        "libopenvino.2024.5.dylib",
+        "libopenvino.dylib",
+    ];
+
+    pub fn probe() -> bool {
+        for name in CANDIDATES {
+            let Ok(cname) = CString::new(*name) else {
+                continue;
+            };
+            // SAFETY: same as the Linux case above.
+            let handle =
+                unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+            if !handle.is_null() {
+                unsafe { libc::dlclose(handle) };
+                return true;
+            }
+        }
+        false
+    }
+}
+
+// ── Windows ───────────────────────────────────────────────────────────────────
+//
+// On Windows OpenVINO is distributed as `openvino.dll` (no `lib` prefix, no
+// version suffix in the DLL name itself — the version lives in the installer
+// path).  Both x86_64 and ARM64 Windows are supported by Intel since 2024.1.
+//
+// We use the raw Win32 `LoadLibraryW` / `FreeLibrary` API via `windows-sys`
+// rather than `libloading` so that this plugin carries no heavyweight
+// dependency that would complicate cross-compilation.
+
+#[cfg(target_os = "windows")]
+mod windows_probe {
+    use std::ffi::OsStr;
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::HMODULE;
+    use windows_sys::Win32::System::LibraryLoader::{FreeLibrary, LoadLibraryW};
+
+    /// Candidate DLL names on Windows.
+    const CANDIDATES: &[&str] = &[
+        "openvino.dll",
+        // The redistributable installer may also place a versioned copy.
+        "openvino_2025_2.dll",
+        "openvino_2024_6.dll",
+    ];
+
+    /// Encode a `&str` as a null-terminated wide string for `LoadLibraryW`.
+    fn to_wide_null(s: &str) -> Vec<u16> {
+        OsStr::new(s).encode_wide().chain(once(0u16)).collect()
+    }
+
+    pub fn probe() -> bool {
+        for name in CANDIDATES {
+            let wide = to_wide_null(name);
+            // SAFETY: `LoadLibraryW` is safe to call with a valid pointer to a
+            // null-terminated wide string.  We immediately `FreeLibrary` the
+            // handle — we only need to know whether the DLL can be found.
+            let handle: HMODULE = unsafe { LoadLibraryW(wide.as_ptr()) };
+            if handle != 0 {
+                unsafe { FreeLibrary(handle) };
+                return true;
+            }
+        }
+        false
+    }
+}
+
+// ── Public probe entry point ──────────────────────────────────────────────────
+
+/// Probe whether OpenVINO is available on this system.
+///
+/// Called by the `inferrs` binary after `dlopen`ing this plugin.
+/// Returns `0` if the OpenVINO runtime library was found, `1` otherwise.
+///
+/// Supported configurations:
+/// - Linux x86_64 and aarch64 (including Raspberry Pi 5, Jetson)
+/// - Android aarch64
+/// - macOS x86_64 and aarch64 (Apple Silicon)
+/// - Windows x86_64 and aarch64
+///
+/// On any other platform the probe always returns `1` (unavailable).
+#[no_mangle]
+pub extern "C" fn inferrs_backend_probe() -> i32 {
+    #[cfg(target_os = "linux")]
+    {
+        // OpenVINO official Linux builds target x86_64 and aarch64 only.
+        // Return unavailable on other arches (riscv64, mips, etc.) without probing.
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            return 1;
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        if linux_probe::probe() {
+            0
+        } else {
+            1
+        }
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        // OpenVINO for Android targets aarch64 devices only; no x86_64 build exists.
+        #[cfg(not(target_arch = "aarch64"))]
+        {
+            return 1;
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        if android_probe::probe() {
+            0
+        } else {
+            1
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            return 1;
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        if macos_probe::probe() {
+            0
+        } else {
+            1
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if windows_probe::probe() {
+            0
+        } else {
+            1
+        }
+    }
+
+    // Any other OS (BSDs, Fuchsia, etc.) — OpenVINO is not available.
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "windows",
+    )))]
+    {
+        1
+    }
+}

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -10,12 +10,12 @@ name = "inferrs"
 path = "src/main.rs"
 
 # On macOS: always enable Metal, and add libloading to probe for
-# the Vulkan/MoltenVK plugin at runtime.
+# the Vulkan/MoltenVK and OpenVINO plugins at runtime.
 [target.'cfg(target_os = "macos")'.dependencies]
+libloading = "0.8"
 candle-core = { workspace = true, features = ["metal"] }
 candle-nn = { workspace = true, features = ["metal"] }
 candle-transformers = { workspace = true, features = ["metal"] }
-libloading = "0.8"
 
 
 [dependencies]
@@ -74,7 +74,11 @@ candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }
 candle-transformers = { workspace = true, features = ["cuda"] }
 
-# Windows x86_64: CUDA + ROCm + Vulkan plugin probing.
+# Android: dynamic backend loading (CANN + Hexagon + Vulkan + OpenVINO); no CUDA.
+[target.'cfg(target_os = "android")'.dependencies]
+libloading = "0.8"
+
+# Windows x86_64: CUDA + ROCm + Vulkan + OpenVINO plugin probing.
 # CUDA is not available on Windows ARM, so this block is x86_64-only.
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 libloading = "0.8"
@@ -82,21 +86,16 @@ candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }
 candle-transformers = { workspace = true, features = ["cuda"] }
 
-# Android aarch64: dynamic backend loading for CANN and Hexagon.
-# No CUDA feature — CUDA is not available on Android.  Both plugins are
-# probed at runtime via libloading.
-[target.'cfg(target_os = "android")'.dependencies]
-libloading = "0.8"
 
 # Linux / Android: libc for low-level dlopen/dlsym used by the CANN HBM
 # memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = "0.2"
 
-# Windows aarch64 (Snapdragon X / 8cx): no CUDA, but Hexagon + Vulkan probing
-# via the plugin system needs libloading.
+# Windows aarch64: no CUDA, but Hexagon + Vulkan + OpenVINO probes are useful.
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 libloading = "0.8"
+
 
 [dev-dependencies]
 ureq = { version = "2", features = ["json"] }

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -1,5 +1,5 @@
-//! GPU/NPU backend discovery via dynamic loading (`dlopen` on Linux/Android,
-//! `LoadLibraryW` on Windows).
+//! GPU/NPU/accelerator backend discovery via dynamic loading (`dlopen` on POSIX,
+//! `LoadLibrary` on Windows).
 //!
 //! The `inferrs` binary is compiled with the `cuda` feature (so
 //! `Device::new_cuda()` is available) but candle-core is patched to use
@@ -38,25 +38,28 @@
 //! Plugin search order (highest priority first):
 //!
 //! **Linux x86_64 / aarch64:**
-//!   1. CUDA    (`.so`)  → `Device::new_cuda(0)`
-//!   2. MUSA    (`.so`)  → `Device::new_cuda(0)` (Moore Threads)
-//!   3. ROCm    (`.so`)  → `Device::new_cuda(0)` (HIP)
-//!   4. CANN    (`.so`)  → CPU fallback with info log (pending candle CANN Device)
-//!   5. Hexagon (`.so`)  → CPU fallback with info log (pending candle Hexagon Device)
-//!   6. Vulkan  (`.so`)  → CPU fallback with info log
-//!   7. CPU     (always available)
+//!   1. CUDA    (`.so`)   → `Device::new_cuda(0)`
+//!   2. MUSA    (`.so`)   → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm    (`.so`)   → `Device::new_cuda(0)` (HIP)
+//!   4. CANN    (`.so`)   → CPU fallback with info log (pending candle CANN Device)
+//!   5. Hexagon (`.so`)   → CPU fallback with info log (pending candle Hexagon Device)
+//!   6. Vulkan  (`.so`)   → CPU fallback with info log
+//!   7. OpenVINO (`.so`)  → CPU fallback with info log (pending candle OpenVINO Device)
+//!   8. CPU     (always available)
 //!
 //! **Windows x86_64:**
-//!   1. CUDA    (`.dll`) → `Device::new_cuda(0)`
-//!   2. MUSA    (`.dll`) → `Device::new_cuda(0)` (Moore Threads)
-//!   3. ROCm    (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
-//!   4. Vulkan  (`.dll`) → CPU fallback with info log
-//!   5. CPU     (always available)
+//!   1. CUDA    (`.dll`)  → `Device::new_cuda(0)`
+//!   2. MUSA    (`.dll`)  → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm    (`.dll`)  → `Device::new_cuda(0)` (HIP SDK for Windows)
+//!   4. Vulkan  (`.dll`)  → CPU fallback with info log
+//!   5. OpenVINO (`.dll`) → CPU fallback with info log
+//!   6. CPU     (always available)
 //!
 //! **Windows aarch64:**
-//!   1. Hexagon (`.dll`) → CPU fallback with info log (pending candle Hexagon Device)
-//!   2. Vulkan  (`.dll`) → CPU fallback with info log
-//!   3. CPU     (always available)
+//!   1. Hexagon (`.dll`)  → CPU fallback with info log (pending candle Hexagon Device)
+//!   2. Vulkan  (`.dll`)  → CPU fallback with info log
+//!   3. OpenVINO (`.dll`) → CPU fallback with info log
+//!   4. CPU     (always available)
 //!
 //! **macOS x86_64 / aarch64:**
 //!   Metal is tried first (linked directly).  If Metal fails:
@@ -64,10 +67,17 @@
 //!   2. CPU    (always available)
 //!
 //! **Android aarch64:**
-//!   1. CANN    (`.so`)  → CPU fallback with info log (pending candle CANN Device)
-//!   2. Hexagon (`.so`)  → CPU fallback with info log (pending candle Hexagon Device)
-//!   3. Vulkan  (`.so`)  → CPU fallback with info log
-//!   4. CPU     (always available)
+//!   1. CANN    (`.so`)   → CPU fallback with info log (pending candle CANN Device)
+//!   2. Hexagon (`.so`)   → CPU fallback with info log (pending candle Hexagon Device)
+//!   3. Vulkan  (`.so`)   → CPU fallback with info log
+//!   4. OpenVINO (`.so`)  → CPU fallback with info log
+//!   5. CPU     (always available)
+//!
+//! **macOS x86_64 / aarch64:**
+//!   Metal is tried first (linked directly).  If Metal fails:
+//!   1. Vulkan  (`.dylib`, via MoltenVK) → CPU fallback with info log
+//!   2. OpenVINO (`.dylib`)              → CPU fallback with info log
+//!   3. CPU     (always available)
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 //
@@ -151,7 +161,7 @@ fn exe_dir() -> Option<std::path::PathBuf> {
 mod linux {
     use std::path::PathBuf;
 
-    /// The detected GPU/NPU backend, in priority order.
+    /// The detected hardware/NPU backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         Cuda,
@@ -177,6 +187,11 @@ mod linux {
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
         /// Falls back to CPU while logging the detection.
         Vulkan,
+        /// OpenVINO runtime was found on the system.  candle does not yet have
+        /// an OpenVINO `Device` variant; detection is logged and the binary
+        /// falls back to CPU.  A future update will enable OpenVINO inference
+        /// once candle gains the corresponding backend.
+        OpenVino,
         Cpu,
     }
 
@@ -184,7 +199,7 @@ mod linux {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → MUSA → ROCm → CANN → Hexagon → Vulkan → CPU.
+        // Priority order: CUDA → MUSA → ROCm → CANN → Hexagon → Vulkan → OpenVINO → CPU.
         // Both x86_64 and aarch64 Linux support CUDA, MUSA, and ROCm.
         //
         // MUSA (Moore Threads) mirrors the CUDA API; its plugin probes
@@ -208,6 +223,7 @@ mod linux {
             ("libinferrs_backend_cann.so", BackendKind::Cann),
             ("libinferrs_backend_hexagon.so", BackendKind::Hexagon),
             ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
+            ("libinferrs_backend_openvino.so", BackendKind::OpenVino),
         ];
 
         for (lib_name, kind) in candidates {
@@ -231,9 +247,9 @@ mod linux {
 pub use linux::{detect_backend, BackendKind};
 
 // ── Android ───────────────────────────────────────────────────────────────────
-// Android aarch64 hosts both Huawei Ascend NPUs (CANN, in some edge devices)
-// and Qualcomm Hexagon NPUs (Snapdragon SoCs).  CUDA and ROCm are unavailable.
-// Vulkan is also available on most Android devices since API 24.
+// Android aarch64 hosts Huawei Ascend NPUs (CANN) and Qualcomm Hexagon NPUs
+// (Snapdragon SoCs).  CUDA and ROCm are unavailable on Android.
+// Vulkan is available on most Android devices since API 24.
 
 #[cfg(target_os = "android")]
 mod android {
@@ -248,20 +264,22 @@ mod android {
         Hexagon,
         /// Vulkan GPU acceleration (available since API 24).
         Vulkan,
+        /// OpenVINO runtime found; falls back to CPU pending candle support.
+        OpenVino,
         Cpu,
     }
 
     pub fn detect_backend() -> BackendKind {
-        // Priority: CANN → Hexagon → Vulkan → CPU.
-        // CANN is probed first; on Snapdragon devices the CANN plugin won't
-        // exist so the probe falls through to Hexagon, then Vulkan.
+        let search_dirs = plugin_search_dirs();
+
+        // Priority: CANN → Hexagon → Vulkan → OpenVINO → CPU.
         let candidates: &[(&str, BackendKind)] = &[
             ("libinferrs_backend_cann.so", BackendKind::Cann),
             ("libinferrs_backend_hexagon.so", BackendKind::Hexagon),
             ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
+            ("libinferrs_backend_openvino.so", BackendKind::OpenVino),
         ];
 
-        let search_dirs = plugin_search_dirs();
         for (lib_name, kind) in candidates {
             if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
@@ -287,9 +305,8 @@ pub use android::{detect_backend, BackendKind};
 // ── macOS ─────────────────────────────────────────────────────────────────────
 //
 // Metal is linked directly and is always preferred.  Vulkan is also available
-// via MoltenVK (a Vulkan 1.3 portability layer over Metal).  We probe for it
-// so that the main binary can log its availability and future wgpu/Vulkan code
-// paths can use it.
+// via MoltenVK.  OpenVINO is probed for future CPU acceleration (Intel provides
+// macOS builds for both x86_64 and aarch64).
 //
 // Architectures: x86_64-apple-darwin, aarch64-apple-darwin.
 
@@ -297,19 +314,32 @@ pub use android::{detect_backend, BackendKind};
 mod macos {
     use std::path::PathBuf;
 
-    /// The detected GPU backend on macOS (Metal is handled directly in
+    /// The detected backend on macOS (Metal is handled directly in
     /// `auto_device` before the plugin system is invoked).
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         /// Vulkan via MoltenVK is detected; candle 0.8 has no Vulkan Device yet.
         Vulkan,
+        /// OpenVINO runtime found; the main binary uses Metal for GPU inference
+        /// but will switch to an OpenVINO CPU path once candle supports it.
+        OpenVino,
         Cpu,
     }
 
     pub fn detect_backend() -> BackendKind {
-        if super::probe_plugin(&plugin_search_dirs(), "libinferrs_backend_vulkan.dylib") {
-            return BackendKind::Vulkan;
+        let search_dirs = plugin_search_dirs();
+
+        let candidates: &[(&str, BackendKind)] = &[
+            ("libinferrs_backend_vulkan.dylib", BackendKind::Vulkan),
+            ("libinferrs_backend_openvino.dylib", BackendKind::OpenVino),
+        ];
+
+        for (lib_name, kind) in candidates {
+            if super::probe_plugin(&search_dirs, lib_name) {
+                return *kind;
+            }
         }
+
         BackendKind::Cpu
     }
 
@@ -320,6 +350,8 @@ mod macos {
         dirs.push(PathBuf::from("/usr/local/lib"));
         dirs.push(PathBuf::from("/opt/homebrew/lib")); // Homebrew Apple Silicon
         dirs.push(PathBuf::from("/usr/local/opt/molten-vk/lib")); // Homebrew Intel
+        dirs.push(PathBuf::from("/usr/local/lib/inferrs")); // inferrs install
+        dirs.push(PathBuf::from("/opt/homebrew/lib/inferrs")); // inferrs ARM
         dirs
     }
 }
@@ -327,95 +359,63 @@ mod macos {
 #[cfg(target_os = "macos")]
 pub use macos::{detect_backend, BackendKind};
 
-// ── Windows x86_64 ───────────────────────────────────────────────────────────
-// CUDA and ROCm are available on Windows x86_64 only.  ROCm on Windows is
-// supported from ROCm 5.5+ (HIP SDK for Windows).  Vulkan is available on
-// both x86_64 and aarch64 (see the Windows aarch64 section below).
-// CANN and Hexagon are not supported on Windows x86_64.
+// ── Windows ───────────────────────────────────────────────────────────────────
+// CUDA/ROCm/MUSA are x86_64-only on Windows.  OpenVINO supports both x86_64
+// and aarch64 (since 2024.1).  Hexagon is aarch64-only (Snapdragon devices).
+// CANN is not supported on Windows (Huawei SDK constraint).
 
-#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-mod windows_x86_64 {
+#[cfg(target_os = "windows")]
+mod windows {
     use std::path::PathBuf;
 
-    /// The detected GPU backend, in priority order.
+    use libloading::{Library, Symbol};
+
+    /// The detected hardware backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
+        /// CUDA — x86_64 only.
+        #[cfg(target_arch = "x86_64")]
         Cuda,
-        /// Moore Threads GPU (MUSA SDK).  Uses `Device::new_cuda(0)` because
-        /// MUSA mirrors the CUDA API.  The plugin probes `musa.dll` at runtime.
+        /// Moore Threads GPU (MUSA SDK) — x86_64 only on Windows.
+        /// Uses `Device::new_cuda(0)` because MUSA mirrors the CUDA API.
+        #[cfg(target_arch = "x86_64")]
         Musa,
-        /// ROCm/HIP device (AMD GPU via ROCm 5.5+ HIP SDK for Windows).
+        /// ROCm/HIP device (AMD GPU via ROCm 5.5+ HIP SDK) — x86_64 only on Windows.
+        #[cfg(target_arch = "x86_64")]
         Rocm,
+        /// Qualcomm Hexagon HTP NPU — aarch64 (Snapdragon X / 8cx) only.
+        /// Falls back to CPU while candle gains a Hexagon device variant.
+        #[cfg(target_arch = "aarch64")]
+        Hexagon,
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
         /// Falls back to CPU while logging the detection.
         Vulkan,
+        /// OpenVINO runtime found — both x86_64 and aarch64 Windows.
+        OpenVino,
         Cpu,
     }
 
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → MUSA → ROCm → Vulkan → CPU.
+        // Priority order (x86_64): CUDA → MUSA → ROCm → Vulkan → OpenVINO → CPU
+        // Priority order (aarch64): Hexagon → Vulkan → OpenVINO → CPU
         // ROCm on Windows x86_64 is supported via AMD's HIP SDK (ROCm 5.5+).
         // MUSA Windows support is announced by Moore Threads.
         // CANN is not supported on Windows (Huawei SDK constraint).
-        // Hexagon does not exist on x86_64.
         let candidates: &[(&str, BackendKind)] = &[
+            #[cfg(target_arch = "x86_64")]
             ("inferrs_backend_cuda.dll", BackendKind::Cuda),
+            #[cfg(target_arch = "x86_64")]
             ("inferrs_backend_musa.dll", BackendKind::Musa),
+            #[cfg(target_arch = "x86_64")]
             ("inferrs_backend_rocm.dll", BackendKind::Rocm),
-            ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
-        ];
-
-        for (lib_name, kind) in candidates {
-            if super::probe_plugin(&search_dirs, lib_name) {
-                return *kind;
-            }
-        }
-
-        BackendKind::Cpu
-    }
-
-    fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
-        if let Ok(pf) = std::env::var("ProgramFiles") {
-            dirs.push(PathBuf::from(pf).join("inferrs"));
-        }
-        dirs
-    }
-}
-
-#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-pub use windows_x86_64::{detect_backend, BackendKind};
-
-// ── Windows aarch64 (Snapdragon X / 8cx) ─────────────────────────────────────
-// Qualcomm ARM64 Windows devices ship a Hexagon NPU and Vulkan-capable GPU,
-// but no CUDA/ROCm/CANN.
-// Priority: Hexagon → Vulkan → CPU.
-
-#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-mod windows_aarch64 {
-    use std::path::PathBuf;
-
-    /// The detected NPU / GPU backend, in priority order.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum BackendKind {
-        /// Hexagon HTP NPU (Qualcomm).  Falls back to CPU while candle gains
-        /// a Hexagon device variant.
-        Hexagon,
-        /// Vulkan GPU.  Falls back to CPU while candle 0.8 has no Vulkan Device.
-        Vulkan,
-        Cpu,
-    }
-
-    pub fn detect_backend() -> BackendKind {
-        // Priority: Hexagon → Vulkan → CPU  (no CUDA/ROCm/CANN on ARM64 Windows)
-        let candidates: &[(&str, BackendKind)] = &[
+            #[cfg(target_arch = "aarch64")]
             ("inferrs_backend_hexagon.dll", BackendKind::Hexagon),
             ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
+            ("inferrs_backend_openvino.dll", BackendKind::OpenVino),
         ];
 
-        let search_dirs = plugin_search_dirs();
         for (lib_name, kind) in candidates {
             if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
@@ -434,17 +434,16 @@ mod windows_aarch64 {
     }
 }
 
-#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
-pub use windows_aarch64::{detect_backend, BackendKind};
+#[cfg(target_os = "windows")]
+pub use windows::{detect_backend, BackendKind};
 
-// ── Any remaining platform (e.g. FreeBSD, bare-metal) ────────────────────────
+// ── Any other platform (FreeBSD, Fuchsia, bare-metal, etc.) ──────────────────
 
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
-    all(target_os = "windows", target_arch = "x86_64"),
-    all(target_os = "windows", target_arch = "aarch64"),
+    target_os = "windows",
 )))]
 #[allow(dead_code)]
 pub fn detect_backend() -> BackendKind {
@@ -455,8 +454,7 @@ pub fn detect_backend() -> BackendKind {
     target_os = "linux",
     target_os = "android",
     target_os = "macos",
-    all(target_os = "windows", target_arch = "x86_64"),
-    all(target_os = "windows", target_arch = "aarch64"),
+    target_os = "windows",
 )))]
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -228,22 +228,42 @@ impl ServeArgs {
 
     fn auto_device() -> Result<candle_core::Device> {
         // macOS: always prefer Metal (linked directly, no plugin needed).
-        // After that, probe for a Vulkan/MoltenVK plugin as a fallback.
+        // After that, probe for Vulkan/MoltenVK and OpenVINO plugins.
         #[cfg(target_os = "macos")]
         {
+            use crate::backend::BackendKind;
             if let Ok(device) = candle_core::Device::new_metal(0) {
                 tracing::info!("Using Metal device");
+                // Still probe for OpenVINO so users know it is (or isn't)
+                // available for a future CPU-only OpenVINO path.
+                if matches!(crate::backend::detect_backend(), BackendKind::OpenVino) {
+                    tracing::info!(
+                        "OpenVINO runtime detected alongside Metal — OpenVINO CPU \
+                         acceleration will be available once candle gains an \
+                         OpenVINO backend."
+                    );
+                }
                 return Ok(device);
             }
 
-            // Metal failed (unlikely). Check whether a Vulkan/MoltenVK plugin
-            // is present so the user gets a helpful log message.
-            use crate::backend::BackendKind;
-            if let BackendKind::Vulkan = crate::backend::detect_backend() {
-                tracing::info!(
-                    "Vulkan/MoltenVK driver detected but candle 0.8 has no \
-                     Vulkan Device yet — falling back to CPU."
-                );
+            // Metal unavailable (e.g. CI VM without GPU): probe for
+            // Vulkan/MoltenVK and OpenVINO and log their availability.
+            match crate::backend::detect_backend() {
+                BackendKind::Vulkan => {
+                    tracing::info!(
+                        "Vulkan/MoltenVK driver detected but candle 0.8 has no \
+                         Vulkan Device yet — falling back to CPU."
+                    );
+                }
+                BackendKind::OpenVino => {
+                    tracing::info!(
+                        "OpenVINO runtime detected (Metal unavailable) — candle \
+                         does not yet have an OpenVINO Device variant; falling \
+                         back to CPU. OpenVINO acceleration will be enabled once \
+                         candle gains the corresponding backend."
+                    );
+                }
+                BackendKind::Cpu => {}
             }
         }
 
@@ -253,11 +273,11 @@ impl ServeArgs {
         // opened on demand — they are not hard-linked into the binary.
         //
         // Platform notes:
-        //   Linux x86_64 / aarch64 : CUDA → ROCm → Hexagon → Vulkan → CPU
-        //   Android aarch64         : Hexagon → CPU
-        //   Windows x86_64          : CUDA → Vulkan → CPU
-        //   Windows aarch64         : Hexagon → Vulkan → CPU
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows",))]
+        //   Linux x86_64 / aarch64 : CUDA → MUSA → ROCm → CANN → Hexagon → Vulkan → OpenVINO → CPU
+        //   Android aarch64         : CANN → Hexagon → OpenVINO → CPU
+        //   Windows x86_64          : CUDA → MUSA → ROCm → Vulkan → OpenVINO → CPU
+        //   Windows aarch64         : Hexagon → Vulkan → OpenVINO → CPU
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
         {
             use crate::backend::BackendKind;
             match crate::backend::detect_backend() {
@@ -334,21 +354,29 @@ impl ServeArgs {
                 }
                 #[cfg(any(target_os = "linux", target_os = "windows",))]
                 BackendKind::Vulkan => {
-                    // Vulkan driver detected. candle 0.8 does not yet have a
+                    // Vulkan driver detected.  candle does not yet have a
                     // Vulkan/wgpu Device variant, so we fall through to CPU.
                     // Vulkan acceleration will be enabled automatically once
                     // candle gains wgpu support and this plugin is updated.
                     tracing::info!(
-                        "Vulkan driver detected but candle 0.8 has no Vulkan \
-                         Device yet — falling back to CPU. Recompile with a \
-                         candle version that supports wgpu to enable Vulkan."
+                        "Vulkan driver detected but candle has no Vulkan Device \
+                         yet — falling back to CPU. Recompile with a candle \
+                         version that supports wgpu to enable Vulkan."
+                    );
+                }
+                BackendKind::OpenVino => {
+                    tracing::info!(
+                        "OpenVINO runtime detected — candle does not yet have an \
+                         OpenVINO Device variant; falling back to CPU. OpenVINO \
+                         CPU/GPU/NPU acceleration will be enabled once candle \
+                         gains the corresponding backend."
                     );
                 }
                 BackendKind::Cpu => {}
             }
         }
 
-        // Android: probe CANN (Huawei Ascend NPU) then Vulkan.
+        // Android: probe CANN, Hexagon, Vulkan, OpenVINO.
         // CUDA and ROCm are not available on Android.
         #[cfg(target_os = "android")]
         {
@@ -356,22 +384,30 @@ impl ServeArgs {
             match crate::backend::detect_backend() {
                 BackendKind::Cann => {
                     tracing::info!(
-                        "Huawei Ascend NPU detected (CANN) on Android but \
-                         candle does not yet have a native CANN Device — \
-                         falling back to CPU."
+                        "Huawei Ascend NPU detected (CANN) but candle does not \
+                         yet have a native CANN Device — falling back to CPU."
+                    );
+                }
+                BackendKind::Hexagon => {
+                    tracing::info!(
+                        "Qualcomm Hexagon HTP detected but candle has no \
+                         Hexagon Device variant yet — falling back to CPU."
                     );
                 }
                 BackendKind::Vulkan => {
                     tracing::info!(
-                        "Vulkan driver detected but candle 0.8 has no Vulkan \
-                         Device yet — falling back to CPU."
+                        "Vulkan driver detected (Android) but candle 0.8 has no \
+                         Vulkan Device yet — falling back to CPU."
                     );
+                }
+                BackendKind::OpenVino => {
+                    tracing::info!("OpenVINO runtime detected (Android) — falling back to CPU.");
                 }
                 BackendKind::Cpu => {}
             }
         }
 
-        // Windows x86_64: CUDA + MUSA + ROCm + Vulkan plugin probing.
+        // Windows x86_64: CUDA + MUSA + ROCm + Vulkan + OpenVINO plugin probing.
         #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
         {
             use crate::backend::BackendKind;
@@ -397,24 +433,39 @@ impl ServeArgs {
                 BackendKind::Vulkan => {
                     tracing::info!(
                         "Vulkan driver detected but candle 0.8 has no Vulkan \
-                         Device yet — falling back to CPU. Recompile with a \
-                         candle version that supports wgpu to enable Vulkan."
+                         Device yet — falling back to CPU."
                     );
+                }
+                BackendKind::OpenVino => {
+                    tracing::info!("OpenVINO runtime detected (Windows) — falling back to CPU.");
                 }
                 BackendKind::Cpu => {}
             }
         }
 
-        // Windows aarch64: Vulkan-only (CUDA unavailable on ARM64 Windows).
+        // Windows aarch64: Hexagon + Vulkan + OpenVINO (CUDA unavailable on ARM64).
         #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
         {
             use crate::backend::BackendKind;
-            if let BackendKind::Vulkan = crate::backend::detect_backend() {
-                tracing::info!(
-                    "Vulkan driver detected but candle 0.8 has no Vulkan \
-                     Device yet — falling back to CPU. Recompile with a \
-                     candle version that supports wgpu to enable Vulkan."
-                );
+            match crate::backend::detect_backend() {
+                BackendKind::Hexagon => {
+                    tracing::info!(
+                        "Qualcomm Hexagon HTP detected but candle has no \
+                         Hexagon Device variant yet — falling back to CPU."
+                    );
+                }
+                BackendKind::Vulkan => {
+                    tracing::info!(
+                        "Vulkan driver detected (Windows ARM64) but candle 0.8 \
+                         has no Vulkan Device yet — falling back to CPU."
+                    );
+                }
+                BackendKind::OpenVino => {
+                    tracing::info!(
+                        "OpenVINO runtime detected (Windows ARM64) — falling back to CPU."
+                    );
+                }
+                BackendKind::Cpu => {}
             }
         }
         tracing::info!("Using CPU device");


### PR DESCRIPTION
Add a new inferrs-backend-openvino cdylib plugin that probes for the OpenVINO runtime at startup using dlopen (Linux/Android/macOS) or LoadLibraryW (Windows) without linking against OpenVINO at compile time.

Extend the backend discovery system in backend.rs with a BackendKind::OpenVino variant on all four supported OS families (Linux, Android, macOS, Windows). The Windows module now covers both x86_64 and aarch64 instead of x86_64 only. macOS gains a full plugin module replacing the previous CPU-only stub, so OpenVINO presence is detected and logged alongside Metal.

When detected, the binary logs that OpenVINO is available and falls back to CPU; a future update will activate inference once candle gains an OpenVINO Device variant.