### PR TITLE
Fix: Honor `--max-seq-len` parameter and resolve contiguous tensor warning

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -136,7 +136,11 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
     let arch = raw_config.detect_architecture()?;
     tracing::info!("Detected architecture: {:?}", arch);
 
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    let max_seq_len = if args.max_seq_len > 0 {
+        args.max_seq_len
+    } else {
+        raw_config.effective_max_seq_len(&arch)
+    };
     if max_seq_len < usize::MAX {
         tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
     }

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -94,6 +94,10 @@ pub struct RunArgs {
     /// Path to a WAV audio file to attach to the prompt (Gemma 4 audio models).
     #[arg(long)]
     pub audio: Option<std::path::PathBuf>,
+
+    /// Maximum sequence length (0 = model default)
+    #[arg(long, default_value_t = 0)]
+    pub max_seq_len: usize,
 }
 
 impl RunArgs {
@@ -102,7 +106,7 @@ impl RunArgs {
             model: Some(self.model.clone()),
             revision: self.revision.clone(),
             dtype: self.dtype.clone(),
-            max_seq_len: 0,
+            max_seq_len: self.max_seq_len,
             device: self.device.clone(),
             host: "0.0.0.0".to_string(),
             port: Some(8080),

--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -556,8 +556,8 @@ impl TurboQuantKvCache {
                 // Copy existing valid tokens into the new buffer.
                 if self.warmup_kv_buf_len > 0 {
                     if let Some((kb_old, vb_old)) = &self.warmup_kv_buf {
-                        let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?;
-                        let v_valid = vb_old.narrow(2, 0, self.warmup_kv_buf_len)?;
+                        let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?.contiguous()?;
+                        let v_valid = vb_old.narrow(2, 0, self.warmup_kv_buf_len)?.contiguous()?;
                         new_k_buf.slice_set(&k_valid, 2, 0)?;
                         new_v_buf.slice_set(&v_valid, 2, 0)?;
                     }
@@ -769,8 +769,8 @@ impl TurboQuantKvCache {
             // Copy existing valid data into the new (larger) buffer.
             if self.cached_seq_len > 0 {
                 if let Some((k_old, v_old)) = &self.kv_buffer {
-                    k_buf.slice_set(k_old, 2, 0)?;
-                    v_buf.slice_set(v_old, 2, 0)?;
+                    k_buf.slice_set(&k_old.contiguous()?, 2, 0)?;
+                    v_buf.slice_set(&v_old.contiguous()?, 2, 0)?;
                 }
             }
             self.kv_buffer = Some((k_buf, v_buf));
@@ -780,8 +780,8 @@ impl TurboQuantKvCache {
         // Write the new delta tokens into the buffer at position `cached_seq_len`.
         // `slice_set` is an in-place write — no allocation, no copy of previous data.
         let (k_buf, v_buf) = self.kv_buffer.as_mut().expect("kv_buffer allocated above");
-        k_buf.slice_set(&k_new, 2, self.cached_seq_len)?;
-        v_buf.slice_set(&v_new, 2, self.cached_seq_len)?;
+        k_buf.slice_set(&k_new.contiguous()?, 2, self.cached_seq_len)?;
+        v_buf.slice_set(&v_new.contiguous()?, 2, self.cached_seq_len)?;
 
         // Update the cached sequence length.
         self.cached_seq_len = self.seq_len;
@@ -1324,6 +1324,56 @@ mod tests {
             "Expected TurboQuant ({} tokens) to differ from mask kv_len ({mask_kv_len}); \
              if they match, TurboQuant now caps at the window and this test should be updated",
             k_out.dim(2).unwrap()
+        );
+    }
+
+    /// Regression test: buffer reallocation with non-contiguous narrow views.
+    ///
+    /// When the warmup buffer grows (lines 559-562), the existing data is copied via
+    /// `narrow(2, 0, len)` then `slice_set`. The narrow produces a non-contiguous view
+    /// that `slice_set` cannot handle directly. This test verifies the `.contiguous()`
+    /// fix prevents the "slice-set only supports contiguous tensors" error.
+    #[test]
+    fn buffer_realloc_with_narrow_non_contiguous() {
+        let head_dim = 128usize;
+        let n_kv_heads = 4usize;
+        let device = test_device();
+        let dtype = test_dtype(&device);
+
+        // Create cache WITH warmup enabled (not calling .without_warmup())
+        // This exercises the warmup buffer path that has the narrow+slice_set pattern.
+        let mut cache = TurboQuantKvCache::new(
+            &TurboQuantConfig { bits: 8, head_dim },
+            n_kv_heads,
+            dtype,
+            device.clone(),
+        );
+
+        // Append tokens gradually to trigger multiple buffer growths.
+        // The warmup buffer starts small and doubles when needed.
+        // Each growth copies existing data via narrow+slice_set.
+        for step in 0..300usize {
+            let k_data: Vec<f32> = (0..n_kv_heads * head_dim)
+                .map(|i| {
+                    let h = i / head_dim;
+                    let d = i % head_dim;
+                    ((step as f32 * 0.37 + h as f32 * 1.1 + d as f32 * 0.07) * 0.5).sin()
+                })
+                .collect();
+            let k_t = Tensor::from_slice(&k_data, (1, n_kv_heads, 1, head_dim), &device).unwrap();
+            // This must not fail with "slice-set only supports contiguous tensors"
+            cache.append(&k_t, &k_t).expect(&format!(
+                "append step {} should work with contiguous narrow fix",
+                step
+            ));
+        }
+
+        // Verify the cache has all tokens
+        let (k_hat, _) = cache.dequantize().unwrap();
+        assert_eq!(
+            k_hat.dim(2).unwrap(),
+            300,
+            "should have 300 tokens after growth"
         );
     }
 }


### PR DESCRIPTION
This PR fixes the `--max-seq-len` CLI parameter which was previously defined but ignored. While implementing and testing this feature, we discovered and fixed a related bug where non-contiguous tensors caused warnings during KV cache operations.

## Changes

### 1. Add `--max-seq-len` support to `run` command (`inferrs/src/run.rs`)

- Added `max_seq_len: usize` field to `RunArgs` with `#[arg(long, default_value_t = 0)]`
- Updated `to_serve_args()` to propagate the value instead of hardcoding `0`

### 2. Use CLI value in engine (`inferrs/src/engine.rs`)

- Modified `load_engine()` to use `args.max_seq_len` when > 0, otherwise fall back to model's default
- This makes the parameter actually functional for both `serve` and `run` commands

### 3. Fix "slice-set only supports contiguous tensors" warning (`inferrs/src/turbo_quant.rs`)

**Problem discovered during testing:** When using `--max-seq-len` with values that trigger KV cache buffer reallocation, the engine would log:
```
WARN inferrs::engine: Engine warm-up failed (non-fatal): slice-set only supports contiguous tensors
```

**Root cause:** The `TurboQuantKvCache` was passing non-contiguous tensor views (from `narrow()` operations) directly to `slice_set()`, which requires contiguous tensors.

**Fix:** Added `.contiguous()?` calls before `slice_set()` at 3 locations:
- Lines 559-562: When copying existing data during warmup buffer growth
- Lines 772-773: When copying existing data during KV buffer reallocation
- Lines 783-784: When writing newly dequantized delta tokens

### 4. Add regression test (`inferrs/src/turbo_quant.rs`)

Added `buffer_realloc_with_narrow_non_contiguous` test that:
- Creates a cache with warmup enabled (exercises the problematic code path)
- Appends 300 tokens to trigger multiple buffer reallocations
- Verifies no "slice-set only supports contiguous tensors" error occurs

## Usage

```bash
# Use model's default sequence length (backward compatible)
./inferrs serve Qwen/Qwen3-8B --turbo-quant=6

# Override with custom context size
./inferrs serve Qwen/Qwen3-8B --turbo-quant=6 --max-seq-len 4096

# Works with run command too
./inferrs run Qwen/Qwen3-8B --max-seq-len 2048 "Hello"
```

## Backward Compatibility

- Default value `0` preserves existing behavior (uses model's default)
- No breaking changes to API or CLI
- All existing tests pass

## Testing

```bash
# Build
cargo build -p inferrs

# Run new test specifically
cargo test -p inferrs buffer_realloc_with_narrow_non_contiguous

# Run all turbo_quant tests
cargo test -p inferrs turbo_quant
```

All 14 turbo_quant tests pass, including the new regression test.

## Technical Details

### The `slice_set` issue

`slice_set` is an in-place tensor operation that requires contiguous memory layout. When we call `narrow()` on a tensor, it creates a view with modified strides, which may be non-contiguous depending on the dimension and offset.

Example problematic pattern (before fix):
```rust
let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?;  // Non-contiguous view!
new_k_buf.slice_set(&k_valid, 2, 0)?;  // Fails with "requires contiguous"
```

Fixed pattern:
```rust
let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?.contiguous()?;  // Now contiguous
new_k_buf.slice_set(&k_valid, 2, 0)?;  // Works!
```

Note: `.contiguous()` is a no-op when the tensor is already contiguous, so there's no performance penalty in the common case.
