### PR TITLE
fix: Qwen3.5 RMSNorm weight convention mismatch causing endless spaces

### DIFF
--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
+use candle_nn::{embedding, linear_no_bias, Embedding, Init, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
@@ -17,6 +17,12 @@ use crate::models::attention_utils::{
     paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx, PagedPassCache,
 };
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
+
+fn rms_norm_with_offset(size: usize, eps: f64, vb: VarBuilder, offset: f64) -> Result<RmsNorm> {
+    let weight = vb.get_with_hints(size, "weight", Init::Const(0.0))?;
+    let adjusted = weight.affine(1.0, offset)?;
+    Ok(RmsNorm::new(adjusted, eps))
+}
 
 // ---------------------------------------------------------------------------
 // Config
@@ -90,8 +96,8 @@ impl FullAttention {
         let k_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("k_proj"))?;
         let v_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("v_proj"))?;
         let o_proj = linear_no_bias(attn_out, cfg.hidden_size, vb.pp("o_proj"))?;
-        let q_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
-        let k_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+        let q_norm = rms_norm_with_offset(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"), 1.0)?;
+        let k_norm = rms_norm_with_offset(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"), 1.0)?;
 
         let tq_cache = tq_cfg.map(|c| {
             TurboQuantKvCache::new(c, cfg.num_key_value_heads, cfg.dtype, cfg.device.clone())
@@ -681,11 +687,17 @@ impl DecoderLayer {
         Ok(Self {
             attn,
             mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
-            input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
-            post_attention_layernorm: rms_norm(
+            input_layernorm: rms_norm_with_offset(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("input_layernorm"),
+                1.0,
+            )?,
+            post_attention_layernorm: rms_norm_with_offset(
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 vb.pp("post_attention_layernorm"),
+                1.0,
             )?,
         })
     }
@@ -789,7 +801,7 @@ impl Qwen35Model {
             layers.push(layer);
         }
 
-        let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"))?;
+        let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"), 1.0)?;
 
         // Tied weights: lm_head = embed_tokens.weight transposed
         let lm_head_weight = embed_tokens.embeddings().clone();


### PR DESCRIPTION
# Fix Qwen3.5 RMSNorm weight loading
## Summary

After implementing https://github.com/ericcurtin/inferrs/pull/146 I've tested more dense models and ran into issues with some of them

Qwen3.5 models produce degenerate output (endless whitespace) because RMSNorm weights are loaded with the wrong convention. The PyTorch `Qwen3_5RMSNorm` stores **residual weights** (initialized at `torch.zeros`, forward computes `(1.0 + weight) * normalize(x)`) but `candle_nn::rms_norm()` treats them as **direct multipliers** (`weight * normalize(x)`), producing near-zero activations throughout the network.

## Details

The Qwen3.5 architecture introduces a custom `Qwen3_5RMSNorm` class that differs from the standard `RMSNorm` used by Qwen2/3:

| | Standard RMSNorm | Qwen3.5 RMSNorm |
|---|---|---|
| Init | `torch.ones(dim)` | `torch.zeros(dim)` |
| Checkpoint values | ~1.0 | ~0.0 (residual from 1.0) |
| Forward | `weight * normalize(x)` | `(1.0 + weight) * normalize(x)` |

When `candle_nn::rms_norm()` loads the Qwen3.5 checkpoint weights (~0.0) and uses them as direct multipliers, every norm layer outputs near-zero values. The model collapses to predicting the same token repeatedly (a whitespace token), producing endless spaces with no stop condition.

## Fix

Add `rms_norm_with_offset()` helper that:
1. Loads the checkpoint weight via `VarBuilder`
2. Adds the offset (1.0) to convert residuals into direct multipliers
3. Constructs `RmsNorm::new(adjusted_weight, eps)`

This is applied to all 5 norm-layer types that use the Qwen3.5 convention:

- `input_layernorm` (all layers)
- `post_attention_layernorm` (all layers)
- `norm` (final layer norm)
- `q_norm` (full-attention layers)
- `k_norm` (full-attention layers)

The `LinearAttn` gated norm is **unaffected** — it uses `rms_norm_tensor()` with weights stored near 1.0 (correct convention).

## Testing

```
inferrs run Qwen/Qwen3.5-2B "What is the capital of France?"
```

Before fix: endless whitespace output, model never stops.
After fix: correct, coherent response.

### Last word

Despite the prefill performances (I'm looking into [Blelloch Algorithm](https://medium.com/nerd-for-tech/understanding-implementation-of-work-efficient-parallel-prefix-scan-cca2d5335c9b) and [GatedDeltaNet](https://github.com/NVlabs/GatedDeltaNet)) qwen 3.5 dense models should be stable
