### PR TITLE
change default Ollama-compatible port from 11434 to 17434

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ inferrs serve --paged-attention google/gemma-4-E2B-it
 inferrs serve --quantize google/gemma-4-E2B-it
 ```
 
-#### Serve without a model (Ollama-compatible mode on port 11434)
+#### Serve without a model (Ollama-compatible mode on port 17434)
 
 ```bash
 inferrs serve
 ```
 
-This behaves like `ollama serve`: the server starts on `0.0.0.0:11434`, responds
-`"Ollama is running"` at `GET /`, and exposes the full Ollama API. Any Ollama
-client — including the `ollama` CLI — can point at it directly.
+This behaves like `ollama serve` the server starts on `0.0.0.0:17434` and
+exposes the full Ollama API. Any Ollama client — including the `ollama`
+CLI — can point at it directly.
 
 ## Architecture
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -80,7 +80,7 @@ enum Commands {
 pub struct ServeArgs {
     /// HuggingFace model ID (e.g. Qwen/Qwen3.5-0.8B).
     /// When omitted, inferrs starts without loading a model and exposes the
-    /// Ollama-compatible API on port 11434 (same behaviour as `ollama serve`).
+    /// Ollama-compatible API on port 17434 (same behaviour as `ollama serve`).
     pub model: Option<String>,
 
     /// Git branch or tag on HuggingFace Hub
@@ -104,7 +104,7 @@ pub struct ServeArgs {
     pub host: String,
 
     /// Port to listen on.
-    /// Defaults to 8080 when a model is specified, or 11434 (Ollama default)
+    /// Defaults to 8080 when a model is specified, or 17434 (Ollama default)
     /// when no model is specified.
     #[arg(long)]
     pub port: Option<u16>,

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -772,7 +772,7 @@ fn image_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) 
 /// Default port when a specific model is pre-loaded (OpenAI-style API).
 const DEFAULT_PORT_MODEL: u16 = 8080;
 /// Default port when running in Ollama-compatible mode (no model pre-loaded).
-const DEFAULT_PORT_OLLAMA: u16 = 11434;
+const DEFAULT_PORT_OLLAMA: u16 = 17434;
 
 pub async fn run(args: ServeArgs) -> Result<()> {
     // When a model is specified, load it; otherwise run in Ollama-compatible
@@ -2161,7 +2161,7 @@ fn inject_tools_into_messages(messages: &[ChatMessage], tool_summary: &str) -> V
 
 /// `GET /` and `HEAD /` — Ollama running check.
 async fn ollama_root() -> impl IntoResponse {
-    (StatusCode::OK, "Ollama is running")
+    (StatusCode::OK, "inferrs is running")
 }
 
 /// `GET /api/version` — Ollama version endpoint.


### PR DESCRIPTION
## Summary

- Change the no-model serve mode default port from `11434` to `17434` to avoid conflicting with a running Ollama instance
- Update `GET /` root response from `"Ollama is running"` to `"inferrs is running"` to correctly identify the server
- Update README and CLI doc comments to reflect the new default port