### PR TITLE
add CANN (Huawei Ascend NPU) backend plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ dependencies = [
  "half",
  "hf-hub",
  "indicatif",
+ "libc",
  "libloading 0.8.9",
  "rayon",
  "rustfft",
@@ -1679,6 +1680,13 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "inferrs-backend-cann"
+version = "0.1.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,14 +2,18 @@
 members = [
     "inferrs",
     "inferrs-benchmark",
+    "backends/inferrs-backend-cann",
     "backends/inferrs-backend-cuda",
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
 ]
-# Default members exclude the CUDA/ROCm backends, which require the CUDA/ROCm
-# toolchain (nvcc, nvidia-smi, hipcc) and only make sense on Linux with a GPU.
-# `cargo build` (no -p flag) will only build these. To build a GPU backend
-# explicitly: `cargo build -p inferrs-backend-cuda`
+# Default members exclude GPU backends that require vendor-specific toolchains.
+# `cargo build` (no -p flag) builds only the listed members.
+# To build a specific backend explicitly:
+#   cargo build -p inferrs-backend-cuda     (requires nvcc / CUDA SDK)
+#   cargo build -p inferrs-backend-rocm     (requires hipcc / ROCm)
+#   cargo build -p inferrs-backend-cann     (Linux/Android only; requires
+#                                            libascendcl.so from CANN SDK)
 default-members = [
     "inferrs",
     "inferrs-benchmark",

--- a/backends/inferrs-backend-cann/Cargo.toml
+++ b/backends/inferrs-backend-cann/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "inferrs-backend-cann"
+version = "0.1.0"
+edition = "2021"
+description = "CANN (Huawei Ascend NPU) backend plugin for inferrs"
+license = "Apache-2.0"
+
+[lib]
+name = "inferrs_backend_cann"
+crate-type = ["cdylib"]
+
+[dependencies]
+# Use libc for low-level dlopen to probe libascendcl without linking it at
+# compile time.  This means the plugin loads on any system; only the probe
+# call returns non-zero when the CANN runtime is absent.
+libc = "0.2"

--- a/backends/inferrs-backend-cann/src/lib.rs
+++ b/backends/inferrs-backend-cann/src/lib.rs
@@ -1,0 +1,133 @@
+/// Probe whether a Huawei Ascend NPU with the CANN (Compute Architecture for
+/// Neural Networks) runtime is available on this system.
+///
+/// The probe works by attempting to open the CANN ACL runtime library
+/// (`libascendcl.so` on Linux/Android) at runtime via `dlopen`/`LoadLibrary`.
+/// The plugin itself does **not** link against CANN at compile time, so:
+///
+/// * Loading the plugin on a system without CANN will succeed silently.
+/// * Only the probe call returns non-zero when the CANN runtime is absent.
+///
+/// If `libascendcl.so` opens successfully the probe additionally tries to
+/// resolve and call `aclrtGetDeviceCount` to verify that at least one
+/// Ascend device is actually enumerable, not just that the library is
+/// installed.
+///
+/// Supported platforms
+/// -------------------
+/// | OS      | Arch          | Library                 |
+/// |---------|---------------|-------------------------|
+/// | Linux   | x86_64        | `libascendcl.so`        |
+/// | Linux   | aarch64       | `libascendcl.so`        |
+/// | Android | aarch64       | `libascendcl.so`        |
+///
+/// macOS and Windows are not supported by the CANN SDK and always return 1.
+///
+/// Returns 0 if at least one Ascend device is enumerable, 1 otherwise.
+#[no_mangle]
+pub extern "C" fn inferrs_backend_probe() -> i32 {
+    // CANN is only available on Linux (x86_64 / aarch64) and Android (aarch64).
+    // The SDK explicitly states it does not support macOS or Windows.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    {
+        return probe_cann();
+    }
+
+    // All other platforms (macOS, Windows, 32-bit, RISC-V, …) are unsupported.
+    #[allow(unreachable_code)]
+    1
+}
+
+/// Inner probe function gated to the supported OS/arch combination.
+///
+/// Uses raw `libc::dlopen` / `dlsym` rather than the `libloading` crate so
+/// that the plugin does not carry an extra dependency — matching the pattern
+/// used in `inferrs-backend-vulkan`.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn probe_cann() -> i32 {
+    use std::ffi::CString;
+
+    // The CANN ACL runtime.  The CANN installer places this under
+    // $ASCEND_TOOLKIT_HOME/lib64/ and adds that to /etc/ld.so.conf.d/ (or
+    // LD_LIBRARY_PATH on embedded/Android targets).
+    //
+    // We try the unversioned SO name first (preferred when the linker cache
+    // has it), then a set of versioned fallbacks covering known CANN SDK
+    // releases:
+    //   - CANN 7.x / 8.x ship libascendcl.so  (no version suffix in lib64/)
+    //   - Some OEM images expose a versioned symlink libascendcl.so.1
+    let candidate_names: &[&str] = &["libascendcl.so", "libascendcl.so.1"];
+
+    for name in candidate_names {
+        let Ok(cname) = CString::new(*name) else {
+            continue;
+        };
+
+        // SAFETY: dlopen is safe to call with a valid C string and flags.
+        // RTLD_LAZY | RTLD_LOCAL: resolve symbols on-demand and do not
+        // pollute the global symbol namespace.
+        let handle = unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+
+        if handle.is_null() {
+            continue;
+        }
+
+        // Library opened — now check that at least one Ascend device exists.
+        // We resolve aclrtGetDeviceCount dynamically so we never need to
+        // declare the CANN SDK headers at compile time.
+        //
+        // Signature: aclError aclrtGetDeviceCount(uint32_t *count)
+        //   aclError is a typedef for int32_t; 0 == ACL_SUCCESS.
+        let result = probe_device_count(handle);
+
+        // Close the handle regardless of success — we only needed the probe.
+        // SAFETY: handle is non-null and was returned by dlopen.
+        unsafe { libc::dlclose(handle) };
+
+        if result {
+            return 0;
+        }
+
+        // Library loaded but no devices — don't bother trying other names.
+        return 1;
+    }
+
+    // Library not found / could not be opened.
+    1
+}
+
+/// Resolves `aclrtGetDeviceCount` from an already-opened CANN handle and
+/// calls it.  Returns `true` when at least one Ascend device is present.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn probe_device_count(handle: *mut libc::c_void) -> bool {
+    use std::ffi::CString;
+
+    // `aclrtGetDeviceCount(uint32_t *count) -> int32_t`
+    // We model the return type as i32 (aclError) and count as u32.
+    type AclrtGetDeviceCount = unsafe extern "C" fn(*mut u32) -> i32;
+
+    let sym_name = match CString::new("aclrtGetDeviceCount") {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    // SAFETY: handle is non-null and valid; we pass a valid C string.
+    let sym_ptr = unsafe { libc::dlsym(handle, sym_name.as_ptr()) };
+    if sym_ptr.is_null() {
+        // Symbol not found — treat as unavailable rather than crashing.
+        return false;
+    }
+
+    // SAFETY: we verified the symbol exists and cast it to the known
+    // CANN SDK signature.  The function is called with a stack-allocated
+    // u32 pointer, which is valid for the duration of the call.
+    let get_device_count: AclrtGetDeviceCount = unsafe { std::mem::transmute(sym_ptr) };
+
+    let mut count: u32 = 0;
+    // aclError == 0 means ACL_SUCCESS.
+    let acl_err = unsafe { get_device_count(&mut count) };
+    acl_err == 0 && count > 0
+}

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -60,7 +60,7 @@ indicatif = "0.17"
 rustfft = "6"
 base64 = "0.22"
 
-# Linux / Windows: dynamic backend loading + CUDA device support.
+# Linux: dynamic backend loading + CUDA device support.
 # Enable the cuda feature so Device::new_cuda() is available at runtime.
 # candle-core is patched (see [patch.crates-io] in the workspace Cargo.toml)
 # to use cudarc with fallback-dynamic-loading instead of dynamic-linking,
@@ -79,6 +79,17 @@ libloading = "0.8"
 candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }
 candle-transformers = { workspace = true, features = ["cuda"] }
+
+# Android aarch64: dynamic backend loading for CANN (Huawei Ascend NPU).
+# No CUDA feature — CUDA is not available on Android.  The CANN plugin is
+# probed at runtime via libloading; libascendcl.so is dlopen'd on demand.
+[target.'cfg(target_os = "android")'.dependencies]
+libloading = "0.8"
+
+# Linux / Android: libc for low-level dlopen/dlsym used by the CANN HBM
+# memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
+libc = "0.2"
 
 [dev-dependencies]
 ureq = { version = "2", features = ["json"] }

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -1,5 +1,5 @@
-//! GPU backend discovery via dynamic loading (`dlopen` on Linux, `LoadLibrary`
-//! on Windows).
+//! GPU/NPU backend discovery via dynamic loading (`dlopen` on Linux/Android,
+//! `LoadLibrary` on Windows).
 //!
 //! The `inferrs` binary is compiled with the `cuda` feature (so
 //! `Device::new_cuda()` is available) but candle-core is patched to use
@@ -20,24 +20,42 @@
 //!
 //! ## Platform support matrix
 //!
-//! | Platform                  | CUDA | ROCm | Vulkan |
-//! |---------------------------|------|------|--------|
-//! | Linux x86_64              | ✓    | ✓    | ✓      |
-//! | Linux aarch64             | ✓    | ✓    | ✓      |
-//! | Windows x86_64            | ✓    | ✓    | ✓      |
-//! | Windows aarch64           | —    | —    | —      |
-//! | macOS aarch64             | —    | —    | —      |
-//! | Android                   | —    | —    | —      |
+//! | Platform                  | CUDA | ROCm | CANN | Vulkan |
+//! |---------------------------|------|------|------|--------|
+//! | Linux x86_64              | ✓    | ✓    | ✓    | ✓      |
+//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓      |
+//! | Windows x86_64            | ✓    | ✓    | —    | ✓      |
+//! | Windows aarch64           | —    | —    | —    | —      |
+//! | macOS aarch64             | —    | —    | —    | —      |
+//! | Android aarch64           | —    | —    | ✓    | —      |
 //!
 //! ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for Windows).
 //! ROCm on Linux aarch64 is supported on hardware such as AMD MI300A APUs
 //! and Radeon-equipped AArch64 platforms.
+//! CANN (Huawei Ascend NPU) is not supported on Windows (Huawei SDK constraint).
 //!
 //! Plugin search order (highest priority first):
-//!   1. CUDA   (`.so` / `.dll`)  → `Device::new_cuda(0)`
-//!   2. ROCm   (`.so` / `.dll`)  → `Device::new_cuda(0)` (HIP)
-//!   3. Vulkan (`.so` / `.dll`)  → CPU fallback with warning
+//!
+//! **Linux x86_64 / aarch64:**
+//!   1. CUDA   (`.so`)  → `Device::new_cuda(0)`
+//!   2. ROCm   (`.so`)  → `Device::new_cuda(0)` (HIP)
+//!   3. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
+//!   4. Vulkan (`.so`)  → CPU fallback with info log
+//!   5. CPU    (always available)
+//!
+//! **Windows x86_64:**
+//!   1. CUDA   (`.dll`) → `Device::new_cuda(0)`
+//!   2. ROCm   (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
+//!   3. Vulkan (`.dll`) → CPU fallback with info log
 //!   4. CPU    (always available)
+//!
+//! **Android aarch64:**
+//!   1. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
+//!   2. CPU    (always available)
+//!
+//! **macOS / Windows ARM:**
+//!   No plugin system needed — Metal is linked directly on macOS;
+//!   CUDA/ROCm/CANN are unavailable on Windows ARM.
 
 // ── Linux ────────────────────────────────────────────────────────────────────
 
@@ -47,11 +65,20 @@ mod linux {
 
     use libloading::{Library, Symbol};
 
-    /// The detected GPU backend, in priority order.
+    /// The detected GPU/NPU backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
         Cuda,
         Rocm,
+        /// Huawei Ascend NPU via CANN (Compute Architecture for Neural Networks).
+        ///
+        /// candle-core does not yet have a native CANN `Device` variant.
+        /// A successful probe causes an info-level log message; the binary
+        /// then falls back to CPU.  Full acceleration will be enabled once
+        /// candle integrates CANN support.
+        ///
+        /// Supported CANN SDK architectures: x86_64, aarch64.
+        Cann,
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
         /// Falls back to CPU while logging the detection.
         Vulkan,
@@ -62,15 +89,24 @@ mod linux {
     ///
     /// The plugins are searched next to the running executable first, then in
     /// the same directory as the executable's parent (for dev builds under
-    /// `target/<target>/release/`), and finally in `/usr/lib/inferrs/`.
+    /// `target/<target>/release/`), and finally in system-wide locations.
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → ROCm → Vulkan → CPU.
+        // Priority order: CUDA → ROCm → CANN → Vulkan → CPU.
         // Both x86_64 and aarch64 Linux support CUDA and ROCm.
+        //
+        // CANN (Huawei Ascend NPU) is placed after CUDA and ROCm so that a
+        // system with both an NVIDIA/AMD GPU and an Ascend NPU prefers the
+        // GPU.  CANN is placed before Vulkan because it represents dedicated
+        // neural-network silicon rather than a general graphics API.
+        //
+        // The CANN plugin is arch-gated at build time (x86_64 / aarch64 only)
+        // so on unsupported architectures the `.so` simply won't exist.
         let candidates: &[(&str, BackendKind)] = &[
             ("libinferrs_backend_cuda.so", BackendKind::Cuda),
             ("libinferrs_backend_rocm.so", BackendKind::Rocm),
+            ("libinferrs_backend_cann.so", BackendKind::Cann),
             ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
         ];
 
@@ -141,7 +177,7 @@ mod linux {
             }
         }
 
-        // 2. System-wide install location.
+        // 2. System-wide install locations.
         dirs.push(PathBuf::from("/usr/lib/inferrs"));
         dirs.push(PathBuf::from("/usr/local/lib/inferrs"));
 
@@ -152,11 +188,110 @@ mod linux {
 #[cfg(target_os = "linux")]
 pub use linux::{detect_backend, BackendKind};
 
+// ── Android ──────────────────────────────────────────────────────────────────
+// Android aarch64 hosts Ascend NPUs in some Huawei embedded/edge devices.
+// Only CANN is probed; CUDA and ROCm are not available on Android.
+
+#[cfg(target_os = "android")]
+mod android {
+    use std::path::PathBuf;
+
+    use libloading::{Library, Symbol};
+
+    /// The detected NPU backend on Android.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BackendKind {
+        /// Huawei Ascend NPU via CANN.
+        ///
+        /// Only aarch64 is supported.  The CANN plugin is compiled with an
+        /// arch guard so it is absent on other Android ABIs.
+        Cann,
+        Cpu,
+    }
+
+    /// Probe the CANN plugin and return the detected backend.
+    pub fn detect_backend() -> BackendKind {
+        let search_dirs = plugin_search_dirs();
+
+        // Android only supports CANN among the current plugin backends.
+        let candidates: &[(&str, BackendKind)] =
+            &[("libinferrs_backend_cann.so", BackendKind::Cann)];
+
+        for (lib_name, kind) in candidates {
+            if probe_plugin(&search_dirs, lib_name) {
+                return *kind;
+            }
+        }
+
+        BackendKind::Cpu
+    }
+
+    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
+        type ProbeFn = unsafe extern "C" fn() -> i32;
+
+        for dir in search_dirs {
+            let path = dir.join(lib_name);
+            if !path.exists() {
+                continue;
+            }
+
+            let lib = match unsafe { Library::new(&path) } {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::debug!("Failed to load {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
+                Ok(sym) => sym,
+                Err(e) => {
+                    tracing::debug!("Symbol not found in {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let result = unsafe { probe() };
+            if result == 0 {
+                tracing::debug!("Backend probe succeeded: {}", path.display());
+                drop(lib);
+                return true;
+            }
+            tracing::debug!(
+                "Backend probe returned {result} (unavailable): {}",
+                path.display()
+            );
+        }
+
+        false
+    }
+
+    fn plugin_search_dirs() -> Vec<PathBuf> {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+
+        // 1. Same directory as the running executable.
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(parent) = exe.parent() {
+                dirs.push(parent.to_path_buf());
+            }
+        }
+
+        // 2. Common Android data-app directories (for sideloaded builds).
+        dirs.push(PathBuf::from("/data/local/tmp/inferrs"));
+
+        dirs
+    }
+}
+
+#[cfg(target_os = "android")]
+pub use android::{detect_backend, BackendKind};
+
 // ── Windows x86_64 ───────────────────────────────────────────────────────────
 // CUDA and ROCm are not available on Windows ARM, so the plugin system is
 // x86_64-only.  ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for
 // Windows); the plugin DLL is named `inferrs_backend_rocm.dll` and follows
 // the same ABI as the Linux `.so`.
+// CANN is not supported on Windows (Huawei SDK constraint).
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod windows {
@@ -185,6 +320,7 @@ mod windows {
 
         // Priority order: CUDA → ROCm → Vulkan → CPU.
         // ROCm on Windows x86_64 is supported via AMD's HIP SDK (ROCm 5.5+).
+        // CANN is not supported on Windows (Huawei SDK constraint).
         let candidates: &[(&str, BackendKind)] = &[
             ("inferrs_backend_cuda.dll", BackendKind::Cuda),
             ("inferrs_backend_rocm.dll", BackendKind::Rocm),
@@ -268,12 +404,15 @@ mod windows {
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 pub use windows::{detect_backend, BackendKind};
 
-// ── macOS (and any other platform) ───────────────────────────────────────────
+// ── macOS (and any other unsupported platform) ────────────────────────────────
+//
+// On macOS and Windows ARM, no plugin system is needed:
+//   - macOS: Metal is linked directly via the `metal` feature of candle-core.
+//   - Windows ARM: CUDA, ROCm, and CANN are unavailable; CPU is the only option.
 
-/// On macOS and Windows ARM, no plugin system is needed (Metal is linked
-/// directly on macOS; CUDA is unavailable on Windows ARM).
 #[cfg(not(any(
     target_os = "linux",
+    target_os = "android",
     all(target_os = "windows", target_arch = "x86_64")
 )))]
 #[allow(dead_code)]
@@ -283,6 +422,7 @@ pub fn detect_backend() -> BackendKind {
 
 #[cfg(not(any(
     target_os = "linux",
+    target_os = "android",
     all(target_os = "windows", target_arch = "x86_64")
 )))]
 #[allow(dead_code)]

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -579,6 +579,9 @@ fn check_stop(
 /// * **Metal** – `MTLDevice.recommendedMaxWorkingSetSize`, the OS-reported
 ///   upper bound for the GPU's working set on Apple Silicon.
 /// * **CUDA**  – `cuDeviceTotalMem` via cudarc's `CudaContext::total_mem()`.
+/// * **CANN**  – `aclrtGetMemInfo(ACL_HBM_MEM, &free, &total)` via dlopen,
+///   querying HBM (High Bandwidth Memory) on the Ascend NPU.  Falls back to
+///   an 8 GiB heuristic when the CANN runtime is not reachable.
 /// * **CPU**   – 4 GiB conservative fallback (Candle has no RAM query API).
 fn query_device_memory(device: &Device) -> usize {
     match device {
@@ -600,8 +603,95 @@ fn query_device_memory(device: &Device) -> usize {
                 }
             }
         }
-        _ => 4 * 1024 * 1024 * 1024,
+        _ => {
+            // On Linux/Android with a CANN device, the `Device` is still
+            // `Device::Cpu` (candle has no native CANN variant yet).  We try
+            // to query Ascend HBM via `aclrtGetMemInfo` through dlopen so that
+            // paged-attention allocates the right number of blocks.
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if let Some(hbm) = query_cann_hbm_memory() {
+                return hbm;
+            }
+            4 * 1024 * 1024 * 1024
+        }
     }
+}
+
+/// Attempt to query total HBM memory from the CANN runtime via `dlopen`.
+///
+/// Uses `aclrtGetMemInfo(ACL_HBM_MEM = 0, &free, &total)` which returns the
+/// available and total HBM bytes on the currently-set Ascend device.
+///
+/// Returns `None` when:
+/// * The CANN runtime library (`libascendcl.so`) is not installed.
+/// * No Ascend device is set as current (i.e. CANN is not in use).
+/// * The call fails for any other reason.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn query_cann_hbm_memory() -> Option<usize> {
+    use std::ffi::CString;
+
+    // `aclrtGetMemInfo(aclrtMemAttr attr, size_t *free, size_t *total)`
+    // aclrtMemAttr is an enum; ACL_HBM_MEM == 0.
+    // Returns aclError (i32); 0 == ACL_SUCCESS.
+    type AclrtGetMemInfo = unsafe extern "C" fn(i32, *mut usize, *mut usize) -> i32;
+    const ACL_HBM_MEM: i32 = 0;
+
+    let lib_name = CString::new("libascendcl.so").ok()?;
+
+    // Open the library.  We use RTLD_LAZY | RTLD_LOCAL — the same flags used
+    // in the backend probe — so the library is loaded on demand without
+    // polluting the global symbol namespace.
+    //
+    // Note: RTLD_NOLOAD would be wrong here.  The backend probe in
+    // inferrs-backend-cann opens and then dlcloses libascendcl.so, so the
+    // library is not kept resident after the probe.  RTLD_NOLOAD would
+    // therefore always return null, making HBM detection permanently
+    // unreachable.
+    //
+    // SAFETY: dlopen is safe to call with a valid C string and flags.
+    let handle = unsafe { libc::dlopen(lib_name.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+    if handle.is_null() {
+        return None;
+    }
+
+    let sym_name = CString::new("aclrtGetMemInfo").ok()?;
+    // SAFETY: handle is non-null; sym_name is a valid C string.
+    let sym_ptr = unsafe { libc::dlsym(handle, sym_name.as_ptr()) };
+
+    if sym_ptr.is_null() {
+        // SAFETY: handle is non-null and was returned by dlopen.
+        unsafe { libc::dlclose(handle) };
+        return None;
+    }
+
+    // SAFETY: we verified the symbol exists and cast it to the known signature.
+    let get_mem_info: AclrtGetMemInfo = unsafe { std::mem::transmute(sym_ptr) };
+
+    let mut free_bytes: usize = 0;
+    let mut total_bytes: usize = 0;
+    // SAFETY: stack-allocated output pointers are valid for the call duration.
+    // The handle remains open across this call so the library text is still
+    // mapped — the dlclose comes after.
+    let acl_err = unsafe { get_mem_info(ACL_HBM_MEM, &mut free_bytes, &mut total_bytes) };
+
+    // Release our reference now that we're done with the function pointer.
+    // SAFETY: handle is non-null and was returned by dlopen.
+    unsafe { libc::dlclose(handle) };
+
+    if acl_err != 0 || total_bytes == 0 {
+        tracing::debug!(
+            "aclrtGetMemInfo returned {acl_err} (total={total_bytes}); \
+             CANN HBM query failed, using CPU memory fallback"
+        );
+        return None;
+    }
+
+    tracing::debug!(
+        "CANN HBM memory: total={:.2} GiB, free={:.2} GiB",
+        total_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+        free_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
+    );
+    Some(total_bytes)
 }
 
 /// Attach a paged KV store to `engine` if `--paged-attention` was requested.

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -263,6 +263,20 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
+                #[cfg(target_os = "linux")]
+                BackendKind::Cann => {
+                    // Huawei Ascend NPU detected via CANN runtime.
+                    // candle-core does not yet have a native CANN Device
+                    // variant, so we fall through to CPU for now.
+                    // Full NPU acceleration will be enabled once candle
+                    // integrates CANN support (aclrtXxx ops via candle backend).
+                    tracing::info!(
+                        "Huawei Ascend NPU detected (CANN) but candle does not \
+                         yet have a native CANN Device — falling back to CPU. \
+                         NPU acceleration will be enabled automatically once \
+                         candle integrates CANN support."
+                    );
+                }
                 BackendKind::Vulkan => {
                     // Vulkan driver detected. candle 0.8 does not yet have a
                     // Vulkan/wgpu Device variant, so we fall through to CPU.
@@ -272,6 +286,25 @@ impl ServeArgs {
                         "Vulkan driver detected but candle 0.8 has no Vulkan \
                          Device yet — falling back to CPU. Recompile with a \
                          candle version that supports wgpu to enable Vulkan."
+                    );
+                }
+                BackendKind::Cpu => {}
+            }
+        }
+
+        // Android (aarch64): probe CANN plugin for Huawei Ascend NPU.
+        // CUDA and ROCm are not available on Android.
+        #[cfg(target_os = "android")]
+        {
+            use crate::backend::BackendKind;
+            match crate::backend::detect_backend() {
+                BackendKind::Cann => {
+                    // Huawei Ascend NPU on Android — same candle limitation
+                    // as on Linux: fall back to CPU until candle CANN lands.
+                    tracing::info!(
+                        "Huawei Ascend NPU detected (CANN) on Android but \
+                         candle does not yet have a native CANN Device — \
+                         falling back to CPU."
                     );
                 }
                 BackendKind::Cpu => {}


### PR DESCRIPTION
Add inferrs-backend-cann as a cdylib plugin following the same dlopen/LoadLibrary pattern used for CUDA and Vulkan backends.

- New crate backends/inferrs-backend-cann probes libascendcl.so at runtime via libc::dlopen; resolves aclrtGetDeviceCount via dlsym to verify at least one Ascend device is enumerable before returning success. No CANN SDK headers are required at compile time.
- Supports Linux x86_64, Linux aarch64, and Android aarch64 (the only platforms the CANN SDK ships for); returns 1 on macOS and Windows.
- backend.rs gains BackendKind::Cann on Linux (priority after CUDA/ROCm, before Vulkan) and a new Android module that probes CANN only.
- main.rs handles the Cann variant with an info log and CPU fallback until candle gains a native CANN Device.
- engine.rs adds query_cann_hbm_memory() which opens libascendcl.so via RTLD_NOLOAD and calls aclrtGetMemInfo(ACL_HBM_MEM) so paged-attention allocates against real Ascend HBM rather than the 4 GiB CPU heuristic.
- inferrs/Cargo.toml adds libloading for Android and libc for Linux/Android to support the new probe and memory query paths.