### PR TITLE
test: expand OpenClaw agent-turn coverage for Gemma4 and tool injection

### DIFF
--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -2572,4 +2572,78 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].content.0, "Available tools:\n- noop");
     }
+
+    #[test]
+    fn format_tools_marks_required_parameters() {
+        // Required parameters must not have the '?' suffix; optional ones must.
+        let tools = serde_json::json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search the web",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "limit": {"type": "integer"}
+                        },
+                        "required": ["query"]
+                    }
+                }
+            }
+        ]);
+        let result = format_tools_as_system_context(&tools);
+        // "query" is required — no '?' marker.
+        assert!(
+            result.contains("query: string"),
+            "required param should have no '?' suffix"
+        );
+        // "limit" is optional — must have '?' marker.
+        assert!(
+            result.contains("limit?: integer"),
+            "optional param must have '?' suffix"
+        );
+    }
+
+    #[test]
+    fn inject_tools_full_openclaw_agent_request_does_not_crash() {
+        // Simulate the full set of messages OpenClaw sends on a realistic agent
+        // turn: system prompt, user message, assistant tool-call (null content),
+        // tool result, and a follow-up user message.  The tool injection logic
+        // must produce a message list that the tokenizer templates can render
+        // without panicking.
+        use crate::tokenizer::Role;
+
+        let tool_summary =
+            "Available tools:\n- get_weather: Get current weather\n  parameters: city: string";
+        let messages: Vec<ChatMessage> = serde_json::from_str(
+            r#"[
+                {"role":"system","content":"You are helpful."},
+                {"role":"user","content":"What is the weather in Paris?"},
+                {"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},
+                {"role":"tool","tool_call_id":"c1","content":"18°C, partly cloudy"},
+                {"role":"user","content":"Thanks!"}
+            ]"#,
+        )
+        .unwrap();
+
+        let result = inject_tools_into_messages(&messages, tool_summary);
+
+        // Injection merges tool summary into the existing system message.
+        assert_eq!(
+            result.len(),
+            messages.len(),
+            "message count must not change"
+        );
+        assert!(matches!(result[0].role, Role::System));
+        assert!(result[0].content.0.contains("You are helpful."));
+        assert!(result[0].content.0.contains("Available tools:"));
+        // Remaining messages are unchanged.
+        assert!(matches!(result[1].role, Role::User));
+        assert!(matches!(result[2].role, Role::Assistant));
+        assert!(result[2].tool_calls.is_some());
+        assert!(matches!(result[3].role, Role::Tool));
+        assert!(matches!(result[4].role, Role::User));
+    }
 }

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -996,6 +996,104 @@ mod tests {
     }
 
     #[test]
+    fn full_openclaw_agent_turn_gemma4_is_well_formed() {
+        // Simulate a realistic OpenClaw multi-tool-call agent conversation
+        // rendered with the Gemma4 template:
+        //   system prompt → user → assistant (tool call, null content) →
+        //   tool result → assistant (text reply) → user follow-up
+        //
+        // After normalization:
+        // - The empty assistant tool-call turn is dropped.
+        // - The tool result (folded to "user") and the final user message are
+        //   consecutive user turns → merged into one.
+        // - Two user turns remain: the original question, and the merged
+        //   (tool-result + follow-up) turn.
+        let json = r#"[
+            {"role":"system","content":"You are a helpful assistant."},
+            {"role":"user","content":"What is the weather in Paris?"},
+            {"role":"assistant","content":null,"tool_calls":[{"id":"c1","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]},
+            {"role":"tool","tool_call_id":"c1","content":"Partly cloudy, 18°C"},
+            {"role":"assistant","content":"The weather in Paris is partly cloudy at 18°C."},
+            {"role":"user","content":"Thanks!"}
+        ]"#;
+        let messages: Vec<ChatMessage> = serde_json::from_str(json).unwrap();
+        let prompt = apply_gemma4(&messages);
+
+        // System turn must be present.
+        assert!(
+            prompt.contains("<|turn>system\nYou are a helpful assistant."),
+            "system turn missing from Gemma4 prompt"
+        );
+        // No empty model turn from the dropped tool-call message.
+        assert!(
+            !prompt.contains("<|turn>model\n<turn|>"),
+            "empty model turn must not appear"
+        );
+        // Two user turns: original question + merged (tool-result + thanks).
+        let user_turns: Vec<_> = prompt.match_indices("<|turn>user").collect();
+        assert_eq!(
+            user_turns.len(),
+            2,
+            "expected: question turn + merged (tool-result + Thanks!) turn; got {} user turns",
+            user_turns.len()
+        );
+        // Text assistant reply is present.
+        assert!(
+            prompt.contains("partly cloudy at 18°C"),
+            "assistant text reply missing"
+        );
+        // Tool result is present.
+        assert!(
+            prompt.contains("Partly cloudy, 18°C"),
+            "tool result missing"
+        );
+        // User follow-up is present.
+        assert!(prompt.contains("Thanks!"), "user follow-up missing");
+        // Prompt ends with the model turn opener.
+        assert!(
+            prompt.ends_with("<|turn>model\n"),
+            "prompt must end with model turn opener"
+        );
+    }
+
+    #[test]
+    fn gemma4_tool_injection_via_system_context() {
+        // Verify that when a system message is already present, tool context
+        // injected into it produces a well-formed Gemma4 prompt with exactly
+        // one system turn containing both the original system text and the tool
+        // summary.  This mirrors the server-level inject_tools_into_messages
+        // path for Gemma4 models.
+        let tool_summary =
+            "Available tools:\n- get_weather: Get current weather\n  parameters: city: string";
+
+        let messages = vec![
+            ChatMessage {
+                role: Role::System,
+                content: MessageContent::from_string(format!(
+                    "You are a helpful assistant.\n\n{tool_summary}"
+                )),
+                audio: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            user_msg("What is the weather in Paris?"),
+        ];
+        let prompt = apply_gemma4(&messages);
+
+        // Exactly one system turn.
+        let system_turns: Vec<_> = prompt.match_indices("<|turn>system").collect();
+        assert_eq!(system_turns.len(), 1, "expected exactly one system turn");
+        // Both the original text and the tool summary are present.
+        assert!(prompt.contains("You are a helpful assistant."));
+        assert!(prompt.contains("Available tools:"));
+        assert!(prompt.contains("get_weather"));
+        // Exactly one user turn.
+        let user_turns: Vec<_> = prompt.match_indices("<|turn>user").collect();
+        assert_eq!(user_turns.len(), 1, "expected exactly one user turn");
+        assert!(prompt.ends_with("<|turn>model\n"));
+    }
+
+    #[test]
     fn full_openclaw_agent_turn_chatml_is_well_formed() {
         // Simulate a realistic OpenClaw multi-tool-call agent conversation:
         //   system prompt → user → assistant (tool call, null content) →

--- a/inferrs/tests/server_integration.rs
+++ b/inferrs/tests/server_integration.rs
@@ -341,6 +341,49 @@ fn gemma4_e2b_long_context_no_crash() {
     }
 }
 
+/// Verifies that `google/gemma-4-E2B-it` with 4-bit TurboQuant compression
+/// returns a coherent response to a basic chat message.
+///
+/// This test exercises the 4-bit KV cache path end-to-end, ensuring that the
+/// nibble-packing/unpacking round-trip does not corrupt inference.
+///
+/// Run with:
+/// ```
+/// cargo test --test server_integration gemma4_e2b_turbo_quant_4bit_returns_intelligible_output -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "requires model download and significant compute; run with --ignored"]
+fn gemma4_e2b_turbo_quant_4bit_returns_intelligible_output() {
+    let model_id = "google/gemma-4-E2B-it";
+    let port = free_port();
+
+    let mut server = spawn_server_turbo(model_id, port, 4);
+
+    let result = std::panic::catch_unwind(|| {
+        wait_for_health(port, Duration::from_secs(300));
+
+        let resp = chat_completion(port, "What is 2 + 2?");
+        assert!(
+            looks_intelligible(&resp),
+            "4-bit TurboQuant response is not intelligible.\nGot: {:?}",
+            resp
+        );
+        assert!(
+            resp.contains('4'),
+            "expected the answer '4' in TurboQuant response.\nGot: {:?}",
+            resp
+        );
+        eprintln!("4-bit TurboQuant response: {:?}", resp);
+    });
+
+    let _ = server.kill();
+    let _ = server.wait();
+
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}
+
 /// Verifies that `google/gemma-4-E2B-it` with `--paged-attention` handles a
 /// long prompt (>512 tokens) and that a second request after the first
 /// completes successfully (exercises block reuse correctness).


### PR DESCRIPTION
Add tests documenting and verifying the fixes for all three critiques raised in the OpenClaw inferrs provider docs:

- full_openclaw_agent_turn_gemma4_is_well_formed: end-to-end Gemma4 template test with system prompt, tool-call turn (null content), tool result, text assistant reply, and user follow-up; asserts no empty model turns and correct user-turn merging.

- gemma4_tool_injection_via_system_context: verifies that tool context injected into an existing Gemma4 system message produces exactly one system turn with both original text and tool summary present.

- format_tools_marks_required_parameters: asserts required params have no '?' suffix and optional params do, so models can form valid calls.

- inject_tools_full_openclaw_agent_request_does_not_crash: exercises inject_tools_into_messages with a full realistic OpenClaw message list (system, user, assistant tool-call, tool result, follow-up).

- gemma4_e2b_turbo_quant_4bit_returns_intelligible_output: integration test (ignored) for the 4-bit TurboQuant KV cache path; also removes the dead-code warning on spawn_server_turbo.