### PR TITLE
add Hexagon HTP backend plugin for Snapdragon NPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferrs-backend-hexagon"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "inferrs-backend-musa"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ members = [
     "backends/inferrs-backend-musa",
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
+    "backends/inferrs-backend-hexagon",
 ]
-# Default members exclude GPU backends that require vendor-specific toolchains.
+# Default members exclude GPU/NPU backends that require vendor-specific toolchains.
 # `cargo build` (no -p flag) builds only the listed members.
 # To build a specific backend explicitly:
 #   cargo build -p inferrs-backend-cuda     (requires nvcc / CUDA SDK)
@@ -17,11 +18,14 @@ members = [
 #                                            libascendcl.so from CANN SDK)
 # The MUSA backend has no compile-time SDK dependency (it probes libmusart.so
 # via dlopen at runtime) so it is included in default-members.
+# The Hexagon backend likewise has no exotic toolchain requirement and compiles
+# to a no-op fast-fail on x86_64 / macOS.
 default-members = [
     "inferrs",
     "inferrs-benchmark",
     "backends/inferrs-backend-musa",
     "backends/inferrs-backend-vulkan",
+    "backends/inferrs-backend-hexagon",
 ]
 resolver = "2"
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
 .DEFAULT_GOAL := build
 
-# Detect OS for conditional package inclusion.
+# Detect OS and architecture for conditional package inclusion.
 UNAME_S := $(shell uname -s)
+UNAME_M := $(shell uname -m)
 
-# inferrs-backend-cuda is only built on Linux or Windows (not macOS).
+# inferrs-backend-cuda is only built on Linux or Windows x86_64 (not macOS,
+# not Windows ARM64).
 ifeq ($(UNAME_S),Darwin)
   CUDA_PKG :=
 else
   CUDA_PKG := -p inferrs-backend-cuda
 endif
 
+# inferrs-backend-hexagon compiles cleanly on all host platforms (it fast-fails
+# at runtime on non-Snapdragon hardware).  Include it unconditionally.
+HEXAGON_PKG := -p inferrs-backend-hexagon
+
 # Packages that can be built/tested without GPU toolchains (CUDA, ROCm).
-NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan $(CUDA_PKG)
+# The Hexagon backend is included because it has no exotic toolchain requirement.
+NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-backend-vulkan $(HEXAGON_PKG) $(CUDA_PKG)
 
 .PHONY: all build release fmt clippy test
 

--- a/backends/inferrs-backend-hexagon/Cargo.toml
+++ b/backends/inferrs-backend-hexagon/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "inferrs-backend-hexagon"
+version = "0.1.0"
+edition = "2021"
+description = "Qualcomm Hexagon HTP backend plugin for inferrs (probe via FastRPC/libcdsprpc)"
+license = "Apache-2.0"
+
+[lib]
+name = "inferrs_backend_hexagon"
+crate-type = ["cdylib"]
+
+[dependencies]
+# Use libc for low-level dlopen on Linux/Android/macOS without linking libcdsprpc.
+# On Windows the winapi crate provides LoadLibraryW / GetProcAddress / FreeLibrary.
+libc = "0.2"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Services",
+    "Win32_System_Registry",
+] }

--- a/backends/inferrs-backend-hexagon/src/fastrpc.rs
+++ b/backends/inferrs-backend-hexagon/src/fastrpc.rs
@@ -1,0 +1,488 @@
+//! Qualcomm FastRPC / Hexagon HTP driver loader.
+//!
+//! This module dynamically loads `libcdsprpc.so` (Linux / Android) or
+//! `libcdsprpc.dll` (Windows ARM64) and resolves all required symbols via
+//! `dlopen` / `LoadLibraryW`.  No link-time dependency on the Qualcomm SDK
+//! is introduced — the backend plugin `.so` / `.dll` compiles and loads on
+//! any system; only the probe call returns non-zero when the Hexagon NPU is
+//! absent.
+//!
+//! The design mirrors `ggml/src/ggml-hexagon/htp-drv.cpp` from the llama.cpp
+//! project.
+
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+use crate::libdl::sys::{dl_error, dl_open, dl_sym, DlHandle};
+
+// ── FastRPC opaque types (forward-declared as integer handles) ────────────────
+
+/// Opaque 64-bit handle to an open remote FastRPC session.
+pub type RemoteHandle64 = u64;
+
+/// Opaque handle to a DSP async command queue.
+pub type DspQueue = *mut c_void;
+
+// ── FastRPC DSP capability query constants ────────────────────────────────────
+
+/// Request code for `remote_handle_control` to query DSP information.
+pub const DSPRPC_GET_DSP_INFO: u32 = 6;
+/// Attribute ID for the Hexagon architecture version.
+pub const ARCH_VER: u32 = 0;
+
+/// FastRPC latency control request code (enable low-latency mode).
+/// Used when opening a session to reduce round-trip latency for inference.
+#[allow(dead_code)]
+pub const DSPRPC_CONTROL_LATENCY: u32 = 1;
+
+/// `remote_session_control` request: reserve a new DSP session slot.
+/// Required for multi-session configurations (GGML_HEXAGON_NDEV > 1).
+#[allow(dead_code)]
+pub const FASTRPC_RESERVE_NEW_SESSION: u32 = 1;
+
+/// `remote_session_control` request: retrieve the session URI.
+/// Used to build the `file:///libggml-htp-v{arch}.so?...` URI for
+/// `remote_handle64_open`.
+#[allow(dead_code)]
+pub const FASTRPC_GET_URI: u32 = 2;
+
+/// `remote_session_control` request: enable unsigned DSP PD.
+/// Required to load unsigned DSP skeleton libraries during development.
+#[allow(dead_code)]
+pub const DSPRPC_CONTROL_UNSIGNED_MODULE: u32 = 3;
+
+/// Raw DSP capability structure passed to `DSPRPC_GET_DSP_INFO`.
+#[repr(C)]
+pub struct RemoteDspCapability {
+    pub domain: u32,
+    pub attribute_id: u32,
+    pub capability: u32,
+}
+
+// ── Function pointer types ────────────────────────────────────────────────────
+
+type RpcmemAllocFn = unsafe extern "C" fn(heapid: i32, flags: u32, size: i32) -> *mut c_void;
+type RpcmemAlloc2Fn = unsafe extern "C" fn(heapid: i32, flags: u32, size: usize) -> *mut c_void;
+type RpcmemFreeFn = unsafe extern "C" fn(po: *mut c_void);
+type RpcmemToFdFn = unsafe extern "C" fn(po: *mut c_void) -> i32;
+
+type FastrpcMmapFn = unsafe extern "C" fn(
+    domain: i32,
+    fd: i32,
+    addr: *mut c_void,
+    offset: i32,
+    length: usize,
+    flags: u32,
+) -> i32;
+type FastrpcMunmapFn =
+    unsafe extern "C" fn(domain: i32, fd: i32, addr: *mut c_void, length: usize) -> i32;
+
+type DspqueueCreateFn = unsafe extern "C" fn(
+    domain: i32,
+    flags: u32,
+    req_queue_size: u32,
+    resp_queue_size: u32,
+    packet_callback: *mut c_void,
+    error_callback: *mut c_void,
+    callback_context: *mut c_void,
+    queue: *mut DspQueue,
+) -> i32;
+type DspqueueCloseFn = unsafe extern "C" fn(queue: DspQueue) -> i32;
+type DspqueueExportFn = unsafe extern "C" fn(queue: DspQueue, queue_id: *mut u64) -> i32;
+type DspqueueWriteFn = unsafe extern "C" fn(
+    queue: DspQueue,
+    flags: u32,
+    num_buffers: u32,
+    buffers: *mut c_void,
+    message_length: u32,
+    message: *const u8,
+    timeout_us: u32,
+) -> i32;
+type DspqueueReadFn = unsafe extern "C" fn(
+    queue: DspQueue,
+    flags: *mut u32,
+    max_buffers: u32,
+    num_buffers: *mut u32,
+    buffers: *mut c_void,
+    max_message_length: u32,
+    message_length: *mut u32,
+    message: *mut u8,
+    timeout_us: u32,
+) -> i32;
+
+type RemoteHandle64OpenFn =
+    unsafe extern "C" fn(name: *const libc::c_char, ph: *mut RemoteHandle64) -> i32;
+type RemoteHandle64InvokeFn =
+    unsafe extern "C" fn(h: RemoteHandle64, dw_scalars: u32, pra: *mut c_void) -> i32;
+type RemoteHandle64CloseFn = unsafe extern "C" fn(h: RemoteHandle64) -> i32;
+type RemoteHandleControlFn = unsafe extern "C" fn(req: u32, data: *mut c_void, datalen: u32) -> i32;
+type RemoteHandle64ControlFn =
+    unsafe extern "C" fn(h: RemoteHandle64, req: u32, data: *mut c_void, datalen: u32) -> i32;
+type RemoteSessionControlFn =
+    unsafe extern "C" fn(req: u32, data: *mut c_void, datalen: u32) -> i32;
+
+// ── Loaded driver state ───────────────────────────────────────────────────────
+
+/// All required FastRPC function pointers, populated after `htpdrv_init()`.
+///
+/// Fields beyond `remote_handle_control` (which is used in the probe) are
+/// resolved eagerly so that any library ABI mismatch is caught at load time
+/// rather than at first use.  They will be exercised once candle grows a
+/// Hexagon device variant.
+#[allow(dead_code)]
+struct FastRpcDriver {
+    // Keep the handle alive so the symbols remain valid.
+    _lib: DlHandle,
+
+    pub rpcmem_alloc: RpcmemAllocFn,
+    pub rpcmem_alloc2: Option<RpcmemAlloc2Fn>, // optional — only on newer SDKs
+    pub rpcmem_free: RpcmemFreeFn,
+    pub rpcmem_to_fd: RpcmemToFdFn,
+
+    pub fastrpc_mmap: FastrpcMmapFn,
+    pub fastrpc_munmap: FastrpcMunmapFn,
+
+    pub dspqueue_create: DspqueueCreateFn,
+    pub dspqueue_close: DspqueueCloseFn,
+    pub dspqueue_export: DspqueueExportFn,
+    pub dspqueue_write: DspqueueWriteFn,
+    pub dspqueue_read: DspqueueReadFn,
+
+    pub remote_handle64_open: RemoteHandle64OpenFn,
+    pub remote_handle64_invoke: RemoteHandle64InvokeFn,
+    pub remote_handle64_close: RemoteHandle64CloseFn,
+    pub remote_handle_control: RemoteHandleControlFn,
+    pub remote_handle64_control: RemoteHandle64ControlFn,
+    pub remote_session_control: RemoteSessionControlFn,
+}
+
+// SAFETY: All function pointers are valid for the lifetime of the loaded
+// library, and FastRpcDriver is only constructed once (via OnceLock).
+unsafe impl Send for FastRpcDriver {}
+unsafe impl Sync for FastRpcDriver {}
+
+/// Global singleton — initialised at most once.
+static DRIVER: OnceLock<FastRpcDriver> = OnceLock::new();
+
+// ── Platform-specific library path resolution ─────────────────────────────────
+
+/// Return the path to `libcdsprpc` for the current platform.
+///
+/// - **Linux / Android**: `"libcdsprpc.so"` — resolved by the dynamic linker
+///   search path, which on Android includes `/vendor/lib64`.
+/// - **macOS**: Hexagon is Qualcomm-only silicon; macOS is x86_64 or Apple
+///   Silicon (ARM64).  Neither ships Hexagon DSP hardware, so we return `None`
+///   immediately to signal that the probe should fail gracefully.
+/// - **Windows ARM64**: query the Service Control Manager for the
+///   `qcnspmcdm` service binary path to locate the driver store directory
+///   where `libcdsprpc.dll` resides.
+/// - **Windows x86_64**: no Hexagon hardware exists; return `None`.
+fn cdsprpc_lib_path() -> Option<String> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        Some("libcdsprpc.so".to_owned())
+    }
+
+    // macOS (x86_64 or aarch64 / Apple Silicon): no Hexagon hardware.
+    #[cfg(target_os = "macos")]
+    {
+        None
+    }
+
+    // Windows ARM64 only: locate libcdsprpc.dll via SCM.
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        windows_driver_path()
+    }
+
+    // Windows x86_64: no Hexagon hardware.
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        None
+    }
+}
+
+/// On Windows ARM64, query the `qcnspmcdm` SCM service to find the driver
+/// store directory containing `libcdsprpc.dll`.
+///
+/// The service binary path looks like:
+/// `\SystemRoot\System32\DriverStore\FileRepository\qcadsprpc8280.inf_arm64_...\...`
+/// We strip `\SystemRoot`, substitute the actual `%windir%` value, take the
+/// parent directory, and append `\libcdsprpc.dll`.
+#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+fn windows_driver_path() -> Option<String> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, NO_ERROR};
+    use windows_sys::Win32::System::Services::{
+        CloseServiceHandle, OpenSCManagerW, OpenServiceW, QueryServiceConfigW,
+        QUERY_SERVICE_CONFIGW, SC_MANAGER_CONNECT, SERVICE_QUERY_CONFIG,
+    };
+
+    const SERVICE_NAME: &[u16] = &[
+        b'q' as u16,
+        b'c' as u16,
+        b'n' as u16,
+        b's' as u16,
+        b'p' as u16,
+        b'm' as u16,
+        b'c' as u16,
+        b'd' as u16,
+        b'm' as u16,
+        0u16,
+    ];
+
+    // SAFETY: Windows SCM API calls with valid parameters.
+    unsafe {
+        let scm = OpenSCManagerW(
+            std::ptr::null(),
+            std::ptr::null(),
+            SC_MANAGER_CONNECT as u32,
+        );
+        if scm == 0 {
+            return None;
+        }
+
+        let svc = OpenServiceW(scm, SERVICE_NAME.as_ptr(), SERVICE_QUERY_CONFIG as u32);
+        if svc == 0 {
+            CloseServiceHandle(scm);
+            return None;
+        }
+
+        // First call to get the required buffer size.
+        let mut buf_size: u32 = 0;
+        QueryServiceConfigW(svc, std::ptr::null_mut(), 0, &mut buf_size);
+        if buf_size == 0 {
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            return None;
+        }
+
+        // Use Vec<u64> to guarantee 8-byte alignment. QUERY_SERVICE_CONFIGW
+        // contains pointers and requires pointer-sized alignment (8 bytes on
+        // aarch64). Vec<u8> only guarantees 1-byte alignment which would cause
+        // UB when casting to *const QUERY_SERVICE_CONFIGW.
+        let mut buf: Vec<u64> = vec![0u64; (buf_size as usize + 7) / 8];
+        if QueryServiceConfigW(
+            svc,
+            buf.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW,
+            buf_size,
+            &mut buf_size,
+        ) == 0
+        {
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            return None;
+        }
+
+        CloseServiceHandle(svc);
+        CloseServiceHandle(scm);
+
+        // SAFETY: buf is 8-byte aligned (Vec<u64>) and QueryServiceConfigW
+        // has written a valid QUERY_SERVICE_CONFIGW into it.
+        let cfg = &*(buf.as_ptr() as *const QUERY_SERVICE_CONFIGW);
+        if cfg.lpBinaryPathName.is_null() {
+            return None;
+        }
+
+        // Convert the wide-string path to a Rust OsString.
+        let mut len = 0usize;
+        while *cfg.lpBinaryPathName.add(len) != 0 {
+            len += 1;
+        }
+        let wide_slice = std::slice::from_raw_parts(cfg.lpBinaryPathName, len);
+        let path_os = OsString::from_wide(wide_slice);
+        let path_str = path_os.to_string_lossy().into_owned();
+
+        // Strip parent filename to get directory, replace \SystemRoot.
+        let dir = path_str.rfind('\\').map(|i| &path_str[..i])?;
+        let system_root_prefix = r"\SystemRoot";
+        if !dir.starts_with(system_root_prefix) {
+            return None;
+        }
+
+        let windir = std::env::var("windir").ok()?;
+        let resolved = format!("{}{}", windir, &dir[system_root_prefix.len()..]);
+        Some(format!(r"{}\libcdsprpc.dll", resolved))
+    }
+}
+
+// ── Symbol resolution helper macro ───────────────────────────────────────────
+
+/// Resolve a required symbol from the loaded library handle.
+///
+/// Returns `Err` if the symbol is missing.
+macro_rules! require_sym {
+    ($handle:expr, $ty:ty, $name:literal) => {{
+        // SAFETY: We cast the raw pointer to the declared function pointer type.
+        // The caller is responsible for declaring the correct type.
+        match unsafe { dl_sym($handle, $name) } {
+            Some(ptr) => Ok(unsafe { std::mem::transmute::<*mut c_void, $ty>(ptr) }),
+            None => Err(format!("symbol '{}' not found: {}", $name, dl_error())),
+        }
+    }};
+}
+
+/// Resolve an optional symbol; returns `None` on failure instead of an error.
+macro_rules! optional_sym {
+    ($handle:expr, $ty:ty, $name:literal) => {{
+        unsafe { dl_sym($handle, $name) }
+            .map(|ptr| unsafe { std::mem::transmute::<*mut c_void, $ty>(ptr) })
+    }};
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Initialise the FastRPC driver.
+///
+/// Opens `libcdsprpc.so` / `libcdsprpc.dll`, resolves all required symbols,
+/// and stores the driver in a global `OnceLock`.
+///
+/// Returns `Ok(())` on success, or an error string describing the first
+/// failure.  Repeated calls are no-ops (returns `Ok(())` if already loaded).
+pub fn htpdrv_init() -> Result<(), String> {
+    if DRIVER.get().is_some() {
+        return Ok(());
+    }
+
+    let path = cdsprpc_lib_path()
+        .ok_or_else(|| "Hexagon HTP is not supported on this platform".to_owned())?;
+
+    let lib = dl_open(&path).ok_or_else(|| format!("failed to open {}: {}", path, dl_error()))?;
+
+    let drv = FastRpcDriver {
+        rpcmem_alloc: require_sym!(&lib, RpcmemAllocFn, "rpcmem_alloc")?,
+        rpcmem_alloc2: optional_sym!(&lib, RpcmemAlloc2Fn, "rpcmem_alloc2"),
+        rpcmem_free: require_sym!(&lib, RpcmemFreeFn, "rpcmem_free")?,
+        rpcmem_to_fd: require_sym!(&lib, RpcmemToFdFn, "rpcmem_to_fd")?,
+
+        fastrpc_mmap: require_sym!(&lib, FastrpcMmapFn, "fastrpc_mmap")?,
+        fastrpc_munmap: require_sym!(&lib, FastrpcMunmapFn, "fastrpc_munmap")?,
+
+        dspqueue_create: require_sym!(&lib, DspqueueCreateFn, "dspqueue_create")?,
+        dspqueue_close: require_sym!(&lib, DspqueueCloseFn, "dspqueue_close")?,
+        dspqueue_export: require_sym!(&lib, DspqueueExportFn, "dspqueue_export")?,
+        dspqueue_write: require_sym!(&lib, DspqueueWriteFn, "dspqueue_write")?,
+        dspqueue_read: require_sym!(&lib, DspqueueReadFn, "dspqueue_read")?,
+
+        remote_handle64_open: require_sym!(&lib, RemoteHandle64OpenFn, "remote_handle64_open")?,
+        remote_handle64_invoke: require_sym!(
+            &lib,
+            RemoteHandle64InvokeFn,
+            "remote_handle64_invoke"
+        )?,
+        remote_handle64_close: require_sym!(&lib, RemoteHandle64CloseFn, "remote_handle64_close")?,
+        remote_handle_control: require_sym!(&lib, RemoteHandleControlFn, "remote_handle_control")?,
+        remote_handle64_control: require_sym!(
+            &lib,
+            RemoteHandle64ControlFn,
+            "remote_handle64_control"
+        )?,
+        remote_session_control: require_sym!(
+            &lib,
+            RemoteSessionControlFn,
+            "remote_session_control"
+        )?,
+
+        _lib: lib,
+    };
+
+    // If another thread raced us to initialise, drop our copy and return.
+    let _ = DRIVER.set(drv);
+    Ok(())
+}
+
+/// Query the Hexagon DSP architecture version from the currently loaded driver.
+///
+/// Uses `remote_handle_control(DSPRPC_GET_DSP_INFO, …)` to query the Hexagon
+/// compute domain on `domain_id` (typically `3` for the compute DSP).
+///
+/// Returns the integer architecture version (`68`, `69`, `73`, `75`, `79`, or
+/// `81`) on success, or an error string if the query fails or the version is
+/// unrecognised.
+///
+/// # Precondition
+/// `htpdrv_init()` must have been called and succeeded.
+pub fn get_hex_arch_ver(domain_id: u32) -> Result<u32, String> {
+    let drv = DRIVER
+        .get()
+        .ok_or_else(|| "FastRPC driver not initialised".to_owned())?;
+
+    let mut cap = RemoteDspCapability {
+        domain: domain_id,
+        attribute_id: ARCH_VER,
+        capability: 0,
+    };
+
+    // SAFETY: `remote_handle_control` is a valid resolved function pointer.
+    // The capability struct is correctly sized and aligned.
+    let err = unsafe {
+        (drv.remote_handle_control)(
+            DSPRPC_GET_DSP_INFO,
+            &mut cap as *mut RemoteDspCapability as *mut c_void,
+            std::mem::size_of::<RemoteDspCapability>() as u32,
+        )
+    };
+
+    if err != 0 {
+        return Err(format!("DSPRPC_GET_DSP_INFO failed with error {err:#x}"));
+    }
+
+    // Map the raw capability byte to the human-readable version number.
+    match cap.capability & 0xff {
+        0x68 => Ok(68),
+        0x69 => Ok(69),
+        0x73 => Ok(73),
+        0x75 => Ok(75),
+        0x79 => Ok(79),
+        0x81 => Ok(81),
+        other => Err(format!(
+            "unrecognised Hexagon arch capability byte: {other:#x}"
+        )),
+    }
+}
+
+/// Allocate a physically-contiguous, CPU/DSP-shared buffer via `rpcmem_alloc2`
+/// (if available) or `rpcmem_alloc` as a fallback.
+///
+/// Returns a raw pointer to the allocation on success, or `null` on failure.
+///
+/// # Safety
+/// The returned memory is owned by the caller and must be freed with
+/// [`rpcmem_free`].
+#[allow(dead_code)]
+pub unsafe fn rpcmem_alloc(heapid: i32, flags: u32, size: usize) -> *mut c_void {
+    let drv = match DRIVER.get() {
+        Some(d) => d,
+        None => return std::ptr::null_mut(),
+    };
+
+    if let Some(alloc2) = drv.rpcmem_alloc2 {
+        // SAFETY: alloc2 is a valid resolved function pointer.
+        unsafe { alloc2(heapid, flags, size) }
+    } else {
+        // The legacy rpcmem_alloc takes an i32 size. Reject allocations that
+        // exceed i32::MAX rather than silently truncating, which could cause
+        // the caller to receive a far-smaller buffer than requested and corrupt
+        // heap memory on first use.
+        let size_i32 = match i32::try_from(size) {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        // SAFETY: rpcmem_alloc is a valid resolved function pointer.
+        unsafe { (drv.rpcmem_alloc)(heapid, flags, size_i32) }
+    }
+}
+
+/// Free a buffer previously allocated by [`rpcmem_alloc`].
+///
+/// # Safety
+/// `ptr` must be a pointer returned by `rpcmem_alloc` that has not yet been
+/// freed.
+#[allow(dead_code)]
+pub unsafe fn rpcmem_free(ptr: *mut c_void) {
+    if let Some(drv) = DRIVER.get() {
+        // SAFETY: ptr is a valid rpcmem allocation.
+        unsafe { (drv.rpcmem_free)(ptr) };
+    }
+}

--- a/backends/inferrs-backend-hexagon/src/lib.rs
+++ b/backends/inferrs-backend-hexagon/src/lib.rs
@@ -1,0 +1,105 @@
+//! Hexagon HTP backend plugin for `inferrs`.
+//!
+//! # Overview
+//!
+//! This crate is compiled as a C dynamic library (`cdylib`) and loaded at
+//! runtime by the `inferrs` binary via `dlopen` / `LoadLibraryW`.  It exports
+//! the single well-known symbol:
+//!
+//! ```c
+//! int inferrs_backend_probe(void);  // 0 = Hexagon available, non-zero = not available
+//! ```
+//!
+//! The probe opens `libcdsprpc.so` (Linux / Android) or `libcdsprpc.dll`
+//! (Windows ARM64), resolves all required FastRPC symbols, and calls
+//! `DSPRPC_GET_DSP_INFO` to confirm that a Hexagon DSP compute domain is
+//! reachable.  On platforms where Hexagon hardware cannot exist (macOS,
+//! Windows x86_64) the probe returns non-zero immediately without attempting
+//! any library load.
+//!
+//! # Platform support matrix
+//!
+//! | OS      | Arch    | Hexagon present? | Library probed            |
+//! |---------|---------|------------------|---------------------------|
+//! | Linux   | x86_64  | No               | fast-fail (returns 1)     |
+//! | Linux   | aarch64 | Possibly (SoC)   | `libcdsprpc.so`           |
+//! | Android | aarch64 | Yes (Snapdragon) | `libcdsprpc.so`           |
+//! | macOS   | x86_64  | No               | fast-fail (returns 1)     |
+//! | macOS   | aarch64 | No (Apple Si.)   | fast-fail (returns 1)     |
+//! | Windows | x86_64  | No               | fast-fail (returns 1)     |
+//! | Windows | aarch64 | Yes (Snapdragon) | `libcdsprpc.dll` via SCM  |
+//!
+//! # Dynamic loading approach
+//!
+//! The approach mirrors `ggml/src/ggml-hexagon/htp-drv.cpp` from llama.cpp:
+//!
+//! 1. `libdl` provides a POSIX/Windows-portable `dlopen`/`LoadLibraryW`
+//!    abstraction (`DlHandle`, `dl_open`, `dl_sym`).
+//! 2. `fastrpc` resolves all Qualcomm FastRPC symbols from `libcdsprpc` into
+//!    a global `OnceLock<FastRpcDriver>`.
+//! 3. The probe calls `get_hex_arch_ver(3)` (compute domain = 3) to confirm
+//!    the DSP is reachable and to log which HTP generation is present.
+
+mod fastrpc;
+mod libdl;
+
+/// Probe whether a Qualcomm Hexagon HTP DSP is available and accessible via
+/// FastRPC on this system.
+///
+/// The probe is platform-aware:
+///
+/// - **Linux aarch64 / Android aarch64**: attempts to open `libcdsprpc.so`
+///   and query the compute DSP (domain 3).  Returns `0` if a Hexagon arch
+///   version ≥ 68 is found, `1` otherwise.
+/// - **Windows aarch64**: locates `libcdsprpc.dll` via the SCM service path
+///   of `qcnspmcdm`, then performs the same DSP query.
+/// - **All other platforms** (x86_64 Linux/Windows, macOS x86_64/aarch64):
+///   returns `1` immediately — Hexagon hardware does not exist on these
+///   targets.
+///
+/// This function is `dlopen`'d by the main `inferrs` binary at runtime so
+/// that the binary itself carries no link-time dependency on the Qualcomm SDK.
+#[no_mangle]
+pub extern "C" fn inferrs_backend_probe() -> i32 {
+    probe_hexagon()
+}
+
+/// Inner implementation, separated for readability.
+fn probe_hexagon() -> i32 {
+    // Fast-fail on platforms that cannot have Hexagon hardware.
+    if !platform_may_have_hexagon() {
+        return 1;
+    }
+
+    // Attempt to load libcdsprpc and resolve all required FastRPC symbols.
+    if let Err(_e) = fastrpc::htpdrv_init() {
+        return 1;
+    }
+
+    // Query the compute DSP (domain 3) for its Hexagon architecture version.
+    // A successful response confirms that a Hexagon NPU is reachable.
+    match fastrpc::get_hex_arch_ver(3) {
+        Ok(_arch) => 0,
+        Err(_e) => 1,
+    }
+}
+
+/// Returns `true` on CPU architectures / OS combinations where Qualcomm
+/// Hexagon hardware is plausible, `false` on targets where it definitively
+/// cannot exist.
+///
+/// This avoids pointless `dlopen` attempts on x86_64 or Apple Silicon
+/// systems and keeps the probe fast.
+const fn platform_may_have_hexagon() -> bool {
+    // Hexagon exists only on Qualcomm Snapdragon SoCs — all of which are
+    // ARM64 (aarch64).  On x86_64 machines and on Apple Silicon (which has
+    // its own ANE, not Hexagon) there is no FastRPC driver at all.
+    cfg!(any(
+        // Linux on ARM (including Android via the linux cfg).
+        all(target_os = "linux", target_arch = "aarch64"),
+        // Android explicit target (cross-compilation target triple).
+        all(target_os = "android", target_arch = "aarch64"),
+        // Windows on ARM64 (Snapdragon X Elite / 8cx devices).
+        all(target_os = "windows", target_arch = "aarch64"),
+    ))
+}

--- a/backends/inferrs-backend-hexagon/src/libdl.rs
+++ b/backends/inferrs-backend-hexagon/src/libdl.rs
@@ -1,0 +1,155 @@
+//! Cross-platform dynamic library loading abstraction.
+//!
+//! On POSIX systems (Linux, Android, macOS) this wraps `dlopen`/`dlsym`/`dlclose`
+//! from libc.  On Windows it wraps `LoadLibraryW`/`GetProcAddress`/`FreeLibrary`.
+//!
+//! This mirrors the `libdl.h` abstraction used in the llama.cpp Hexagon backend
+//! (`ggml/src/ggml-hexagon/libdl.h`).
+
+// ── POSIX (Linux, Android, macOS) ────────────────────────────────────────────
+
+#[cfg(not(target_os = "windows"))]
+pub mod sys {
+    use std::ffi::{c_void, CString};
+
+    /// RAII wrapper around a `dlopen` handle.
+    pub struct DlHandle(*mut c_void);
+
+    // SAFETY: The pointer is only used through our own API which serialises access.
+    unsafe impl Send for DlHandle {}
+    unsafe impl Sync for DlHandle {}
+
+    impl Drop for DlHandle {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: handle is valid and non-null.
+                unsafe { libc::dlclose(self.0) };
+            }
+        }
+    }
+
+    /// Open a shared library by path.
+    ///
+    /// Uses `RTLD_NOW | RTLD_LOCAL`: resolve all symbols immediately and do
+    /// not expose them to subsequently loaded libraries (matches llama.cpp
+    /// behaviour).
+    ///
+    /// Returns `None` if the library cannot be found or loaded.
+    pub fn dl_open(path: &str) -> Option<DlHandle> {
+        let c_path = CString::new(path).ok()?;
+        // SAFETY: dlopen is safe to call with a valid C string and flags.
+        let handle = unsafe { libc::dlopen(c_path.as_ptr(), libc::RTLD_NOW | libc::RTLD_LOCAL) };
+        if handle.is_null() {
+            None
+        } else {
+            Some(DlHandle(handle))
+        }
+    }
+
+    /// Look up a symbol in an already-opened library handle.
+    ///
+    /// Returns `None` if the symbol is not found.
+    ///
+    /// # Safety
+    /// The returned pointer is valid only as long as `handle` is live.
+    /// The caller must cast it to the correct function pointer type.
+    pub unsafe fn dl_sym(handle: &DlHandle, name: &str) -> Option<*mut c_void> {
+        let c_name = CString::new(name).ok()?;
+        // SAFETY: handle is non-null and name is a valid C string.
+        let sym = unsafe { libc::dlsym(handle.0, c_name.as_ptr()) };
+        if sym.is_null() {
+            None
+        } else {
+            Some(sym)
+        }
+    }
+
+    /// Return the last dynamic linker error string, or an empty string.
+    pub fn dl_error() -> String {
+        // SAFETY: dlerror() is always safe to call.
+        let err = unsafe { libc::dlerror() };
+        if err.is_null() {
+            String::new()
+        } else {
+            // SAFETY: dlerror returns a valid C string or null.
+            unsafe { std::ffi::CStr::from_ptr(err) }
+                .to_string_lossy()
+                .into_owned()
+        }
+    }
+}
+
+// ── Windows ───────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "windows")]
+pub mod sys {
+    use std::ffi::{c_void, OsStr};
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::HMODULE;
+    use windows_sys::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryW};
+
+    /// RAII wrapper around a `LoadLibraryW` handle.
+    pub struct DlHandle(HMODULE);
+
+    // SAFETY: The handle is only used through our own serialised API.
+    unsafe impl Send for DlHandle {}
+    unsafe impl Sync for DlHandle {}
+
+    impl Drop for DlHandle {
+        fn drop(&mut self) {
+            if self.0 != 0 {
+                // SAFETY: handle is valid and non-zero.
+                unsafe { FreeLibrary(self.0) };
+            }
+        }
+    }
+
+    /// Encode a Rust `&str` as a null-terminated wide string.
+    fn to_wide(s: &str) -> Vec<u16> {
+        OsStr::new(s)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    /// Open a shared library by path (wide-string, suppressing error dialogs).
+    ///
+    /// Returns `None` if the DLL cannot be loaded.
+    pub fn dl_open(path: &str) -> Option<DlHandle> {
+        let wide = to_wide(path);
+        // SAFETY: LoadLibraryW is safe to call with a valid null-terminated
+        // wide string.  We suppress the critical-error dialog box that Windows
+        // would otherwise show when a DLL or one of its dependencies is missing.
+        // SAFETY: LoadLibraryW is safe with a valid null-terminated wide string.
+        // The SEM_FAILCRITICALERRORS dialog suppression from the C++ reference
+        // (libdl.h) is unnecessary here because we check the return value and
+        // handle failure gracefully via the Option return type.
+        let handle = unsafe { LoadLibraryW(wide.as_ptr()) };
+        if handle == 0 {
+            None
+        } else {
+            Some(DlHandle(handle))
+        }
+    }
+
+    /// Look up a symbol in an already-opened library handle.
+    ///
+    /// Returns `None` if the symbol is not present.
+    ///
+    /// # Safety
+    /// The returned pointer is valid only as long as `handle` is live.
+    /// The caller must cast it to the correct function pointer type.
+    pub unsafe fn dl_sym(handle: &DlHandle, name: &str) -> Option<*mut c_void> {
+        // GetProcAddress expects a null-terminated byte string, not wide.
+        let c_name: Vec<u8> = name.bytes().chain(std::iter::once(0)).collect();
+        // SAFETY: handle is non-zero and c_name is a valid null-terminated
+        // ASCII string.
+        let sym = unsafe { GetProcAddress(handle.0, c_name.as_ptr()) };
+        sym.map(|f| f as *mut c_void)
+    }
+
+    /// On Windows we do not expose `dlerror`; callers use `GetLastError`.
+    pub fn dl_error() -> String {
+        String::new()
+    }
+}

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -80,9 +80,9 @@ candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }
 candle-transformers = { workspace = true, features = ["cuda"] }
 
-# Android aarch64: dynamic backend loading for CANN (Huawei Ascend NPU).
-# No CUDA feature — CUDA is not available on Android.  The CANN plugin is
-# probed at runtime via libloading; libascendcl.so is dlopen'd on demand.
+# Android aarch64: dynamic backend loading for CANN and Hexagon.
+# No CUDA feature — CUDA is not available on Android.  Both plugins are
+# probed at runtime via libloading.
 [target.'cfg(target_os = "android")'.dependencies]
 libloading = "0.8"
 
@@ -90,6 +90,16 @@ libloading = "0.8"
 # memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = "0.2"
+
+# Windows aarch64 (Snapdragon X / 8cx): no CUDA, but Hexagon probing via
+# the plugin system needs libloading.
+[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
+libloading = "0.8"
+
+# macOS: Metal is linked directly, but libloading is still needed for the
+# macOS plugin extension point to compile cleanly.
+[target.'cfg(target_os = "macos")'.dependencies.libloading]
+version = "0.8"
 
 [dev-dependencies]
 ureq = { version = "2", features = ["json"] }

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -1,5 +1,5 @@
 //! GPU/NPU backend discovery via dynamic loading (`dlopen` on Linux/Android,
-//! `LoadLibrary` on Windows).
+//! `LoadLibraryW` on Windows).
 //!
 //! The `inferrs` binary is compiled with the `cuda` feature (so
 //! `Device::new_cuda()` is available) but candle-core is patched to use
@@ -20,42 +20,50 @@
 //!
 //! ## Platform support matrix
 //!
-//! | Platform                  | CUDA | ROCm | CANN | Vulkan |
-//! |---------------------------|------|------|------|--------|
-//! | Linux x86_64              | ✓    | ✓    | ✓    | ✓      |
-//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓      |
-//! | Windows x86_64            | ✓    | ✓    | —    | ✓      |
-//! | Windows aarch64           | —    | —    | —    | —      |
-//! | macOS aarch64             | —    | —    | —    | —      |
-//! | Android aarch64           | —    | —    | ✓    | —      |
+//! | Platform                  | CUDA | ROCm | CANN | Hexagon | Vulkan |
+//! |---------------------------|------|------|------|---------|--------|
+//! | Linux x86_64              | ✓    | ✓    | ✓    | —       | ✓      |
+//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓       | ✓      |
+//! | Windows x86_64            | ✓    | ✓    | —    | —       | ✓      |
+//! | Windows aarch64           | —    | —    | —    | ✓       | ✓      |
+//! | macOS aarch64             | —    | —    | —    | —       | —      |
+//! | Android aarch64           | —    | —    | ✓    | ✓       | —      |
 //!
 //! ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for Windows).
 //! ROCm on Linux aarch64 is supported on hardware such as AMD MI300A APUs
 //! and Radeon-equipped AArch64 platforms.
 //! CANN (Huawei Ascend NPU) is not supported on Windows (Huawei SDK constraint).
+//! Hexagon (Qualcomm HTP NPU) is only present on Snapdragon SoCs (aarch64).
 //!
 //! Plugin search order (highest priority first):
 //!
 //! **Linux x86_64 / aarch64:**
-//!   1. CUDA   (`.so`)  → `Device::new_cuda(0)`
-//!   2. MUSA   (`.so`)  → `Device::new_cuda(0)` (Moore Threads)
-//!   3. ROCm   (`.so`)  → `Device::new_cuda(0)` (HIP)
-//!   4. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
-//!   5. Vulkan (`.so`)  → CPU fallback with info log
-//!   6. CPU    (always available)
+//!   1. CUDA    (`.so`)  → `Device::new_cuda(0)`
+//!   2. MUSA    (`.so`)  → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm    (`.so`)  → `Device::new_cuda(0)` (HIP)
+//!   4. CANN    (`.so`)  → CPU fallback with info log (pending candle CANN Device)
+//!   5. Hexagon (`.so`)  → CPU fallback with info log (pending candle Hexagon Device)
+//!   6. Vulkan  (`.so`)  → CPU fallback with info log
+//!   7. CPU     (always available)
 //!
 //! **Windows x86_64:**
-//!   1. CUDA   (`.dll`) → `Device::new_cuda(0)`
-//!   2. MUSA   (`.dll`) → `Device::new_cuda(0)` (Moore Threads)
-//!   3. ROCm   (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
-//!   4. Vulkan (`.dll`) → CPU fallback with info log
-//!   5. CPU    (always available)
+//!   1. CUDA    (`.dll`) → `Device::new_cuda(0)`
+//!   2. MUSA    (`.dll`) → `Device::new_cuda(0)` (Moore Threads)
+//!   3. ROCm    (`.dll`) → `Device::new_cuda(0)` (HIP SDK for Windows)
+//!   4. Vulkan  (`.dll`) → CPU fallback with info log
+//!   5. CPU     (always available)
+//!
+//! **Windows aarch64:**
+//!   1. Hexagon (`.dll`) → CPU fallback with info log (pending candle Hexagon Device)
+//!   2. Vulkan  (`.dll`) → CPU fallback with info log
+//!   3. CPU     (always available)
 //!
 //! **Android aarch64:**
-//!   1. CANN   (`.so`)  → CPU fallback with info log (pending candle CANN Device)
-//!   2. CPU    (always available)
+//!   1. CANN    (`.so`)  → CPU fallback with info log (pending candle CANN Device)
+//!   2. Hexagon (`.so`)  → CPU fallback with info log (pending candle Hexagon Device)
+//!   3. CPU     (always available)
 //!
-//! **macOS / Windows ARM:**
+//! **macOS / Windows ARM (no Hexagon):**
 //!   No plugin system needed — Metal is linked directly on macOS;
 //!   CUDA/ROCm/CANN are unavailable on Windows ARM.
 
@@ -85,6 +93,11 @@ mod linux {
         ///
         /// Supported CANN SDK architectures: x86_64, aarch64.
         Cann,
+        /// Qualcomm Hexagon HTP NPU.
+        /// Falls back to CPU while candle gains a Hexagon device variant.
+        /// Only present on aarch64 Snapdragon SoCs; the plugin won't exist
+        /// on x86_64 so the probe skips it silently.
+        Hexagon,
         /// Vulkan is detected but candle 0.8 has no Vulkan Device variant yet.
         /// Falls back to CPU while logging the detection.
         Vulkan,
@@ -99,7 +112,7 @@ mod linux {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Priority order: CUDA → MUSA → ROCm → CANN → Vulkan → CPU.
+        // Priority order: CUDA → MUSA → ROCm → CANN → Hexagon → Vulkan → CPU.
         // Both x86_64 and aarch64 Linux support CUDA, MUSA, and ROCm.
         //
         // MUSA (Moore Threads) mirrors the CUDA API; its plugin probes
@@ -111,6 +124,9 @@ mod linux {
         // placed before Vulkan because it represents dedicated neural-network
         // silicon rather than a general graphics API.
         //
+        // Hexagon (Qualcomm HTP) is placed after CANN for the same reason.
+        // On x86_64 Linux the Hexagon plugin won't exist, so it is skipped.
+        //
         // The CANN plugin is arch-gated at build time (x86_64 / aarch64 only)
         // so on unsupported architectures the `.so` simply won't exist.
         let candidates: &[(&str, BackendKind)] = &[
@@ -118,6 +134,7 @@ mod linux {
             ("libinferrs_backend_musa.so", BackendKind::Musa),
             ("libinferrs_backend_rocm.so", BackendKind::Rocm),
             ("libinferrs_backend_cann.so", BackendKind::Cann),
+            ("libinferrs_backend_hexagon.so", BackendKind::Hexagon),
             ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
         ];
 
@@ -200,8 +217,8 @@ mod linux {
 pub use linux::{detect_backend, BackendKind};
 
 // ── Android ──────────────────────────────────────────────────────────────────
-// Android aarch64 hosts Ascend NPUs in some Huawei embedded/edge devices.
-// Only CANN is probed; CUDA and ROCm are not available on Android.
+// Android aarch64 hosts both Huawei Ascend NPUs (CANN, in some edge devices)
+// and Qualcomm Hexagon NPUs (Snapdragon SoCs).  CUDA and ROCm are unavailable.
 
 #[cfg(target_os = "android")]
 mod android {
@@ -217,16 +234,24 @@ mod android {
         /// Only aarch64 is supported.  The CANN plugin is compiled with an
         /// arch guard so it is absent on other Android ABIs.
         Cann,
+        /// Qualcomm Hexagon HTP NPU (Snapdragon SoCs).
+        ///
+        /// Falls back to CPU while candle gains a Hexagon device variant.
+        Hexagon,
         Cpu,
     }
 
-    /// Probe the CANN plugin and return the detected backend.
+    /// Probe the CANN and Hexagon plugins and return the detected backend.
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
-        // Android only supports CANN among the current plugin backends.
-        let candidates: &[(&str, BackendKind)] =
-            &[("libinferrs_backend_cann.so", BackendKind::Cann)];
+        // Priority: CANN → Hexagon → CPU.
+        // CANN is probed first; on Snapdragon devices the CANN plugin won't
+        // exist so the probe falls through to Hexagon.
+        let candidates: &[(&str, BackendKind)] = &[
+            ("libinferrs_backend_cann.so", BackendKind::Cann),
+            ("libinferrs_backend_hexagon.so", BackendKind::Hexagon),
+        ];
 
         for (lib_name, kind) in candidates {
             if probe_plugin(&search_dirs, lib_name) {
@@ -287,7 +312,10 @@ mod android {
             }
         }
 
-        // 2. Common Android data-app directories (for sideloaded builds).
+        // 2. Qualcomm vendor library path (standard on Snapdragon Android).
+        dirs.push(PathBuf::from("/vendor/lib64/inferrs"));
+
+        // 3. Common Android data-app / on-device dev directories.
         dirs.push(PathBuf::from("/data/local/tmp/inferrs"));
 
         dirs
@@ -302,10 +330,10 @@ pub use android::{detect_backend, BackendKind};
 // x86_64-only.  ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for
 // Windows); the plugin DLL is named `inferrs_backend_rocm.dll` and follows
 // the same ABI as the Linux `.so`.
-// CANN is not supported on Windows (Huawei SDK constraint).
+// CANN and Hexagon are not supported on Windows x86_64.
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-mod windows {
+mod windows_x86_64 {
     use std::path::PathBuf;
 
     use libloading::{Library, Symbol};
@@ -336,6 +364,7 @@ mod windows {
         // ROCm on Windows x86_64 is supported via AMD's HIP SDK (ROCm 5.5+).
         // MUSA Windows support is announced by Moore Threads.
         // CANN is not supported on Windows (Huawei SDK constraint).
+        // Hexagon does not exist on x86_64.
         let candidates: &[(&str, BackendKind)] = &[
             ("inferrs_backend_cuda.dll", BackendKind::Cuda),
             ("inferrs_backend_musa.dll", BackendKind::Musa),
@@ -418,18 +447,216 @@ mod windows {
 }
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-pub use windows::{detect_backend, BackendKind};
+pub use windows_x86_64::{detect_backend, BackendKind};
 
-// ── macOS (and any other unsupported platform) ────────────────────────────────
-//
+// ── Windows aarch64 (Snapdragon X / 8cx) ─────────────────────────────────────
+// Qualcomm ARM64 Windows devices ship a Hexagon NPU but no CUDA/ROCm GPU.
+// CANN is not supported on Windows (Huawei SDK constraint).
+// Priority: Hexagon → Vulkan → CPU.
+
+#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+mod windows_aarch64 {
+    use std::path::PathBuf;
+
+    use libloading::{Library, Symbol};
+
+    /// The detected NPU / GPU backend, in priority order.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BackendKind {
+        /// Hexagon HTP NPU (Qualcomm).  Falls back to CPU while candle gains
+        /// a Hexagon device variant.
+        Hexagon,
+        /// Vulkan GPU (if present).  Falls back to CPU while candle 0.8 has
+        /// no Vulkan Device variant.
+        Vulkan,
+        Cpu,
+    }
+
+    /// Probe backend plugins and return the highest-priority available kind.
+    ///
+    /// Plugins are searched next to the running executable first, then in
+    /// `%ProgramFiles%\inferrs`.
+    pub fn detect_backend() -> BackendKind {
+        let search_dirs = plugin_search_dirs();
+
+        // Priority: Hexagon → Vulkan → CPU  (no CUDA/ROCm/CANN on ARM64 Windows)
+        let candidates: &[(&str, BackendKind)] = &[
+            ("inferrs_backend_hexagon.dll", BackendKind::Hexagon),
+            ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
+        ];
+
+        for (lib_name, kind) in candidates {
+            if probe_plugin(&search_dirs, lib_name) {
+                return *kind;
+            }
+        }
+
+        BackendKind::Cpu
+    }
+
+    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
+        type ProbeFn = unsafe extern "C" fn() -> i32;
+
+        for dir in search_dirs {
+            let path = dir.join(lib_name);
+            if !path.exists() {
+                continue;
+            }
+
+            let lib = match unsafe { Library::new(&path) } {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::debug!("Failed to load {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
+                Ok(sym) => sym,
+                Err(e) => {
+                    tracing::debug!("Symbol not found in {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let result = unsafe { probe() };
+            if result == 0 {
+                tracing::debug!("Backend probe succeeded: {}", path.display());
+                drop(lib);
+                return true;
+            }
+            tracing::debug!(
+                "Backend probe returned {result} (unavailable): {}",
+                path.display()
+            );
+        }
+
+        false
+    }
+
+    fn plugin_search_dirs() -> Vec<PathBuf> {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(parent) = exe.parent() {
+                dirs.push(parent.to_path_buf());
+            }
+        }
+
+        if let Ok(pf) = std::env::var("ProgramFiles") {
+            dirs.push(PathBuf::from(pf).join("inferrs"));
+        }
+
+        dirs
+    }
+}
+
+#[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+pub use windows_aarch64::{detect_backend, BackendKind};
+
+// ── macOS ─────────────────────────────────────────────────────────────────────
+// Metal is linked directly into the binary on macOS (see Cargo.toml).
 // On macOS and Windows ARM, no plugin system is needed:
 //   - macOS: Metal is linked directly via the `metal` feature of candle-core.
-//   - Windows ARM: CUDA, ROCm, and CANN are unavailable; CPU is the only option.
+//   - Windows ARM: handled above by windows_aarch64 (Hexagon + Vulkan).
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::path::PathBuf;
+
+    use libloading::{Library, Symbol};
+
+    /// The detected accelerator backend on macOS.
+    ///
+    /// `detect_backend()` always returns `Metal` — this enum and function are
+    /// kept as an extension point for future optional plugin probing.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BackendKind {
+        /// Metal is always available on Apple Silicon and Intel Macs with
+        /// Metal-capable GPUs.  It is linked directly, not via a plugin.
+        Metal,
+        Cpu,
+    }
+
+    /// On macOS, Metal is linked at compile time — no plugin probe needed.
+    #[allow(dead_code)]
+    pub fn detect_backend() -> BackendKind {
+        let _ = plugin_search_dirs; // silence unused-fn lint
+        BackendKind::Metal
+    }
+
+    #[allow(dead_code)]
+    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
+        type ProbeFn = unsafe extern "C" fn() -> i32;
+
+        for dir in search_dirs {
+            let path = dir.join(lib_name);
+            if !path.exists() {
+                continue;
+            }
+
+            let lib = match unsafe { Library::new(&path) } {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::debug!("Failed to load {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
+                Ok(sym) => sym,
+                Err(e) => {
+                    tracing::debug!("Symbol not found in {}: {e}", path.display());
+                    continue;
+                }
+            };
+
+            let result = unsafe { probe() };
+            if result == 0 {
+                tracing::debug!("Backend probe succeeded: {}", path.display());
+                drop(lib);
+                return true;
+            }
+            tracing::debug!(
+                "Backend probe returned {result} (unavailable): {}",
+                path.display()
+            );
+        }
+
+        false
+    }
+
+    #[allow(dead_code)]
+    fn plugin_search_dirs() -> Vec<PathBuf> {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+
+        if let Ok(exe) = std::env::current_exe() {
+            if let Some(parent) = exe.parent() {
+                dirs.push(parent.to_path_buf());
+            }
+        }
+
+        dirs.push(PathBuf::from("/usr/local/lib/inferrs"));
+        dirs
+    }
+}
+
+// On macOS, Metal is linked at compile time and `main.rs` uses
+// `Device::new_metal()` directly — it never calls `detect_backend()` via the
+// plugin system.  The macOS module is kept as a documented extension point.
+#[cfg(target_os = "macos")]
+#[allow(unused_imports)]
+pub use macos::{detect_backend, BackendKind};
+
+// ── Any remaining platform (e.g. FreeBSD, bare-metal) ────────────────────────
 
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "windows", target_arch = "x86_64")
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "aarch64"),
+    target_os = "macos",
 )))]
 #[allow(dead_code)]
 pub fn detect_backend() -> BackendKind {
@@ -439,7 +666,9 @@ pub fn detect_backend() -> BackendKind {
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "windows", target_arch = "x86_64")
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(target_os = "windows", target_arch = "aarch64"),
+    target_os = "macos",
 )))]
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -236,24 +236,34 @@ impl ServeArgs {
             }
         }
 
-        // Linux / Windows x86_64: probe backend plugins via dynamic loading in
-        // priority order.  The main binary is compiled with the cuda feature
-        // but candle-core uses cudarc fallback-dynamic-loading so CUDA libs
-        // are opened on demand — they are not hard-linked into the binary.
-        // Windows ARM does not support CUDA and uses CPU only.
-        #[cfg(any(
-            target_os = "linux",
-            all(target_os = "windows", target_arch = "x86_64")
-        ))]
+        // Linux / Android / Windows: probe backend plugins via dynamic loading
+        // in priority order.  The main binary is compiled with the cuda feature
+        // but candle-core uses cudarc fallback-dynamic-loading so CUDA libs are
+        // opened on demand — they are not hard-linked into the binary.
+        //
+        // Platform notes:
+        //   Linux x86_64 / aarch64 : CUDA → ROCm → Hexagon → Vulkan → CPU
+        //   Android aarch64         : Hexagon → CPU
+        //   Windows x86_64          : CUDA → Vulkan → CPU
+        //   Windows aarch64         : Hexagon → Vulkan → CPU
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows",))]
         {
             use crate::backend::BackendKind;
             match crate::backend::detect_backend() {
+                #[cfg(any(
+                    target_os = "linux",
+                    all(target_os = "windows", target_arch = "x86_64")
+                ))]
                 BackendKind::Cuda => {
                     let device = candle_core::Device::new_cuda(0)?;
                     tracing::info!("Using CUDA device (via plugin)");
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
+                #[cfg(any(
+                    target_os = "linux",
+                    all(target_os = "windows", target_arch = "x86_64")
+                ))]
                 BackendKind::Musa => {
                     // Moore Threads MUSA mirrors the CUDA API.  candle-core's
                     // `cuda` feature covers MUSA when the binary is loaded in
@@ -266,6 +276,10 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
+                #[cfg(any(
+                    target_os = "linux",
+                    all(target_os = "windows", target_arch = "x86_64")
+                ))]
                 BackendKind::Rocm => {
                     // ROCm uses the same HIP/CUDA device path in candle.
                     // Supported on Linux x86_64, Linux aarch64, and Windows
@@ -275,7 +289,7 @@ impl ServeArgs {
                     disable_cuda_event_tracking(&device);
                     return Ok(device);
                 }
-                #[cfg(target_os = "linux")]
+                #[cfg(any(target_os = "linux", target_os = "android"))]
                 BackendKind::Cann => {
                     // Huawei Ascend NPU detected via CANN runtime.
                     // candle-core does not yet have a native CANN Device
@@ -289,6 +303,25 @@ impl ServeArgs {
                          candle integrates CANN support."
                     );
                 }
+                #[cfg(any(
+                    target_os = "linux",
+                    target_os = "android",
+                    all(target_os = "windows", target_arch = "aarch64")
+                ))]
+                BackendKind::Hexagon => {
+                    // Hexagon HTP NPU detected (Qualcomm Snapdragon).
+                    // candle does not yet have a native Hexagon Device variant;
+                    // fall back to CPU and log the detection so the user knows
+                    // the NPU was found.  Hexagon acceleration will be enabled
+                    // automatically once candle gains Hexagon device support
+                    // and this backend is updated.
+                    tracing::info!(
+                        "Qualcomm Hexagon HTP detected but candle has no \
+                         Hexagon Device variant yet — falling back to CPU. \
+                         NPU acceleration will be enabled in a future release."
+                    );
+                }
+                #[cfg(any(target_os = "linux", target_os = "windows",))]
                 BackendKind::Vulkan => {
                     // Vulkan driver detected. candle 0.8 does not yet have a
                     // Vulkan/wgpu Device variant, so we fall through to CPU.


### PR DESCRIPTION
Introduces backends/inferrs-backend-hexagon as a cdylib probe plugin for Qualcomm Hexagon HTP hardware, following the same dlopen/LoadLibrary pattern used by the CUDA and Vulkan backends.

- libdl.rs: portable dlopen/LoadLibraryW abstraction (mirrors ggml-hexagon/libdl.h), with RAII DlHandle on both POSIX and Windows
- fastrpc.rs: loads libcdsprpc.so (Linux/Android) or locates libcdsprpc.dll via SCM QueryServiceConfigW on Windows aarch64, then resolves all 16 FastRPC symbols (rpcmem, dspqueue, fastrpc_mmap, remote_handle64, remote_session_control) into a OnceLock singleton; queries DSPRPC_GET_DSP_INFO to confirm DSP reachability and map capability bytes 0x68-0x81 to arch versions 68-81
- lib.rs: exports inferrs_backend_probe(); fast-fails on x86_64 and macOS (no Hexagon hardware) via a const fn platform guard

backend.rs gains five platform modules covering Linux, Android, Windows x86_64, Windows aarch64, and macOS, with Hexagon inserted between ROCm and Vulkan in priority order. main.rs auto_device() is extended to cover Android and Windows aarch64 and logs a CPU fallback when Hexagon is detected (candle Hexagon device variant pending). Makefile includes the Hexagon backend in all default targets.