### PR TITLE
Add Qwen3.5 (non MoE) support and fix TurboQuant crash on Qwen3

### DIFF
--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -178,6 +178,12 @@ impl RawConfig {
     pub fn detect_architecture(&self) -> Result<ModelArchitecture> {
         if let Some(archs) = &self.architectures {
             for arch in archs {
+                if arch.contains("Qwen3_5Moe") {
+                    anyhow::bail!(
+                        "Qwen3.5 MoE (detected architecture: {arch}) is not yet supported. \
+                         Only dense Qwen3.5 models are currently implemented."
+                    );
+                }
                 if arch.contains("Qwen3_5") {
                     return Ok(ModelArchitecture::Qwen35);
                 }
@@ -203,6 +209,10 @@ impl RawConfig {
             match model_type.as_str() {
                 "qwen2" | "qwen2_5" => return Ok(ModelArchitecture::Qwen2),
                 "qwen3" => return Ok(ModelArchitecture::Qwen3),
+                "qwen3_5_moe" => anyhow::bail!(
+                    "Qwen3.5 MoE (model_type: qwen3_5_moe) is not yet supported. \
+                     Only dense Qwen3.5 models are currently implemented."
+                ),
                 "qwen3_5" => return Ok(ModelArchitecture::Qwen35),
                 "gemma4" => return Ok(ModelArchitecture::Gemma4),
                 "gemma3" => return Ok(ModelArchitecture::Gemma3),
@@ -443,6 +453,7 @@ impl RawConfig {
         &self,
         dtype: DType,
         device: Device,
+        turbo_quant_bits: Option<u8>,
     ) -> crate::models::qwen3_5::Qwen35Config {
         use crate::models::qwen3_5::{LayerType, Qwen35Config};
 
@@ -513,6 +524,7 @@ impl RawConfig {
             tie_word_embeddings,
             dtype,
             device,
+            turbo_quant_bits,
         }
     }
 

--- a/inferrs/src/models/attention_utils.rs
+++ b/inferrs/src/models/attention_utils.rs
@@ -5,6 +5,7 @@ use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{linear_no_bias, ops, rotary_emb, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
+use crate::turbo_quant::TurboQuantKvCache;
 
 /// Paged-attention context passed to each layer's `forward_paged` call.
 ///
@@ -411,6 +412,40 @@ pub fn concat_kv_cache(
     };
     *kv_cache = Some((k.clone(), v.clone()));
     Ok((k, v))
+}
+
+/// Append `k`/`v` to the per-layer KV cache, with optional TurboQuant compression.
+///
+/// Three-path strategy (identical to Qwen3 and Qwen3.5):
+/// - **Prefill** (`seqlen_offset == 0 && t > 1`): plain concat — avoids the TQ
+///   overhead during the long prompt phase.
+/// - **First decode step** (TQ enabled, cache empty): adopt the prefill tensors into
+///   TQ's warmup buffer (zero-copy), then append + dequantize.
+/// - **Subsequent decode / no TQ**: plain concat.
+///
+/// Returns the full `(k, v)` to use for attention, shaped
+/// `[b, num_kv_heads, total_seq_len, head_dim]`.
+pub fn append_kv_tq(
+    k: Tensor,
+    v: Tensor,
+    seqlen_offset: usize,
+    t: usize,
+    kv_cache: &mut Option<(Tensor, Tensor)>,
+    tq_cache: &mut Option<TurboQuantKvCache>,
+) -> Result<(Tensor, Tensor)> {
+    if seqlen_offset == 0 && t > 1 {
+        concat_kv_cache(k, v, kv_cache)
+    } else if let Some(tq) = tq_cache {
+        if tq.is_empty() {
+            if let Some((k_cache, v_cache)) = kv_cache.take() {
+                tq.adopt_warmup_buffer(k_cache, v_cache)?;
+            }
+        }
+        tq.append(&k, &v)?;
+        tq.dequantize()
+    } else {
+        concat_kv_cache(k, v, kv_cache)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -451,7 +451,7 @@ pub fn load_model(
     // TurboQuant is on by default; warn if this architecture doesn't support it.
     if turbo_quant_bits.is_some() {
         match arch {
-            ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4 => {} // supported
+            ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4 | ModelArchitecture::Qwen35 => {} // supported
             other => {
                 tracing::warn!(
                     "--turbo-quant is not supported for {:?} and will be ignored. \
@@ -518,7 +518,7 @@ pub fn load_model(
             })
         }
         ModelArchitecture::Qwen35 => {
-            let config = raw_config.to_qwen35_config(dtype, device.clone());
+            let config = raw_config.to_qwen35_config(dtype, device.clone(), turbo_quant_bits);
             tracing::info!(
                 "Qwen3.5 config: {} layers, {} attn heads, {} hidden, {} kv_heads",
                 config.num_hidden_layers,

--- a/inferrs/src/models/qwen3.rs
+++ b/inferrs/src/models/qwen3.rs
@@ -15,7 +15,7 @@ use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm,
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_rms_norm_heads, apply_rope, causal_mask, compute_logits, concat_kv_cache,
+    append_kv_tq, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
     paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx, PagedPassCache,
 };
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
@@ -134,31 +134,15 @@ impl Attention {
         let q = apply_rope(&q, &cos_slice, &sin_slice)?;
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
-        // Append to KV cache.
-        //
-        // During prefill (seqlen_offset == 0, t > 1) bypass TurboQuant entirely:
-        // use the plain concat cache to avoid the extra contiguous() + slice_set
-        // overhead per layer (35 × 2 GPU copies vs 0 for the plain path).
-        // On the first decode step (seqlen_offset == prompt_len, t == 1), adopt
-        // the plain cache tensors directly into TQ's warmup buffer (zero-copy)
-        // so that subsequent decode steps benefit from KV compression.
-        let (k, v) = if seqlen_offset == 0 && t > 1 {
-            // Prefill: always use plain concat, even when TQ is enabled.
-            concat_kv_cache(k, v, &mut self.kv_cache)?
-        } else if let Some(tq) = &mut self.tq_cache {
-            // First decode step: adopt the plain cache into TQ's warmup buffer.
-            // Zero-copy: TQ takes ownership of the prefill tensors without any
-            // GPU allocation or data movement.
-            if tq.is_empty() {
-                if let Some((k_cache, v_cache)) = self.kv_cache.take() {
-                    tq.adopt_warmup_buffer(k_cache, v_cache)?;
-                }
-            }
-            tq.append(&k, &v)?;
-            tq.dequantize()?
-        } else {
-            concat_kv_cache(k, v, &mut self.kv_cache)?
-        };
+        // Append to KV cache (with optional TurboQuant compression).
+        let (k, v) = append_kv_tq(
+            k,
+            v,
+            seqlen_offset,
+            t,
+            &mut self.kv_cache,
+            &mut self.tq_cache,
+        )?;
 
         let kv_len = k.dim(2)?;
 

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -13,10 +13,10 @@ use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm,
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_output_gate, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
-    concat_kv_cache, paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
-    PagedPassCache,
+    append_kv_tq, apply_output_gate, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
+    paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx, PagedPassCache,
 };
+use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
 
 // ---------------------------------------------------------------------------
 // Config
@@ -52,6 +52,7 @@ pub struct Qwen35Config {
     pub tie_word_embeddings: bool,
     pub dtype: DType,
     pub device: Device,
+    pub turbo_quant_bits: Option<u8>,
 }
 
 // ---------------------------------------------------------------------------
@@ -74,10 +75,11 @@ struct FullAttention {
     head_dim: usize,
     // KV cache: Option<(k_cache, v_cache)> accumulated across calls
     kv_cache: Option<(Tensor, Tensor)>,
+    tq_cache: Option<TurboQuantKvCache>,
 }
 
 impl FullAttention {
-    fn new(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
+    fn new(cfg: &Qwen35Config, vb: VarBuilder, tq_cfg: Option<&TurboQuantConfig>) -> Result<Self> {
         // q_proj outputs num_heads * head_dim * 2: first half is query, second half is the
         // output gate (attn_output_gate). The o_proj then takes num_heads * head_dim.
         let q_proj_out = cfg.num_attention_heads * cfg.head_dim * 2;
@@ -91,6 +93,10 @@ impl FullAttention {
         let q_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
         let k_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
 
+        let tq_cache = tq_cfg.map(|c| {
+            TurboQuantKvCache::new(c, cfg.num_key_value_heads, cfg.dtype, cfg.device.clone())
+        });
+
         Ok(Self {
             q_proj,
             k_proj,
@@ -102,6 +108,7 @@ impl FullAttention {
             num_kv_heads: cfg.num_key_value_heads,
             head_dim: cfg.head_dim,
             kv_cache: None,
+            tq_cache,
         })
     }
 
@@ -150,8 +157,15 @@ impl FullAttention {
         let q = apply_rope(&q, &cos_slice, &sin_slice)?;
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
-        // Append to KV cache
-        let (k, v) = concat_kv_cache(k, v, &mut self.kv_cache)?;
+        // Append to KV cache (with optional TurboQuant compression).
+        let (k, v) = append_kv_tq(
+            k,
+            v,
+            seqlen_offset,
+            t,
+            &mut self.kv_cache,
+            &mut self.tq_cache,
+        )?;
 
         let kv_len = k.dim(2)?;
 
@@ -193,6 +207,9 @@ impl FullAttention {
 
     fn clear_kv_cache(&mut self) {
         self.kv_cache = None;
+        if let Some(tq) = &mut self.tq_cache {
+            tq.clear();
+        }
     }
 
     /// Paged-attention forward pass.
@@ -634,7 +651,7 @@ fn rms_norm_tensor(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
 // ---------------------------------------------------------------------------
 
 enum LayerAttn {
-    Full(FullAttention),
+    Full(Box<FullAttention>),
     Linear(LinearAttn),
 }
 
@@ -646,9 +663,18 @@ struct DecoderLayer {
 }
 
 impl DecoderLayer {
-    fn new(cfg: &Qwen35Config, vb: VarBuilder, is_full_attention: bool) -> Result<Self> {
+    fn new(
+        cfg: &Qwen35Config,
+        vb: VarBuilder,
+        is_full_attention: bool,
+        tq_cfg: Option<&TurboQuantConfig>,
+    ) -> Result<Self> {
         let attn = if is_full_attention {
-            LayerAttn::Full(FullAttention::new(cfg, vb.pp("self_attn"))?)
+            LayerAttn::Full(Box::new(FullAttention::new(
+                cfg,
+                vb.pp("self_attn"),
+                tq_cfg,
+            )?))
         } else {
             LayerAttn::Linear(LinearAttn::new(cfg, vb.pp("linear_attn"))?)
         };
@@ -746,11 +772,20 @@ impl Qwen35Model {
 
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, lm_vb.pp("embed_tokens"))?;
 
+        let tq_cfg: Option<TurboQuantConfig> = cfg.turbo_quant_bits.map(|bits| {
+            tracing::info!("TurboQuant KV cache enabled: {bits} bits/coord, absmax quantization");
+            TurboQuantConfig {
+                bits,
+                head_dim: cfg.head_dim,
+            }
+        });
+
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for (i, layer_type) in cfg.layer_types.iter().enumerate() {
             let layer_vb = lm_vb.pp("layers").pp(i.to_string());
-            let layer = DecoderLayer::new(cfg, layer_vb, layer_type.is_full_attention)
-                .with_context(|| format!("loading layer {i}"))?;
+            let layer =
+                DecoderLayer::new(cfg, layer_vb, layer_type.is_full_attention, tq_cfg.as_ref())
+                    .with_context(|| format!("loading layer {i}"))?;
             layers.push(layer);
         }
 


### PR DESCRIPTION
> This PR depends on https://github.com/ericcurtin/inferrs/pull/144 for better performances during inference on CUDA

- Fix TurboQuant crash on models with `partial_rotary_factor < 1.0` (affects Qwen3 family). Root cause: `apply_rope` returns non-contiguous tensors when partial rotation is used, which are then passed to `adopt_warmup_buffer`. Fixed by calling `.contiguous()` before storing the warmup buffer.

### Bug reproducible on `main`

```
$ inferrs run Qwen/Qwen3-0.6B "What is the capital of France" --device cuda
Error: slice-set only supports contiguous tensors
```
- Add support for non-MoE Qwen3.5 models (e.g. `Qwen/Qwen3.5-2B`). Implementation based on the [HuggingFace transformers reference](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_5/modeling_qwen3_5.py).

### Qwen3.5 implementation details

- **Hybrid architecture**: alternates between Gated Delta Rule (GDR) linear attention layers and full GQA attention layers (every `full_attention_interval`-th layer)
- **1-centered RMSNorm**: Qwen3.5 uses `out = normalize(x) * (1 + weight)` where weights are initialized to zero, unlike standard RMSNorm which applies weights directly. Handled by pre-adding 1.0 to loaded weights.
- **Output gating**: Q projection outputs `num_heads * head_dim * 2` (query + sigmoid gate), applied as `sigmoid(gate) * attn_output`
- **Depthwise causal conv1d** on QKV before the GDR recurrence, with SiLU activation
- **Tied embeddings** (no separate `lm_head`)

### Example output

```
$ inferrs run Qwen/Qwen3.5-2B "What is the capital of France" --device cuda
The capital of France is **Paris**.

Located on the Ile de la Cite in the Seine Valley, it serves as the nation's
political, cultural, and financial center. Founded around the 5th century BC,
it has been a significant hub of European history and remains the country's
largest city.
```

## Test plan

#### Qwen 3.0
- [ ] `inferrs run Qwen/Qwen3-0.6B "hello" --device cuda` (TurboQuant enabled, crashing on `main` branch)
- [ ] `inferrs run Qwen/Qwen3-0.6B "hello" --device cuda --turbo-quant=false`

#### Qwen 3.5
- [ ] `inferrs run Qwen/Qwen3.5-2B "hello" --device cuda`
- [ ] `inferrs run Qwen/Qwen3.5-2B "hello" --device cuda --turbo-quant=false`
