### PR TITLE
fix: upgrade float8 to v0.7.0 and repair CUDA linker paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
           sudo ln -sfn /usr/local/cuda/lib64/stubs/libcuda.so \
                        /usr/local/cuda/lib64/stubs/libcuda.so.1
           echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+          # candle-kernels/build.rs emits `cargo:rustc-link-lib=dylib=cudart`.
+          # The linker needs to find libcudart.so which lives in lib64 (not stubs).
+          echo "LIBRARY_PATH=/usr/local/cuda/lib64:${LIBRARY_PATH}" >> "$GITHUB_ENV"
 
       # Install CUDA toolkit and set up MSVC environment on Windows x86_64.
       # Jimver/cuda-toolkit installs nvcc and adds it to PATH; ilammy/msvc-dev-cmd
@@ -111,6 +114,16 @@ jobs:
       - name: Set up MSVC environment (Windows x86_64 — nvcc needs cl.exe)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         uses: ilammy/msvc-dev-cmd@v1
+
+      # candle-kernels/build.rs emits `cargo:rustc-link-lib=dylib=cudart`.
+      # The MSVC linker resolves .lib files via the LIB env var; expose the
+      # CUDA lib/x64 directory so cudart.lib can be found at link time.
+      - name: Add CUDA lib to MSVC linker search path (Windows x86_64)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $cudaLib = "$env:CUDA_PATH\lib\x64"
+          echo "LIB=$cudaLib;$env:LIB" >> $env:GITHUB_ENV
 
       # Git ships its own link.exe in usr/bin which shadows MSVC's link.exe
       # when bash shells are used. Rename it so the MSVC linker is found first.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
  "candle-metal-kernels",
  "candle-ug",
  "cudarc 0.19.4",
- "float8 0.6.1",
+ "float8",
  "gemm 0.19.0",
  "half",
  "libm",
@@ -606,7 +606,7 @@ version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
 dependencies = [
- "float8 0.7.0",
+ "float8",
  "half",
  "libloading 0.9.0",
 ]
@@ -837,24 +837,14 @@ dependencies = [
 
 [[package]]
 name = "float8"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
-dependencies = [
- "cudarc 0.19.4",
- "half",
- "num-traits",
- "rand",
- "rand_distr",
-]
-
-[[package]]
-name = "float8"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
+ "num-traits",
+ "rand",
+ "rand_distr",
 ]
 
 [[package]]

--- a/candle-core/Cargo.toml
+++ b/candle-core/Cargo.toml
@@ -39,7 +39,6 @@ cuda = [
     "cudarc",
     "dep:candle-kernels",
     "candle-ug?/cuda",
-    "float8/cuda",
 ]
 cudnn = [
     "cuda",
@@ -175,7 +174,7 @@ optional = true
 default-features = false
 
 [dependencies.float8]
-version = "0.6.0"
+version = "0.7.0"
 features = [
     "num-traits",
     "rand_distr",


### PR DESCRIPTION
Remove the float8/cuda feature from candle-core's cuda feature gate and
unify the float8 dependency to v0.7.0, which drops the cudarc hard dep
that float8 0.6.1 carried. This prevents a transitive cudart link from
being pulled in unintentionally.

Because float8 0.6.1's cuda feature also activated cudarc/dynamic-linking
(which emitted rustc-link-search paths for the CUDA libraries), removing
it left the linker unable to find libcudart.so on Linux and cudart.lib on
Windows. Fix by explicitly exposing the CUDA library directories in CI via
LIBRARY_PATH on Linux and the LIB env var on Windows.