### PR TITLE
fix: sliding-window layers to crash

### DIFF
--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -1240,8 +1240,18 @@ impl Attention {
             KvCache::Normal(RetainingKvCache::new(cfg.max_position_embeddings))
         };
 
-        let tq_cache =
-            tq_cfg.map(|c| TurboQuantKvCache::new(c, num_kv_heads, cfg.dtype, cfg.device.clone()));
+        // TurboQuant KV compression is only applied to global (non-sliding) attention
+        // layers.  Sliding layers use a fixed-size rotating KV cache (512 tokens) and
+        // `RetainingRotatingKvCache::append` already returns only the most-recent
+        // `sliding_window` tokens.  If TurboQuant were used for a sliding layer it
+        // would return all accumulated tokens (no truncation), causing a shape mismatch
+        // between the KV tensor and the sliding attention mask on the second prompt when
+        // the total conversation length exceeds the sliding window size.
+        let tq_cache = if is_sliding {
+            None
+        } else {
+            tq_cfg.map(|c| TurboQuantKvCache::new(c, num_kv_heads, cfg.dtype, cfg.device.clone()))
+        };
 
         // Enable the fused SDPA kernel for Metal when the head dim is supported.
         // The Metal SDPA vector kernel (q_seq=1) supports head dims {32,64,96,128,256}
@@ -3468,6 +3478,114 @@ mod tests {
             assert_eq!(
                 v, 0.0,
                 "slot {j} should be visible after long prompt decode"
+            );
+        }
+    }
+
+    // ── Regression: multi-turn conversation KV/mask shape agreement ──────────
+    //
+    // Issue: "shape mismatch in broadcast_add, lhs: [1, 8, 662, 662], rhs: [1, 1, 662, 512]"
+    //        (also reported as [1,8,716,716] vs [1,1,716,512] and [1,8,741,741] vs [1,1,741,512])
+    //
+    // Root cause: TurboQuant was enabled for *both* global and sliding attention
+    // layers.  The REPL feeds the full conversation history as a fresh prefill
+    // every turn.  By the second or third turn the combined token count exceeds
+    // `sliding_window = 512`.  TurboQuant returns all N tokens (no truncation),
+    // but `prepare_decoder_attention_mask` builds the mask for `min(N, 512)` KV
+    // positions.  The `broadcast_add(attn_weights, mask)` then sees mismatched
+    // last dimensions (N vs 512) and crashes.
+    //
+    // Fix: `tq_cache = None` for sliding layers (`Attention::new`, gemma4.rs).
+    // Sliding layers fall back to `RetainingRotatingKvCache`, which already caps
+    // its output at `sliding_window`.
+    //
+    // This test simulates the REPL's multi-turn prefill pattern directly:
+    // it feeds accumulated conversation token counts (as a full re-prefill each
+    // turn, `seqlen_offset = 0`) through `RetainingRotatingKvCache` and checks
+    // that the KV output length always equals the mask's `kv_len`.  If TurboQuant
+    // were re-enabled for sliding layers the analogous check in turbo_quant.rs
+    // (`turbo_quant_kv_output_exceeds_sliding_window_without_cap`) would catch it.
+
+    /// Simulate N turns of the REPL through `RetainingRotatingKvCache`.
+    ///
+    /// Each turn re-prefills the full conversation history (no `seqlen_offset`).
+    /// Returns `(kv_out_len, mask_kv_len)` for every turn; they must always be
+    /// equal — a mismatch is the exact condition that causes the broadcast_add crash.
+    fn simulate_repl_turns(
+        sliding_window: usize,
+        turn_token_counts: &[usize],
+    ) -> Vec<(usize, usize)> {
+        let head_dim = 4usize;
+        let mut cumulative = 0usize;
+        let mut results = Vec::new();
+
+        for &turn_len in turn_token_counts {
+            cumulative += turn_len;
+
+            // Each turn: fresh cache reset + full re-prefill (seqlen_offset = 0).
+            let mut cache = RetainingRotatingKvCache::new(sliding_window);
+            cache.reset();
+            let k =
+                Tensor::ones((1usize, 1usize, cumulative, head_dim), DType::F32, &cpu()).unwrap();
+            let (k_out, _) = cache.append(&k, &k).unwrap();
+            let kv_out_len = k_out.dim(2).unwrap();
+            let mask_kv_len = cumulative.min(sliding_window);
+            results.push((kv_out_len, mask_kv_len));
+        }
+
+        results
+    }
+
+    /// Regression test for GitHub issue #130:
+    /// "shape mismatch in broadcast_add" in multi-turn conversations.
+    ///
+    /// Simulates the exact scenario from the issue: a real-estate assistant
+    /// conversation where 3 turns push the cumulative token count past 512.
+    /// Each turn re-prefills the full history (seqlen_offset = 0).
+    ///
+    /// For every turn, the KV output length from the sliding-window cache must
+    /// equal the mask's kv_len.  A mismatch → broadcast_add crash.
+    #[test]
+    fn multi_turn_sliding_kv_matches_mask_no_crash() {
+        // Approximate token counts from the GitHub issue reproduction:
+        //   turn 1: long system+user prompt       (~380 tokens)
+        //   turn 2: short follow-up               (~50 tokens)
+        //   turn 3: another follow-up             (~232 tokens, cumulative 662 → crash)
+        let turn_tokens = [380usize, 50, 232];
+        let sliding_window = 512usize;
+
+        for (i, (kv_out_len, mask_kv_len)) in simulate_repl_turns(sliding_window, &turn_tokens)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(
+                kv_out_len,
+                mask_kv_len,
+                "turn {}: KV output len ({kv_out_len}) != mask kv_len ({mask_kv_len}) \
+                 — this is the broadcast_add shape mismatch from issue #130",
+                i + 1
+            );
+        }
+    }
+
+    /// Same scenario but using the exact shapes from the second reporter
+    /// in issue #130: crash at [1,8,716,716] vs [1,1,716,512].
+    #[test]
+    fn multi_turn_sliding_kv_matches_mask_716_tokens() {
+        // turn 1: ~380 tokens (large system+user), turn 2: ~84, turn 3: ~252 → 716
+        let turn_tokens = [380usize, 84, 252];
+        let sliding_window = 512usize;
+
+        for (i, (kv_out_len, mask_kv_len)) in simulate_repl_turns(sliding_window, &turn_tokens)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(
+                kv_out_len,
+                mask_kv_len,
+                "turn {}: KV output len ({kv_out_len}) != mask kv_len ({mask_kv_len}) \
+                 — broadcast_add would crash at [1,8,716,716] vs [1,1,716,512]",
+                i + 1
             );
         }
     }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1757,6 +1757,18 @@ fn format_tools_as_system_context(tools: &serde_json::Value) -> String {
         return String::new();
     }
 
+    // Collect the set of required parameter names for a tool schema, if any.
+    fn required_set(tool: &serde_json::Value) -> std::collections::HashSet<&str> {
+        tool.pointer("/function/parameters/required")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<std::collections::HashSet<_>>()
+            })
+            .unwrap_or_default()
+    }
+
     let mut lines = Vec::new();
     lines.push("Available tools:".to_string());
     for tool in arr {
@@ -1775,14 +1787,25 @@ fn format_tools_as_system_context(tools: &serde_json::Value) -> String {
         } else {
             lines.push(format!("- {name}: {description}"));
         }
-        // Include parameter names when present so the model can form valid calls.
+        // Include parameter names, types, and whether each is required so the
+        // model can form valid calls with the correct argument shapes.
         if let Some(props) = tool
             .pointer("/function/parameters/properties")
             .and_then(|v| v.as_object())
         {
-            let param_names: Vec<&str> = props.keys().map(String::as_str).collect();
-            if !param_names.is_empty() {
-                lines.push(format!("  parameters: {}", param_names.join(", ")));
+            if !props.is_empty() {
+                let required = required_set(tool);
+                let mut param_parts: Vec<String> = Vec::with_capacity(props.len());
+                for (param_name, schema) in props {
+                    let type_str = schema.get("type").and_then(|v| v.as_str()).unwrap_or("any");
+                    let req_marker = if required.contains(param_name.as_str()) {
+                        ""
+                    } else {
+                        "?"
+                    };
+                    param_parts.push(format!("{param_name}{req_marker}: {type_str}"));
+                }
+                lines.push(format!("  parameters: {}", param_parts.join(", ")));
             }
         }
     }
@@ -1884,10 +1907,12 @@ async fn ollama_show(
     Json(req): Json<OllamaShowRequest>,
 ) -> impl IntoResponse {
     // Check that the requested model matches the loaded model (if any).
+    // Uses flexible matching so clients that omit the org prefix (e.g.
+    // "gemma-4-E2B-it" vs "google/gemma-4-E2B-it") are not rejected.
     let model_matches = state
         .model_id
         .as_deref()
-        .map(|id| id == req.model)
+        .map(|id| model_matches_id(id, &req.model))
         .unwrap_or(false);
     if !model_matches {
         return Err((
@@ -1983,12 +2008,41 @@ fn ollama_options_to_params(
 /// HTTP error response type for Ollama-compatible endpoints.
 type OllamaHttpError = (StatusCode, Json<serde_json::Value>);
 
+/// Check whether a client-supplied `model` string matches the loaded model ID.
+///
+/// Ollama clients may omit the HuggingFace org prefix — for example a client
+/// may send `"gemma-4-E2B-it"` while the server was started with
+/// `"google/gemma-4-E2B-it"`.  Both forms are accepted:
+///
+/// - Exact match: `"google/gemma-4-E2B-it"` == `"google/gemma-4-E2B-it"`
+/// - Prefix-stripped match: `"gemma-4-E2B-it"` matches `"google/gemma-4-E2B-it"`
+///   (client omitted the `org/` prefix)
+fn model_matches_id(loaded_id: &str, requested: &str) -> bool {
+    if loaded_id == requested {
+        return true;
+    }
+    // Allow clients that strip the `org/` prefix.
+    if let Some(after_slash) = loaded_id.split_once('/').map(|(_, name)| name) {
+        if after_slash == requested {
+            return true;
+        }
+    }
+    false
+}
+
 fn require_ollama_tokenizer<'a>(
     state: &'a AppState,
     model: &str,
 ) -> Result<&'a Tokenizer, OllamaHttpError> {
     match state.tokenizer.as_deref() {
-        Some(t) if state.model_id.as_deref() == Some(model) => Ok(t),
+        Some(t)
+            if state
+                .model_id
+                .as_deref()
+                .is_some_and(|id| model_matches_id(id, model)) =>
+        {
+            Ok(t)
+        }
         Some(_) => Err((
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({

--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -1218,4 +1218,60 @@ mod tests {
             t_prefill + 1
         );
     }
+
+    /// Document that `TurboQuantKvCache` returns *all* accumulated tokens with no
+    /// sliding-window cap — confirming why it must not be used for sliding-window
+    /// attention layers.
+    ///
+    /// The multi-turn crash (GitHub issue #130, "shape mismatch in broadcast_add,
+    /// lhs: [1,8,662,662], rhs: [1,1,662,512]") occurred because TurboQuant was
+    /// used for sliding layers: it returned all N > 512 tokens from the combined
+    /// multi-turn prefill, while `prepare_decoder_attention_mask` built a mask only
+    /// 512 columns wide.  `broadcast_add` then saw mismatched last dimensions.
+    ///
+    /// `RetainingRotatingKvCache` is the correct cache for sliding layers because it
+    /// caps its output at `sliding_window`; this test verifies TurboQuant does NOT.
+    #[test]
+    fn turbo_quant_kv_output_exceeds_sliding_window_without_cap() {
+        // Reproduce the exact token count from issue #130 (662 tokens, window 512).
+        let head_dim = 32usize;
+        let n_kv_heads = 1usize;
+        let sliding_window = 512usize;
+        let combined_prefill = 662usize; // cumulative turns 1+2+3 token count at crash
+
+        let device = test_device();
+        let dtype = test_dtype(&device);
+        let mut tq_cache = TurboQuantKvCache::new(
+            &TurboQuantConfig { bits: 8, head_dim },
+            n_kv_heads,
+            dtype,
+            device.clone(),
+        )
+        .without_warmup();
+
+        let k = Tensor::zeros((1, n_kv_heads, combined_prefill, head_dim), dtype, &device).unwrap();
+        tq_cache.append(&k, &k).unwrap();
+        let (k_out, _) = tq_cache.dequantize().unwrap();
+
+        // TurboQuant returns all 662 tokens — no sliding-window cap.
+        assert_eq!(
+            k_out.dim(2).unwrap(),
+            combined_prefill,
+            "TurboQuantKvCache must return all tokens (no sliding cap); \
+             if this fails the cache has been made sliding-window-aware"
+        );
+
+        // The mask would be built for min(662, 512) = 512 columns.
+        let mask_kv_len = combined_prefill.min(sliding_window);
+
+        // These differ → broadcast_add would crash: [1,8,662,662] vs [1,1,662,512].
+        // This is why `Attention::new` sets `tq_cache = None` for sliding layers.
+        assert_ne!(
+            k_out.dim(2).unwrap(),
+            mask_kv_len,
+            "Expected TurboQuant ({} tokens) to differ from mask kv_len ({mask_kv_len}); \
+             if they match, TurboQuant now caps at the window and this test should be updated",
+            k_out.dim(2).unwrap()
+        );
+    }
 }


### PR DESCRIPTION
TurboQuantKvCache has no sliding-window cap — it returns all accumulated tokens. Sliding attention layers use a fixed rotating KV cache (512 tokens) and prepare_decoder_attention_mask builds a mask of width min(seq, 512). When TurboQuant was enabled for sliding layers the KV output width (N) and mask width (512) diverged on any multi-turn prefill where N > 512, causing:

  shape mismatch in broadcast_add, lhs: [1,8,662,662], rhs: [1,1,662,512]

Fix: set tq_cache = None for is_sliding layers in Attention::new so they fall back to RetainingRotatingKvCache, which already caps output correctly. Global layers continue using TurboQuant compression unchanged.

Also fix Ollama model-ID matching to accept org-prefixed IDs (google/gemma-4-E2B-it) alongside bare IDs (gemma-4-E2B-it), and improve format_tools_as_system_context to include parameter types and required markers so models without native tool-call support can form valid calls.

Tests: add turbo_quant_kv_output_exceeds_sliding_window_without_cap to document TurboQuant's uncapped behaviour, and multi_turn_sliding_kv_* to simulate the exact REPL conversation shapes from issue #130.