### PR TITLE
fix: accept OpenAI structured content-part arrays in chat messages

### DIFF
--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -15,7 +15,9 @@ use std::sync::mpsc as stdmpsc;
 
 use crate::engine::{load_engine, AudioEmbedContext, StreamToken, SyncEngineRequest};
 use crate::sampler::SamplingParams;
-use crate::tokenizer::{apply_gemma4_with_audio, AudioInput, ChatMessage, Role, Tokenizer};
+use crate::tokenizer::{
+    apply_gemma4_with_audio, AudioInput, ChatMessage, MessageContent, Role, Tokenizer,
+};
 use crate::ServeArgs;
 
 // ─── CLI args ────────────────────────────────────────────────────────────────
@@ -188,7 +190,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         messages.push(ChatMessage {
             role: Role::System,
             audio: None,
-            content: sys.clone(),
+            content: MessageContent::from_string(sys),
         });
     }
 
@@ -217,7 +219,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
                     data: String::new(),
                     format: "wav".to_string(),
                 }),
-                content: prompt,
+                content: MessageContent::from_string(prompt),
             });
             let prompt_str = apply_gemma4_with_audio(&messages, &[n_audio_tokens]);
             let prompt_tokens = tokenizer.encode(&prompt_str, false)?;
@@ -235,7 +237,7 @@ fn run_blocking(args: RunArgs) -> Result<()> {
         messages.push(ChatMessage {
             role: Role::User,
             audio: None,
-            content: prompt,
+            content: MessageContent::from_string(prompt),
         });
         let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
         stream_response_collect(&engine_tx, prompt_tokens, audio_ctx, &sampling_params)?;
@@ -344,7 +346,7 @@ fn repl(
 
         messages.push(ChatMessage {
             role: Role::User,
-            content: user_content,
+            content: MessageContent::from_string(user_content),
             audio: None,
         });
 
@@ -375,7 +377,7 @@ fn repl(
         messages.push(ChatMessage {
             role: Role::Assistant,
             audio: None,
-            content: assistant_text,
+            content: MessageContent::from_string(assistant_text),
         });
     }
 
@@ -408,7 +410,7 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
                         0,
                         ChatMessage {
                             role: Role::System,
-                            content: parts[2].to_string(),
+                            content: MessageContent::from_string(parts[2]),
                             audio: None,
                         },
                     );

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -24,7 +24,9 @@ use crate::engine::{
     load_engine, AudioEmbedContext, EngineRequest, GenerationResult, OutputBuffer, StreamToken,
 };
 use crate::sampler::SamplingParams;
-use crate::tokenizer::{apply_gemma4_with_audio, AudioInput, ChatMessage, Role, Tokenizer};
+use crate::tokenizer::{
+    apply_gemma4_with_audio, AudioInput, ChatMessage, MessageContent, Role, Tokenizer,
+};
 use crate::ServeArgs;
 
 // ---------------------------------------------------------------------------
@@ -615,7 +617,7 @@ fn anthropic_messages_to_chat(
     if let Some(sys) = system {
         chat_messages.push(ChatMessage {
             role: Role::System,
-            content: sys.to_string(),
+            content: MessageContent::from_string(sys),
             audio: None,
         });
     }
@@ -626,7 +628,7 @@ fn anthropic_messages_to_chat(
         };
         chat_messages.push(ChatMessage {
             role,
-            content: msg.content.clone(),
+            content: MessageContent::from_string(&msg.content),
             audio: None,
         });
     }
@@ -1804,7 +1806,7 @@ async fn ollama_generate(
     } else {
         let msgs = vec![ChatMessage {
             role: Role::User,
-            content: prompt.to_string(),
+            content: MessageContent::from_string(prompt),
             audio: None,
         }];
         match tokenizer.apply_chat_template_and_encode(&msgs) {
@@ -1996,7 +1998,7 @@ async fn ollama_chat(
             };
             ChatMessage {
                 role,
-                content: m.content.clone(),
+                content: MessageContent::from_string(&m.content),
                 audio: None,
             }
         })

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -38,11 +38,117 @@ fn default_audio_format() -> String {
     "wav".to_string()
 }
 
+/// A single content part inside an OpenAI structured content array.
+///
+/// OpenAI clients may send `messages[].content` as either a plain string or an
+/// array of content-part objects.  This type covers the text-part case; other
+/// part types (image_url, etc.) are accepted and silently ignored so that
+/// clients do not receive a deserialization error.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContentPart {
+    /// Content part type — `"text"`, `"image_url"`, etc.
+    #[serde(rename = "type")]
+    pub part_type: String,
+    /// Text payload, present only when `type == "text"`.
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+/// The `content` field of a chat message.
+///
+/// OpenAI-compatible clients may send either:
+/// - a plain JSON string, or
+/// - a JSON array of content-part objects (e.g. `[{"type":"text","text":"…"}]`).
+///
+/// Both forms are accepted and normalised to a plain `String`.  Only `"text"`
+/// parts contribute to the string; all other part types (e.g. `"image_url"`)
+/// are ignored.
+#[derive(Debug, Clone)]
+pub struct MessageContent(pub String);
+
+impl<'de> Deserialize<'de> for MessageContent {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{self, Visitor};
+        use std::fmt;
+
+        struct MessageContentVisitor;
+
+        impl<'de> Visitor<'de> for MessageContentVisitor {
+            type Value = MessageContent;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a string or an array of content parts")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<MessageContent, E> {
+                Ok(MessageContent(v.to_owned()))
+            }
+
+            fn visit_string<E: de::Error>(self, v: String) -> Result<MessageContent, E> {
+                Ok(MessageContent(v))
+            }
+
+            fn visit_seq<A: de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<MessageContent, A::Error> {
+                let mut text = String::new();
+                while let Some(part) = seq.next_element::<ContentPart>()? {
+                    if part.part_type == "text" {
+                        if let Some(t) = part.text {
+                            text.push_str(&t);
+                        }
+                    }
+                    // Non-text parts (image_url, etc.) are silently ignored.
+                }
+                Ok(MessageContent(text))
+            }
+        }
+
+        deserializer.deserialize_any(MessageContentVisitor)
+    }
+}
+
+impl serde::Serialize for MessageContent {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl std::fmt::Display for MessageContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::ops::Deref for MessageContent {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl MessageContent {
+    /// Return the inner string content.
+    #[allow(dead_code)]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Construct from a plain string (for tests and internal use).
+    pub fn from_string(s: impl Into<String>) -> Self {
+        MessageContent(s.into())
+    }
+}
+
 /// A chat message (text + optional audio attachment).
 #[derive(Debug, Clone, serde::Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
-    pub content: String,
+    /// Message content — accepts a plain string or an OpenAI structured
+    /// content-part array (`[{"type":"text","text":"…"},…]`).
+    pub content: MessageContent,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio: Option<AudioInput>,
 }
@@ -417,7 +523,7 @@ mod tests {
         ChatMessage {
             role: Role::User,
             audio: None,
-            content: content.to_string(),
+            content: MessageContent::from_string(content),
         }
     }
 
@@ -425,7 +531,7 @@ mod tests {
         ChatMessage {
             role: Role::System,
             audio: None,
-            content: content.to_string(),
+            content: MessageContent::from_string(content),
         }
     }
 
@@ -433,7 +539,7 @@ mod tests {
         ChatMessage {
             role: Role::Assistant,
             audio: None,
-            content: content.to_string(),
+            content: MessageContent::from_string(content),
         }
     }
 
@@ -566,5 +672,53 @@ mod tests {
     #[test]
     fn detect_defaults_to_chatml_when_no_config() {
         assert!(matches!(detect_chat_template(&None), ChatTemplate::ChatML));
+    }
+
+    #[test]
+    fn message_content_deserializes_plain_string() {
+        let json = r#""Hello, world!""#;
+        let mc: MessageContent = serde_json::from_str(json).unwrap();
+        assert_eq!(mc.0, "Hello, world!");
+    }
+
+    #[test]
+    fn message_content_deserializes_content_part_array() {
+        let json = r#"[{"type":"text","text":"Hello"},{"type":"text","text":" world"}]"#;
+        let mc: MessageContent = serde_json::from_str(json).unwrap();
+        assert_eq!(mc.0, "Hello world");
+    }
+
+    #[test]
+    fn message_content_ignores_non_text_parts() {
+        let json = r#"[{"type":"image_url","url":"http://example.com/img.png"},{"type":"text","text":"What is this?"}]"#;
+        let mc: MessageContent = serde_json::from_str(json).unwrap();
+        assert_eq!(mc.0, "What is this?");
+    }
+
+    #[test]
+    fn chat_message_accepts_string_content() {
+        let json = r#"{"role":"user","content":"Hello!"}"#;
+        let msg: ChatMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.content.0, "Hello!");
+    }
+
+    #[test]
+    fn chat_message_accepts_content_part_array() {
+        let json = r#"{"role":"user","content":[{"type":"text","text":"Hello!"}]}"#;
+        let msg: ChatMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.content.0, "Hello!");
+    }
+
+    #[test]
+    fn content_part_array_works_in_chatml_template() {
+        // Verify that a ChatMessage built from a content-part array produces
+        // the same ChatML prompt as one built from a plain string.
+        let from_string = user_msg("Hello!");
+        let from_parts: ChatMessage =
+            serde_json::from_str(r#"{"role":"user","content":[{"type":"text","text":"Hello!"}]}"#)
+                .unwrap();
+        let prompt_string = apply_chatml(&[from_string], &None);
+        let prompt_parts = apply_chatml(&[from_parts], &None);
+        assert_eq!(prompt_string, prompt_parts);
     }
 }


### PR DESCRIPTION
The OpenAI spec allows messages[].content to be either a plain string or an array of content-part objects (e.g. [{"type":"text","text":"..."}]). inferrs only accepted plain strings, causing clients like OpenClaw to fail with a serde deserialization error when sending structured content.

Introduce MessageContent, a newtype that deserializes from either form, concatenating text parts and silently ignoring non-text parts such as image_url. Deref<Target=str> and Display keep all existing call sites unchanged. Add six tests covering string, array, and mixed-part inputs.