### PR TITLE
Fix/think filter cli arg

### DIFF
--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -179,7 +179,7 @@ pub struct ServeArgs {
     /// Enabled by default for models that emit thinking blocks (Gemma4, Qwen3,
     /// NVFP4).  Pass `--think-filter=false` to pass those tokens through to the
     /// client unchanged, matching the behaviour of llama-server.
-    #[arg(long, default_value_t = true, require_equals(true))]
+    #[arg(long, default_value = "true", require_equals(true), num_args(1))]
     pub think_filter: bool,
 }
 

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -99,7 +99,7 @@ pub struct RunArgs {
     ///
     /// Enabled by default for models that emit thinking blocks (Gemma4, Qwen3,
     /// NVFP4).  Pass `--think-filter=false` to see raw reasoning tokens.
-    #[arg(long, default_value_t = true, require_equals(true))]
+    #[arg(long, default_value = "true", require_equals(true), num_args(1))]
     pub think_filter: bool,
 }
 

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -770,3 +770,39 @@ fn print_dim(text: &str) {
     )
     .ok();
 }
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// `--think-filter=false` must parse to `false`.
+    ///
+    /// Before the fix (using `default_value_t = true` without `num_args(1)`),
+    /// clap did not consume the `=false` value correctly with `require_equals`,
+    /// causing the flag to always be `true` or the parse to fail.
+    #[test]
+    fn think_filter_false() {
+        let args = RunArgs::try_parse_from(["inferrs", "some-model", "--think-filter=false"])
+            .expect("should parse --think-filter=false");
+        assert!(!args.think_filter, "--think-filter=false should set think_filter to false");
+    }
+
+    /// `--think-filter=true` must parse to `true`.
+    #[test]
+    fn think_filter_true() {
+        let args = RunArgs::try_parse_from(["inferrs", "some-model", "--think-filter=true"])
+            .expect("should parse --think-filter=true");
+        assert!(args.think_filter, "--think-filter=true should set think_filter to true");
+    }
+
+    /// When `--think-filter` is omitted, the default should be `true`.
+    #[test]
+    fn think_filter_default_is_true() {
+        let args = RunArgs::try_parse_from(["inferrs", "some-model"])
+            .expect("should parse without --think-filter");
+        assert!(args.think_filter, "default think_filter should be true");
+    }
+}


### PR DESCRIPTION
`--think-filter=false` panics at runtime with clap 4.6's debug assertion: *"Arg::is_takes_value_set is required when Arg::is_require_equals_set is set"*.

The fix switches from `default_value_t = true` to `default_value = "true"` with explicit `num_args(1)`, which tells clap the flag always takes exactly one value after `=`.

Includes unit tests covering `--think-filter=false`, `--think-filter=true`, and the default (omitted → `true`).