### PR TITLE
feat: add run memory reporting and document memory semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Most LLM serving stacks force a trade-off between features and resource usage.
 
 ## Capability Matrix
 
-| Feature | Qwen3 | Gemma4 | Other architectures |
+| Feature | Qwen3 / Qwen3.5 | Gemma4 | Other architectures |
 |---|---|---|---|
 | `--turbo-quant` KV compression | Yes | Yes | Falls back to regular KV |
 | `--paged-attention` block pool | Yes | Yes | Allocates paged KV pool but decode may use concat-KV fallback |
@@ -36,7 +36,7 @@ Most LLM serving stacks force a trade-off between features and resource usage.
 ## Memory Semantics
 
 - `--quantize` reduces **model weight** size by converting weights to a cached GGUF file.
-- `--turbo-quant` reduces **KV cache** size for supported models only. It does not change model weights.
+- `--turbo-quant` reduces **KV cache** size for supported models only (`Qwen3`, `Qwen3.5`, `Gemma4`). It does not change model weights.
 - `--paged-attention` reserves a paged KV pool from the runtime device/dtype budget. In paged mode, TurboQuant does not reduce the reserved pool size.
 - `--quantize` and `--turbo-quant` can be combined: one affects weights, the other affects KV cache.
 
@@ -49,7 +49,7 @@ inferrs serve --quantize --turbo-quant=4 google/gemma-4-E2B-it
 inferrs serve --paged-attention google/gemma-4-E2B-it
 ```
 
-In `inferrs run`, `/show memory` reports model weights, KV estimates, and live paged-KV usage separately so you can see which setting changed which part of memory.
+In `inferrs run`, `/show memory` queries the server and reports model weights, KV estimates, live paged-KV usage, and the last completed paged allocation snapshot separately so you can see which setting changed which part of memory.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ Most LLM serving stacks force a trade-off between features and resource usage.
 - **Hardware backends** — CUDA, ROCm, Metal, Hexagon, OpenVino, MUSA, CANN,
   Vulkan and CPU
 
+## Capability Matrix
+
+| Feature | Qwen3 | Gemma4 | Other architectures |
+|---|---|---|---|
+| `--turbo-quant` KV compression | Yes | Yes | Falls back to regular KV |
+| `--paged-attention` block pool | Yes | Yes | Allocates paged KV pool but decode may use concat-KV fallback |
+| `--quantize` GGUF weight cache | Yes | Yes | Yes |
+
+## Memory Semantics
+
+- `--quantize` reduces **model weight** size by converting weights to a cached GGUF file.
+- `--turbo-quant` reduces **KV cache** size for supported models only. It does not change model weights.
+- `--paged-attention` reserves a paged KV pool from the runtime device/dtype budget. In paged mode, TurboQuant does not reduce the reserved pool size.
+- `--quantize` and `--turbo-quant` can be combined: one affects weights, the other affects KV cache.
+
+Examples:
+
+```bash
+inferrs serve --quantize google/gemma-4-E2B-it
+inferrs serve --turbo-quant=4 google/gemma-4-E2B-it
+inferrs serve --quantize --turbo-quant=4 google/gemma-4-E2B-it
+inferrs serve --paged-attention google/gemma-4-E2B-it
+```
+
+In `inferrs run`, `/show memory` reports model weights, KV estimates, and live paged-KV usage separately so you can see which setting changed which part of memory.
+
 ## Quick start
 
 ### Install
@@ -90,4 +116,3 @@ CLI — can point at it directly.
                                ▼          ▼          ▼          ▼
                           Scheduler    Transformer  KV Cache  Sampler
 ```
-

--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -183,14 +183,8 @@ pub fn run(args: BenchArgs) -> Result<()> {
         let (num_kv_heads, head_dim, num_layers) = raw_config.kv_cache_params(&arch);
         // bytes consumed per token across all layers (K + V combined)
         let bytes_per_token: usize = if let Some(bits) = serve.turbo_quant.0 {
-            // TurboQuant: nibble-packed indices + f32 per-group absmax scales
-            let index_bytes = if bits <= 4 {
-                // two indices packed per byte
-                head_dim.div_ceil(2)
-            } else {
-                // one index per byte
-                head_dim
-            };
+            // TurboQuant: dense bit-packed indices + f32 per-group absmax scales.
+            let index_bytes = (head_dim * bits as usize).div_ceil(8);
             let n_groups = head_dim.div_ceil(GROUP_SIZE);
             let scale_bytes = n_groups * 4; // f32 per group
                                             // K and V each have index_bytes + scale_bytes, times num_kv_heads, times num_layers

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1547,6 +1547,11 @@ impl Engine {
             }
             self.model.clear_kv_cache();
         }
+        if let Some(ps) = &mut self.paged {
+            // Warmup allocations are synthetic startup traffic and should not
+            // appear as the "last generation" in runtime memory snapshots.
+            ps.last_generation_usage = None;
+        }
         tracing::debug!("Engine warm-up complete (3 rounds, benchmark prompt)");
     }
 
@@ -1591,97 +1596,80 @@ impl Engine {
         );
 
         let mut active: VecDeque<ActiveSequence> = VecDeque::new();
+        let mut pending: VecDeque<EngineRequest> = VecDeque::new();
+        let mut channel_closed = false;
 
         loop {
-            // ── 1. Accept new requests (non-blocking) ─────────────────────
+            // ── 1. Admit pending generation requests up to capacity ───────
             while active.len() < effective_batch_size {
+                let Some(req) = pending.pop_front() else {
+                    break;
+                };
+                Self::admit_sequence(req, block_size, &tokenizer, &mut active);
+            }
+
+            // ── 2. Drain control requests regardless of generation capacity ─
+            while !channel_closed {
                 match rx.try_recv() {
                     Ok(req) => {
-                        // Embed requests are handled inline without becoming an
-                        // ActiveSequence (they don't generate tokens).
-                        if let EngineRequest::Embed {
-                            prompt_tokens,
-                            response_tx,
-                        } = req
-                        {
-                            let result = Self::run_embed(&mut model, &device, &prompt_tokens);
-                            let _ = response_tx.send(result);
-                            continue;
+                        if let Some(req) = Self::handle_control_request(
+                            req,
+                            &mut model,
+                            &device,
+                            kv_cache_dtype,
+                            paged.as_ref(),
+                            &active,
+                        ) {
+                            if active.len() < effective_batch_size {
+                                Self::admit_sequence(req, block_size, &tokenizer, &mut active);
+                            } else {
+                                pending.push_back(req);
+                            }
                         }
-                        if let EngineRequest::MemorySnapshot { response_tx } = req {
-                            let _ = response_tx.send(Self::build_memory_snapshot(
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => break,
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        channel_closed = true;
+                        break;
+                    }
+                }
+            }
+
+            // ── 3. If idle, block until the next request arrives ──────────
+            if active.is_empty() && pending.is_empty() {
+                if channel_closed {
+                    break;
+                }
+                loop {
+                    match rx.blocking_recv() {
+                        Some(req) => {
+                            if let Some(req) = Self::handle_control_request(
+                                req,
+                                &mut model,
                                 &device,
                                 kv_cache_dtype,
                                 paged.as_ref(),
                                 &active,
-                            ));
-                            continue;
-                        }
-                        let mut seq = ActiveSequence::from_engine_request(req, block_size);
-                        seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
-                        // If the prompt ends with a thinking delimiter (e.g. the
-                        // server injected <|think|> for think=true), the model
-                        // is already "inside" thinking and the first output token
-                        // will be reasoning content, not a delimiter.
-                        if let Some(&last) = seq.prompt_tokens.last() {
-                            if seq.think_filter.is_open_delimiter(last) {
-                                seq.think_filter.set_in_think(true);
+                            ) {
+                                pending.push_back(req);
+                                break;
                             }
                         }
-                        tracing::debug!(
-                            "Accepted request {} ({} prompt tokens, batch_size={})",
-                            seq.request_id,
-                            seq.prompt_tokens.len(),
-                            active.len() + 1,
-                        );
-                        active.push_back(seq);
+                        None => {
+                            channel_closed = true;
+                            break;
+                        }
                     }
-                    Err(_) => break,
+                }
+                while active.len() < effective_batch_size {
+                    let Some(req) = pending.pop_front() else {
+                        break;
+                    };
+                    Self::admit_sequence(req, block_size, &tokenizer, &mut active);
                 }
             }
 
-            // ── 2. If idle, block until the next request arrives ──────────
-            if active.is_empty() {
-                match rx.blocking_recv() {
-                    Some(req) => {
-                        // Embed requests are handled inline.
-                        if let EngineRequest::Embed {
-                            prompt_tokens,
-                            response_tx,
-                        } = req
-                        {
-                            let result = Self::run_embed(&mut model, &device, &prompt_tokens);
-                            let _ = response_tx.send(result);
-                            continue;
-                        }
-                        if let EngineRequest::MemorySnapshot { response_tx } = req {
-                            let _ = response_tx.send(Self::build_memory_snapshot(
-                                &device,
-                                kv_cache_dtype,
-                                paged.as_ref(),
-                                &active,
-                            ));
-                            continue;
-                        }
-                        let mut seq = ActiveSequence::from_engine_request(req, block_size);
-                        seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
-                        if let Some(&last) = seq.prompt_tokens.last() {
-                            if seq.think_filter.is_open_delimiter(last) {
-                                seq.think_filter.set_in_think(true);
-                            }
-                        }
-                        tracing::debug!(
-                            "Accepted request {} ({} prompt tokens)",
-                            seq.request_id,
-                            seq.prompt_tokens.len(),
-                        );
-                        active.push_back(seq);
-                    }
-                    None => break, // channel closed
-                }
-            }
-
-            // ── 3. Process one step per active sequence ───────────────────
+            // ── 4. Process one step per active sequence ───────────────────
             for seq in active.iter_mut() {
                 if seq.finished {
                     continue;
@@ -1957,7 +1945,7 @@ impl Engine {
                 }
             }
 
-            // ── 4. Remove completed sequences ─────────────────────────────
+            // ── 5. Remove completed sequences ─────────────────────────────
             active.retain(|s| !s.finished);
         }
 
@@ -2390,6 +2378,62 @@ impl Engine {
             allocated_tokens: block_table.num_tokens(),
             allocated_bytes: block_table.num_blocks() * bytes_per_block,
         })
+    }
+
+    fn handle_control_request(
+        req: EngineRequest,
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        kv_cache_dtype: DType,
+        paged: Option<&PagedState>,
+        active: &VecDeque<ActiveSequence>,
+    ) -> Option<EngineRequest> {
+        match req {
+            EngineRequest::Embed {
+                prompt_tokens,
+                response_tx,
+            } => {
+                let result = Self::run_embed(model, device, &prompt_tokens);
+                let _ = response_tx.send(result);
+                None
+            }
+            EngineRequest::MemorySnapshot { response_tx } => {
+                let _ = response_tx.send(Self::build_memory_snapshot(
+                    device,
+                    kv_cache_dtype,
+                    paged,
+                    active,
+                ));
+                None
+            }
+            other => Some(other),
+        }
+    }
+
+    fn admit_sequence(
+        req: EngineRequest,
+        block_size: Option<usize>,
+        tokenizer: &Tokenizer,
+        active: &mut VecDeque<ActiveSequence>,
+    ) {
+        let mut seq = ActiveSequence::from_engine_request(req, block_size);
+        seq.think_filter = ThinkFilter::from_tokenizer(tokenizer);
+        // If the prompt ends with a thinking delimiter (e.g. the
+        // server injected <|think|> for think=true), the model
+        // is already "inside" thinking and the first output token
+        // will be reasoning content, not a delimiter.
+        if let Some(&last) = seq.prompt_tokens.last() {
+            if seq.think_filter.is_open_delimiter(last) {
+                seq.think_filter.set_in_think(true);
+            }
+        }
+        tracing::debug!(
+            "Accepted request {} ({} prompt tokens, batch_size={})",
+            seq.request_id,
+            seq.prompt_tokens.len(),
+            active.len() + 1,
+        );
+        active.push_back(seq);
     }
 
     // ── Streaming generation ──────────────────────────────────────────────────

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -96,6 +96,7 @@ pub struct EngineContext {
     pub model_files: ModelFiles,
     pub dtype: DType,
     pub max_seq_len: usize,
+    pub weight_bytes: Option<u64>,
 }
 
 /// Build an [`Engine`] from [`ServeArgs`], handling the repeated sequence:
@@ -137,6 +138,17 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         args.gguf_file.as_deref(),
         quant_dtype,
     )?;
+    let weight_bytes = if let Some(path) = &model_files.gguf_path {
+        std::fs::metadata(path).ok().map(|m| m.len())
+    } else {
+        model_files
+            .weight_paths
+            .iter()
+            .try_fold(0u64, |acc, path| {
+                Ok::<u64, std::io::Error>(acc + std::fs::metadata(path)?.len())
+            })
+            .ok()
+    };
 
     let raw_config = RawConfig::from_file(&model_files.config_path)?;
     let arch = raw_config.detect_architecture()?;
@@ -194,6 +206,7 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         model_files,
         dtype,
         max_seq_len,
+        weight_bytes,
     })
 }
 

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1600,12 +1600,19 @@ impl Engine {
         let mut channel_closed = false;
 
         loop {
-            // ── 1. Admit pending generation requests up to capacity ───────
+            // ── 1. Admit pending work up to capacity ──────────────────────
             while active.len() < effective_batch_size {
                 let Some(req) = pending.pop_front() else {
                     break;
                 };
-                Self::admit_sequence(req, block_size, &tokenizer, &mut active);
+                Self::admit_request(
+                    req,
+                    block_size,
+                    &tokenizer,
+                    &mut active,
+                    &mut model,
+                    &device,
+                );
             }
 
             // ── 2. Drain control requests regardless of generation capacity ─
@@ -1614,14 +1621,20 @@ impl Engine {
                     Ok(req) => {
                         if let Some(req) = Self::handle_control_request(
                             req,
-                            &mut model,
                             &device,
                             kv_cache_dtype,
                             paged.as_ref(),
                             &active,
                         ) {
                             if active.len() < effective_batch_size {
-                                Self::admit_sequence(req, block_size, &tokenizer, &mut active);
+                                Self::admit_request(
+                                    req,
+                                    block_size,
+                                    &tokenizer,
+                                    &mut active,
+                                    &mut model,
+                                    &device,
+                                );
                             } else {
                                 pending.push_back(req);
                             }
@@ -1645,7 +1658,6 @@ impl Engine {
                         Some(req) => {
                             if let Some(req) = Self::handle_control_request(
                                 req,
-                                &mut model,
                                 &device,
                                 kv_cache_dtype,
                                 paged.as_ref(),
@@ -1665,7 +1677,14 @@ impl Engine {
                     let Some(req) = pending.pop_front() else {
                         break;
                     };
-                    Self::admit_sequence(req, block_size, &tokenizer, &mut active);
+                    Self::admit_request(
+                        req,
+                        block_size,
+                        &tokenizer,
+                        &mut active,
+                        &mut model,
+                        &device,
+                    );
                 }
             }
 
@@ -2382,21 +2401,12 @@ impl Engine {
 
     fn handle_control_request(
         req: EngineRequest,
-        model: &mut Box<dyn CausalLM>,
         device: &Device,
         kv_cache_dtype: DType,
         paged: Option<&PagedState>,
         active: &VecDeque<ActiveSequence>,
     ) -> Option<EngineRequest> {
         match req {
-            EngineRequest::Embed {
-                prompt_tokens,
-                response_tx,
-            } => {
-                let result = Self::run_embed(model, device, &prompt_tokens);
-                let _ = response_tx.send(result);
-                None
-            }
             EngineRequest::MemorySnapshot { response_tx } => {
                 let _ = response_tx.send(Self::build_memory_snapshot(
                     device,
@@ -2407,6 +2417,26 @@ impl Engine {
                 None
             }
             other => Some(other),
+        }
+    }
+
+    fn admit_request(
+        req: EngineRequest,
+        block_size: Option<usize>,
+        tokenizer: &Tokenizer,
+        active: &mut VecDeque<ActiveSequence>,
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+    ) {
+        match req {
+            EngineRequest::Embed {
+                prompt_tokens,
+                response_tx,
+            } => {
+                let result = Self::run_embed(model, device, &prompt_tokens);
+                let _ = response_tx.send(result);
+            }
+            req => Self::admit_sequence(req, block_size, tokenizer, active),
         }
     }
 

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1600,6 +1600,7 @@ impl Engine {
                                 &device,
                                 kv_cache_dtype,
                                 paged.as_ref(),
+                                &active,
                             ));
                             continue;
                         }
@@ -1645,6 +1646,7 @@ impl Engine {
                                 &device,
                                 kv_cache_dtype,
                                 paged.as_ref(),
+                                &active,
                             ));
                             continue;
                         }
@@ -2319,6 +2321,7 @@ impl Engine {
         device: &Device,
         kv_cache_dtype: DType,
         paged: Option<&PagedState>,
+        active: &VecDeque<ActiveSequence>,
     ) -> SyncMemorySnapshot {
         SyncMemorySnapshot {
             device: device_name(device),
@@ -2331,12 +2334,17 @@ impl Engine {
                 let bytes_per_block = paged_bytes_per_block(ps, kv_cache_dtype);
                 let reserved_bytes = total_blocks * bytes_per_block;
                 let allocated_bytes = used_blocks * bytes_per_block;
+                let active_allocated_tokens: usize = active
+                    .iter()
+                    .filter_map(|seq| seq.block_table.as_ref())
+                    .map(BlockTable::num_tokens)
+                    .sum();
                 PagedMemorySnapshot {
                     block_size,
                     total_blocks,
                     free_blocks,
                     used_blocks,
-                    allocated_tokens: ps.block_table.num_tokens(),
+                    allocated_tokens: active_allocated_tokens + ps.block_table.num_tokens(),
                     total_slots,
                     bytes_per_block,
                     reserved_bytes,

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
+use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot, Notify};
 
 use crate::config::{ModelArchitecture, RawConfig};
@@ -171,6 +172,7 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         model,
         engine_tokenizer,
         device.clone(),
+        dtype,
         args.max_batch_size,
         args.max_tokens_per_step,
     );
@@ -270,6 +272,10 @@ pub enum EngineRequest {
     Embed {
         prompt_tokens: Vec<u32>,
         response_tx: oneshot::Sender<Result<EmbedResult>>,
+    },
+    /// Return a snapshot of the engine's current memory state.
+    MemorySnapshot {
+        response_tx: oneshot::Sender<SyncMemorySnapshot>,
     },
 }
 
@@ -481,6 +487,37 @@ pub struct EmbedResult {
     pub embedding: Vec<f32>,
     #[allow(dead_code)]
     pub prompt_tokens: usize,
+}
+
+/// Memory usage snapshot returned by the live engine thread.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncMemorySnapshot {
+    pub device: &'static str,
+    pub paged: Option<PagedMemorySnapshot>,
+}
+
+/// Paged KV usage derived from the actual engine state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PagedMemorySnapshot {
+    pub block_size: usize,
+    pub total_blocks: usize,
+    pub free_blocks: usize,
+    pub used_blocks: usize,
+    pub allocated_tokens: usize,
+    pub total_slots: usize,
+    pub bytes_per_block: usize,
+    pub reserved_bytes: usize,
+    pub allocated_bytes: usize,
+    pub last_generation_used_blocks: Option<usize>,
+    pub last_generation_allocated_tokens: Option<usize>,
+    pub last_generation_allocated_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CompletedPagedUsage {
+    used_blocks: usize,
+    allocated_tokens: usize,
+    allocated_bytes: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -715,7 +752,27 @@ impl ActiveSequence {
             EngineRequest::Embed { .. } => {
                 panic!("Embed requests must not be converted to ActiveSequence")
             }
+            EngineRequest::MemorySnapshot { .. } => {
+                panic!("MemorySnapshot requests must not be converted to ActiveSequence")
+            }
         }
+    }
+
+    fn snapshot_paged_usage(
+        &self,
+        paged: &PagedState,
+        kv_cache_dtype: DType,
+    ) -> Option<CompletedPagedUsage> {
+        let bt = self.block_table.as_ref()?;
+        if bt.num_blocks() == 0 && bt.num_tokens() == 0 {
+            return None;
+        }
+        let bytes_per_block = paged_bytes_per_block(paged, kv_cache_dtype);
+        Some(CompletedPagedUsage {
+            used_blocks: bt.num_blocks(),
+            allocated_tokens: bt.num_tokens(),
+            allocated_bytes: bt.num_blocks() * bytes_per_block,
+        })
     }
 
     /// Mark the sequence as successfully finished and send the final result
@@ -1274,6 +1331,7 @@ pub struct Engine {
     model: Box<dyn CausalLM>,
     tokenizer: Tokenizer,
     device: Device,
+    kv_cache_dtype: DType,
     stop_token_ids: Vec<u32>,
     max_batch_size: usize,
     #[allow(dead_code)]
@@ -1300,6 +1358,7 @@ struct PagedState {
     /// time.  The continuous-batching loop maintains per-sequence block
     /// tables instead.
     block_table: BlockTable,
+    last_generation_usage: Option<CompletedPagedUsage>,
 }
 
 impl Engine {
@@ -1307,6 +1366,7 @@ impl Engine {
         model: Box<dyn CausalLM>,
         tokenizer: Tokenizer,
         device: Device,
+        kv_cache_dtype: DType,
         max_batch_size: usize,
         max_tokens_per_step: usize,
     ) -> Self {
@@ -1338,6 +1398,7 @@ impl Engine {
             model,
             tokenizer,
             device,
+            kv_cache_dtype,
             stop_token_ids,
             max_batch_size,
             max_tokens_per_step,
@@ -1353,6 +1414,7 @@ impl Engine {
             block_pool,
             kv_store,
             block_table: BlockTable::new(block_size),
+            last_generation_usage: None,
         });
         self
     }
@@ -1492,6 +1554,7 @@ impl Engine {
             mut model,
             tokenizer,
             device,
+            kv_cache_dtype,
             stop_token_ids,
             max_batch_size,
             max_tokens_per_step: _,
@@ -1532,6 +1595,14 @@ impl Engine {
                             let _ = response_tx.send(result);
                             continue;
                         }
+                        if let EngineRequest::MemorySnapshot { response_tx } = req {
+                            let _ = response_tx.send(Self::build_memory_snapshot(
+                                &device,
+                                kv_cache_dtype,
+                                paged.as_ref(),
+                            ));
+                            continue;
+                        }
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         // If the prompt ends with a thinking delimiter (e.g. the
@@ -1569,6 +1640,14 @@ impl Engine {
                             let _ = response_tx.send(result);
                             continue;
                         }
+                        if let EngineRequest::MemorySnapshot { response_tx } = req {
+                            let _ = response_tx.send(Self::build_memory_snapshot(
+                                &device,
+                                kv_cache_dtype,
+                                paged.as_ref(),
+                            ));
+                            continue;
+                        }
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         if let Some(&last) = seq.prompt_tokens.last() {
@@ -1602,6 +1681,10 @@ impl Engine {
                             &seq.prompt_tokens,
                             audio_ctx,
                         ) {
+                            if let Some(ps) = paged.as_mut() {
+                                ps.last_generation_usage =
+                                    seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                            }
                             seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
                             continue;
                         }
@@ -1614,6 +1697,10 @@ impl Engine {
                             &seq.prompt_tokens,
                             image_ctx,
                         ) {
+                            if let Some(ps) = paged.as_mut() {
+                                ps.last_generation_usage =
+                                    seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                            }
                             seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
                             continue;
                         }
@@ -1637,6 +1724,10 @@ impl Engine {
                     let last_token = match seq.output_tokens.last() {
                         Some(&t) => t,
                         None => {
+                            if let Some(ps) = paged.as_mut() {
+                                ps.last_generation_usage =
+                                    seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                            }
                             seq.finish_error(
                                 anyhow::anyhow!("internal error: decode before prefill"),
                                 paged.as_mut().map(|ps| &mut ps.block_pool),
@@ -1659,6 +1750,9 @@ impl Engine {
                 let logits = match logits_result {
                     Ok(l) => l,
                     Err(e) => {
+                        if let Some(ps) = paged.as_mut() {
+                            ps.last_generation_usage = seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                        }
                         seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
                         continue;
                     }
@@ -1687,6 +1781,10 @@ impl Engine {
                     match sampler::sample_token(&logits, &seq.sampling_params, &seq.all_tokens) {
                         Ok(t) => t,
                         Err(e) => {
+                            if let Some(ps) = paged.as_mut() {
+                                ps.last_generation_usage =
+                                    seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                            }
                             seq.finish_error(e, paged.as_mut().map(|ps| &mut ps.block_pool));
                             continue;
                         }
@@ -1833,6 +1931,9 @@ impl Engine {
 
                 if finish_reason.is_some() || client_gone {
                     let reason = finish_reason.unwrap_or_else(|| "cancelled".to_string());
+                    if let Some(ps) = paged.as_mut() {
+                        ps.last_generation_usage = seq.snapshot_paged_usage(ps, kv_cache_dtype);
+                    }
                     seq.finish_ok(
                         &reason,
                         &tokenizer,
@@ -2208,8 +2309,66 @@ impl Engine {
     /// Free all paged KV blocks (no-op when paged attention is not active).
     fn free_paged_blocks(&mut self) {
         if let Some(ps) = &mut self.paged {
+            ps.last_generation_usage =
+                Self::snapshot_block_table_usage(&ps.block_table, ps, self.kv_cache_dtype);
             ps.block_table.free_all(&mut ps.block_pool);
         }
+    }
+
+    fn build_memory_snapshot(
+        device: &Device,
+        kv_cache_dtype: DType,
+        paged: Option<&PagedState>,
+    ) -> SyncMemorySnapshot {
+        SyncMemorySnapshot {
+            device: device_name(device),
+            paged: paged.map(|ps| {
+                let block_size = ps.block_pool.block_size;
+                let total_blocks = ps.block_pool.num_blocks();
+                let free_blocks = ps.block_pool.num_free_blocks();
+                let used_blocks = total_blocks.saturating_sub(free_blocks);
+                let total_slots = total_blocks * block_size;
+                let bytes_per_block = paged_bytes_per_block(ps, kv_cache_dtype);
+                let reserved_bytes = total_blocks * bytes_per_block;
+                let allocated_bytes = used_blocks * bytes_per_block;
+                PagedMemorySnapshot {
+                    block_size,
+                    total_blocks,
+                    free_blocks,
+                    used_blocks,
+                    allocated_tokens: ps.block_table.num_tokens(),
+                    total_slots,
+                    bytes_per_block,
+                    reserved_bytes,
+                    allocated_bytes,
+                    last_generation_used_blocks: ps
+                        .last_generation_usage
+                        .map(|usage| usage.used_blocks),
+                    last_generation_allocated_tokens: ps
+                        .last_generation_usage
+                        .map(|usage| usage.allocated_tokens),
+                    last_generation_allocated_bytes: ps
+                        .last_generation_usage
+                        .map(|usage| usage.allocated_bytes),
+                }
+            }),
+        }
+    }
+
+    fn snapshot_block_table_usage(
+        block_table: &BlockTable,
+        paged: &PagedState,
+        kv_cache_dtype: DType,
+    ) -> Option<CompletedPagedUsage> {
+        if block_table.num_blocks() == 0 && block_table.num_tokens() == 0 {
+            return None;
+        }
+        let bytes_per_block = paged_bytes_per_block(paged, kv_cache_dtype);
+        Some(CompletedPagedUsage {
+            used_blocks: block_table.num_blocks(),
+            allocated_tokens: block_table.num_tokens(),
+            allocated_bytes: block_table.num_blocks() * bytes_per_block,
+        })
     }
 
     // ── Streaming generation ──────────────────────────────────────────────────
@@ -2468,5 +2627,23 @@ impl Engine {
             return Some("length".to_string());
         }
         None
+    }
+}
+
+fn paged_bytes_per_block(paged: &PagedState, kv_cache_dtype: DType) -> usize {
+    let cfg = &paged.kv_store.cfg;
+    cfg.block_size
+        * cfg.num_kv_heads
+        * cfg.head_dim
+        * 2
+        * cfg.num_layers
+        * kv_cache_dtype.size_in_bytes()
+}
+
+fn device_name(device: &Device) -> &'static str {
+    match device {
+        Device::Cpu => "cpu",
+        Device::Cuda(_) => "cuda",
+        Device::Metal(_) => "metal",
     }
 }

--- a/inferrs/src/kv_cache.rs
+++ b/inferrs/src/kv_cache.rs
@@ -104,9 +104,13 @@ impl BlockPool {
     }
 
     /// Number of blocks currently available for allocation.
-    #[allow(dead_code)]
     pub fn num_free_blocks(&self) -> usize {
         self.free_list.len()
+    }
+
+    /// Total number of physical blocks managed by the pool.
+    pub fn num_blocks(&self) -> usize {
+        self.blocks.len()
     }
 
     /// Allocate `n` blocks.  Returns `None` if there are not enough free blocks.
@@ -173,13 +177,11 @@ impl BlockTable {
     }
 
     /// Number of tokens already mapped in the block table.
-    #[allow(dead_code)]
     pub fn num_tokens(&self) -> usize {
         self.num_tokens
     }
 
     /// Number of physical blocks currently allocated.
-    #[allow(dead_code)]
     pub fn num_blocks(&self) -> usize {
         self.physical_blocks.len()
     }

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -24,6 +24,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Write};
 
+use crate::util::format_bytes;
+
 // ─── CLI args ────────────────────────────────────────────────────────────────
 
 /// Default port for the Ollama-compatible API (matches `inferrs serve` default
@@ -230,6 +232,38 @@ struct OaiDelta {
 #[derive(Debug, Deserialize)]
 struct OaiChunk {
     choices: Vec<OaiChunkChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MemoryReportResponse {
+    device: String,
+    dtype: String,
+    arch: String,
+    turbo_quant: Option<u8>,
+    turbo_quant_note: Option<String>,
+    kv_estimate_mode: String,
+    weight_source: String,
+    weight_quantization: Option<String>,
+    weight_bytes: Option<u64>,
+    max_seq_len: Option<usize>,
+    max_kv_cache_bytes: Option<u64>,
+    paged: Option<PagedMemoryResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PagedMemoryResponse {
+    block_size: usize,
+    total_blocks: usize,
+    free_blocks: usize,
+    used_blocks: usize,
+    allocated_tokens: usize,
+    total_slots: usize,
+    bytes_per_block: usize,
+    reserved_bytes: usize,
+    allocated_bytes: usize,
+    last_generation_used_blocks: Option<usize>,
+    last_generation_allocated_tokens: Option<usize>,
+    last_generation_allocated_bytes: Option<usize>,
 }
 
 // ─── HTTP client helpers ─────────────────────────────────────────────────────
@@ -651,6 +685,92 @@ fn base64_encode(data: &[u8]) -> String {
     base64::engine::general_purpose::STANDARD.encode(data)
 }
 
+async fn show_memory(client: &Client, base_url: &str) -> Result<()> {
+    let url = format!("{base_url}/api/inferrs/memory");
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url} failed"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("Server returned {status}: {text}");
+    }
+
+    let report: MemoryReportResponse = response.json().await.context("invalid memory response")?;
+
+    println!(
+        "device={} dtype={} arch={}",
+        report.device, report.dtype, report.arch
+    );
+    match report.turbo_quant {
+        Some(bits) => println!("turbo_quant={}bit", bits),
+        None => println!("turbo_quant=disabled"),
+    }
+    if let Some(note) = &report.turbo_quant_note {
+        println!("turbo_quant_note={note}");
+    }
+    println!("kv_estimate_mode={}", report.kv_estimate_mode);
+    match &report.weight_quantization {
+        Some(format) => println!("weight_format={} ({})", format, report.weight_source),
+        None => println!("weight_format=full precision ({})", report.weight_source),
+    }
+    if let Some(weight_bytes) = report.weight_bytes {
+        println!("model_weight_estimate={}", format_bytes(weight_bytes));
+    }
+    match report.max_seq_len {
+        Some(max_seq_len) => println!("model_kv_capacity={} tokens", max_seq_len),
+        None => println!("model_kv_capacity=unknown"),
+    }
+    if let Some(max_bytes) = report.max_kv_cache_bytes {
+        println!("max_kv_cache_estimate={}", format_bytes(max_bytes));
+        if let Some(weight_bytes) = report.weight_bytes {
+            println!(
+                "model_plus_max_kv_estimate={}",
+                format_bytes(weight_bytes.saturating_add(max_bytes))
+            );
+        }
+    }
+
+    if let Some(paged) = report.paged {
+        println!(
+            "paged_pool={} blocks x {} tokens = {} slots",
+            paged.total_blocks, paged.block_size, paged.total_slots
+        );
+        println!(
+            "paged_blocks_used={} free={} allocated_tokens={}",
+            paged.used_blocks, paged.free_blocks, paged.allocated_tokens
+        );
+        println!(
+            "paged_memory_reserved={} active_estimate={} bytes_per_block={}",
+            format_bytes(paged.reserved_bytes as u64),
+            format_bytes(paged.allocated_bytes as u64),
+            format_bytes(paged.bytes_per_block as u64),
+        );
+        if let (Some(last_used_blocks), Some(last_allocated_tokens), Some(last_allocated_bytes)) = (
+            paged.last_generation_used_blocks,
+            paged.last_generation_allocated_tokens,
+            paged.last_generation_allocated_bytes,
+        ) {
+            println!(
+                "last_generation_paged_blocks_used={} allocated_tokens={}",
+                last_used_blocks, last_allocated_tokens
+            );
+            println!(
+                "last_generation_paged_memory_estimate={}",
+                format_bytes(last_allocated_bytes as u64)
+            );
+        }
+    } else {
+        println!("paged_attention=disabled");
+        println!("live_kv_usage=not tracked in concat-KV mode");
+    }
+
+    Ok(())
+}
+
 // ─── Interactive REPL ────────────────────────────────────────────────────────
 
 /// Multiline input state.
@@ -738,11 +858,15 @@ async fn repl(
                     handle_command(
                         &trimmed,
                         &mut messages,
+                        &client,
+                        &base_url,
+                        &mut load_rx,
                         &mut temperature,
                         &mut top_p,
                         &mut top_k,
                         &mut max_tokens,
-                    );
+                    )
+                    .await;
                     buf.clear();
                     continue;
                 }
@@ -814,9 +938,12 @@ async fn repl(
 
 // ─── Slash command handler ────────────────────────────────────────────────────
 
-fn handle_command(
+async fn handle_command(
     cmd: &str,
     messages: &mut Vec<ApiMessage>,
+    client: &Client,
+    base_url: &str,
+    load_rx: &mut tokio::sync::watch::Receiver<LoadState>,
     temperature: &mut f64,
     top_p: &mut f64,
     top_k: &mut usize,
@@ -885,6 +1012,17 @@ fn handle_command(
                     println!("[{}] {}: {}", i, m.role, m.content);
                 }
             }
+            "memory" => {
+                if matches!(*load_rx.borrow(), LoadState::Loading) {
+                    if let Err(e) = wait_for_load(load_rx).await {
+                        eprintln!("{e}");
+                        return;
+                    }
+                }
+                if let Err(e) = show_memory(client, base_url).await {
+                    eprintln!("Memory query error: {e}");
+                }
+            }
             "params" => {
                 println!(
                     "temperature={temperature} top_p={top_p} top_k={top_k} max_tokens={max_tokens}"
@@ -902,6 +1040,7 @@ fn handle_command(
             println!("  /set top_k <n>               Set top-k sampling");
             println!("  /set max_tokens <n>          Set max tokens per response");
             println!("  /show history                Print conversation history");
+            println!("  /show memory                 Print runtime memory information");
             println!("  /show params                 Print sampling parameters");
             println!("  /help, /?                    Show this help");
             println!();

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1220,7 +1220,7 @@ fn build_memory_config(args: &ServeArgs, ctx: &crate::engine::EngineContext) -> 
     let (num_kv_heads, head_dim, num_layers) = ctx.raw_config.kv_cache_params(&ctx.arch);
     let turbo_quant_supported = matches!(
         ctx.arch,
-        ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4
+        ModelArchitecture::Qwen3 | ModelArchitecture::Qwen35 | ModelArchitecture::Gemma4
     );
     let turbo_quant = if args.paged_attention.is_some() || !turbo_quant_supported {
         None

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -20,15 +20,17 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tower_http::cors::CorsLayer;
 
+use crate::config::ModelArchitecture;
 use crate::engine::{
     load_engine, AudioEmbedContext, EngineRequest, GenerationResult, ImageEmbedContext,
-    OutputBuffer, StreamToken,
+    OutputBuffer, StreamToken, SyncMemorySnapshot,
 };
 use crate::sampler::SamplingParams;
 use crate::tokenizer::{
     apply_gemma4_with_audio, apply_gemma4_with_images, AudioInput, ChatMessage, ImageInput,
     MessageContent, Role, Tokenizer,
 };
+use crate::turbo_quant::GROUP_SIZE;
 use crate::ServeArgs;
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,36 @@ use crate::ServeArgs;
 /// SSE handler for that request.  Entries are inserted just before the engine
 /// request is sent and removed once the final token (or an error) is routed.
 type StreamRegistry = Arc<Mutex<HashMap<String, mpsc::Sender<StreamToken>>>>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MemoryReportResponse {
+    device: String,
+    dtype: String,
+    arch: String,
+    turbo_quant: Option<u8>,
+    turbo_quant_note: Option<String>,
+    kv_estimate_mode: String,
+    weight_source: String,
+    weight_quantization: Option<String>,
+    weight_bytes: Option<u64>,
+    max_seq_len: Option<usize>,
+    max_kv_cache_bytes: Option<u64>,
+    paged: Option<crate::engine::PagedMemorySnapshot>,
+}
+
+#[derive(Debug, Clone)]
+struct ServeMemoryConfig {
+    dtype: String,
+    arch: String,
+    turbo_quant: Option<u8>,
+    turbo_quant_note: Option<String>,
+    kv_estimate_mode: String,
+    weight_source: String,
+    weight_quantization: Option<String>,
+    weight_bytes: Option<u64>,
+    max_seq_len: Option<usize>,
+    max_kv_cache_bytes: Option<u64>,
+}
 
 /// Spawn a background task that drains the shared [`OutputBuffer`] and routes
 /// each token to the correct per-request channel.
@@ -959,6 +991,7 @@ enum ModelBackend {
         engine_tx: mpsc::Sender<EngineRequest>,
         tokenizer: Arc<Tokenizer>,
         max_seq_len: usize,
+        memory_config: ServeMemoryConfig,
         output_buf: OutputBuffer,
         stream_registry: StreamRegistry,
         audio_token_id: Option<u32>,
@@ -1094,8 +1127,10 @@ const DEFAULT_PORT_OLLAMA: u16 = 17434;
 /// Build an in-process `Worker` `LoadedModel` from an `EngineContext`.
 fn loaded_model_from_ctx(
     model_id: String,
+    serve_args: &ServeArgs,
     ctx: crate::engine::EngineContext,
 ) -> Result<LoadedModel> {
+    let memory_config = build_memory_config(serve_args, &ctx);
     let tok = Arc::new(Tokenizer::from_file_with_arch(
         &ctx.model_files.tokenizer_path,
         ctx.model_files.tokenizer_config_path.as_deref(),
@@ -1135,6 +1170,7 @@ fn loaded_model_from_ctx(
             engine_tx,
             tokenizer: tok,
             max_seq_len,
+            memory_config,
             output_buf,
             stream_registry,
             audio_token_id,
@@ -1146,6 +1182,98 @@ fn loaded_model_from_ctx(
             vision_default_output_length,
         },
     })
+}
+
+fn turbo_quant_index_bytes(head_dim: usize, bits: u8) -> usize {
+    (head_dim * bits as usize).div_ceil(8)
+}
+
+fn build_memory_config(args: &ServeArgs, ctx: &crate::engine::EngineContext) -> ServeMemoryConfig {
+    let arch = format!("{:?}", ctx.arch);
+    let dtype = format!("{:?}", ctx.dtype);
+    let max_seq_len = (ctx.max_seq_len != usize::MAX).then_some(ctx.max_seq_len);
+    let weight_source = if ctx.model_files.gguf_path.is_some() {
+        "gguf".to_string()
+    } else {
+        "safetensors".to_string()
+    };
+    let weight_bytes = if let Some(path) = &ctx.model_files.gguf_path {
+        std::fs::metadata(path).ok().map(|m| m.len())
+    } else {
+        let total = ctx
+            .model_files
+            .weight_paths
+            .iter()
+            .try_fold(0u64, |acc, path| {
+                Ok::<u64, std::io::Error>(acc + std::fs::metadata(path)?.len())
+            });
+        total.ok()
+    };
+    let weight_quantization = ctx.model_files.gguf_path.as_ref().map(|path| {
+        path.file_stem()
+            .and_then(|stem| stem.to_str())
+            .and_then(|stem| stem.rsplit('.').next())
+            .unwrap_or("GGUF")
+            .to_uppercase()
+    });
+
+    let (num_kv_heads, head_dim, num_layers) = ctx.raw_config.kv_cache_params(&ctx.arch);
+    let turbo_quant_supported = matches!(
+        ctx.arch,
+        ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4
+    );
+    let turbo_quant = if args.paged_attention.is_some() || !turbo_quant_supported {
+        None
+    } else {
+        args.turbo_quant.0
+    };
+    let turbo_quant_note = if args.paged_attention.is_some() && args.turbo_quant.0.is_some() {
+        Some("paged attention reserves KV from runtime dtype; TurboQuant does not reduce the paged pool".to_string())
+    } else if args.turbo_quant.0.is_some() && !turbo_quant_supported {
+        Some(format!(
+            "TurboQuant is not active for {arch}; KV uses runtime dtype sizing"
+        ))
+    } else {
+        None
+    };
+    let (kv_estimate_mode, max_kv_cache_bytes) = if args.paged_attention.is_some() {
+        let bytes_per_token = head_dim * 2 * num_kv_heads * num_layers * ctx.dtype.size_in_bytes();
+        (
+            "paged-dtype".to_string(),
+            max_seq_len.map(|seq_len| (bytes_per_token * seq_len) as u64),
+        )
+    } else if let Some(bits) = turbo_quant {
+        let index_bytes = turbo_quant_index_bytes(head_dim, bits);
+        let scale_bytes = head_dim.div_ceil(GROUP_SIZE) * 4;
+        let bytes_per_token = (index_bytes + scale_bytes) * 2 * num_kv_heads * num_layers;
+        (
+            "turbo-quant".to_string(),
+            max_seq_len.map(|seq_len| (bytes_per_token * seq_len) as u64),
+        )
+    } else {
+        let bytes_per_token = head_dim * 2 * num_kv_heads * num_layers * ctx.dtype.size_in_bytes();
+        (
+            "plain-dtype".to_string(),
+            max_seq_len.map(|seq_len| (bytes_per_token * seq_len) as u64),
+        )
+    };
+
+    ServeMemoryConfig {
+        dtype,
+        arch,
+        turbo_quant,
+        turbo_quant_note,
+        kv_estimate_mode,
+        weight_source,
+        weight_quantization: args
+            .quantize
+            .as_ref()
+            .map(|q| q.to_uppercase())
+            .or(weight_quantization),
+        weight_bytes,
+        max_seq_len,
+        max_kv_cache_bytes,
+    }
 }
 
 /// Pick a free TCP port on localhost by binding to port 0.
@@ -1331,13 +1459,14 @@ async fn load_model_on_demand(
         let mut serve_args = state.serve_args.clone();
         serve_args.model = Some(model_id.to_string());
         let model_id_owned = model_id.to_string();
-        let ctx = tokio::task::spawn_blocking(move || load_engine(&serve_args))
+        let load_args = serve_args.clone();
+        let ctx = tokio::task::spawn_blocking(move || load_engine(&load_args))
                 .await
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({"error": format!("model load panicked: {e}")}))))?
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({"error": format!("failed to load '{}': {e}", model_id_owned)}))))?;
-        loaded_model_from_ctx(model_id_owned, ctx).map_err(|e| {
+        loaded_model_from_ctx(model_id_owned, &serve_args, ctx).map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(serde_json::json!({"error": format!("engine init failed: {e}")})),
@@ -1413,7 +1542,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
     // If a model was specified on the CLI, pre-load it eagerly.
     let initial_slot = if let Some(ref model) = args.model {
         let ctx = load_engine(&args)?;
-        let lm = Arc::new(loaded_model_from_ctx(model.clone(), ctx)?);
+        let lm = Arc::new(loaded_model_from_ctx(model.clone(), &args, ctx)?);
         ModelSlot::Ready(lm)
     } else {
         ModelSlot::Empty
@@ -1452,6 +1581,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .route("/api/tags", get(ollama_tags).head(ollama_tags))
         .route("/api/ps", get(ollama_ps))
         .route("/api/show", post(ollama_show))
+        .route("/api/inferrs/memory", get(inferrs_memory))
         .route("/api/generate", post(ollama_generate))
         .route("/api/chat", post(ollama_chat))
         .route("/api/embed", post(ollama_embed))
@@ -3273,6 +3403,97 @@ async fn ollama_show(
         details: OllamaModelDetails::default(),
         model_info: serde_json::Value::Object(serde_json::Map::new()),
     }))
+}
+
+async fn inferrs_memory(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<MemoryReportResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let lm = {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => Arc::clone(lm),
+            _ => {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({"error": "memory reporting requires a loaded model"})),
+                ))
+            }
+        }
+    };
+
+    match &lm.backend {
+        ModelBackend::Worker {
+            engine_tx,
+            memory_config,
+            ..
+        } => {
+            let (response_tx, response_rx) = oneshot::channel::<SyncMemorySnapshot>();
+            engine_tx
+                .send(EngineRequest::MemorySnapshot { response_tx })
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": format!("failed to request memory snapshot: {e}")})),
+                    )
+                })?;
+            let snapshot = response_rx.await.map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("memory snapshot response dropped: {e}")})),
+                )
+            })?;
+            let max_kv_cache_bytes = snapshot
+                .paged
+                .as_ref()
+                .map(|paged| paged.reserved_bytes as u64)
+                .or(memory_config.max_kv_cache_bytes);
+
+            Ok(Json(MemoryReportResponse {
+                device: snapshot.device.to_string(),
+                dtype: memory_config.dtype.clone(),
+                arch: memory_config.arch.clone(),
+                turbo_quant: memory_config.turbo_quant,
+                turbo_quant_note: memory_config.turbo_quant_note.clone(),
+                kv_estimate_mode: memory_config.kv_estimate_mode.clone(),
+                weight_source: memory_config.weight_source.clone(),
+                weight_quantization: memory_config.weight_quantization.clone(),
+                weight_bytes: memory_config.weight_bytes,
+                max_seq_len: memory_config.max_seq_len,
+                max_kv_cache_bytes,
+                paged: snapshot.paged,
+            }))
+        }
+        ModelBackend::Proxy { worker_url, .. } => {
+            let url = format!("{worker_url}/api/inferrs/memory");
+            let response = state.http_client.get(&url).send().await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(
+                        serde_json::json!({"error": format!("worker memory request failed: {e}")}),
+                    ),
+                )
+            })?;
+            let status = response.status();
+            if !status.is_success() {
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "worker returned an error".to_string());
+                return Err((
+                    StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::BAD_GATEWAY),
+                    Json(serde_json::json!({"error": body})),
+                ));
+            }
+            let report = response.json::<MemoryReportResponse>().await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({"error": format!("invalid worker memory response: {e}")})),
+                )
+            })?;
+            Ok(Json(report))
+        }
+    }
 }
 
 /// Return the RFC3339 timestamp for right now (UTC).

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1210,7 +1210,7 @@ fn build_memory_config(args: &ServeArgs, ctx: &crate::engine::EngineContext) -> 
         ctx.arch,
         ModelArchitecture::Qwen3 | ModelArchitecture::Qwen35 | ModelArchitecture::Gemma4
     );
-    let turbo_quant = if args.paged_attention.is_some() || !turbo_quant_supported {
+    let turbo_quant = if !turbo_quant_supported {
         None
     } else {
         args.turbo_quant.0

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1197,18 +1197,6 @@ fn build_memory_config(args: &ServeArgs, ctx: &crate::engine::EngineContext) -> 
     } else {
         "safetensors".to_string()
     };
-    let weight_bytes = if let Some(path) = &ctx.model_files.gguf_path {
-        std::fs::metadata(path).ok().map(|m| m.len())
-    } else {
-        let total = ctx
-            .model_files
-            .weight_paths
-            .iter()
-            .try_fold(0u64, |acc, path| {
-                Ok::<u64, std::io::Error>(acc + std::fs::metadata(path)?.len())
-            });
-        total.ok()
-    };
     let weight_quantization = ctx.model_files.gguf_path.as_ref().map(|path| {
         path.file_stem()
             .and_then(|stem| stem.to_str())
@@ -1270,7 +1258,7 @@ fn build_memory_config(args: &ServeArgs, ctx: &crate::engine::EngineContext) -> 
             .as_ref()
             .map(|q| q.to_uppercase())
             .or(weight_quantization),
-        weight_bytes,
+        weight_bytes: ctx.weight_bytes,
         max_seq_len,
         max_kv_cache_bytes,
     }


### PR DESCRIPTION
## Summary
- add `/show memory` support to `inferrs run`
- report effective KV sizing, paged pool details, and model weight estimates
- document the capability matrix and memory semantics for `--quantize`, `--turbo-quant`, and `--paged-attention`

## Why this is helpful
Memory behavior is one of the main things users need to understand when tuning local inference. The runtime feature makes that visible from inside the REPL, and the README changes explain how the knobs interact so users can reason about weight size vs KV size without digging through code.

In particular, the docs now spell out that:
- `--quantize` affects model weights
- `--turbo-quant` affects the KV cache
- `--paged-attention` changes KV reservation/management
- `--quantize` and `--turbo-quant` can be combined because they act on different parts of the system

## Verification
- `cargo fmt --all`
- `cargo check -p inferrs`
- `cargo build --release -p inferrs`