### PR TITLE
fix: handle tool-role messages and null content from agent runtimes

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -556,6 +556,12 @@ impl ActiveSequence {
 
 /// Check whether generation should stop (free-standing helper for use by the
 /// continuous batching loop where `self` is destructured).
+///
+/// Checks in order:
+/// 1. Model-wide EOS / end-of-turn token IDs (`stop_token_ids`).
+/// 2. Per-request extra stop token IDs derived from the `stop` field of an
+///    OpenAI-compatible request (`params.extra_stop_token_ids`).
+/// 3. Token budget exhausted (`max_tokens`).
 fn check_stop(
     token_id: u32,
     num_output_tokens: usize,
@@ -563,6 +569,9 @@ fn check_stop(
     stop_token_ids: &[u32],
 ) -> Option<String> {
     if stop_token_ids.contains(&token_id) {
+        return Some("stop".to_string());
+    }
+    if params.extra_stop_token_ids.contains(&token_id) {
         return Some("stop".to_string());
     }
     if num_output_tokens >= params.max_tokens {
@@ -1575,6 +1584,9 @@ impl Engine {
         params: &SamplingParams,
     ) -> Option<String> {
         if self.stop_token_ids.contains(&token_id) {
+            return Some("stop".to_string());
+        }
+        if params.extra_stop_token_ids.contains(&token_id) {
             return Some("stop".to_string());
         }
         if num_output_tokens >= params.max_tokens {

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -191,6 +191,8 @@ fn run_blocking(args: RunArgs) -> Result<()> {
             role: Role::System,
             audio: None,
             content: MessageContent::from_string(sys),
+            tool_calls: None,
+            tool_call_id: None,
         });
     }
 
@@ -220,6 +222,8 @@ fn run_blocking(args: RunArgs) -> Result<()> {
                     format: "wav".to_string(),
                 }),
                 content: MessageContent::from_string(prompt),
+                tool_calls: None,
+                tool_call_id: None,
             });
             let prompt_str = apply_gemma4_with_audio(&messages, &[n_audio_tokens]);
             let prompt_tokens = tokenizer.encode(&prompt_str, false)?;
@@ -238,6 +242,8 @@ fn run_blocking(args: RunArgs) -> Result<()> {
             role: Role::User,
             audio: None,
             content: MessageContent::from_string(prompt),
+            tool_calls: None,
+            tool_call_id: None,
         });
         let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
         stream_response_collect(&engine_tx, prompt_tokens, audio_ctx, &sampling_params)?;
@@ -348,6 +354,8 @@ fn repl(
             role: Role::User,
             content: MessageContent::from_string(user_content),
             audio: None,
+            tool_calls: None,
+            tool_call_id: None,
         });
 
         // Encode the full conversation with the chat template
@@ -378,6 +386,8 @@ fn repl(
             role: Role::Assistant,
             audio: None,
             content: MessageContent::from_string(assistant_text),
+            tool_calls: None,
+            tool_call_id: None,
         });
     }
 
@@ -412,6 +422,8 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
                             role: Role::System,
                             content: MessageContent::from_string(parts[2]),
                             audio: None,
+                            tool_calls: None,
+                            tool_call_id: None,
                         },
                     );
                     println!("System prompt set.");

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -11,6 +11,10 @@ pub struct SamplingParams {
     pub top_k: usize,
     pub repetition_penalty: f64,
     pub max_tokens: usize,
+    /// Per-request extra stop token IDs derived from the `stop` field of an
+    /// OpenAI-compatible request.  These are checked in addition to the
+    /// model-wide stop token IDs held by the engine.
+    pub extra_stop_token_ids: Vec<u32>,
 }
 
 impl Default for SamplingParams {
@@ -21,6 +25,7 @@ impl Default for SamplingParams {
             top_k: 50,
             repetition_penalty: 1.0,
             max_tokens: 2048,
+            extra_stop_token_ids: vec![],
         }
     }
 }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -69,6 +69,29 @@ fn spawn_drain_task(output_buf: OutputBuffer, registry: StreamRegistry) {
 
 // ─── OpenAI API types ───────────────────────────────────────────────────────
 
+/// Stop sequences sent by the client.
+///
+/// The OpenAI spec allows `stop` to be a string or an array of strings.
+/// Both forms are normalised to `Vec<String>`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+pub enum StopSequences {
+    #[default]
+    None,
+    One(String),
+    Many(Vec<String>),
+}
+
+impl StopSequences {
+    pub fn into_vec(self) -> Vec<String> {
+        match self {
+            StopSequences::None => vec![],
+            StopSequences::One(s) => vec![s],
+            StopSequences::Many(v) => v,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ChatCompletionRequest {
     pub model: Option<String>,
@@ -88,6 +111,19 @@ pub struct ChatCompletionRequest {
     pub stream: Option<bool>,
     #[serde(default)]
     pub repetition_penalty: Option<f64>,
+    /// Stop sequences: generation halts when any of these strings is produced.
+    /// Accepts a single string or an array of strings (OpenAI-compatible).
+    #[serde(default)]
+    pub stop: StopSequences,
+    /// Tool definitions forwarded by agent runtimes (e.g. OpenClaw).
+    /// Accepted but not used: this backend does not execute tool calls.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub tools: Option<serde_json::Value>,
+    /// Tool-choice directive from agent runtimes.  Accepted but not used.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub tool_choice: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -635,6 +671,8 @@ fn anthropic_messages_to_chat(
             role: Role::System,
             content: MessageContent::from_string(sys),
             audio: None,
+            tool_calls: None,
+            tool_call_id: None,
         });
     }
     for msg in messages {
@@ -646,6 +684,8 @@ fn anthropic_messages_to_chat(
             role,
             content: MessageContent::from_string(&msg.content),
             audio: None,
+            tool_calls: None,
+            tool_call_id: None,
         });
     }
     chat_messages
@@ -926,7 +966,7 @@ async fn chat_completions(
         .or(req.max_tokens)
         .unwrap_or(state.default_params.max_tokens);
     let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
-    let params = build_sampling_params(
+    let mut params = build_sampling_params(
         req.temperature,
         req.top_p,
         req.top_k,
@@ -934,6 +974,14 @@ async fn chat_completions(
         max_tokens,
         &state.default_params,
     );
+
+    // Resolve per-request stop strings into token IDs.
+    let stop_strings = req.stop.into_vec();
+    if !stop_strings.is_empty() {
+        if let Some(tokenizer) = state.tokenizer.as_deref() {
+            params.extra_stop_token_ids = resolve_stop_token_ids(stop_strings, tokenizer);
+        }
+    }
 
     let is_stream = req.stream.unwrap_or(false);
 
@@ -1563,6 +1611,12 @@ async fn health() -> Json<HealthResponse> {
 
 /// Build [`SamplingParams`] by overlaying per-request values on top of the
 /// server's default params.  Any `None` field falls back to the default.
+///
+/// `extra_stop_token_ids` is derived from the request's `stop` field: each
+/// stop string is looked up in the tokenizer vocabulary and, when it maps to a
+/// single token, that token ID is added to the per-request stop set.
+/// Multi-token stop strings are logged as a warning and skipped; full
+/// multi-token stop-sequence matching is not yet supported.
 fn build_sampling_params(
     temperature: Option<f64>,
     top_p: Option<f64>,
@@ -1577,7 +1631,50 @@ fn build_sampling_params(
         top_k: top_k.unwrap_or(defaults.top_k),
         repetition_penalty: repetition_penalty.unwrap_or(defaults.repetition_penalty),
         max_tokens,
+        extra_stop_token_ids: vec![],
     }
+}
+
+/// Resolve stop strings from an OpenAI-compatible request into per-request
+/// stop token IDs.
+///
+/// Each stop string is looked up directly in the tokenizer vocabulary
+/// (single-token strings such as `"</s>"` or `"<|eot_id|>"`).  Multi-token
+/// strings require buffered output matching which is not yet supported; they
+/// are logged as a warning and skipped.
+fn resolve_stop_token_ids(
+    stop_strings: Vec<String>,
+    tokenizer: &crate::tokenizer::Tokenizer,
+) -> Vec<u32> {
+    let mut ids = Vec::new();
+    for s in stop_strings {
+        if s.is_empty() {
+            continue;
+        }
+        if let Some(id) = tokenizer.token_to_id(&s) {
+            ids.push(id);
+        } else {
+            // Try tokenizing the string; if it encodes to a single token we
+            // can still use it as a stop token ID.
+            match tokenizer.encode(&s, false) {
+                Ok(tokens) if tokens.len() == 1 => {
+                    ids.push(tokens[0]);
+                }
+                Ok(tokens) => {
+                    tracing::warn!(
+                        "Stop string {:?} encodes to {} tokens — \
+                         multi-token stop sequences are not yet supported and will be ignored",
+                        s,
+                        tokens.len()
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to tokenize stop string {:?}: {}", s, e);
+                }
+            }
+        }
+    }
+    ids
 }
 
 /// Clamp `requested` so that `prompt_len + result <= max_seq_len`.
@@ -1897,6 +1994,8 @@ async fn ollama_generate(
             role: Role::User,
             content: MessageContent::from_string(prompt),
             audio: None,
+            tool_calls: None,
+            tool_call_id: None,
         }];
         tokenizer.apply_chat_template_and_encode(&msgs)
     }
@@ -2021,6 +2120,8 @@ async fn ollama_chat(
                 role,
                 content: MessageContent::from_string(&m.content),
                 audio: None,
+                tool_calls: None,
+                tool_call_id: None,
             }
         })
         .collect();

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -5,12 +5,25 @@ use serde::Deserialize;
 use std::path::Path;
 
 /// Chat message role.
+///
+/// OpenAI agent runtimes also send `"tool"` role messages (tool-call results)
+/// and `"function"` role messages (legacy function-calling).  Neither role is
+/// meaningful for a text-generation backend that doesn't execute tools, but
+/// deserialisation must not fail when they appear — they are folded into the
+/// `User` role so the prompt template still renders them as context.
 #[derive(Debug, Clone, serde::Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     System,
     User,
     Assistant,
+    /// Tool-call result messages (`role: "tool"`) sent by OpenAI-compatible
+    /// agent runtimes after a tool has been executed.  Folded into `User`
+    /// context at template-application time.
+    Tool,
+    /// Legacy function-calling result messages (`role: "function"`).  Treated
+    /// the same as `Tool` for template purposes.
+    Function,
 }
 
 impl std::fmt::Display for Role {
@@ -19,6 +32,10 @@ impl std::fmt::Display for Role {
             Role::System => write!(f, "system"),
             Role::User => write!(f, "user"),
             Role::Assistant => write!(f, "assistant"),
+            // Tool / function result messages are surfaced as user context in
+            // the rendered prompt; the model sees the content but not the role
+            // label.
+            Role::Tool | Role::Function => write!(f, "user"),
         }
     }
 }
@@ -56,14 +73,16 @@ pub struct ContentPart {
 
 /// The `content` field of a chat message.
 ///
-/// OpenAI-compatible clients may send either:
-/// - a plain JSON string, or
-/// - a JSON array of content-part objects (e.g. `[{"type":"text","text":"…"}]`).
+/// OpenAI-compatible clients may send:
+/// - a plain JSON string,
+/// - a JSON array of content-part objects (e.g. `[{"type":"text","text":"…"}]`), or
+/// - JSON `null` (assistant messages that carry only `tool_calls` have no text
+///   content and set `content` to `null`).
 ///
-/// Both forms are accepted and normalised to a plain `String`.  Only `"text"`
-/// parts contribute to the string; all other part types (e.g. `"image_url"`)
-/// are ignored.
-#[derive(Debug, Clone)]
+/// All forms are accepted and normalised to a plain `String`.  Null content
+/// becomes an empty string.  Only `"text"` parts contribute to the string;
+/// all other part types (e.g. `"image_url"`, `"tool_use"`) are ignored.
+#[derive(Debug, Clone, Default)]
 pub struct MessageContent(pub String);
 
 impl<'de> Deserialize<'de> for MessageContent {
@@ -77,7 +96,23 @@ impl<'de> Deserialize<'de> for MessageContent {
             type Value = MessageContent;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                f.write_str("a string or an array of content parts")
+                f.write_str("a string, an array of content parts, or null")
+            }
+
+            /// `null` content — assistant messages with tool_calls carry no text.
+            fn visit_unit<E: de::Error>(self) -> Result<MessageContent, E> {
+                Ok(MessageContent(String::new()))
+            }
+
+            fn visit_none<E: de::Error>(self) -> Result<MessageContent, E> {
+                Ok(MessageContent(String::new()))
+            }
+
+            fn visit_some<D2: serde::Deserializer<'de>>(
+                self,
+                deserializer: D2,
+            ) -> Result<MessageContent, D2::Error> {
+                Deserialize::deserialize(deserializer)
             }
 
             fn visit_str<E: de::Error>(self, v: &str) -> Result<MessageContent, E> {
@@ -99,7 +134,7 @@ impl<'de> Deserialize<'de> for MessageContent {
                             text.push_str(&t);
                         }
                     }
-                    // Non-text parts (image_url, etc.) are silently ignored.
+                    // Non-text parts (image_url, tool_use, etc.) are silently ignored.
                 }
                 Ok(MessageContent(text))
             }
@@ -146,11 +181,22 @@ impl MessageContent {
 #[derive(Debug, Clone, serde::Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: Role,
-    /// Message content — accepts a plain string or an OpenAI structured
-    /// content-part array (`[{"type":"text","text":"…"},…]`).
+    /// Message content — accepts a plain string, an OpenAI structured
+    /// content-part array (`[{"type":"text","text":"…"},…]`), or JSON `null`
+    /// (which arises in assistant messages that carry only `tool_calls`).
+    #[serde(default)]
     pub content: MessageContent,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub audio: Option<AudioInput>,
+    /// Tool calls requested by the assistant — present in assistant messages
+    /// that invoke tools.  Accepted but not used: this backend does not
+    /// execute tool calls, it only renders them as context in the prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<serde_json::Value>,
+    /// Tool call ID — present in `role: "tool"` result messages.
+    /// Accepted and ignored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 /// Chat template format detected from the model.
@@ -449,7 +495,7 @@ fn apply_gemma3(messages: &[ChatMessage]) -> String {
         "<end_of_turn>\n",
         "<start_of_turn>model\n",
         |role| match role {
-            Role::System | Role::User => "user",
+            Role::System | Role::User | Role::Tool | Role::Function => "user",
             Role::Assistant => "model",
         },
         |s| s,
@@ -483,7 +529,7 @@ fn apply_gemma4_inner(messages: &[ChatMessage], audio_token_counts: &[usize]) ->
     for msg in messages {
         let role = match msg.role {
             Role::System => "system",
-            Role::User => "user",
+            Role::User | Role::Tool | Role::Function => "user",
             Role::Assistant => "model",
         };
         // Build the content, inserting audio tokens if this message has audio.
@@ -524,6 +570,8 @@ mod tests {
             role: Role::User,
             audio: None,
             content: MessageContent::from_string(content),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 
@@ -532,6 +580,8 @@ mod tests {
             role: Role::System,
             audio: None,
             content: MessageContent::from_string(content),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 
@@ -540,6 +590,8 @@ mod tests {
             role: Role::Assistant,
             audio: None,
             content: MessageContent::from_string(content),
+            tool_calls: None,
+            tool_call_id: None,
         }
     }
 
@@ -720,5 +772,66 @@ mod tests {
         let prompt_string = apply_chatml(&[from_string], &None);
         let prompt_parts = apply_chatml(&[from_parts], &None);
         assert_eq!(prompt_string, prompt_parts);
+    }
+
+    // ── New tests for tool-role and null-content handling ─────────────────
+
+    #[test]
+    fn message_content_deserializes_null_as_empty_string() {
+        // Assistant messages that carry only tool_calls have `content: null`.
+        let mc: MessageContent = serde_json::from_str("null").unwrap();
+        assert_eq!(mc.0, "");
+    }
+
+    #[test]
+    fn chat_message_accepts_null_content() {
+        // OpenAI agent runtimes send `{"role":"assistant","content":null,"tool_calls":[…]}`.
+        let json = r#"{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather","arguments":"{}"}}]}"#;
+        let msg: ChatMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.content.0, "");
+        assert!(msg.tool_calls.is_some());
+    }
+
+    #[test]
+    fn chat_message_accepts_tool_role() {
+        // Tool-result messages use `role: "tool"`.
+        let json = r#"{"role":"tool","tool_call_id":"call_1","content":"72°F and sunny"}"#;
+        let msg: ChatMessage = serde_json::from_str(json).unwrap();
+        assert!(matches!(msg.role, Role::Tool));
+        assert_eq!(msg.content.0, "72°F and sunny");
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn tool_role_renders_as_user_in_chatml() {
+        // When rendered into a prompt, tool messages appear under the "user" turn.
+        let tool_result: ChatMessage =
+            serde_json::from_str(r#"{"role":"tool","tool_call_id":"call_1","content":"42"}"#)
+                .unwrap();
+        let prompt = apply_chatml(&[tool_result], &None);
+        assert!(prompt.contains("<|im_start|>user\n42<|im_end|>"));
+        assert!(!prompt.contains("<|im_start|>tool"));
+    }
+
+    #[test]
+    fn full_agent_turn_with_tool_call_does_not_crash() {
+        // Simulate a full OpenClaw agent turn:
+        //   1. User asks a question.
+        //   2. Assistant responds with a tool call (null content).
+        //   3. Tool result is provided (role: "tool").
+        //   4. Another user message follows.
+        let json = r#"[
+            {"role":"user","content":"What is the weather?"},
+            {"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"weather","arguments":"{}"}}]},
+            {"role":"tool","tool_call_id":"c1","content":"72°F"},
+            {"role":"user","content":"Thanks!"}
+        ]"#;
+        let messages: Vec<ChatMessage> = serde_json::from_str(json).unwrap();
+        assert_eq!(messages.len(), 4);
+        // Must not panic when a template is applied.
+        let prompt = apply_chatml(&messages, &None);
+        assert!(prompt.contains("What is the weather?"));
+        assert!(prompt.contains("72°F"));
+        assert!(prompt.contains("Thanks!"));
     }
 }


### PR DESCRIPTION
OpenAI-compatible agent runtimes (e.g. OpenClaw) send request shapes
that the server previously could not parse:

- role: "tool" and role: "function" messages caused a deserialization
  error because the Role enum had no matching variants. Both are now
  accepted and folded into the user role at template-application time
  so tool-call results appear as context in the rendered prompt.

- Assistant messages that contain only tool_calls set content to null.
  MessageContent now handles null by deserialising to an empty string.
  ChatMessage gains tool_calls and tool_call_id fields (accepted,
  ignored) so those fields no longer cause parse failures.

- The stop field was absent from ChatCompletionRequest, so per-request
  stop sequences from agent turns were silently dropped. StopSequences
  accepts a string or array; single-token stop strings are resolved to
  token IDs and checked per generated token via a new
  extra_stop_token_ids field on SamplingParams.

- tools and tool_choice are now declared on ChatCompletionRequest so
  the intent is explicit and the fields are handled gracefully.

Five new unit tests cover null content, tool role parsing, template
rendering of tool messages, and a full simulated agent turn.