### PR TITLE
add Vulkan backend support for all CPU arches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,6 +1727,7 @@ name = "inferrs-backend-vulkan"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/backends/inferrs-backend-vulkan/Cargo.toml
+++ b/backends/inferrs-backend-vulkan/Cargo.toml
@@ -9,6 +9,13 @@ license = "Apache-2.0"
 name = "inferrs_backend_vulkan"
 crate-type = ["cdylib"]
 
-[dependencies]
-# Use libc for low-level dlopen to probe libvulkan without linking it.
+# POSIX platforms (Linux, Android, macOS): dlopen to probe for libvulkan
+# without linking against it at build time.
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))'.dependencies]
 libc = "0.2"
+
+# Windows (x86_64 and aarch64): LoadLibraryW / FreeLibrary to probe vulkan-1.dll.
+# FreeLibrary lives in Win32_Foundation (not Win32_System_LibraryLoader) in
+# windows-sys >= 0.59.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_LibraryLoader", "Win32_Foundation"] }

--- a/backends/inferrs-backend-vulkan/src/lib.rs
+++ b/backends/inferrs-backend-vulkan/src/lib.rs
@@ -1,8 +1,9 @@
 /// Probe whether a Vulkan-capable driver is available on this system.
 ///
-/// This is implemented by attempting to `dlopen` `libvulkan.so.1` at runtime.
-/// The backend `.so` itself does **not** link against Vulkan at compile time,
-/// so loading this plugin on a system without Vulkan will not fail — only the
+/// This is implemented by attempting to open the Vulkan loader library at
+/// runtime using `dlopen` (POSIX) or `LoadLibraryW` (Windows).  The backend
+/// shared library itself does **not** link against Vulkan at compile time, so
+/// loading this plugin on a system without Vulkan will not fail — only the
 /// probe call will return non-zero.
 ///
 /// NOTE: candle-core 0.8 does not yet have a Vulkan/wgpu `Device` variant.
@@ -10,34 +11,144 @@
 /// available and will accelerate inference once candle gains wgpu support.
 /// Until then the binary falls back to CPU after logging the detection.
 ///
-/// Platform coverage: Linux only. The probe always returns 1 (unavailable) on
-/// Windows and macOS. When candle gains wgpu support and the Vulkan probe is
-/// extended to Windows, update the cfg guard below and the release workflow.
+/// Platform library names tried, in order:
 ///
-/// Returns 0 if `libvulkan.so.1` can be opened, 1 otherwise.
+/// | Platform              | Library names                                         |
+/// |-----------------------|-------------------------------------------------------|
+/// | Linux  (any arch)     | `libvulkan.so.1`, `libvulkan.so`                      |
+/// | Android (any arch)    | `libvulkan.so`  (OS-provided since API 24)            |
+/// | macOS  (any arch)     | `libvulkan.1.dylib`, `libvulkan.dylib`,               |
+/// |                       | `libMoltenVK.dylib`  (MoltenVK portability layer)     |
+/// | Windows (x86_64/ARM)  | `vulkan-1.dll`  (via `LoadLibraryW`)                  |
+///
+/// Returns 0 if any candidate library can be opened, 1 otherwise.
 #[no_mangle]
 pub extern "C" fn inferrs_backend_probe() -> i32 {
-    #[cfg(target_os = "linux")]
-    {
-        use std::ffi::CString;
+    if try_load_vulkan() {
+        0
+    } else {
+        1
+    }
+}
 
-        // Try both versioned and unversioned library names.
-        for name in &["libvulkan.so.1", "libvulkan.so"] {
-            let Ok(cname) = CString::new(*name) else {
-                continue;
-            };
-            // SAFETY: dlopen is safe to call with a valid C string and flags.
-            let handle =
-                unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
-            if !handle.is_null() {
-                unsafe { libc::dlclose(handle) };
-                return 0;
-            }
+// ── Linux ─────────────────────────────────────────────────────────────────────
+//
+// Covers x86_64 and aarch64 (and any other Linux architecture).
+// Android is a separate target_os so it does not fall into this branch.
+
+#[cfg(target_os = "linux")]
+fn try_load_vulkan() -> bool {
+    dlopen_any(&["libvulkan.so.1", "libvulkan.so"])
+}
+
+// ── Android ───────────────────────────────────────────────────────────────────
+//
+// On Android the Vulkan loader is a system library named `libvulkan.so`
+// (no version suffix) baked into the OS since API level 24 (Android 7.0).
+// The NDK exposes it at link time, but we probe at runtime via dlopen to
+// match the pattern used for every other backend.
+//
+// Architectures: aarch64-linux-android, x86_64-linux-android,
+//                armv7-linux-androideabi, i686-linux-android.
+
+#[cfg(target_os = "android")]
+fn try_load_vulkan() -> bool {
+    dlopen_any(&["libvulkan.so"])
+}
+
+// ── macOS ─────────────────────────────────────────────────────────────────────
+//
+// On macOS, Vulkan is available through:
+//   1. A full Vulkan SDK installation → `libvulkan.1.dylib` / `libvulkan.dylib`
+//   2. MoltenVK installed stand-alone or via Homebrew → `libMoltenVK.dylib`
+//
+// MoltenVK implements Vulkan 1.3 on top of Metal.  Homebrew installs it at
+// `/opt/homebrew/lib/libMoltenVK.dylib` (Apple Silicon) or
+// `/usr/local/lib/libMoltenVK.dylib` (Intel), which are on the default
+// `DYLD_LIBRARY_PATH` for Homebrew-aware shells.
+//
+// The portability-enumeration extension (VK_KHR_portability_enumeration) is
+// required for MoltenVK devices to appear during instance enumeration; the
+// actual inference runtime must pass VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
+// when creating its VkInstance (as llama.cpp does in ggml-vulkan.cpp).
+//
+// Architectures: x86_64-apple-darwin, aarch64-apple-darwin.
+
+#[cfg(target_os = "macos")]
+fn try_load_vulkan() -> bool {
+    dlopen_any(&["libvulkan.1.dylib", "libvulkan.dylib", "libMoltenVK.dylib"])
+}
+
+// ── Windows ───────────────────────────────────────────────────────────────────
+//
+// On Windows the Vulkan loader DLL is always named `vulkan-1.dll` for both
+// x86_64 and aarch64.  We use `LoadLibraryW` (wide-string variant) to avoid
+// ANSI code-page issues.  The Windows loader searches:
+//   1. The directory containing the application executable
+//   2. The current working directory
+//   3. System32 (where GPU driver installers place `vulkan-1.dll`)
+//   4. Entries in the PATH environment variable
+//
+// Architectures: x86_64-pc-windows-msvc, aarch64-pc-windows-msvc,
+//                x86_64-pc-windows-gnu, aarch64-pc-windows-gnu.
+
+#[cfg(target_os = "windows")]
+fn try_load_vulkan() -> bool {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+
+    // Encode the DLL name as a null-terminated UTF-16 string.
+    let name_wide: Vec<u16> = OsStr::new("vulkan-1.dll")
+        .encode_wide()
+        .chain(std::iter::once(0u16))
+        .collect();
+
+    // SAFETY: `LoadLibraryW` is safe to call with a valid null-terminated
+    // UTF-16 string.  We immediately free the handle if loading succeeds.
+    // HMODULE is `*mut c_void` in windows-sys 0.59; null check via
+    // `!= std::ptr::null_mut()`.  FreeLibrary lives in Win32::Foundation.
+    unsafe {
+        let handle = windows_sys::Win32::System::LibraryLoader::LoadLibraryW(name_wide.as_ptr());
+        if !handle.is_null() {
+            windows_sys::Win32::Foundation::FreeLibrary(handle);
+            return true;
         }
-        1
     }
-    #[cfg(not(target_os = "linux"))]
-    {
-        1
+    false
+}
+
+// ── Fallback (unsupported platforms) ─────────────────────────────────────────
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "windows",
+)))]
+fn try_load_vulkan() -> bool {
+    false
+}
+
+// ── Shared POSIX helper ───────────────────────────────────────────────────────
+
+/// Try each library name in `names` via `dlopen(RTLD_LAZY | RTLD_LOCAL)`.
+/// Returns `true` and immediately closes the handle if any candidate succeeds.
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+fn dlopen_any(names: &[&str]) -> bool {
+    use std::ffi::CString;
+
+    for name in names {
+        let Ok(cname) = CString::new(*name) else {
+            continue;
+        };
+        // SAFETY: `dlopen` is safe to call with a valid C string and flags.
+        // We immediately `dlclose` the handle — we only need to know whether
+        // the library is present and loadable.
+        let handle = unsafe { libc::dlopen(cname.as_ptr(), libc::RTLD_LAZY | libc::RTLD_LOCAL) };
+        if !handle.is_null() {
+            unsafe { libc::dlclose(handle) };
+            return true;
+        }
     }
+    false
 }

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -9,11 +9,13 @@ license = "Apache-2.0"
 name = "inferrs"
 path = "src/main.rs"
 
-# On macOS, always enable Metal — in debug, release, and test builds alike.
+# On macOS: always enable Metal, and add libloading to probe for
+# the Vulkan/MoltenVK plugin at runtime.
 [target.'cfg(target_os = "macos")'.dependencies]
 candle-core = { workspace = true, features = ["metal"] }
 candle-nn = { workspace = true, features = ["metal"] }
 candle-transformers = { workspace = true, features = ["metal"] }
+libloading = "0.8"
 
 
 [dependencies]
@@ -65,15 +67,15 @@ base64 = "0.22"
 # candle-core is patched (see [patch.crates-io] in the workspace Cargo.toml)
 # to use cudarc with fallback-dynamic-loading instead of dynamic-linking,
 # so libcuda / libcurand / libcublas are NOT hard-linked into the binary —
-# they are dlopen'd (LoadLibrary on Windows) on demand when a CUDA device
-# is first used.
+# they are dlopen'd on demand when a CUDA device is first used.
 [target.'cfg(target_os = "linux")'.dependencies]
 libloading = "0.8"
 candle-core = { workspace = true, features = ["cuda"] }
 candle-nn = { workspace = true, features = ["cuda"] }
 candle-transformers = { workspace = true, features = ["cuda"] }
 
-# Windows x86_64 only: CUDA is not available on Windows ARM.
+# Windows x86_64: CUDA + ROCm + Vulkan plugin probing.
+# CUDA is not available on Windows ARM, so this block is x86_64-only.
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
 libloading = "0.8"
 candle-core = { workspace = true, features = ["cuda"] }
@@ -91,15 +93,10 @@ libloading = "0.8"
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = "0.2"
 
-# Windows aarch64 (Snapdragon X / 8cx): no CUDA, but Hexagon probing via
-# the plugin system needs libloading.
+# Windows aarch64 (Snapdragon X / 8cx): no CUDA, but Hexagon + Vulkan probing
+# via the plugin system needs libloading.
 [target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
 libloading = "0.8"
-
-# macOS: Metal is linked directly, but libloading is still needed for the
-# macOS plugin extension point to compile cleanly.
-[target.'cfg(target_os = "macos")'.dependencies.libloading]
-version = "0.8"
 
 [dev-dependencies]
 ureq = { version = "2", features = ["json"] }

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -20,14 +20,14 @@
 //!
 //! ## Platform support matrix
 //!
-//! | Platform                  | CUDA | ROCm | CANN | Hexagon | Vulkan |
-//! |---------------------------|------|------|------|---------|--------|
-//! | Linux x86_64              | ✓    | ✓    | ✓    | —       | ✓      |
-//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓       | ✓      |
-//! | Windows x86_64            | ✓    | ✓    | —    | —       | ✓      |
-//! | Windows aarch64           | —    | —    | —    | ✓       | ✓      |
-//! | macOS aarch64             | —    | —    | —    | —       | —      |
-//! | Android aarch64           | —    | —    | ✓    | ✓       | —      |
+//! | Platform                  | CUDA | MUSA | ROCm | CANN | Hexagon | Vulkan |
+//! |---------------------------|------|------|------|------|---------|--------|
+//! | Linux x86_64              | ✓    | ✓    | ✓    | ✓    | —       | ✓      |
+//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓    | ✓       | ✓      |
+//! | Windows x86_64            | ✓    | ✓    | ✓    | —    | —       | ✓      |
+//! | Windows aarch64           | —    | —    | —    | —    | ✓       | ✓      |
+//! | macOS x86_64 / aarch64    | —    | —    | —    | —    | —       | ✓      |
+//! | Android aarch64           | —    | —    | —    | ✓    | ✓       | ✓      |
 //!
 //! ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for Windows).
 //! ROCm on Linux aarch64 is supported on hardware such as AMD MI300A APUs
@@ -58,22 +58,98 @@
 //!   2. Vulkan  (`.dll`) → CPU fallback with info log
 //!   3. CPU     (always available)
 //!
+//! **macOS x86_64 / aarch64:**
+//!   Metal is tried first (linked directly).  If Metal fails:
+//!   1. Vulkan (`.dylib`, via MoltenVK) → CPU fallback with info log
+//!   2. CPU    (always available)
+//!
 //! **Android aarch64:**
 //!   1. CANN    (`.so`)  → CPU fallback with info log (pending candle CANN Device)
 //!   2. Hexagon (`.so`)  → CPU fallback with info log (pending candle Hexagon Device)
-//!   3. CPU     (always available)
-//!
-//! **macOS / Windows ARM (no Hexagon):**
-//!   No plugin system needed — Metal is linked directly on macOS;
-//!   CUDA/ROCm/CANN are unavailable on Windows ARM.
+//!   3. Vulkan  (`.so`)  → CPU fallback with info log
+//!   4. CPU     (always available)
 
-// ── Linux ────────────────────────────────────────────────────────────────────
+// ── Shared helpers ────────────────────────────────────────────────────────────
+//
+// `probe_plugin` and `exe_dir` are used by every platform module.
+// They are compiled only on platforms that actually use the plugin system.
+
+/// Try to load `lib_name` from each directory in `search_dirs` and call
+/// `inferrs_backend_probe()`.  Returns `true` if the probe returns 0.
+///
+/// This single implementation is shared by every platform module; only the
+/// search-directory list and the candidate file names differ per platform.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "windows",
+))]
+fn probe_plugin(search_dirs: &[std::path::PathBuf], lib_name: &str) -> bool {
+    use libloading::{Library, Symbol};
+    type ProbeFn = unsafe extern "C" fn() -> i32;
+
+    for dir in search_dirs {
+        let path = dir.join(lib_name);
+        if !path.exists() {
+            continue;
+        }
+
+        // SAFETY: We are loading a well-known plugin whose ABI we control.
+        let lib = match unsafe { Library::new(&path) } {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::debug!("Failed to load {}: {e}", path.display());
+                continue;
+            }
+        };
+
+        // SAFETY: We know the exported symbol name and its signature.
+        let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
+            Ok(sym) => sym,
+            Err(e) => {
+                tracing::debug!("Symbol not found in {}: {e}", path.display());
+                continue;
+            }
+        };
+
+        // SAFETY: Calling a C function with no arguments is safe.
+        let result = unsafe { probe() };
+        if result == 0 {
+            tracing::debug!("Backend probe succeeded: {}", path.display());
+            // `lib` is dropped here — that is fine because we only needed
+            // the probe call; the plugin does not need to stay loaded.
+            drop(lib);
+            return true;
+        }
+        tracing::debug!(
+            "Backend probe returned {result} (unavailable): {}",
+            path.display()
+        );
+    }
+
+    false
+}
+
+/// Return the directory that contains the running executable, if available.
+/// This is the highest-priority search location on every platform.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "windows",
+))]
+fn exe_dir() -> Option<std::path::PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+}
+
+// ── Linux ─────────────────────────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
 mod linux {
     use std::path::PathBuf;
-
-    use libloading::{Library, Symbol};
 
     /// The detected GPU/NPU backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -105,10 +181,6 @@ mod linux {
     }
 
     /// Probe the backend plugins and return the highest-priority available kind.
-    ///
-    /// The plugins are searched next to the running executable first, then in
-    /// the same directory as the executable's parent (for dev builds under
-    /// `target/<target>/release/`), and finally in system-wide locations.
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
@@ -139,7 +211,7 @@ mod linux {
         ];
 
         for (lib_name, kind) in candidates {
-            if probe_plugin(&search_dirs, lib_name) {
+            if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
             }
         }
@@ -147,68 +219,10 @@ mod linux {
         BackendKind::Cpu
     }
 
-    /// Try to load `lib_name` from each search directory and call
-    /// `inferrs_backend_probe()`.  Returns `true` if the probe returns 0.
-    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
-        type ProbeFn = unsafe extern "C" fn() -> i32;
-
-        for dir in search_dirs {
-            let path = dir.join(lib_name);
-            if !path.exists() {
-                continue;
-            }
-
-            // SAFETY: We are loading a well-known plugin whose ABI we control.
-            let lib = match unsafe { Library::new(&path) } {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::debug!("Failed to load {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            // SAFETY: We know the exported symbol name and its signature.
-            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
-                Ok(sym) => sym,
-                Err(e) => {
-                    tracing::debug!("Symbol not found in {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            // SAFETY: Calling a C function with no arguments is safe.
-            let result = unsafe { probe() };
-            if result == 0 {
-                tracing::debug!("Backend probe succeeded: {}", path.display());
-                // Keep `lib` alive until probe result is used — it's dropped here
-                // which is fine because we only needed the probe call.
-                drop(lib);
-                return true;
-            }
-            tracing::debug!(
-                "Backend probe returned {result} (unavailable): {}",
-                path.display()
-            );
-        }
-
-        false
-    }
-
-    /// Directories to search for backend plugins, in priority order.
     fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-
-        // 1. Same directory as the running executable.
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                dirs.push(parent.to_path_buf());
-            }
-        }
-
-        // 2. System-wide install locations.
+        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
         dirs.push(PathBuf::from("/usr/lib/inferrs"));
         dirs.push(PathBuf::from("/usr/local/lib/inferrs"));
-
         dirs
     }
 }
@@ -216,45 +230,40 @@ mod linux {
 #[cfg(target_os = "linux")]
 pub use linux::{detect_backend, BackendKind};
 
-// ── Android ──────────────────────────────────────────────────────────────────
+// ── Android ───────────────────────────────────────────────────────────────────
 // Android aarch64 hosts both Huawei Ascend NPUs (CANN, in some edge devices)
 // and Qualcomm Hexagon NPUs (Snapdragon SoCs).  CUDA and ROCm are unavailable.
+// Vulkan is also available on most Android devices since API 24.
 
 #[cfg(target_os = "android")]
 mod android {
     use std::path::PathBuf;
 
-    use libloading::{Library, Symbol};
-
-    /// The detected NPU backend on Android.
+    /// The detected NPU/GPU backend on Android.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
-        /// Huawei Ascend NPU via CANN.
-        ///
-        /// Only aarch64 is supported.  The CANN plugin is compiled with an
-        /// arch guard so it is absent on other Android ABIs.
+        /// Huawei Ascend NPU via CANN (aarch64 only).
         Cann,
         /// Qualcomm Hexagon HTP NPU (Snapdragon SoCs).
-        ///
-        /// Falls back to CPU while candle gains a Hexagon device variant.
         Hexagon,
+        /// Vulkan GPU acceleration (available since API 24).
+        Vulkan,
         Cpu,
     }
 
-    /// Probe the CANN and Hexagon plugins and return the detected backend.
     pub fn detect_backend() -> BackendKind {
-        let search_dirs = plugin_search_dirs();
-
-        // Priority: CANN → Hexagon → CPU.
+        // Priority: CANN → Hexagon → Vulkan → CPU.
         // CANN is probed first; on Snapdragon devices the CANN plugin won't
-        // exist so the probe falls through to Hexagon.
+        // exist so the probe falls through to Hexagon, then Vulkan.
         let candidates: &[(&str, BackendKind)] = &[
             ("libinferrs_backend_cann.so", BackendKind::Cann),
             ("libinferrs_backend_hexagon.so", BackendKind::Hexagon),
+            ("libinferrs_backend_vulkan.so", BackendKind::Vulkan),
         ];
 
+        let search_dirs = plugin_search_dirs();
         for (lib_name, kind) in candidates {
-            if probe_plugin(&search_dirs, lib_name) {
+            if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
             }
         }
@@ -262,62 +271,12 @@ mod android {
         BackendKind::Cpu
     }
 
-    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
-        type ProbeFn = unsafe extern "C" fn() -> i32;
-
-        for dir in search_dirs {
-            let path = dir.join(lib_name);
-            if !path.exists() {
-                continue;
-            }
-
-            let lib = match unsafe { Library::new(&path) } {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::debug!("Failed to load {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
-                Ok(sym) => sym,
-                Err(e) => {
-                    tracing::debug!("Symbol not found in {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let result = unsafe { probe() };
-            if result == 0 {
-                tracing::debug!("Backend probe succeeded: {}", path.display());
-                drop(lib);
-                return true;
-            }
-            tracing::debug!(
-                "Backend probe returned {result} (unavailable): {}",
-                path.display()
-            );
-        }
-
-        false
-    }
-
     fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-
-        // 1. Same directory as the running executable.
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                dirs.push(parent.to_path_buf());
-            }
-        }
-
-        // 2. Qualcomm vendor library path (standard on Snapdragon Android).
+        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
+        // Qualcomm vendor library path (standard on Snapdragon Android).
         dirs.push(PathBuf::from("/vendor/lib64/inferrs"));
-
-        // 3. Common Android data-app / on-device dev directories.
+        // Common Android data-app / on-device dev directories.
         dirs.push(PathBuf::from("/data/local/tmp/inferrs"));
-
         dirs
     }
 }
@@ -325,18 +284,58 @@ mod android {
 #[cfg(target_os = "android")]
 pub use android::{detect_backend, BackendKind};
 
+// ── macOS ─────────────────────────────────────────────────────────────────────
+//
+// Metal is linked directly and is always preferred.  Vulkan is also available
+// via MoltenVK (a Vulkan 1.3 portability layer over Metal).  We probe for it
+// so that the main binary can log its availability and future wgpu/Vulkan code
+// paths can use it.
+//
+// Architectures: x86_64-apple-darwin, aarch64-apple-darwin.
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use std::path::PathBuf;
+
+    /// The detected GPU backend on macOS (Metal is handled directly in
+    /// `auto_device` before the plugin system is invoked).
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum BackendKind {
+        /// Vulkan via MoltenVK is detected; candle 0.8 has no Vulkan Device yet.
+        Vulkan,
+        Cpu,
+    }
+
+    pub fn detect_backend() -> BackendKind {
+        if super::probe_plugin(&plugin_search_dirs(), "libinferrs_backend_vulkan.dylib") {
+            return BackendKind::Vulkan;
+        }
+        BackendKind::Cpu
+    }
+
+    fn plugin_search_dirs() -> Vec<PathBuf> {
+        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
+        // Standard macOS library paths, including Homebrew locations where
+        // MoltenVK is typically installed.
+        dirs.push(PathBuf::from("/usr/local/lib"));
+        dirs.push(PathBuf::from("/opt/homebrew/lib")); // Homebrew Apple Silicon
+        dirs.push(PathBuf::from("/usr/local/opt/molten-vk/lib")); // Homebrew Intel
+        dirs
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub use macos::{detect_backend, BackendKind};
+
 // ── Windows x86_64 ───────────────────────────────────────────────────────────
-// CUDA and ROCm are not available on Windows ARM, so the plugin system is
-// x86_64-only.  ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for
-// Windows); the plugin DLL is named `inferrs_backend_rocm.dll` and follows
-// the same ABI as the Linux `.so`.
+// CUDA and ROCm are available on Windows x86_64 only.  ROCm on Windows is
+// supported from ROCm 5.5+ (HIP SDK for Windows).  Vulkan is available on
+// both x86_64 and aarch64 (see the Windows aarch64 section below).
 // CANN and Hexagon are not supported on Windows x86_64.
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod windows_x86_64 {
     use std::path::PathBuf;
-
-    use libloading::{Library, Symbol};
 
     /// The detected GPU backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -353,10 +352,6 @@ mod windows_x86_64 {
         Cpu,
     }
 
-    /// Probe the backend plugins and return the highest-priority available kind.
-    ///
-    /// The plugins are searched next to the running executable first, then in
-    /// `%ProgramFiles%\inferrs`.
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
@@ -373,7 +368,7 @@ mod windows_x86_64 {
         ];
 
         for (lib_name, kind) in candidates {
-            if probe_plugin(&search_dirs, lib_name) {
+            if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
             }
         }
@@ -381,67 +376,11 @@ mod windows_x86_64 {
         BackendKind::Cpu
     }
 
-    /// Try to load `lib_name` from each search directory and call
-    /// `inferrs_backend_probe()`.  Returns `true` if the probe returns 0.
-    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
-        type ProbeFn = unsafe extern "C" fn() -> i32;
-
-        for dir in search_dirs {
-            let path = dir.join(lib_name);
-            if !path.exists() {
-                continue;
-            }
-
-            // SAFETY: We are loading a well-known plugin whose ABI we control.
-            let lib = match unsafe { Library::new(&path) } {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::debug!("Failed to load {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            // SAFETY: We know the exported symbol name and its signature.
-            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
-                Ok(sym) => sym,
-                Err(e) => {
-                    tracing::debug!("Symbol not found in {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            // SAFETY: Calling a C function with no arguments is safe.
-            let result = unsafe { probe() };
-            if result == 0 {
-                tracing::debug!("Backend probe succeeded: {}", path.display());
-                drop(lib);
-                return true;
-            }
-            tracing::debug!(
-                "Backend probe returned {result} (unavailable): {}",
-                path.display()
-            );
-        }
-
-        false
-    }
-
-    /// Directories to search for backend plugins, in priority order.
     fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-
-        // 1. Same directory as the running executable.
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                dirs.push(parent.to_path_buf());
-            }
-        }
-
-        // 2. System-wide install location.
+        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
         if let Ok(pf) = std::env::var("ProgramFiles") {
             dirs.push(PathBuf::from(pf).join("inferrs"));
         }
-
         dirs
     }
 }
@@ -450,15 +389,13 @@ mod windows_x86_64 {
 pub use windows_x86_64::{detect_backend, BackendKind};
 
 // ── Windows aarch64 (Snapdragon X / 8cx) ─────────────────────────────────────
-// Qualcomm ARM64 Windows devices ship a Hexagon NPU but no CUDA/ROCm GPU.
-// CANN is not supported on Windows (Huawei SDK constraint).
+// Qualcomm ARM64 Windows devices ship a Hexagon NPU and Vulkan-capable GPU,
+// but no CUDA/ROCm/CANN.
 // Priority: Hexagon → Vulkan → CPU.
 
 #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
 mod windows_aarch64 {
     use std::path::PathBuf;
-
-    use libloading::{Library, Symbol};
 
     /// The detected NPU / GPU backend, in priority order.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -466,27 +403,21 @@ mod windows_aarch64 {
         /// Hexagon HTP NPU (Qualcomm).  Falls back to CPU while candle gains
         /// a Hexagon device variant.
         Hexagon,
-        /// Vulkan GPU (if present).  Falls back to CPU while candle 0.8 has
-        /// no Vulkan Device variant.
+        /// Vulkan GPU.  Falls back to CPU while candle 0.8 has no Vulkan Device.
         Vulkan,
         Cpu,
     }
 
-    /// Probe backend plugins and return the highest-priority available kind.
-    ///
-    /// Plugins are searched next to the running executable first, then in
-    /// `%ProgramFiles%\inferrs`.
     pub fn detect_backend() -> BackendKind {
-        let search_dirs = plugin_search_dirs();
-
         // Priority: Hexagon → Vulkan → CPU  (no CUDA/ROCm/CANN on ARM64 Windows)
         let candidates: &[(&str, BackendKind)] = &[
             ("inferrs_backend_hexagon.dll", BackendKind::Hexagon),
             ("inferrs_backend_vulkan.dll", BackendKind::Vulkan),
         ];
 
+        let search_dirs = plugin_search_dirs();
         for (lib_name, kind) in candidates {
-            if probe_plugin(&search_dirs, lib_name) {
+            if super::probe_plugin(&search_dirs, lib_name) {
                 return *kind;
             }
         }
@@ -494,59 +425,11 @@ mod windows_aarch64 {
         BackendKind::Cpu
     }
 
-    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
-        type ProbeFn = unsafe extern "C" fn() -> i32;
-
-        for dir in search_dirs {
-            let path = dir.join(lib_name);
-            if !path.exists() {
-                continue;
-            }
-
-            let lib = match unsafe { Library::new(&path) } {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::debug!("Failed to load {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
-                Ok(sym) => sym,
-                Err(e) => {
-                    tracing::debug!("Symbol not found in {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let result = unsafe { probe() };
-            if result == 0 {
-                tracing::debug!("Backend probe succeeded: {}", path.display());
-                drop(lib);
-                return true;
-            }
-            tracing::debug!(
-                "Backend probe returned {result} (unavailable): {}",
-                path.display()
-            );
-        }
-
-        false
-    }
-
     fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                dirs.push(parent.to_path_buf());
-            }
-        }
-
+        let mut dirs: Vec<PathBuf> = super::exe_dir().into_iter().collect();
         if let Ok(pf) = std::env::var("ProgramFiles") {
             dirs.push(PathBuf::from(pf).join("inferrs"));
         }
-
         dirs
     }
 }
@@ -554,109 +437,14 @@ mod windows_aarch64 {
 #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
 pub use windows_aarch64::{detect_backend, BackendKind};
 
-// ── macOS ─────────────────────────────────────────────────────────────────────
-// Metal is linked directly into the binary on macOS (see Cargo.toml).
-// On macOS and Windows ARM, no plugin system is needed:
-//   - macOS: Metal is linked directly via the `metal` feature of candle-core.
-//   - Windows ARM: handled above by windows_aarch64 (Hexagon + Vulkan).
-
-#[cfg(target_os = "macos")]
-mod macos {
-    use std::path::PathBuf;
-
-    use libloading::{Library, Symbol};
-
-    /// The detected accelerator backend on macOS.
-    ///
-    /// `detect_backend()` always returns `Metal` — this enum and function are
-    /// kept as an extension point for future optional plugin probing.
-    #[allow(dead_code)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub enum BackendKind {
-        /// Metal is always available on Apple Silicon and Intel Macs with
-        /// Metal-capable GPUs.  It is linked directly, not via a plugin.
-        Metal,
-        Cpu,
-    }
-
-    /// On macOS, Metal is linked at compile time — no plugin probe needed.
-    #[allow(dead_code)]
-    pub fn detect_backend() -> BackendKind {
-        let _ = plugin_search_dirs; // silence unused-fn lint
-        BackendKind::Metal
-    }
-
-    #[allow(dead_code)]
-    fn probe_plugin(search_dirs: &[PathBuf], lib_name: &str) -> bool {
-        type ProbeFn = unsafe extern "C" fn() -> i32;
-
-        for dir in search_dirs {
-            let path = dir.join(lib_name);
-            if !path.exists() {
-                continue;
-            }
-
-            let lib = match unsafe { Library::new(&path) } {
-                Ok(l) => l,
-                Err(e) => {
-                    tracing::debug!("Failed to load {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let probe: Symbol<ProbeFn> = match unsafe { lib.get(b"inferrs_backend_probe\0") } {
-                Ok(sym) => sym,
-                Err(e) => {
-                    tracing::debug!("Symbol not found in {}: {e}", path.display());
-                    continue;
-                }
-            };
-
-            let result = unsafe { probe() };
-            if result == 0 {
-                tracing::debug!("Backend probe succeeded: {}", path.display());
-                drop(lib);
-                return true;
-            }
-            tracing::debug!(
-                "Backend probe returned {result} (unavailable): {}",
-                path.display()
-            );
-        }
-
-        false
-    }
-
-    #[allow(dead_code)]
-    fn plugin_search_dirs() -> Vec<PathBuf> {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-
-        if let Ok(exe) = std::env::current_exe() {
-            if let Some(parent) = exe.parent() {
-                dirs.push(parent.to_path_buf());
-            }
-        }
-
-        dirs.push(PathBuf::from("/usr/local/lib/inferrs"));
-        dirs
-    }
-}
-
-// On macOS, Metal is linked at compile time and `main.rs` uses
-// `Device::new_metal()` directly — it never calls `detect_backend()` via the
-// plugin system.  The macOS module is kept as a documented extension point.
-#[cfg(target_os = "macos")]
-#[allow(unused_imports)]
-pub use macos::{detect_backend, BackendKind};
-
 // ── Any remaining platform (e.g. FreeBSD, bare-metal) ────────────────────────
 
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
+    target_os = "macos",
     all(target_os = "windows", target_arch = "x86_64"),
     all(target_os = "windows", target_arch = "aarch64"),
-    target_os = "macos",
 )))]
 #[allow(dead_code)]
 pub fn detect_backend() -> BackendKind {
@@ -666,9 +454,9 @@ pub fn detect_backend() -> BackendKind {
 #[cfg(not(any(
     target_os = "linux",
     target_os = "android",
+    target_os = "macos",
     all(target_os = "windows", target_arch = "x86_64"),
     all(target_os = "windows", target_arch = "aarch64"),
-    target_os = "macos",
 )))]
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -228,11 +228,22 @@ impl ServeArgs {
 
     fn auto_device() -> Result<candle_core::Device> {
         // macOS: always prefer Metal (linked directly, no plugin needed).
+        // After that, probe for a Vulkan/MoltenVK plugin as a fallback.
         #[cfg(target_os = "macos")]
         {
             if let Ok(device) = candle_core::Device::new_metal(0) {
                 tracing::info!("Using Metal device");
                 return Ok(device);
+            }
+
+            // Metal failed (unlikely). Check whether a Vulkan/MoltenVK plugin
+            // is present so the user gets a helpful log message.
+            use crate::backend::BackendKind;
+            if let BackendKind::Vulkan = crate::backend::detect_backend() {
+                tracing::info!(
+                    "Vulkan/MoltenVK driver detected but candle 0.8 has no \
+                     Vulkan Device yet — falling back to CPU."
+                );
             }
         }
 
@@ -337,25 +348,75 @@ impl ServeArgs {
             }
         }
 
-        // Android (aarch64): probe CANN plugin for Huawei Ascend NPU.
+        // Android: probe CANN (Huawei Ascend NPU) then Vulkan.
         // CUDA and ROCm are not available on Android.
         #[cfg(target_os = "android")]
         {
             use crate::backend::BackendKind;
             match crate::backend::detect_backend() {
                 BackendKind::Cann => {
-                    // Huawei Ascend NPU on Android — same candle limitation
-                    // as on Linux: fall back to CPU until candle CANN lands.
                     tracing::info!(
                         "Huawei Ascend NPU detected (CANN) on Android but \
                          candle does not yet have a native CANN Device — \
                          falling back to CPU."
                     );
                 }
+                BackendKind::Vulkan => {
+                    tracing::info!(
+                        "Vulkan driver detected but candle 0.8 has no Vulkan \
+                         Device yet — falling back to CPU."
+                    );
+                }
                 BackendKind::Cpu => {}
             }
         }
 
+        // Windows x86_64: CUDA + MUSA + ROCm + Vulkan plugin probing.
+        #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+        {
+            use crate::backend::BackendKind;
+            match crate::backend::detect_backend() {
+                BackendKind::Cuda => {
+                    let device = candle_core::Device::new_cuda(0)?;
+                    tracing::info!("Using CUDA device (via plugin)");
+                    disable_cuda_event_tracking(&device);
+                    return Ok(device);
+                }
+                BackendKind::Musa => {
+                    let device = candle_core::Device::new_cuda(0)?;
+                    tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
+                    disable_cuda_event_tracking(&device);
+                    return Ok(device);
+                }
+                BackendKind::Rocm => {
+                    let device = candle_core::Device::new_cuda(0)?;
+                    tracing::info!("Using ROCm device (via plugin)");
+                    disable_cuda_event_tracking(&device);
+                    return Ok(device);
+                }
+                BackendKind::Vulkan => {
+                    tracing::info!(
+                        "Vulkan driver detected but candle 0.8 has no Vulkan \
+                         Device yet — falling back to CPU. Recompile with a \
+                         candle version that supports wgpu to enable Vulkan."
+                    );
+                }
+                BackendKind::Cpu => {}
+            }
+        }
+
+        // Windows aarch64: Vulkan-only (CUDA unavailable on ARM64 Windows).
+        #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+        {
+            use crate::backend::BackendKind;
+            if let BackendKind::Vulkan = crate::backend::detect_backend() {
+                tracing::info!(
+                    "Vulkan driver detected but candle 0.8 has no Vulkan \
+                     Device yet — falling back to CPU. Recompile with a \
+                     candle version that supports wgpu to enable Vulkan."
+                );
+            }
+        }
         tracing::info!("Using CPU device");
         Ok(candle_core::Device::Cpu)
     }


### PR DESCRIPTION
Expand the Vulkan backend plugin from a Linux-only stub to full coverage across all relevant platforms and architectures:

- Linux (x86_64, aarch64): dlopen libvulkan.so.1 then libvulkan.so
- Android (aarch64, x86_64, arm32): dlopen libvulkan.so (no .1 suffix; OS-provided system library since API level 24)
- macOS (x86_64, aarch64): dlopen libvulkan.1.dylib, libvulkan.dylib, libMoltenVK.dylib (MoltenVK Vulkan 1.3 portability layer over Metal)
- Windows (x86_64, aarch64): LoadLibraryW(L"vulkan-1.dll") matching the CUDA backend's use of LoadLibrary on Windows

The backend plugin (inferrs-backend-vulkan) uses libc::dlopen on POSIX and windows-sys LoadLibraryW on Windows, mirroring how the CUDA backend relies on cudarc fallback-dynamic-loading rather than hard-linking.

backend.rs gains dedicated platform modules for Android, macOS, and Windows aarch64, each with appropriate BackendKind variants and plugin search directories (Homebrew paths on macOS, /system/lib64 on Android, %ProgramFiles%\inferrs on Windows).

auto_device() in main.rs is split into per-platform cfg blocks so each OS gets the correct BackendKind match arms and log messages without dead-code warnings from mismatched variant sets.