### PR TITLE
feat: make inferrs run/serve follow the Ollama daemon/worker model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,8 +1280,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1285,9 +1293,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1482,6 +1492,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1701,6 +1712,7 @@ dependencies = [
  "libc",
  "libloading 0.8.9",
  "rayon",
+ "reqwest",
  "rustfft",
  "serde",
  "serde_json",
@@ -1914,6 +1926,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2490,6 +2508,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2669,6 +2742,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2676,6 +2751,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http 0.6.8",
@@ -2685,6 +2761,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2700,6 +2777,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustfft"
@@ -2762,6 +2845,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -3220,6 +3304,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -29,6 +29,9 @@ tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["json"] }
 tower-http = { version = "0.5", features = ["cors"] }
 
+# HTTP client (used by `inferrs run` to talk to `inferrs serve`)
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -188,6 +188,7 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
 /// Abstraction over the two streaming channel flavours:
 /// - `tokio::sync::mpsc::Sender` (used by the HTTP server)
 /// - `std::sync::mpsc::SyncSender` (used by `inferrs run` on a plain OS thread)
+#[allow(dead_code)]
 trait TokenSender: Send {
     fn send_token(&self, token: StreamToken) -> bool;
 }
@@ -254,6 +255,7 @@ pub enum EngineRequest {
 }
 
 /// Request to the engine using only stdlib channels (no Tokio, used by `inferrs run`).
+#[allow(dead_code)]
 pub enum SyncEngineRequest {
     /// Generate tokens with streaming, sending each token over a stdlib channel.
     GenerateStream {
@@ -1570,6 +1572,7 @@ impl Engine {
 
     /// Run the engine loop using only stdlib channels — no Tokio runtime required.
     /// Used by `inferrs run` so that blocking sends/recvs work on a plain OS thread.
+    #[allow(dead_code)]
     pub fn run_sync(mut self, rx: std::sync::mpsc::Receiver<SyncEngineRequest>) {
         tracing::info!("Engine loop started (sync)");
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -511,7 +511,7 @@ async fn main() -> Result<()> {
             server::run(args).await?;
         }
         Commands::Run(args) => {
-            run::run(args)?;
+            run::run(args).await?;
         }
         Commands::Bench(args) => {
             tracing::info!(

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -1,7 +1,17 @@
-//! Interactive REPL for `inferrs run` — runs a model in a
-//! single process (no HTTP server, no separate daemon).
+//! Interactive REPL for `inferrs run` — talks to a running `inferrs serve`
+//! daemon via the Ollama-compatible HTTP API, exactly as `ollama run` does.
+//!
+//! The server URL is resolved from (in priority order):
+//!   1. `--host` / `--port` CLI flags
+//!   2. `INFERRS_HOST` environment variable  (e.g. `http://10.0.0.5:17434`)
+//!   3. Default: `http://127.0.0.1:17434`
+//!
+//! When the server is not reachable, `inferrs run` automatically starts
+//! `inferrs serve` (no arguments — the bare daemon) in the background and
+//! waits for it to become ready, mirroring `ollama run`'s `ensureServerRunning`.
+//! Hardware and model-loading configuration belongs on `inferrs serve`, not here.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use crossterm::{
     cursor,
@@ -10,42 +20,30 @@ use crossterm::{
     style::{Color, Print, ResetColor, SetForegroundColor},
     terminal::{self, ClearType},
 };
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
 use std::io::{self, Write};
-use std::sync::mpsc as stdmpsc;
-
-use crate::engine::{
-    load_engine, AudioEmbedContext, ImageEmbedContext, StreamToken, SyncEngineRequest,
-};
-use crate::sampler::SamplingParams;
-use crate::server::patchify_image_bytes;
-use crate::tokenizer::{
-    apply_gemma4_with_audio, apply_gemma4_with_images, AudioInput, ChatMessage, ImageInput,
-    MessageContent, Role, Tokenizer,
-};
-use crate::ServeArgs;
 
 // ─── CLI args ────────────────────────────────────────────────────────────────
 
+/// Default port for the Ollama-compatible API (matches `inferrs serve` default
+/// and real Ollama's default port).
+const DEFAULT_PORT: u16 = 17434;
+
 #[derive(Parser, Clone)]
 pub struct RunArgs {
-    /// HuggingFace model ID (e.g. google/gemma-3-1b-it)
+    /// HuggingFace model ID (e.g. Qwen/Qwen3-0.6B).
+    /// Passed to `inferrs serve` when auto-starting the daemon.
     pub model: String,
 
     /// Optional prompt — when given, run non-interactively and exit
     pub prompt: Option<String>,
 
-    /// Git branch or tag on HuggingFace Hub
-    #[arg(long, default_value = "main")]
-    pub revision: String,
+    /// System prompt
+    #[arg(long)]
+    pub system: Option<String>,
 
-    /// Weight data type: f32, f16, bf16
-    #[arg(long, default_value = "bf16")]
-    pub dtype: String,
-
-    /// Device: cpu, cuda, metal, or auto
-    #[arg(long, default_value = "auto")]
-    pub device: String,
-
+    // ── Sampling ──────────────────────────────────────────────────────────────
     /// Default sampling temperature
     #[arg(long, default_value_t = 0.7)]
     pub temperature: f64,
@@ -62,275 +60,584 @@ pub struct RunArgs {
     #[arg(long, default_value_t = 2048)]
     pub max_tokens: usize,
 
-    /// Repetition penalty (1.0 = disabled, >1.0 discourages repeated tokens).
-    /// Defaults to 1.1 to prevent the model from getting stuck in repetition loops.
-    #[arg(long, default_value_t = 1.1)]
-    pub repetition_penalty: f64,
+    // ── Server connection ─────────────────────────────────────────────────────
+    /// Address of the `inferrs serve` daemon.
+    /// Overrides `INFERRS_HOST`.  Defaults to `127.0.0.1`.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
 
-    /// System prompt
-    #[arg(long)]
-    pub system: Option<String>,
+    /// Port of the `inferrs serve` daemon.
+    /// Overrides the port part of `INFERRS_HOST`.  Defaults to 17434.
+    #[arg(long, default_value_t = DEFAULT_PORT)]
+    pub port: u16,
 
-    /// Fraction of GPU/CPU memory to reserve for paged KV blocks (vLLM-style block management).
-    /// e.g. `--paged-attention=0.9` reserves 90% of available memory.
-    /// When used as a plain flag (`--paged-attention`) the default 0.9 (90%) is used.
-    /// Omit the flag entirely to disable paged attention.
+    // ── Model-loading flags (forwarded to `inferrs serve` on auto-start) ────────
+    /// Git branch or tag on HuggingFace Hub
+    #[arg(long, default_value = "main")]
+    pub revision: String,
+
+    /// Weight data type: f32, f16, bf16
+    #[arg(long, default_value = "bf16")]
+    pub dtype: String,
+
+    /// Device: cpu, cuda, metal, or auto
+    #[arg(long, default_value = "auto")]
+    pub device: String,
+
+    /// Fraction of GPU/CPU memory to reserve for paged KV blocks.
+    /// e.g. `--paged-attention=0.9` reserves 90 % of available memory.
+    /// When used as a plain flag the default 0.9 is applied.
+    /// Omit entirely to disable paged attention.
     #[arg(long, num_args(0..=1), default_missing_value("0.9"), require_equals(true),
           value_name = "FRACTION")]
     pub paged_attention: Option<f64>,
 
     /// TurboQuant KV cache compression bit-width (Qwen3/Gemma4).
-    /// Enabled by default at 8 bits (~2× KV memory reduction, near-lossless quality).
-    /// Pass an explicit bit-width (`--turbo-quant=N`, 1–8) to change the compression level.
-    /// 4-bit gives ~3.5× but may produce poor output on models with large QK-norm values.
-    /// Disable entirely with `--turbo-quant=false`.
+    /// Enabled by default at 8 bits. Pass a bit-width (1–8) or `false`.
     #[arg(long, default_value = "8", require_equals(true))]
     pub turbo_quant: crate::TurboQuantArg,
 
-    /// Quantize model weights and cache the result on disk as a GGUF file.
-    /// On first use the weights are quantized and saved next to the HuggingFace cache;
-    /// subsequent runs reuse the cached GGUF, so the slow conversion only happens once.
-    ///
-    /// Accepted formats (case-insensitive): Q4_0, Q4_1, Q5_0, Q5_1, Q8_0,
-    /// Q2K, Q3K, Q4K (Q4_K_M), Q5K, Q6K.
-    ///
-    /// When used as a plain flag (`--quantize`) the default Q4_K_M (= Q4K) is used.
-    /// Embedding and output (lm_head) tensors are kept at F16 for accuracy.
+    /// Quantize model weights on first use and cache as GGUF.
+    /// Accepted formats: Q4_0, Q4_1, Q5_0, Q5_1, Q8_0, Q2K, Q3K, Q4K, Q5K, Q6K.
+    /// Plain `--quantize` defaults to Q4K.
     #[arg(long, num_args(0..=1), default_missing_value("Q4K"), require_equals(true),
           value_name = "FORMAT")]
     pub quantize: Option<String>,
 
+    // ── Media attachments (non-interactive / single-turn only) ────────────────
     /// Path to a WAV audio file to attach to the prompt (Gemma 4 audio models).
     #[arg(long)]
     pub audio: Option<std::path::PathBuf>,
 
-    /// Path to an image file to attach to the prompt (Gemma 4 vision models).
+    /// Path to an image file to attach to the prompt (vision models).
     /// Accepts JPEG, PNG, GIF, WebP, and other formats supported by the `image` crate.
     #[arg(long)]
     pub image: Option<std::path::PathBuf>,
 }
 
 impl RunArgs {
-    fn to_serve_args(&self) -> ServeArgs {
-        ServeArgs {
-            model: Some(self.model.clone()),
-            revision: self.revision.clone(),
-            dtype: self.dtype.clone(),
-            max_seq_len: 0,
-            device: self.device.clone(),
-            host: "0.0.0.0".to_string(),
-            port: Some(8080),
-            block_size: 16,
-            initial_blocks: 16,
-            max_blocks: 0,
-            max_batch_size: 1,
-            max_tokens_per_step: 2048,
-            temperature: self.temperature,
-            top_p: self.top_p,
-            top_k: self.top_k,
-            max_tokens: self.max_tokens,
-            paged_attention: self.paged_attention,
-            turbo_quant: self.turbo_quant.clone(),
-            quantize: self.quantize.clone(),
+    /// Resolve the base URL for the server, using the same priority as
+    /// `ollama run` uses for `OLLAMA_HOST`:
+    ///   CLI flags > `INFERRS_HOST` env var > default.
+    fn server_url(&self) -> String {
+        // Detect whether the user explicitly overrode the defaults.
+        let from_flags = self.host != "127.0.0.1" || self.port != DEFAULT_PORT;
+        if from_flags {
+            return format!("http://{}:{}", self.host, self.port);
+        }
+
+        if let Ok(env) = std::env::var("INFERRS_HOST") {
+            let env = env.trim().to_string();
+            if !env.is_empty() {
+                // Accept plain `host:port` as well as `http://host:port`.
+                return if env.starts_with("http://") || env.starts_with("https://") {
+                    env
+                } else {
+                    format!("http://{env}")
+                };
+            }
+        }
+
+        format!("http://{}:{}", self.host, self.port)
+    }
+}
+
+// ─── Sampling params bundle ──────────────────────────────────────────────────
+
+/// Sampling parameters passed to generation functions.
+/// Bundled into a struct to keep function argument counts within clippy limits.
+#[derive(Debug, Clone, Copy)]
+struct SamplingParams {
+    temperature: f64,
+    top_p: f64,
+    top_k: usize,
+    max_tokens: usize,
+}
+
+impl SamplingParams {
+    fn from_args(args: &RunArgs) -> Self {
+        Self {
+            temperature: args.temperature,
+            top_p: args.top_p,
+            top_k: args.top_k,
+            max_tokens: args.max_tokens,
         }
     }
+}
+
+// ─── Ollama API wire types ───────────────────────────────────────────────────
+
+/// A single message in the `/api/chat` conversation history.
+///
+/// The `images` field carries base64-encoded image data and is part of the
+/// standard Ollama wire format for vision requests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiMessage {
+    pub role: String,
+    pub content: String,
+    /// Base64-encoded image data (standard Ollama vision field).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<String>,
+}
+
+/// `POST /api/chat` request body.
+#[derive(Debug, Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: &'a [ApiMessage],
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    options: Option<ChatOptions>,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatOptions {
+    temperature: f64,
+    top_p: f64,
+    top_k: usize,
+    num_predict: usize,
+}
+
+/// One NDJSON line from a streaming `/api/chat` response.
+#[derive(Debug, Deserialize)]
+struct ChatChunk {
+    message: Option<ApiMessage>,
+    done: bool,
+}
+
+// ─── OpenAI SSE types (used for /v1/chat/completions with audio) ─────────────
+
+/// One SSE data line from a `/v1/chat/completions` streaming response.
+#[derive(Debug, Deserialize)]
+struct OaiChunkChoice {
+    delta: OaiDelta,
+}
+
+#[derive(Debug, Deserialize)]
+struct OaiDelta {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OaiChunk {
+    choices: Vec<OaiChunkChoice>,
+}
+
+// ─── HTTP client helpers ─────────────────────────────────────────────────────
+
+/// Probe the server with `HEAD /` (Ollama heartbeat endpoint).
+/// Returns `true` if the server responded, `false` if connection was refused.
+async fn heartbeat(client: &Client, base_url: &str) -> bool {
+    let url = format!("{base_url}/");
+    client.head(&url).send().await.is_ok()
+}
+
+/// Ensure the server is running, auto-starting it in the background if needed.
+///
+/// Mirrors `ollama run`'s `ensureServerRunning`: probe the heartbeat, and if
+/// the server is not up, spawn `inferrs serve` (no arguments — the bare daemon,
+/// just like `ollama serve`) using the same executable that is currently
+/// running, then poll every 200 ms until it responds (up to 60 s).
+async fn ensure_server_running(client: &Client, base_url: &str) -> Result<()> {
+    if heartbeat(client, base_url).await {
+        return Ok(());
+    }
+
+    // Server not running — spawn `inferrs serve` (no args) in the background.
+    let exe = std::env::current_exe().context("Could not determine inferrs executable path")?;
+
+    std::process::Command::new(&exe)
+        .arg("serve")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("Failed to spawn `inferrs serve` ({})", exe.display()))?;
+
+    // Poll until the server is ready (up to 60 s).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        if heartbeat(client, base_url).await {
+            return Ok(());
+        }
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "inferrs serve did not become ready within 60 s at {base_url}.\n\
+                 Check its logs for errors."
+            );
+        }
+    }
+}
+
+/// Send `POST /api/chat` with streaming enabled and print tokens to stdout as
+/// they arrive.  Returns the full assembled response text.
+///
+/// Uses the Ollama NDJSON streaming format (`application/x-ndjson`).
+async fn chat_stream(
+    client: &Client,
+    base_url: &str,
+    model: &str,
+    messages: &[ApiMessage],
+    params: SamplingParams,
+) -> Result<String> {
+    let url = format!("{base_url}/api/chat");
+
+    let body = ChatRequest {
+        model,
+        messages,
+        stream: true,
+        options: Some(ChatOptions {
+            temperature: params.temperature,
+            top_p: params.top_p,
+            top_k: params.top_k,
+            num_predict: params.max_tokens,
+        }),
+    };
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url} failed"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("Server returned {status}: {text}");
+    }
+
+    drain_ndjson_stream(response).await
+}
+
+/// Send `POST /v1/chat/completions` (OpenAI SSE format) for requests that
+/// carry an audio attachment.  The server's `/api/chat` Ollama endpoint does
+/// not yet accept audio, so audio requests are routed through the OpenAI
+/// endpoint which has full audio preprocessing support.
+async fn audio_stream(
+    client: &Client,
+    base_url: &str,
+    model: &str,
+    text_messages: &[ApiMessage], // prior conversation (text only)
+    prompt: &str,
+    audio_b64: &str,
+    params: SamplingParams,
+) -> Result<String> {
+    let url = format!("{base_url}/v1/chat/completions");
+
+    // Rebuild prior turns as plain OpenAI messages, then append the audio turn.
+    let mut messages: Vec<serde_json::Value> = text_messages
+        .iter()
+        .map(|m| serde_json::json!({"role": m.role, "content": m.content}))
+        .collect();
+
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": [
+            {"type": "text", "text": prompt},
+            {"type": "input_audio", "input_audio": {"data": audio_b64, "format": "wav"}}
+        ]
+    }));
+
+    let body = serde_json::json!({
+        "model": model,
+        "messages": messages,
+        "stream": true,
+        "max_tokens": params.max_tokens,
+        "temperature": params.temperature,
+        "top_p": params.top_p,
+        "top_k": params.top_k,
+    });
+
+    let response = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url} failed"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("Server returned {status}: {text}");
+    }
+
+    drain_openai_sse_stream(response).await
+}
+
+// ─── Stream drainers ─────────────────────────────────────────────────────────
+
+/// Drain an Ollama NDJSON response stream, printing and collecting all tokens.
+async fn drain_ndjson_stream(response: reqwest::Response) -> Result<String> {
+    use futures::StreamExt;
+
+    let mut full_text = String::new();
+    let mut stdout = io::stdout();
+    let mut byte_stream = response.bytes_stream();
+    let mut line_buf = String::new();
+
+    while let Some(chunk) = byte_stream.next().await {
+        let chunk = chunk.context("Error reading response stream")?;
+        let text = std::str::from_utf8(&chunk).context("Non-UTF-8 bytes in response")?;
+        line_buf.push_str(text);
+
+        while let Some(newline_pos) = line_buf.find('\n') {
+            let line = line_buf[..newline_pos].trim().to_string();
+            line_buf.drain(..=newline_pos);
+
+            if line.is_empty() {
+                continue;
+            }
+
+            let parsed: ChatChunk = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Failed to parse NDJSON chunk: {e}: {line}");
+                    continue;
+                }
+            };
+
+            if let Some(msg) = parsed.message {
+                full_text.push_str(&msg.content);
+                print!("{}", msg.content);
+                stdout.flush()?;
+            }
+
+            if parsed.done {
+                return Ok(full_text);
+            }
+        }
+    }
+
+    Ok(full_text)
+}
+
+/// Drain an OpenAI SSE response stream (`text/event-stream`), printing and
+/// collecting all content tokens.
+async fn drain_openai_sse_stream(response: reqwest::Response) -> Result<String> {
+    use futures::StreamExt;
+
+    let mut full_text = String::new();
+    let mut stdout = io::stdout();
+    let mut byte_stream = response.bytes_stream();
+    let mut line_buf = String::new();
+
+    while let Some(chunk) = byte_stream.next().await {
+        let chunk = chunk.context("Error reading SSE stream")?;
+        let text = std::str::from_utf8(&chunk).context("Non-UTF-8 bytes in SSE response")?;
+        line_buf.push_str(text);
+
+        while let Some(newline_pos) = line_buf.find('\n') {
+            let line = line_buf[..newline_pos].trim().to_string();
+            line_buf.drain(..=newline_pos);
+
+            // SSE lines are `data: <json>` or `data: [DONE]`
+            let Some(json) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            if json == "[DONE]" {
+                return Ok(full_text);
+            }
+
+            let parsed: OaiChunk = match serde_json::from_str(json) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Failed to parse SSE chunk: {e}: {json}");
+                    continue;
+                }
+            };
+
+            for choice in parsed.choices {
+                if let Some(content) = choice.delta.content {
+                    full_text.push_str(&content);
+                    print!("{content}");
+                    stdout.flush()?;
+                }
+            }
+        }
+    }
+
+    Ok(full_text)
 }
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
-/// Called from `main` (inside the Tokio runtime).  All blocking work —
-/// model loading, the engine loop, and the REPL — is moved onto plain OS
-/// threads so that `blocking_send` / `blocking_recv` never run inside an
-/// async context.
-pub fn run(args: RunArgs) -> Result<()> {
-    // `std::thread::spawn` exits the Tokio runtime context for this thread.
-    let handle = std::thread::Builder::new()
-        .name("run-main".to_string())
-        .spawn(move || run_blocking(args))
-        .expect("Failed to spawn run thread");
-
-    handle
-        .join()
-        .map_err(|_| anyhow::anyhow!("run thread panicked"))?
+/// Loading state shared between the background warm-up task and the REPL.
+#[derive(Debug, Clone, PartialEq)]
+enum LoadState {
+    Loading,
+    Ready,
+    Failed(String),
 }
 
-/// All blocking work: model download, weight loading, engine spawn, REPL.
-/// This runs on a plain OS thread, never inside the Tokio executor.
-fn run_blocking(args: RunArgs) -> Result<()> {
-    let serve = args.to_serve_args();
+/// Send an empty-prompt `POST /api/generate` request to trigger server-side
+/// model loading without waiting for any generated tokens.  This is the same
+/// "warm-up" pattern used by `ollama run` (`loadOrUnloadModel` with no prompt).
+///
+/// Model-loading options (dtype, device, revision, etc.) are passed in the
+/// `options` field and read by the daemon when it spawns the worker process.
+async fn warm_up_model(client: &Client, base_url: &str, args: &RunArgs) -> Result<()> {
+    let url = format!("{base_url}/api/generate");
 
-    // Load model, build engine, attach paged KV.
-    let ctx = load_engine(&serve)?;
+    // Build the options object with any non-default model-loading fields.
+    let mut options = serde_json::Map::new();
+    if args.revision != "main" {
+        options.insert("revision".into(), args.revision.clone().into());
+    }
+    if args.dtype != "bf16" {
+        options.insert("dtype".into(), args.dtype.clone().into());
+    }
+    if args.device != "auto" {
+        options.insert("device".into(), args.device.clone().into());
+    }
+    if let Some(pa) = args.paged_attention {
+        options.insert("paged_attention".into(), pa.into());
+    }
+    if args.turbo_quant.0 != Some(8) {
+        options.insert("turbo_quant".into(), args.turbo_quant.to_string().into());
+    }
+    if let Some(ref q) = args.quantize {
+        options.insert("quantize".into(), q.clone().into());
+    }
 
-    // Extract fields needed before ctx is partially moved.
-    let audio_token_id = ctx.raw_config.audio_token_id;
-    let image_token_id = ctx.raw_config.image_token_id;
-    let vision_patch_size = ctx.raw_config.vision_config.as_ref().map(|v| v.patch_size);
-    let vision_pooling_kernel = ctx
-        .raw_config
-        .vision_config
-        .as_ref()
-        .map(|v| v.pooling_kernel_size);
-    let vision_output_length = ctx
-        .raw_config
-        .vision_config
-        .as_ref()
-        .map(|v| v.default_output_length);
-    let max_seq_len = ctx.max_seq_len;
+    let mut body = serde_json::json!({
+        "model": args.model,
+        "prompt": "",   // empty prompt = load-only signal
+        "stream": false,
+    });
+    if !options.is_empty() {
+        body["options"] = serde_json::Value::Object(options);
+    }
 
-    // REPL needs its own tokenizer for chat-template encoding.
-    let tokenizer = Tokenizer::from_file_with_arch(
-        &ctx.model_files.tokenizer_path,
-        ctx.model_files.tokenizer_config_path.as_deref(),
-        Some(&ctx.arch),
-    )?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("warm-up request failed")?;
+    if !resp.status().is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("warm-up returned error: {text}");
+    }
+    Ok(())
+}
 
-    // Spawn engine on a dedicated OS thread using stdlib channels (no Tokio).
-    let (engine_tx, engine_rx) = stdmpsc::sync_channel::<SyncEngineRequest>(4);
-    std::thread::Builder::new()
-        .name("engine".to_string())
-        .spawn(move || ctx.engine.run_sync(engine_rx))
-        .expect("Failed to spawn engine thread");
+/// Called from `main` (inside the Tokio runtime).
+pub async fn run(args: RunArgs) -> Result<()> {
+    let base_url = args.server_url();
+    let client = Client::new();
 
-    let sampling_params = SamplingParams {
-        temperature: args.temperature,
-        top_p: args.top_p,
-        top_k: args.top_k,
-        repetition_penalty: args.repetition_penalty,
-        max_tokens: args
-            .max_tokens
-            .min(max_seq_len.saturating_sub(4096).max(256)),
-        ..SamplingParams::default()
-    };
+    // Ensure the daemon is up, auto-starting it when needed.
+    ensure_server_running(&client, &base_url).await?;
 
-    // Build initial message history (optional system prompt)
-    let mut messages: Vec<ChatMessage> = Vec::new();
-    if let Some(sys) = &args.system {
-        messages.push(ChatMessage {
-            role: Role::System,
-            audio: None,
-            content: MessageContent::from_string(sys),
-            tool_calls: None,
-            tool_call_id: None,
+    // Kick off model loading immediately in a background task so the server
+    // starts downloading/loading weights right now, without blocking the REPL.
+    let (load_tx, load_rx) = tokio::sync::watch::channel(LoadState::Loading);
+    {
+        let client2 = client.clone();
+        let base_url2 = base_url.clone();
+        let args2 = args.clone();
+        tokio::spawn(async move {
+            let result = warm_up_model(&client2, &base_url2, &args2).await;
+            let state = match result {
+                Ok(()) => LoadState::Ready,
+                Err(e) => LoadState::Failed(e.to_string()),
+            };
+            // Ignore send error — REPL may have already exited.
+            let _ = load_tx.send(state);
         });
     }
 
-    // Non-interactive: single prompt then exit
-    if let Some(prompt) = args.prompt {
-        // Build audio context if --audio was given.
-        if let Some(audio_path) = &args.audio {
-            let token_id = audio_token_id.ok_or_else(|| {
-                anyhow::anyhow!("This model does not support audio (no audio_token_id in config)")
-            })?;
-            let raw_bytes = std::fs::read(audio_path)?;
-            let samples = crate::audio::decode_audio(&raw_bytes, "wav")?;
-            let (mel_data, n_mel_frames) = crate::audio::compute_log_mel(&samples)?;
-            let effective_mel =
-                n_mel_frames.min(crate::models::audio_encoder::AudioEncoder::MAX_MEL_FRAMES);
-            let after_pass1 = (effective_mel.saturating_sub(1)) / 2 + 1;
-            let n_audio_tokens = (after_pass1.saturating_sub(1)) / 2 + 1;
-            let mel_tensor = candle_core::Tensor::from_vec(
-                mel_data,
-                (1, n_mel_frames, crate::audio::N_MEL),
-                &candle_core::Device::Cpu,
-            )?;
-            messages.push(ChatMessage {
-                role: Role::User,
-                audio: Some(AudioInput {
-                    data: String::new(),
-                    format: "wav".to_string(),
-                }),
-                content: MessageContent::from_string(prompt),
-                tool_calls: None,
-                tool_call_id: None,
-            });
-            let prompt_str = apply_gemma4_with_audio(&messages, &[n_audio_tokens]);
-            let prompt_tokens = tokenizer.encode(&prompt_str, false)?;
-            let audio_ctx = AudioEmbedContext {
-                mel: mel_tensor,
-                audio_token_id: token_id,
-            };
-            stream_response_collect(
-                &engine_tx,
-                prompt_tokens,
-                Some(audio_ctx),
-                None,
-                &sampling_params,
-            )?;
-            println!();
-            return Ok(());
-        }
-
-        // Build image context if --image was given.
-        if let Some(image_path) = &args.image {
-            let token_id = image_token_id.ok_or_else(|| {
-                anyhow::anyhow!("This model does not support vision (no image_token_id in config)")
-            })?;
-            let patch_size = vision_patch_size.unwrap_or(16);
-            let pooling_kernel = vision_pooling_kernel.unwrap_or(3);
-            let output_length = vision_output_length.unwrap_or(280);
-
-            let raw_bytes = std::fs::read(image_path)?;
-            let (pixel_values, position_ids, n_patches, n_soft_tokens) =
-                patchify_image_bytes(&raw_bytes, patch_size, pooling_kernel, output_length)?;
-
-            let pixel_tensor = candle_core::Tensor::from_vec(
-                pixel_values,
-                (n_patches, patch_size * patch_size * 3),
-                &candle_core::Device::Cpu,
-            )?;
-            let pos_tensor = candle_core::Tensor::from_vec(
-                position_ids,
-                (n_patches, 2),
-                &candle_core::Device::Cpu,
-            )?;
-
-            messages.push(ChatMessage {
-                role: Role::User,
-                audio: None,
-                content: MessageContent {
-                    text: prompt.clone(),
-                    // A single placeholder entry signals to apply_gemma4_with_images
-                    // that this message carries one image.
-                    images: vec![ImageInput { url: String::new() }],
-                },
-                tool_calls: None,
-                tool_call_id: None,
-            });
-            let prompt_str = apply_gemma4_with_images(&messages, &[n_soft_tokens]);
-            let prompt_tokens = tokenizer.encode(&prompt_str, false)?;
-            let image_ctx = ImageEmbedContext {
-                pixel_values: pixel_tensor,
-                position_ids: pos_tensor,
-                n_soft_tokens,
-                image_token_id: token_id,
-            };
-            stream_response_collect(
-                &engine_tx,
-                prompt_tokens,
-                None,
-                Some(image_ctx),
-                &sampling_params,
-            )?;
-            println!();
-            return Ok(());
-        }
-
-        messages.push(ChatMessage {
-            role: Role::User,
-            audio: None,
-            content: MessageContent::from_string(prompt),
-            tool_calls: None,
-            tool_call_id: None,
+    // Build initial message history (optional system prompt).
+    let mut messages: Vec<ApiMessage> = Vec::new();
+    if let Some(sys) = &args.system {
+        messages.push(ApiMessage {
+            role: "system".to_string(),
+            content: sys.clone(),
+            images: vec![],
         });
-        let prompt_tokens = tokenizer.apply_chat_template_and_encode(&messages)?;
-        stream_response_collect(&engine_tx, prompt_tokens, None, None, &sampling_params)?;
+    }
+
+    // ── Non-interactive: single prompt then exit ──────────────────────────────
+
+    if let Some(prompt) = args.prompt.clone() {
+        // Wait for the model to be ready before sending the single prompt.
+        wait_for_load(&mut load_rx.clone()).await?;
+
+        // Audio attachment — route through /v1/chat/completions.
+        if let Some(audio_path) = &args.audio {
+            let raw = std::fs::read(audio_path)
+                .with_context(|| format!("Could not read audio file: {}", audio_path.display()))?;
+            let audio_b64 = base64_encode(&raw);
+            audio_stream(
+                &client,
+                &base_url,
+                &args.model,
+                &messages,
+                &prompt,
+                &audio_b64,
+                SamplingParams::from_args(&args),
+            )
+            .await?;
+            println!();
+            return Ok(());
+        }
+
+        // Image attachment — include via the standard Ollama `images` field.
+        let images = if let Some(image_path) = &args.image {
+            let raw = std::fs::read(image_path)
+                .with_context(|| format!("Could not read image file: {}", image_path.display()))?;
+            vec![base64_encode(&raw)]
+        } else {
+            vec![]
+        };
+
+        messages.push(ApiMessage {
+            role: "user".to_string(),
+            content: prompt,
+            images,
+        });
+        chat_stream(
+            &client,
+            &base_url,
+            &args.model,
+            &messages,
+            SamplingParams::from_args(&args),
+        )
+        .await?;
         println!();
         return Ok(());
     }
 
-    // Interactive REPL
-    repl(tokenizer, engine_tx, sampling_params, messages)
+    // Interactive REPL — enter immediately; model loads in the background.
+    repl(client, base_url, load_rx, args).await
+}
+
+/// Wait for the background load to finish, returning an error if it failed.
+async fn wait_for_load(rx: &mut tokio::sync::watch::Receiver<LoadState>) -> Result<()> {
+    loop {
+        {
+            let state = rx.borrow();
+            match &*state {
+                LoadState::Ready => return Ok(()),
+                LoadState::Failed(e) => anyhow::bail!("Model failed to load: {e}"),
+                LoadState::Loading => {}
+            }
+        }
+        // Wait for the next state change from the background task.
+        if rx.changed().await.is_err() {
+            // Sender dropped without sending Ready/Failed — treat as ready
+            // (server may have responded before the watch was set up).
+            return Ok(());
+        }
+    }
+}
+
+/// Encode raw bytes as standard base64 (no line breaks).
+fn base64_encode(data: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(data)
 }
 
 // ─── Interactive REPL ────────────────────────────────────────────────────────
@@ -342,35 +649,47 @@ enum MultilineState {
     Prompt,
 }
 
-fn repl(
-    tokenizer: Tokenizer,
-    engine_tx: stdmpsc::SyncSender<SyncEngineRequest>,
-    sampling_params: SamplingParams,
-    mut messages: Vec<ChatMessage>,
+async fn repl(
+    client: Client,
+    base_url: String,
+    mut load_rx: tokio::sync::watch::Receiver<LoadState>,
+    args: RunArgs,
 ) -> Result<()> {
+    let mut messages: Vec<ApiMessage> = Vec::new();
+    if let Some(sys) = &args.system {
+        messages.push(ApiMessage {
+            role: "system".to_string(),
+            content: sys.clone(),
+            images: vec![],
+        });
+    }
+
+    let mut temperature = args.temperature;
+    let mut top_p = args.top_p;
+    let mut top_k = args.top_k;
+    let mut max_tokens = args.max_tokens;
+
     let mut multiline = MultilineState::None;
-    let mut buf = String::new(); // current multi-line accumulation buffer
+    let mut buf = String::new();
 
     loop {
+        // Show a loading indicator in the prompt while the model is still loading.
         let prompt_str = match multiline {
-            MultilineState::None => "> ",
             MultilineState::Prompt => ". ",
+            MultilineState::None => "> ",
         };
         print!("{prompt_str}");
         io::stdout().flush()?;
 
-        // Read a line using crossterm raw mode so we get per-key control
         let line = match read_line()? {
             ReadResult::Line(l) => l,
             ReadResult::Interrupt => {
-                // Ctrl+C — cancel current input
                 println!();
                 buf.clear();
                 multiline = MultilineState::None;
                 continue;
             }
             ReadResult::Eof => {
-                // Ctrl+D / EOF — exit
                 println!();
                 break;
             }
@@ -378,11 +697,9 @@ fn repl(
 
         match multiline {
             MultilineState::Prompt => {
-                // Check for closing """
                 if let Some(before) = line.strip_suffix("\"\"\"") {
                     buf.push_str(before);
                     multiline = MultilineState::None;
-                    // Fall through: buf now has the complete multi-line input
                 } else {
                     buf.push_str(&line);
                     buf.push('\n');
@@ -390,12 +707,9 @@ fn repl(
                 }
             }
             MultilineState::None => {
-                // Check for opening """
                 if let Some(rest) = line.strip_prefix("\"\"\"") {
-                    // Might open AND close on the same line: """text"""
                     if let Some(inner) = rest.strip_suffix("\"\"\"") {
                         buf = inner.to_string();
-                        // buf is ready — fall through
                     } else {
                         buf = rest.to_string();
                         if !buf.is_empty() {
@@ -408,15 +722,20 @@ fn repl(
                     buf = line.clone();
                 }
 
-                // Slash commands
-                let trimmed = buf.trim();
+                let trimmed = buf.trim().to_string();
                 if trimmed.starts_with('/') {
-                    handle_command(trimmed, &mut messages, &sampling_params);
+                    handle_command(
+                        &trimmed,
+                        &mut messages,
+                        &mut temperature,
+                        &mut top_p,
+                        &mut top_k,
+                        &mut max_tokens,
+                    );
                     buf.clear();
                     continue;
                 }
 
-                // Empty input: just loop
                 if trimmed.is_empty() {
                     buf.clear();
                     continue;
@@ -424,36 +743,38 @@ fn repl(
             }
         }
 
-        // Send the user message
         let user_content = buf.trim().to_string();
         buf.clear();
 
-        messages.push(ChatMessage {
-            role: Role::User,
-            content: MessageContent::from_string(user_content),
-            audio: None,
-            tool_calls: None,
-            tool_call_id: None,
-        });
-
-        // Encode the full conversation with the chat template
-        let prompt_tokens = match tokenizer.apply_chat_template_and_encode(&messages) {
-            Ok(t) => t,
-            Err(e) => {
-                eprintln!("Tokenization error: {e}");
-                messages.pop();
+        // If the model is still loading, wait for it before sending the request.
+        // Print a notice only if we actually have to wait.
+        if matches!(*load_rx.borrow(), LoadState::Loading) {
+            if let Err(e) = wait_for_load(&mut load_rx).await {
+                eprintln!("{e}");
                 continue;
             }
-        };
+        }
 
-        // Stream the response and collect the full text for history
-        let assistant_text = match stream_response_collect(
-            &engine_tx,
-            prompt_tokens,
-            None,
-            None,
-            &sampling_params,
-        ) {
+        messages.push(ApiMessage {
+            role: "user".to_string(),
+            content: user_content,
+            images: vec![],
+        });
+
+        let assistant_text = match chat_stream(
+            &client,
+            &base_url,
+            &args.model,
+            &messages,
+            SamplingParams {
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+            },
+        )
+        .await
+        {
             Ok(t) => t,
             Err(e) => {
                 eprintln!("Generation error: {e}");
@@ -464,13 +785,10 @@ fn repl(
 
         println!();
 
-        // Append assistant turn to history
-        messages.push(ChatMessage {
-            role: Role::Assistant,
-            audio: None,
-            content: MessageContent::from_string(assistant_text),
-            tool_calls: None,
-            tool_call_id: None,
+        messages.push(ApiMessage {
+            role: "assistant".to_string(),
+            content: assistant_text,
+            images: vec![],
         });
     }
 
@@ -479,41 +797,71 @@ fn repl(
 
 // ─── Slash command handler ────────────────────────────────────────────────────
 
-fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingParams) {
+fn handle_command(
+    cmd: &str,
+    messages: &mut Vec<ApiMessage>,
+    temperature: &mut f64,
+    top_p: &mut f64,
+    top_k: &mut usize,
+    max_tokens: &mut usize,
+) {
     let parts: Vec<&str> = cmd.splitn(3, ' ').collect();
     match parts[0] {
         "/bye" | "/exit" | "/quit" => {
             std::process::exit(0);
         }
         "/clear" => {
-            // Keep system message if present
-            let sys: Vec<ChatMessage> = messages
-                .drain(..)
-                .filter(|m| matches!(m.role, Role::System))
-                .collect();
+            let sys: Vec<ApiMessage> = messages.drain(..).filter(|m| m.role == "system").collect();
             *messages = sys;
             println!("Conversation cleared.");
         }
-        "/set" if parts.len() >= 3 => {
-            match parts[1] {
-                "system" => {
-                    // Remove any existing system messages
-                    messages.retain(|m| !matches!(m.role, Role::System));
-                    messages.insert(
-                        0,
-                        ChatMessage {
-                            role: Role::System,
-                            content: MessageContent::from_string(parts[2]),
-                            audio: None,
-                            tool_calls: None,
-                            tool_call_id: None,
-                        },
-                    );
-                    println!("System prompt set.");
-                }
-                _ => println!("Unknown /set option: {}", parts[1]),
+        "/set" if parts.len() >= 3 => match parts[1] {
+            "system" => {
+                messages.retain(|m| m.role != "system");
+                messages.insert(
+                    0,
+                    ApiMessage {
+                        role: "system".to_string(),
+                        content: parts[2].to_string(),
+                        images: vec![],
+                    },
+                );
+                println!("System prompt set.");
             }
-        }
+            "temperature" => {
+                if let Ok(v) = parts[2].parse::<f64>() {
+                    *temperature = v;
+                    println!("temperature set to {v}");
+                } else {
+                    println!("Invalid value: {}", parts[2]);
+                }
+            }
+            "top_p" => {
+                if let Ok(v) = parts[2].parse::<f64>() {
+                    *top_p = v;
+                    println!("top_p set to {v}");
+                } else {
+                    println!("Invalid value: {}", parts[2]);
+                }
+            }
+            "top_k" => {
+                if let Ok(v) = parts[2].parse::<usize>() {
+                    *top_k = v;
+                    println!("top_k set to {v}");
+                } else {
+                    println!("Invalid value: {}", parts[2]);
+                }
+            }
+            "num_predict" | "max_tokens" => {
+                if let Ok(v) = parts[2].parse::<usize>() {
+                    *max_tokens = v;
+                    println!("max_tokens set to {v}");
+                } else {
+                    println!("Invalid value: {}", parts[2]);
+                }
+            }
+            _ => println!("Unknown /set option: {}", parts[1]),
+        },
         "/show" if parts.len() >= 2 => match parts[1] {
             "history" => {
                 for (i, m) in messages.iter().enumerate() {
@@ -522,24 +870,27 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
             }
             "params" => {
                 println!(
-                    "temperature={} top_p={} top_k={} max_tokens={}",
-                    params.temperature, params.top_p, params.top_k, params.max_tokens
+                    "temperature={temperature} top_p={top_p} top_k={top_k} max_tokens={max_tokens}"
                 );
             }
             _ => println!("Unknown /show option: {}", parts[1]),
         },
         "/help" | "/?" => {
             println!("Commands:");
-            println!("  /bye, /exit, /quit     Exit the REPL");
-            println!("  /clear                 Clear conversation history");
-            println!("  /set system <text>     Set a system prompt");
-            println!("  /show history          Print conversation history");
-            println!("  /show params           Print sampling parameters");
-            println!("  /help, /?              Show this help");
+            println!("  /bye, /exit, /quit          Exit the REPL");
+            println!("  /clear                       Clear conversation history");
+            println!("  /set system <text>           Set a system prompt");
+            println!("  /set temperature <n>         Set sampling temperature");
+            println!("  /set top_p <n>               Set nucleus sampling threshold");
+            println!("  /set top_k <n>               Set top-k sampling");
+            println!("  /set max_tokens <n>          Set max tokens per response");
+            println!("  /show history                Print conversation history");
+            println!("  /show params                 Print sampling parameters");
+            println!("  /help, /?                    Show this help");
             println!();
             println!("Keyboard shortcuts:");
-            println!("  Ctrl+D / EOF           Exit");
-            println!("  Ctrl+C                 Cancel current input");
+            println!("  Ctrl+D / EOF                 Exit");
+            println!("  Ctrl+C                       Cancel current input");
             println!();
             println!("Multiline input:");
             println!("  Start a message with \"\"\" to enter multi-line mode.");
@@ -547,52 +898,6 @@ fn handle_command(cmd: &str, messages: &mut Vec<ChatMessage>, params: &SamplingP
         }
         other => println!("Unknown command: {other}"),
     }
-}
-
-// ─── Streaming helpers ────────────────────────────────────────────────────────
-
-/// Stream tokens from the engine to stdout, returning the full assembled text.
-fn stream_response_collect(
-    engine_tx: &stdmpsc::SyncSender<SyncEngineRequest>,
-    prompt_tokens: Vec<u32>,
-    audio: Option<AudioEmbedContext>,
-    image: Option<ImageEmbedContext>,
-    sampling_params: &SamplingParams,
-) -> Result<String> {
-    let (token_tx, token_rx) = stdmpsc::sync_channel::<StreamToken>(256);
-
-    let request_id = uuid::Uuid::new_v4().to_string();
-    engine_tx.send(SyncEngineRequest::GenerateStream {
-        request_id,
-        prompt_tokens,
-        audio,
-        image,
-        sampling_params: sampling_params.clone(),
-        token_tx,
-    })?;
-
-    let mut full_text = String::new();
-    let mut stdout = io::stdout();
-
-    // Drain tokens until the channel closes or we get a finish reason.
-    // Raw mode must NOT be active while printing: it suppresses the implicit
-    // carriage-return on '\n', causing a staircase layout.  We stay in
-    // cooked mode throughout and simply print each token as it arrives.
-    loop {
-        match token_rx.recv() {
-            Err(_) => break, // channel closed — engine done
-            Ok(tok) => {
-                full_text.push_str(&tok.text);
-                print!("{}", tok.text);
-                stdout.flush()?;
-                if tok.finish_reason.is_some() {
-                    break;
-                }
-            }
-        }
-    }
-
-    Ok(full_text)
 }
 
 // ─── Raw-mode line reader ────────────────────────────────────────────────────
@@ -604,18 +909,9 @@ enum ReadResult {
 }
 
 /// Read a single line from stdin using crossterm raw mode.
-///
-/// Supports:
-/// - Regular character input with inline echo
-/// - Backspace / Delete
-/// - Arrow keys (left/right, up/down — up/down currently no-ops)
-/// - Ctrl+C → Interrupt
-/// - Ctrl+D on empty line → Eof
-/// - Enter → submit line
-/// - Bracketed paste (the terminal may send a paste burst; we accept it as-is)
 fn read_line() -> Result<ReadResult> {
     let mut buf: Vec<char> = Vec::new();
-    let mut cursor_pos: usize = 0; // logical position in buf
+    let mut cursor_pos: usize = 0;
 
     terminal::enable_raw_mode()?;
     let _guard = RawModeGuard;
@@ -628,168 +924,141 @@ fn read_line() -> Result<ReadResult> {
         match ev {
             Event::Key(KeyEvent {
                 code, modifiers, ..
-            }) => {
-                match code {
-                    // ── Submit ──────────────────────────────────────────────
-                    KeyCode::Enter => {
-                        // Echo newline
-                        execute!(stdout, Print("\r\n"))?;
-                        let line: String = buf.iter().collect();
-                        return Ok(ReadResult::Line(line));
-                    }
-
-                    // ── EOF ─────────────────────────────────────────────────
-                    KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        if buf.is_empty() {
-                            execute!(stdout, Print("\r\n"))?;
-                            return Ok(ReadResult::Eof);
-                        }
-                        // Ctrl+D mid-line: delete char forward (like readline)
-                        if cursor_pos < buf.len() {
-                            buf.remove(cursor_pos);
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    // ── Interrupt ────────────────────────────────────────────
-                    KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        execute!(stdout, Print("^C\r\n"))?;
-                        return Ok(ReadResult::Interrupt);
-                    }
-
-                    // ── Backspace ────────────────────────────────────────────
-                    KeyCode::Backspace => {
-                        if cursor_pos > 0 {
-                            cursor_pos -= 1;
-                            buf.remove(cursor_pos);
-                            // Move cursor left, redraw rest of line, clear tail
-                            execute!(stdout, cursor::MoveLeft(1))?;
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    // ── Delete ────────────────────────────────────────────────
-                    KeyCode::Delete => {
-                        if cursor_pos < buf.len() {
-                            buf.remove(cursor_pos);
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    // ── Left arrow ────────────────────────────────────────────
-                    KeyCode::Left => {
-                        if cursor_pos > 0 {
-                            cursor_pos -= 1;
-                            execute!(stdout, cursor::MoveLeft(1))?;
-                        }
-                    }
-
-                    // ── Right arrow ───────────────────────────────────────────
-                    KeyCode::Right => {
-                        if cursor_pos < buf.len() {
-                            cursor_pos += 1;
-                            execute!(stdout, cursor::MoveRight(1))?;
-                        }
-                    }
-
-                    // ── Home / Ctrl+A ─────────────────────────────────────────
-                    KeyCode::Home => {
-                        if cursor_pos > 0 {
-                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                            cursor_pos = 0;
-                        }
-                    }
-                    KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        if cursor_pos > 0 {
-                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                            cursor_pos = 0;
-                        }
-                    }
-
-                    // ── End / Ctrl+E ──────────────────────────────────────────
-                    KeyCode::End => {
-                        let remaining = buf.len() - cursor_pos;
-                        if remaining > 0 {
-                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
-                            cursor_pos = buf.len();
-                        }
-                    }
-                    KeyCode::Char('e') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        let remaining = buf.len() - cursor_pos;
-                        if remaining > 0 {
-                            execute!(stdout, cursor::MoveRight(remaining as u16))?;
-                            cursor_pos = buf.len();
-                        }
-                    }
-
-                    // ── Kill to EOL (Ctrl+K) ──────────────────────────────────
-                    KeyCode::Char('k') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        buf.truncate(cursor_pos);
-                        execute!(stdout, terminal::Clear(ClearType::UntilNewLine))?;
-                    }
-
-                    // ── Kill to BOL (Ctrl+U) ──────────────────────────────────
-                    KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        if cursor_pos > 0 {
-                            execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                            buf.drain(..cursor_pos);
-                            cursor_pos = 0;
-                            redraw_from_cursor(&mut stdout, &buf, 0)?;
-                        }
-                    }
-
-                    // ── Kill word before cursor (Ctrl+W) ──────────────────────
-                    KeyCode::Char('w') if modifiers.contains(KeyModifiers::CONTROL) => {
-                        if cursor_pos > 0 {
-                            // Find previous word boundary
-                            let mut end = cursor_pos;
-                            // skip trailing spaces
-                            while end > 0 && buf[end - 1] == ' ' {
-                                end -= 1;
-                            }
-                            // skip word chars
-                            while end > 0 && buf[end - 1] != ' ' {
-                                end -= 1;
-                            }
-                            let deleted = cursor_pos - end;
-                            execute!(stdout, cursor::MoveLeft(deleted as u16))?;
-                            buf.drain(end..cursor_pos);
-                            cursor_pos = end;
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    // ── Regular printable character ───────────────────────────
-                    KeyCode::Char(c) => {
-                        buf.insert(cursor_pos, c);
-                        cursor_pos += 1;
-                        if cursor_pos == buf.len() {
-                            // Appending at end — simple echo
-                            execute!(stdout, Print(c))?;
-                        } else {
-                            // Inserting mid-line — redraw tail
-                            execute!(stdout, Print(c))?;
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    // ── Tab → 4 spaces ───────────────────────────────────────
-                    KeyCode::Tab => {
-                        for _ in 0..4 {
-                            buf.insert(cursor_pos, ' ');
-                            cursor_pos += 1;
-                        }
-                        execute!(stdout, Print("    "))?;
-                        if cursor_pos < buf.len() {
-                            redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                        }
-                    }
-
-                    _ => {}
+            }) => match code {
+                KeyCode::Enter => {
+                    execute!(stdout, Print("\r\n"))?;
+                    let line: String = buf.iter().collect();
+                    return Ok(ReadResult::Line(line));
                 }
-            }
 
-            // Paste events — append each char as if typed
+                KeyCode::Char('d') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    if buf.is_empty() {
+                        execute!(stdout, Print("\r\n"))?;
+                        return Ok(ReadResult::Eof);
+                    }
+                    if cursor_pos < buf.len() {
+                        buf.remove(cursor_pos);
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    execute!(stdout, Print("^C\r\n"))?;
+                    return Ok(ReadResult::Interrupt);
+                }
+
+                KeyCode::Backspace => {
+                    if cursor_pos > 0 {
+                        cursor_pos -= 1;
+                        buf.remove(cursor_pos);
+                        execute!(stdout, cursor::MoveLeft(1))?;
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                KeyCode::Delete => {
+                    if cursor_pos < buf.len() {
+                        buf.remove(cursor_pos);
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                KeyCode::Left => {
+                    if cursor_pos > 0 {
+                        cursor_pos -= 1;
+                        execute!(stdout, cursor::MoveLeft(1))?;
+                    }
+                }
+
+                KeyCode::Right => {
+                    if cursor_pos < buf.len() {
+                        cursor_pos += 1;
+                        execute!(stdout, cursor::MoveRight(1))?;
+                    }
+                }
+
+                KeyCode::Home => {
+                    if cursor_pos > 0 {
+                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                        cursor_pos = 0;
+                    }
+                }
+                KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    if cursor_pos > 0 {
+                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                        cursor_pos = 0;
+                    }
+                }
+
+                KeyCode::End => {
+                    let remaining = buf.len() - cursor_pos;
+                    if remaining > 0 {
+                        execute!(stdout, cursor::MoveRight(remaining as u16))?;
+                        cursor_pos = buf.len();
+                    }
+                }
+                KeyCode::Char('e') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    let remaining = buf.len() - cursor_pos;
+                    if remaining > 0 {
+                        execute!(stdout, cursor::MoveRight(remaining as u16))?;
+                        cursor_pos = buf.len();
+                    }
+                }
+
+                KeyCode::Char('k') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    buf.truncate(cursor_pos);
+                    execute!(stdout, terminal::Clear(ClearType::UntilNewLine))?;
+                }
+
+                KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    if cursor_pos > 0 {
+                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                        buf.drain(..cursor_pos);
+                        cursor_pos = 0;
+                        redraw_from_cursor(&mut stdout, &buf, 0)?;
+                    }
+                }
+
+                KeyCode::Char('w') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    if cursor_pos > 0 {
+                        let mut end = cursor_pos;
+                        while end > 0 && buf[end - 1] == ' ' {
+                            end -= 1;
+                        }
+                        while end > 0 && buf[end - 1] != ' ' {
+                            end -= 1;
+                        }
+                        let deleted = cursor_pos - end;
+                        execute!(stdout, cursor::MoveLeft(deleted as u16))?;
+                        buf.drain(end..cursor_pos);
+                        cursor_pos = end;
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                KeyCode::Char(c) => {
+                    buf.insert(cursor_pos, c);
+                    cursor_pos += 1;
+                    execute!(stdout, Print(c))?;
+                    if cursor_pos < buf.len() {
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                KeyCode::Tab => {
+                    for _ in 0..4 {
+                        buf.insert(cursor_pos, ' ');
+                        cursor_pos += 1;
+                    }
+                    execute!(stdout, Print("    "))?;
+                    if cursor_pos < buf.len() {
+                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                    }
+                }
+
+                _ => {}
+            },
+
             Event::Paste(text) => {
                 for c in text.chars() {
                     if c == '\n' || c == '\r' {
@@ -800,7 +1069,6 @@ fn read_line() -> Result<ReadResult> {
                         cursor_pos += 1;
                     }
                 }
-                // Redraw the whole buffer tail from start
                 let before: String = buf[..cursor_pos].iter().collect();
                 execute!(
                     stdout,
@@ -815,8 +1083,6 @@ fn read_line() -> Result<ReadResult> {
     }
 }
 
-/// Redraw the characters of `buf` starting at logical position `from`,
-/// then move the terminal cursor back to `from`.
 fn redraw_from_cursor(stdout: &mut io::Stdout, buf: &[char], from: usize) -> Result<()> {
     let tail: String = buf[from..].iter().collect();
     let tail_len = tail.chars().count();
@@ -825,7 +1091,6 @@ fn redraw_from_cursor(stdout: &mut io::Stdout, buf: &[char], from: usize) -> Res
         Print(&tail),
         terminal::Clear(ClearType::UntilNewLine),
     )?;
-    // Move cursor back to `from`
     if tail_len > 0 {
         execute!(stdout, cursor::MoveLeft(tail_len as u16))?;
     }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -75,7 +75,7 @@ fn spawn_drain_task(output_buf: OutputBuffer, registry: StreamRegistry) {
 ///
 /// The OpenAI spec allows `stop` to be a string or an array of strings.
 /// Both forms are normalised to `Vec<String>`.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum StopSequences {
     #[default]
@@ -94,7 +94,7 @@ impl StopSequences {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ChatCompletionRequest {
     pub model: Option<String>,
     pub messages: Vec<ChatMessage>,
@@ -240,7 +240,7 @@ const ANTHROPIC_STOP_MAX_TOKENS: &str = "max_tokens";
 
 /// Role enum for Anthropic messages (only "user" and "assistant" – system
 /// messages are passed at the top level).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AnthropicRole {
     User,
@@ -248,14 +248,14 @@ pub enum AnthropicRole {
 }
 
 /// A single message in an Anthropic Messages request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct AnthropicMessage {
     pub role: AnthropicRole,
     pub content: String,
 }
 
 /// Request body for `POST /v1/messages` (Anthropic Messages API).
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct AnthropicMessagesRequest {
     pub model: Option<String>,
     pub messages: Vec<AnthropicMessage>,
@@ -400,7 +400,7 @@ pub struct AnthropicErrorDetail {
 // ─── Ollama API types ────────────────────────────────────────────────────────
 
 /// Ollama `POST /api/generate` request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct OllamaGenerateRequest {
     pub model: String,
     pub prompt: Option<String>,
@@ -418,7 +418,7 @@ pub struct OllamaGenerateRequest {
 }
 
 /// Ollama `POST /api/chat` request.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct OllamaChatRequest {
     pub model: String,
     pub messages: Vec<OllamaChatMessage>,
@@ -436,13 +436,33 @@ pub struct OllamaChatMessage {
 }
 
 /// Sampling options passed inside an Ollama request.
-#[derive(Debug, Deserialize, Default)]
+///
+/// In addition to the standard Ollama sampling fields, inferrs extends this
+/// struct with model-loading fields (`dtype`, `device`, `revision`, etc.).
+/// These are read by the daemon when spawning a worker process and are ignored
+/// by worker processes themselves (which are already serving a loaded model).
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct OllamaOptions {
+    // ── Standard Ollama sampling fields ──────────────────────────────────────
     pub temperature: Option<f64>,
     pub top_p: Option<f64>,
     pub top_k: Option<usize>,
     pub num_predict: Option<usize>,
     pub repeat_penalty: Option<f64>,
+
+    // ── inferrs model-loading extensions ─────────────────────────────────────
+    /// Weight data type: f32, f16, bf16
+    pub dtype: Option<String>,
+    /// Device: cpu, cuda, metal, auto
+    pub device: Option<String>,
+    /// Git revision/branch/tag on HuggingFace Hub
+    pub revision: Option<String>,
+    /// Fraction of memory for paged-attention KV blocks
+    pub paged_attention: Option<f64>,
+    /// TurboQuant KV cache bit-width (stringified so "false" disables it)
+    pub turbo_quant: Option<String>,
+    /// GGUF quantization format, e.g. "Q4K"
+    pub quantize: Option<String>,
 }
 
 /// Non-streaming `POST /api/generate` response.
@@ -714,33 +734,85 @@ fn anthropic_messages_to_chat(
 
 // ─── Server state ───────────────────────────────────────────────────────────
 
+/// A running model worker.  In daemon mode (no model arg) the daemon spawns
+/// `inferrs serve --port <N> <model>` as a child process and stores a reference
+/// to it here so it can proxy requests and keep the child alive.
+/// In direct/worker mode (model arg given) this struct holds the in-process
+/// engine state instead.
+struct LoadedModel {
+    model_id: String,
+    /// How this model is served.
+    backend: ModelBackend,
+}
+
+/// Two operating modes, mirroring Ollama's daemon↔runner split:
+///
+/// - `Worker`: this process IS the model server — engine runs in-process.
+/// - `Proxy`: this process is the daemon — it spawned a worker child and
+///   forwards all inference requests to it over HTTP.
 #[allow(dead_code)]
+enum ModelBackend {
+    /// In-process engine (used when `inferrs serve <model>` is run directly).
+    Worker {
+        engine_tx: mpsc::Sender<EngineRequest>,
+        tokenizer: Arc<Tokenizer>,
+        max_seq_len: usize,
+        output_buf: OutputBuffer,
+        stream_registry: StreamRegistry,
+        audio_token_id: Option<u32>,
+        image_token_id: Option<u32>,
+        boi_token_id: Option<u32>,
+        eoi_token_id: Option<u32>,
+        vision_patch_size: Option<usize>,
+        vision_pooling_kernel: Option<usize>,
+        vision_default_output_length: Option<usize>,
+    },
+    /// HTTP proxy to a worker child process.
+    Proxy {
+        /// Base URL of the worker, e.g. `http://127.0.0.1:34821`.
+        worker_url: String,
+        /// Worker process — killed when this variant is dropped.
+        child: std::process::Child,
+    },
+}
+
+impl Drop for ModelBackend {
+    fn drop(&mut self) {
+        if let ModelBackend::Proxy { child, .. } = self {
+            let _ = child.kill();
+            let _ = child.wait(); // reap the zombie
+        }
+    }
+}
+
+/// The loading state of the model slot.
+///
+/// The write lock on `AppState::slot` is held only for the instant needed to
+/// transition between variants — never across I/O.  Concurrent requests that
+/// arrive while a load is in progress receive a clone of the watch receiver and
+/// await the result outside the lock.
+enum ModelSlot {
+    /// No model loaded yet.
+    Empty,
+    /// A load is in progress.  Callers clone the receiver and wait on it.
+    Loading {
+        model_id: String,
+        /// Receives `Ok(lm)` when loading succeeds or `Err(msg)` on failure.
+        rx: tokio::sync::watch::Receiver<Option<Result<Arc<LoadedModel>, String>>>,
+    },
+    /// A model is loaded and ready.
+    Ready(Arc<LoadedModel>),
+}
+
 struct AppState {
-    /// The model ID as known to the server.  `None` when running in
-    /// Ollama-compatible mode with no model pre-loaded.
-    model_id: Option<String>,
-    engine_tx: mpsc::Sender<EngineRequest>,
-    /// `None` when no model is loaded (Ollama-compatible mode with no model).
-    tokenizer: Option<Arc<Tokenizer>>,
+    /// The current model slot — empty, loading, or ready.
+    slot: tokio::sync::RwLock<ModelSlot>,
+    /// Server-level sampling defaults (from CLI flags).
     default_params: SamplingParams,
-    /// Hard upper bound on (prompt_tokens + output_tokens) for this model.
-    max_seq_len: usize,
-    /// Shared buffer that the engine writes tokens into.
-    output_buf: OutputBuffer,
-    /// Maps request_id → per-client SSE channel.
-    stream_registry: StreamRegistry,
-    /// Token ID for `<|audio|>` soft tokens, present when model supports audio.
-    audio_token_id: Option<u32>,
-    /// Token ID for `<|image|>` soft tokens, present when model supports vision.
-    image_token_id: Option<u32>,
-    /// Token ID for `<|image>` (begin-of-image).
-    boi_token_id: Option<u32>,
-    /// Token ID for `<image|>` (end-of-image).
-    eoi_token_id: Option<u32>,
-    /// Vision config: patch_size and pooling_kernel_size, when available.
-    vision_patch_size: Option<usize>,
-    vision_pooling_kernel: Option<usize>,
-    vision_default_output_length: Option<usize>,
+    /// `ServeArgs` snapshot; `model` field is `None` in daemon mode.
+    serve_args: crate::ServeArgs,
+    /// HTTP client used by the daemon to proxy requests to workers.
+    http_client: reqwest::Client,
 }
 
 fn audio_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
@@ -774,63 +846,51 @@ const DEFAULT_PORT_MODEL: u16 = 8080;
 /// Default port when running in Ollama-compatible mode (no model pre-loaded).
 const DEFAULT_PORT_OLLAMA: u16 = 17434;
 
-pub async fn run(args: ServeArgs) -> Result<()> {
-    // When a model is specified, load it; otherwise run in Ollama-compatible
-    // mode where each request carries its own `model` field.
-    let (
+/// Build an in-process `Worker` `LoadedModel` from an `EngineContext`.
+fn loaded_model_from_ctx(
+    model_id: String,
+    ctx: crate::engine::EngineContext,
+) -> Result<LoadedModel> {
+    let tok = Arc::new(Tokenizer::from_file_with_arch(
+        &ctx.model_files.tokenizer_path,
+        ctx.model_files.tokenizer_config_path.as_deref(),
+        Some(&ctx.arch),
+    )?);
+
+    let max_seq_len = ctx.max_seq_len;
+    let audio_token_id = ctx.raw_config.audio_token_id;
+    let image_token_id = ctx.raw_config.image_token_id;
+    let boi_token_id = ctx.raw_config.boi_token_id;
+    let eoi_token_id = ctx.raw_config.eoi_token_id;
+    let (vision_patch_size, vision_pooling_kernel, vision_default_output_length) =
+        if let Some(vc) = &ctx.raw_config.vision_config {
+            (
+                Some(vc.patch_size),
+                Some(vc.pooling_kernel_size),
+                Some(vc.default_output_length),
+            )
+        } else {
+            (None, None, None)
+        };
+
+    let output_buf = OutputBuffer::new();
+    let stream_registry: StreamRegistry = Arc::new(Mutex::new(HashMap::new()));
+    spawn_drain_task(output_buf.clone(), stream_registry.clone());
+
+    let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
+    std::thread::Builder::new()
+        .name("engine".to_string())
+        .spawn(move || ctx.engine.run(engine_rx))
+        .expect("Failed to spawn engine thread");
+
+    Ok(LoadedModel {
         model_id,
-        tokenizer,
-        max_seq_len,
-        audio_token_id,
-        image_token_id,
-        boi_token_id,
-        eoi_token_id,
-        vision_patch_size,
-        vision_pooling_kernel,
-        vision_default_output_length,
-        engine_tx,
-        output_buf,
-        stream_registry,
-    ) = if let Some(ref model) = args.model {
-        // ── Model-loaded path ─────────────────────────────────────────────
-        let ctx = load_engine(&args)?;
-
-        let tok = Arc::new(Tokenizer::from_file_with_arch(
-            &ctx.model_files.tokenizer_path,
-            ctx.model_files.tokenizer_config_path.as_deref(),
-            Some(&ctx.arch),
-        )?);
-
-        let max_seq_len = ctx.max_seq_len;
-        let audio_token_id = ctx.raw_config.audio_token_id;
-        let image_token_id = ctx.raw_config.image_token_id;
-        let boi_token_id = ctx.raw_config.boi_token_id;
-        let eoi_token_id = ctx.raw_config.eoi_token_id;
-        let (vision_patch_size, vision_pooling_kernel, vision_default_output_length) =
-            if let Some(vc) = &ctx.raw_config.vision_config {
-                (
-                    Some(vc.patch_size),
-                    Some(vc.pooling_kernel_size),
-                    Some(vc.default_output_length),
-                )
-            } else {
-                (None, None, None)
-            };
-
-        let output_buf = OutputBuffer::new();
-        let stream_registry: StreamRegistry = Arc::new(Mutex::new(HashMap::new()));
-        spawn_drain_task(output_buf.clone(), stream_registry.clone());
-
-        let (engine_tx, engine_rx) = mpsc::channel::<EngineRequest>(64);
-        std::thread::Builder::new()
-            .name("engine".to_string())
-            .spawn(move || ctx.engine.run(engine_rx))
-            .expect("Failed to spawn engine thread");
-
-        (
-            Some(model.clone()),
-            Some(tok),
+        backend: ModelBackend::Worker {
+            engine_tx,
+            tokenizer: tok,
             max_seq_len,
+            output_buf,
+            stream_registry,
             audio_token_id,
             image_token_id,
             boi_token_id,
@@ -838,35 +898,261 @@ pub async fn run(args: ServeArgs) -> Result<()> {
             vision_patch_size,
             vision_pooling_kernel,
             vision_default_output_length,
-            engine_tx,
-            output_buf,
-            stream_registry,
-        )
-    } else {
-        // ── Ollama-compatible mode — no model pre-loaded ──────────────────
-        let (engine_tx, _engine_rx) = mpsc::channel::<EngineRequest>(1);
+        },
+    })
+}
 
-        let output_buf = OutputBuffer::new();
-        let stream_registry: StreamRegistry = Arc::new(Mutex::new(HashMap::new()));
+/// Pick a free TCP port on localhost by binding to port 0.
+fn pick_free_port() -> u16 {
+    use std::net::TcpListener;
+    TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind to an ephemeral port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
 
+/// Spawn `inferrs serve --port <N> <model>` as a child process (the worker),
+/// wait for its heartbeat, and return a `Proxy` `LoadedModel`.
+///
+/// This mirrors `ollama serve`'s `StartRunner` + scheduler pattern: the daemon
+/// (no-model `inferrs serve`) never loads weights itself; it delegates to a
+/// child worker process and proxies HTTP traffic to it.
+async fn spawn_worker(
+    model_id: &str,
+    opts: Option<&OllamaOptions>,
+    http_client: &reqwest::Client,
+) -> Result<LoadedModel, OllamaHttpError> {
+    let port = pick_free_port();
+    let worker_url = format!("http://127.0.0.1:{port}");
+
+    let exe = std::env::current_exe().map_err(|e| {
         (
-            None,
-            None,
-            usize::MAX,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            engine_tx,
-            output_buf,
-            stream_registry,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("cannot find executable: {e}")})),
         )
+    })?;
+
+    // Build args: flags first, then the positional model arg — same ordering
+    // as ServeArgs so clap parses them correctly.
+    let mut args: Vec<String> = vec!["serve".to_string()];
+
+    // Apply model-loading fields from the request options (sent by `inferrs run`
+    // in the warm-up request), falling back to inferrs defaults when absent.
+    if let Some(o) = opts {
+        if let Some(ref rev) = o.revision {
+            args.extend(["--revision".into(), rev.clone()]);
+        }
+        if let Some(ref dt) = o.dtype {
+            args.extend(["--dtype".into(), dt.clone()]);
+        }
+        if let Some(ref dev) = o.device {
+            args.extend(["--device".into(), dev.clone()]);
+        }
+        if let Some(pa) = o.paged_attention {
+            args.push(format!("--paged-attention={pa}"));
+        }
+        if let Some(ref tq) = o.turbo_quant {
+            args.push(format!("--turbo-quant={tq}"));
+        }
+        if let Some(ref q) = o.quantize {
+            args.push(format!("--quantize={q}"));
+        }
+    }
+
+    // Worker binds on an ephemeral port, accessible only on loopback.
+    args.extend(["--host".into(), "127.0.0.1".into()]);
+    args.extend(["--port".into(), port.to_string()]);
+
+    // `--` ensures a model name that starts with `-` is not parsed as a flag.
+    args.push("--".into());
+    args.push(model_id.to_string());
+
+    tracing::info!("Spawning worker: inferrs {}", args.join(" "));
+
+    let mut child = std::process::Command::new(&exe)
+        .args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("failed to spawn worker: {e}")})),
+            )
+        })?;
+
+    // Poll until the worker's heartbeat responds (up to 120 s for large models).
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        if http_client
+            .head(format!("{worker_url}/"))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill(); // best-effort; ignore errors
+            return Err((
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(serde_json::json!({
+                    "error": format!("worker for '{}' did not become ready within 120 s", model_id)
+                })),
+            ));
+        }
+    }
+
+    tracing::info!("Worker for '{}' ready at {}", model_id, worker_url);
+
+    Ok(LoadedModel {
+        model_id: model_id.to_string(),
+        backend: ModelBackend::Proxy { worker_url, child },
+    })
+}
+
+/// Ensure a model is loaded and return a handle to it.
+///
+/// The write lock on `state.slot` is held only for the instant needed to read
+/// the current state and install a `Loading` sentinel.  All I/O (spawning a
+/// worker or loading the engine) happens outside the lock, so the server
+/// remains responsive to heartbeats, `/api/tags`, and other read-only requests
+/// while a model is loading.  Concurrent callers for the same model share a
+/// single in-flight load via a `watch` channel.
+async fn load_model_on_demand(
+    state: &AppState,
+    model_id: &str,
+    opts: Option<&OllamaOptions>,
+) -> Result<Arc<LoadedModel>, OllamaHttpError> {
+    // ── Fast read path ────────────────────────────────────────────────────────
+    {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) if model_matches_id(&lm.model_id, model_id) => {
+                return Ok(Arc::clone(lm));
+            }
+            ModelSlot::Loading {
+                model_id: loading_id,
+                rx,
+            } if model_matches_id(loading_id, model_id) => {
+                // Another task is already loading this model — wait on its result.
+                let mut rx = rx.clone();
+                drop(guard); // release read lock before awaiting
+                return wait_for_slot_load(&mut rx).await;
+            }
+            _ => {}
+        }
+    }
+
+    // ── Slow path: become the loader ─────────────────────────────────────────
+    // Install a Loading sentinel under a brief write lock, then drop it.
+    let (tx, rx) = tokio::sync::watch::channel::<Option<Result<Arc<LoadedModel>, String>>>(None);
+    {
+        let mut guard = state.slot.write().await;
+        // Double-check: another task may have loaded while we waited for the lock.
+        match &*guard {
+            ModelSlot::Ready(lm) if model_matches_id(&lm.model_id, model_id) => {
+                return Ok(Arc::clone(lm));
+            }
+            ModelSlot::Loading {
+                model_id: loading_id,
+                rx: existing_rx,
+            } if model_matches_id(loading_id, model_id) => {
+                let mut rx = existing_rx.clone();
+                drop(guard);
+                return wait_for_slot_load(&mut rx).await;
+            }
+            _ => {}
+        }
+        *guard = ModelSlot::Loading {
+            model_id: model_id.to_string(),
+            rx: rx.clone(),
+        };
+        // Write lock released here — all other tasks can now proceed concurrently.
+    }
+
+    tracing::info!("Loading model on demand: {}", model_id);
+
+    // ── Perform the actual load outside any lock ──────────────────────────────
+    let load_result: Result<LoadedModel, OllamaHttpError> = if state.serve_args.model.is_none() {
+        spawn_worker(model_id, opts, &state.http_client).await
+    } else {
+        let mut serve_args = state.serve_args.clone();
+        serve_args.model = Some(model_id.to_string());
+        let model_id_owned = model_id.to_string();
+        let ctx = tokio::task::spawn_blocking(move || load_engine(&serve_args))
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("model load panicked: {e}")}))))?
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": format!("failed to load '{}': {e}", model_id_owned)}))))?;
+        loaded_model_from_ctx(model_id_owned, ctx).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("engine init failed: {e}")})),
+            )
+        })
     };
 
-    // Default sampling params from CLI args
+    // ── Publish result and update slot ────────────────────────────────────────
+    match load_result {
+        Ok(lm) => {
+            let lm = Arc::new(lm);
+            {
+                let mut guard = state.slot.write().await;
+                *guard = ModelSlot::Ready(Arc::clone(&lm));
+            }
+            let _ = tx.send(Some(Ok(Arc::clone(&lm))));
+            Ok(lm)
+        }
+        Err((status, json)) => {
+            {
+                let mut guard = state.slot.write().await;
+                *guard = ModelSlot::Empty;
+            }
+            let msg = json
+                .0
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("load failed")
+                .to_string();
+            let _ = tx.send(Some(Err(msg)));
+            Err((status, json))
+        }
+    }
+}
+
+/// Wait for a `Loading` slot to resolve, returning the `Arc<LoadedModel>` or
+/// an error.  Called by concurrent requests that arrive while a load is already
+/// in progress.
+async fn wait_for_slot_load(
+    rx: &mut tokio::sync::watch::Receiver<Option<Result<Arc<LoadedModel>, String>>>,
+) -> Result<Arc<LoadedModel>, OllamaHttpError> {
+    loop {
+        // Wait for a value to be published.
+        if rx.changed().await.is_err() {
+            // Sender dropped without publishing — treat as error.
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "model load abandoned"})),
+            ));
+        }
+        match rx.borrow().as_ref() {
+            None => continue, // spurious wake
+            Some(Ok(lm)) => return Ok(Arc::clone(lm)),
+            Some(Err(msg)) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": msg.clone()})),
+                ))
+            }
+        }
+    }
+}
+
+pub async fn run(args: ServeArgs) -> Result<()> {
     let default_params = SamplingParams {
         temperature: args.temperature,
         top_p: args.top_p,
@@ -875,27 +1161,24 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         ..SamplingParams::default()
     };
 
-    // Build app state
+    // If a model was specified on the CLI, pre-load it eagerly.
+    let initial_slot = if let Some(ref model) = args.model {
+        let ctx = load_engine(&args)?;
+        let lm = Arc::new(loaded_model_from_ctx(model.clone(), ctx)?);
+        ModelSlot::Ready(lm)
+    } else {
+        ModelSlot::Empty
+    };
+
+    let model_id_hint = args.model.clone();
+
     let state = Arc::new(AppState {
-        model_id: model_id.clone(),
-        engine_tx,
-        tokenizer, // Option<Arc<Tokenizer>>
+        slot: tokio::sync::RwLock::new(initial_slot),
         default_params,
-        max_seq_len,
-        output_buf,
-        stream_registry,
-        audio_token_id,
-        image_token_id,
-        boi_token_id,
-        eoi_token_id,
-        vision_patch_size,
-        vision_pooling_kernel,
-        vision_default_output_length,
+        serve_args: args.clone(),
+        http_client: reqwest::Client::new(),
     });
 
-    // Build router — OpenAI/Anthropic routes always present; Ollama routes
-    // are always mounted so that any client expecting the Ollama API works
-    // regardless of whether a model was pre-loaded.
     let app = Router::new()
         // ── OpenAI-compatible ────────────────────────────────────────────────
         .route("/v1/chat/completions", post(chat_completions))
@@ -915,9 +1198,8 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .layer(CorsLayer::permissive())
         .with_state(state);
 
-    // Choose the default port based on whether a model was pre-loaded.
     let port = args.port.unwrap_or_else(|| {
-        if model_id.is_some() {
+        if model_id_hint.is_some() {
             DEFAULT_PORT_MODEL
         } else {
             DEFAULT_PORT_OLLAMA
@@ -934,26 +1216,91 @@ pub async fn run(args: ServeArgs) -> Result<()> {
 
 // ─── Handlers ───────────────────────────────────────────────────────────────
 
+/// Resolve the model name for an OpenAI-format request: use the name from the
+/// request body if present, otherwise fall back to whatever model is currently
+/// loaded.  Returns an error if no model is named and none is loaded.
+async fn resolve_openai_model(
+    state: &AppState,
+    requested: Option<&str>,
+) -> Result<Arc<LoadedModel>, (StatusCode, Json<ErrorResponse>)> {
+    let model_name = if let Some(m) = requested {
+        m.to_string()
+    } else {
+        // No model in request — use whatever is already loaded.
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => lm.model_id.clone(),
+            _ => return Err(server_error("No model specified and no model is loaded")),
+        }
+    };
+    load_model_on_demand(state, &model_name, None)
+        .await
+        .map_err(|(status, json)| {
+            // Convert OllamaHttpError → standard ErrorResponse
+            let msg = json
+                .0
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("model load failed")
+                .to_string();
+            (
+                status,
+                Json(ErrorResponse {
+                    error: ErrorDetail {
+                        message: msg,
+                        r#type: "server_error".to_string(),
+                    },
+                }),
+            )
+        })
+}
+
 async fn chat_completions(
     State(state): State<Arc<AppState>>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> impl IntoResponse {
     let request_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
     let created = unix_now();
-    let model_id = req
-        .model
-        .clone()
-        .or_else(|| state.model_id.clone())
-        .unwrap_or_else(|| "unknown".to_string());
+
+    let lm = resolve_openai_model(&state, req.model.as_deref()).await?;
+    let model_id = lm.model_id.clone();
+
+    // Proxy mode: forward to the worker.
+    if let ModelBackend::Proxy { worker_url, .. } = &lm.backend {
+        return proxy_to_worker(&state.http_client, worker_url, "/v1/chat/completions", &req)
+            .await
+            .map_err(|(s, j)| {
+                let msg =
+                    j.0.get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("proxy error")
+                        .to_string();
+                (
+                    s,
+                    Json(ErrorResponse {
+                        error: ErrorDetail {
+                            message: msg,
+                            r#type: "server_error".to_string(),
+                        },
+                    }),
+                )
+            });
+    }
+
+    let (
+        engine_tx,
+        tokenizer,
+        max_seq_len,
+        output_buf,
+        stream_registry,
+        audio_token_id_opt,
+        image_token_id_opt,
+        vision_patch_size,
+        vision_pooling_kernel,
+        vision_default_output_length,
+    ) = worker_fields(&lm)?;
 
     // ── Audio preprocessing ──────────────────────────────────────────────────
-    // If any message has an audio attachment:
-    //   1. Decode audio bytes → PCM samples
-    //   2. Compute log-mel spectrogram → Tensor [1, T, 128]
-    //   3. Determine N = T / 4 (audio soft tokens after 4× subsampling)
-    //   4. Tokenize the prompt with N audio soft-token placeholders
-    //   5. Build AudioEmbedContext carrying the mel tensor (encoding happens on
-    //      the engine thread which owns the model weights)
     let has_audio = req.messages.iter().any(|m| m.audio.is_some());
 
     // When the caller provides tool definitions (e.g. from an OpenClaw agent
@@ -983,7 +1330,7 @@ async fn chat_completions(
     let has_images = req.messages.iter().any(|m| !m.content.images.is_empty());
 
     let (prompt_tokens, audio_ctx, image_ctx) = if has_audio {
-        let audio_token_id = state.audio_token_id.ok_or_else(|| {
+        let audio_token_id = audio_token_id_opt.ok_or_else(|| {
             audio_error("This model does not support audio input (no audio_token_id in config)")
         })?;
 
@@ -1021,13 +1368,12 @@ async fn chat_completions(
 
         // Tokenize with audio soft-token placeholders.
         let prompt = apply_gemma4_with_audio(messages, &[n_audio_tokens]);
-        let tokenizer = state
-            .tokenizer
-            .as_deref()
-            .ok_or_else(|| server_error("No model loaded"))?;
-        let tokens = tokenizer
-            .encode(&prompt, false)
-            .map_err(tokenization_error)?;
+        let tokenizer = tokenizer.as_ref();
+
+        let tokens = match tokenizer.encode(&prompt, false) {
+            Ok(t) => t,
+            Err(e) => return Err(tokenization_error(e)),
+        };
 
         // Build mel tensor on CPU (engine thread moves it to device).
         let mel_tensor = candle_core::Tensor::from_vec(
@@ -1047,20 +1393,12 @@ async fn chat_completions(
         (tokens, Some(audio_ctx), None)
     } else if has_images {
         // ── Vision preprocessing ──────────────────────────────────────────────
-        // For each image_url content part across all messages:
-        //   1. Decode base64 data URL or reject HTTP URLs
-        //   2. Decode JPEG/PNG → RGB DynamicImage
-        //   3. Aspect-ratio-preserving resize to patch grid dimensions
-        //   4. Rescale [0,255] → [0,1] and patchify
-        //   5. Build pixel_values [N_patches, patch_pixels] and position_ids [N_patches, 2]
-        //   6. Count soft tokens = N_patches / pooling_kernel²
-        //   7. Tokenize with image soft-token placeholders
-        let image_token_id = state.image_token_id.ok_or_else(|| {
+        let image_token_id = image_token_id_opt.ok_or_else(|| {
             image_error("This model does not support vision input (no image_token_id in config)")
         })?;
-        let patch_size = state.vision_patch_size.unwrap_or(16);
-        let pooling_kernel = state.vision_pooling_kernel.unwrap_or(3);
-        let default_output_length = state.vision_default_output_length.unwrap_or(280);
+        let patch_size = vision_patch_size.unwrap_or(16);
+        let pooling_kernel = vision_pooling_kernel.unwrap_or(3);
+        let default_output_length = vision_default_output_length.unwrap_or(280);
 
         // Collect all images in message order.
         let mut all_images: Vec<&ImageInput> = Vec::new();
@@ -1089,10 +1427,6 @@ async fn chat_completions(
 
         // Tokenize with image soft-token placeholders.
         let prompt = apply_gemma4_with_images(messages, &image_token_counts);
-        let tokenizer = state
-            .tokenizer
-            .as_deref()
-            .ok_or_else(|| server_error("No model loaded"))?;
         let tokens = tokenizer
             .encode(&prompt, false)
             .map_err(tokenization_error)?;
@@ -1124,11 +1458,6 @@ async fn chat_completions(
 
         (tokens, None, Some(image_ctx))
     } else {
-        let tokenizer = state
-            .tokenizer
-            .as_deref()
-            .ok_or_else(|| server_error("No model loaded"))?;
-
         let tokens = match tokenizer.apply_chat_template_and_encode(messages) {
             Ok(t) => t,
             Err(e) => return Err(tokenization_error(e)),
@@ -1151,14 +1480,14 @@ async fn chat_completions(
         modality_note
     );
 
-    check_prompt_length(prompt_tokens.len(), state.max_seq_len)?;
+    check_prompt_length(prompt_tokens.len(), max_seq_len)?;
 
     // Build sampling params, clamping max_tokens to the model's KV cache capacity.
     let requested_max_tokens = req
         .max_completion_tokens
         .or(req.max_tokens)
         .unwrap_or(state.default_params.max_tokens);
-    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
+    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), max_seq_len);
     let mut params = build_sampling_params(
         req.temperature,
         req.top_p,
@@ -1171,9 +1500,7 @@ async fn chat_completions(
     // Resolve per-request stop strings into token IDs.
     let stop_strings = req.stop.into_vec();
     if !stop_strings.is_empty() {
-        if let Some(tokenizer) = state.tokenizer.as_deref() {
-            params.extra_stop_token_ids = resolve_stop_token_ids(stop_strings, tokenizer);
-        }
+        params.extra_stop_token_ids = resolve_stop_token_ids(stop_strings, tokenizer);
     }
 
     let is_stream = req.stream.unwrap_or(false);
@@ -1181,8 +1508,7 @@ async fn chat_completions(
     if is_stream {
         // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
-        state
-            .stream_registry
+        stream_registry
             .lock()
             .await
             .insert(request_id.clone(), token_tx);
@@ -1193,11 +1519,11 @@ async fn chat_completions(
             audio: audio_ctx,
             image: image_ctx,
             sampling_params: params,
-            output_buf: state.output_buf.clone(),
+            output_buf: output_buf.clone(),
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
-            state.stream_registry.lock().await.remove(&request_id);
+        if engine_tx.send(engine_req).await.is_err() {
+            stream_registry.lock().await.remove(&request_id);
             return Err(server_error("Engine unavailable"));
         }
 
@@ -1216,7 +1542,7 @@ async fn chat_completions(
             response_tx,
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
+        if engine_tx.send(engine_req).await.is_err() {
             return Err(server_error("Engine unavailable"));
         }
 
@@ -1333,7 +1659,7 @@ fn make_sse_stream(
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CompletionRequest {
     pub model: Option<String>,
     pub prompt: String,
@@ -1390,26 +1716,43 @@ async fn completions(
 ) -> impl IntoResponse {
     let request_id = format!("cmpl-{}", uuid::Uuid::new_v4());
     let created = unix_now();
-    let model_id = req
-        .model
-        .clone()
-        .or_else(|| state.model_id.clone())
-        .unwrap_or_else(|| "unknown".to_string());
 
-    // Tokenize the prompt directly
-    let tokenizer = state
-        .tokenizer
-        .as_deref()
-        .ok_or_else(|| server_error("No model loaded"))?;
+    let lm = resolve_openai_model(&state, req.model.as_deref()).await?;
+    let model_id = lm.model_id.clone();
+
+    // Proxy mode.
+    if let ModelBackend::Proxy { worker_url, .. } = &lm.backend {
+        return proxy_to_worker(&state.http_client, worker_url, "/v1/completions", &req)
+            .await
+            .map_err(|(s, j)| {
+                let msg =
+                    j.0.get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("proxy error")
+                        .to_string();
+                (
+                    s,
+                    Json(ErrorResponse {
+                        error: ErrorDetail {
+                            message: msg,
+                            r#type: "server_error".to_string(),
+                        },
+                    }),
+                )
+            });
+    }
+
+    let (engine_tx, tokenizer, max_seq_len, output_buf, stream_registry, ..) = worker_fields(&lm)?;
+
     let prompt_tokens = match tokenizer.encode(&req.prompt, true) {
         Ok(tokens) => tokens,
         Err(e) => return Err(tokenization_error(e)),
     };
 
-    check_prompt_length(prompt_tokens.len(), state.max_seq_len)?;
+    check_prompt_length(prompt_tokens.len(), max_seq_len)?;
 
     let requested_max_tokens = req.max_tokens.unwrap_or(state.default_params.max_tokens);
-    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), state.max_seq_len);
+    let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), max_seq_len);
     let params = build_sampling_params(
         req.temperature,
         req.top_p,
@@ -1422,10 +1765,8 @@ async fn completions(
     let is_stream = req.stream.unwrap_or(false);
 
     if is_stream {
-        // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
-        state
-            .stream_registry
+        stream_registry
             .lock()
             .await
             .insert(request_id.clone(), token_tx);
@@ -1436,18 +1777,17 @@ async fn completions(
             audio: None,
             image: None,
             sampling_params: params,
-            output_buf: state.output_buf.clone(),
+            output_buf: output_buf.clone(),
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
-            state.stream_registry.lock().await.remove(&request_id);
+        if engine_tx.send(engine_req).await.is_err() {
+            stream_registry.lock().await.remove(&request_id);
             return Err(server_error("Engine unavailable"));
         }
 
         let stream = make_completion_sse_stream(token_rx, request_id, model_id, created);
         Ok(Sse::new(stream).into_response())
     } else {
-        // Non-streaming response.
         let (response_tx, response_rx) = oneshot::channel::<GenerationResult>();
 
         let engine_req = EngineRequest::Generate {
@@ -1459,7 +1799,7 @@ async fn completions(
             response_tx,
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
+        if engine_tx.send(engine_req).await.is_err() {
             return Err(server_error("Engine unavailable"));
         }
 
@@ -1537,23 +1877,32 @@ async fn anthropic_messages(
     Json(req): Json<AnthropicMessagesRequest>,
 ) -> impl IntoResponse {
     let request_id = format!("msg_{}", uuid::Uuid::new_v4());
-    let model_id = req
-        .model
-        .clone()
-        .or_else(|| state.model_id.clone())
-        .unwrap_or_else(|| "unknown".to_string());
+
+    let lm = resolve_openai_model(&state, req.model.as_deref())
+        .await
+        .map_err(|(status, json)| anthropic_error(status, "api_error", json.0.error.message))?;
+    let model_id = lm.model_id.clone();
+
+    // Proxy mode.
+    if let ModelBackend::Proxy { worker_url, .. } = &lm.backend {
+        return proxy_to_worker(&state.http_client, worker_url, "/v1/messages", &req)
+            .await
+            .map_err(|(s, j)| {
+                let msg =
+                    j.0.get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("proxy error")
+                        .to_string();
+                anthropic_error(s, "api_error", msg)
+            });
+    }
+
+    let (engine_tx, tokenizer, max_seq_len, output_buf, stream_registry, ..) =
+        worker_fields(&lm).map_err(|(s, j)| anthropic_error(s, "api_error", j.0.error.message))?;
 
     // Convert Anthropic messages (with optional top-level system) to ChatMessage list.
     let chat_messages = anthropic_messages_to_chat(req.system.as_deref(), &req.messages);
 
-    // Apply chat template and tokenize.
-    let tokenizer = state.tokenizer.as_deref().ok_or_else(|| {
-        anthropic_error(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "api_error",
-            "No model loaded",
-        )
-    })?;
     let prompt_tokens = match tokenizer.apply_chat_template_and_encode(&chat_messages) {
         Ok(tokens) => tokens,
         Err(e) => {
@@ -1572,24 +1921,24 @@ async fn anthropic_messages(
         prompt_tokens.len()
     );
 
-    if state.max_seq_len != usize::MAX && prompt_tokens.len() >= state.max_seq_len {
+    if max_seq_len != usize::MAX && prompt_tokens.len() >= max_seq_len {
         return Err(anthropic_error(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             format!(
                 "Prompt length ({} tokens) exceeds the model's maximum context length ({} tokens).",
                 prompt_tokens.len(),
-                state.max_seq_len
+                max_seq_len
             ),
         ));
     }
 
-    let max_tokens = clamp_max_tokens(req.max_tokens, prompt_tokens.len(), state.max_seq_len);
+    let max_tokens = clamp_max_tokens(req.max_tokens, prompt_tokens.len(), max_seq_len);
     let params = build_sampling_params(
         req.temperature,
         req.top_p,
         req.top_k,
-        None, // Anthropic API does not have repetition_penalty
+        None,
         max_tokens,
         &state.default_params,
     );
@@ -1597,10 +1946,8 @@ async fn anthropic_messages(
     let is_stream = req.stream.unwrap_or(false);
 
     if is_stream {
-        // Streaming response — register per-request channel, then dispatch.
         let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
-        state
-            .stream_registry
+        stream_registry
             .lock()
             .await
             .insert(request_id.clone(), token_tx);
@@ -1611,11 +1958,11 @@ async fn anthropic_messages(
             audio: None,
             image: None,
             sampling_params: params,
-            output_buf: state.output_buf.clone(),
+            output_buf: output_buf.clone(),
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
-            state.stream_registry.lock().await.remove(&request_id);
+        if engine_tx.send(engine_req).await.is_err() {
+            stream_registry.lock().await.remove(&request_id);
             return Err(anthropic_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "api_error",
@@ -1637,7 +1984,7 @@ async fn anthropic_messages(
             response_tx,
         };
 
-        if state.engine_tx.send(engine_req).await.is_err() {
+        if engine_tx.send(engine_req).await.is_err() {
             return Err(anthropic_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "api_error",
@@ -1805,17 +2152,16 @@ fn make_anthropic_sse_stream(
 
 async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListResponse> {
     let created = unix_now();
-
-    let data = match &state.model_id {
-        Some(id) => vec![ModelInfo {
-            id: id.clone(),
+    let guard = state.slot.read().await;
+    let data = match &*guard {
+        ModelSlot::Ready(lm) => vec![ModelInfo {
+            id: lm.model_id.clone(),
             object: "model",
             created,
             owned_by: "inferrs".to_string(),
         }],
-        None => vec![],
+        _ => vec![],
     };
-
     Json(ModelListResponse {
         object: "list",
         data,
@@ -2174,51 +2520,48 @@ async fn ollama_version() -> Json<OllamaVersionResponse> {
 
 /// `GET /api/tags` and `HEAD /api/tags` — list locally available models.
 async fn ollama_tags(State(state): State<Arc<AppState>>) -> Json<OllamaListResponse> {
-    let models = match &state.model_id {
-        Some(id) => vec![OllamaModelEntry {
-            name: id.clone(),
-            model: id.clone(),
+    let guard = state.slot.read().await;
+    let models = match &*guard {
+        ModelSlot::Ready(lm) => vec![OllamaModelEntry {
+            name: lm.model_id.clone(),
+            model: lm.model_id.clone(),
             modified_at: "2025-01-01T00:00:00Z".to_string(),
             size: 0,
             digest: OLLAMA_PLACEHOLDER_DIGEST.to_string(),
             details: OllamaModelDetails::default(),
         }],
-        None => vec![],
+        _ => vec![],
     };
     Json(OllamaListResponse { models })
 }
 
 /// `GET /api/ps` — list running (currently loaded) models.
 async fn ollama_ps(State(state): State<Arc<AppState>>) -> Json<OllamaPsResponse> {
-    let models = match &state.model_id {
-        Some(id) => vec![OllamaRunningModel {
-            name: id.clone(),
-            model: id.clone(),
+    let guard = state.slot.read().await;
+    let models = match &*guard {
+        ModelSlot::Ready(lm) => vec![OllamaRunningModel {
+            name: lm.model_id.clone(),
+            model: lm.model_id.clone(),
             size: 0,
             digest: OLLAMA_PLACEHOLDER_DIGEST.to_string(),
             details: OllamaModelDetails::default(),
             expires_at: "0001-01-01T00:00:00Z".to_string(),
             size_vram: 0,
         }],
-        None => vec![],
+        _ => vec![],
     };
     Json(OllamaPsResponse { models })
 }
 
 /// `POST /api/show` — return information about a model.
+///
+/// Triggers on-demand loading so the response contains accurate model info.
 async fn ollama_show(
     State(state): State<Arc<AppState>>,
     Json(req): Json<OllamaShowRequest>,
 ) -> impl IntoResponse {
-    // Check that the requested model matches the loaded model (if any).
-    // Uses flexible matching so clients that omit the org prefix (e.g.
-    // "gemma-4-E2B-it" vs "google/gemma-4-E2B-it") are not rejected.
-    let model_matches = state
-        .model_id
-        .as_deref()
-        .map(|id| model_matches_id(id, &req.model))
-        .unwrap_or(false);
-    if !model_matches {
+    let lm = load_model_on_demand(&state, &req.model, None).await?;
+    if !model_matches_id(&lm.model_id, &req.model) {
         return Err((
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
@@ -2334,47 +2677,128 @@ fn model_matches_id(loaded_id: &str, requested: &str) -> bool {
     false
 }
 
-fn require_ollama_tokenizer<'a>(
-    state: &'a AppState,
-    model: &str,
-) -> Result<&'a Tokenizer, OllamaHttpError> {
-    match state.tokenizer.as_deref() {
-        Some(t)
-            if state
-                .model_id
-                .as_deref()
-                .is_some_and(|id| model_matches_id(id, model)) =>
-        {
-            Ok(t)
+/// Forward a JSON-serialisable request body to the worker at `worker_url/<path>`
+/// and stream the response back as a raw byte-body axum response.
+/// Content-Type from the worker is preserved so NDJSON and SSE both work.
+async fn proxy_to_worker<B: serde::Serialize>(
+    http_client: &reqwest::Client,
+    worker_url: &str,
+    path: &str,
+    body: &B,
+) -> Result<axum::response::Response, OllamaHttpError> {
+    use futures::StreamExt;
+
+    let url = format!("{worker_url}{path}");
+    let resp = http_client
+        .post(&url)
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({"error": format!("worker unreachable: {e}")})),
+            )
+        })?;
+
+    let status = axum::http::StatusCode::from_u16(resp.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    // Preserve Content-Type so the client gets the right streaming format.
+    let content_type = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_owned();
+
+    let byte_stream = resp
+        .bytes_stream()
+        .map(|r| r.map_err(std::io::Error::other));
+
+    Ok((
+        status,
+        [(axum::http::header::CONTENT_TYPE, content_type)],
+        axum::body::Body::from_stream(byte_stream),
+    )
+        .into_response())
+}
+
+/// Extract the worker fields from a `LoadedModel`, returning an error if it is
+/// in proxy mode.  Used after a proxy-branch guard has been passed.
+#[allow(clippy::type_complexity)]
+fn worker_fields(
+    lm: &LoadedModel,
+) -> Result<
+    (
+        &mpsc::Sender<EngineRequest>,
+        &Arc<Tokenizer>,
+        usize,
+        &OutputBuffer,
+        &StreamRegistry,
+        Option<u32>,   // audio_token_id
+        Option<u32>,   // image_token_id
+        Option<usize>, // vision_patch_size
+        Option<usize>, // vision_pooling_kernel
+        Option<usize>, // vision_default_output_length
+    ),
+    (StatusCode, Json<ErrorResponse>),
+> {
+    match &lm.backend {
+        ModelBackend::Worker {
+            engine_tx,
+            tokenizer,
+            max_seq_len,
+            output_buf,
+            stream_registry,
+            audio_token_id,
+            image_token_id,
+            vision_patch_size,
+            vision_pooling_kernel,
+            vision_default_output_length,
+            ..
+        } => Ok((
+            engine_tx,
+            tokenizer,
+            *max_seq_len,
+            output_buf,
+            stream_registry,
+            *audio_token_id,
+            *image_token_id,
+            *vision_patch_size,
+            *vision_pooling_kernel,
+            *vision_default_output_length,
+        )),
+        ModelBackend::Proxy { .. } => {
+            Err(server_error("unexpected proxy backend in worker context"))
         }
-        Some(_) => Err((
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({
-                "error": format!("model '{}' not found", model)
-            })),
-        )),
-        None => Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({
-                "error": format!("model '{}' is not loaded — start inferrs with a model argument", model)
-            })),
-        )),
     }
 }
 
-/// Dispatch a streaming Ollama generation request to the engine.
-///
-/// Registers a per-request channel in the stream registry, sends the engine
-/// request, and returns `Ok(token_rx)` on success.
+/// Dispatch a streaming Ollama generation request to the in-process engine.
 async fn ollama_dispatch_stream(
-    state: &AppState,
+    backend: &ModelBackend,
     request_id: &str,
     prompt_tokens: Vec<u32>,
     params: SamplingParams,
 ) -> Result<mpsc::Receiver<StreamToken>, OllamaHttpError> {
+    let (engine_tx, output_buf, stream_registry) = match backend {
+        ModelBackend::Worker {
+            engine_tx,
+            output_buf,
+            stream_registry,
+            ..
+        } => (engine_tx, output_buf, stream_registry),
+        ModelBackend::Proxy { .. } => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "dispatch called on proxy backend"})),
+            ))
+        }
+    };
+
     let (token_tx, token_rx) = mpsc::channel::<StreamToken>(256);
-    state
-        .stream_registry
+    stream_registry
         .lock()
         .await
         .insert(request_id.to_string(), token_tx);
@@ -2385,15 +2809,11 @@ async fn ollama_dispatch_stream(
         audio: None,
         image: None,
         sampling_params: params,
-        output_buf: state.output_buf.clone(),
+        output_buf: output_buf.clone(),
     };
 
-    if state.engine_tx.send(engine_req).await.is_err() {
-        state
-            .stream_registry
-            .lock()
-            .await
-            .remove(&request_id.to_string());
+    if engine_tx.send(engine_req).await.is_err() {
+        stream_registry.lock().await.remove(request_id);
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({"error": "engine unavailable"})),
@@ -2403,15 +2823,23 @@ async fn ollama_dispatch_stream(
     Ok(token_rx)
 }
 
-/// Dispatch a non-streaming Ollama generation request to the engine.
-///
-/// Sends the engine request and waits for the result.
+/// Dispatch a non-streaming Ollama generation request to the in-process engine.
 async fn ollama_dispatch_blocking(
-    state: &AppState,
+    backend: &ModelBackend,
     request_id: String,
     prompt_tokens: Vec<u32>,
     params: SamplingParams,
 ) -> Result<GenerationResult, OllamaHttpError> {
+    let engine_tx = match backend {
+        ModelBackend::Worker { engine_tx, .. } => engine_tx,
+        ModelBackend::Proxy { .. } => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "dispatch called on proxy backend"})),
+            ))
+        }
+    };
+
     let (response_tx, response_rx) = oneshot::channel::<GenerationResult>();
 
     let engine_req = EngineRequest::Generate {
@@ -2423,7 +2851,7 @@ async fn ollama_dispatch_blocking(
         response_tx,
     };
 
-    if state.engine_tx.send(engine_req).await.is_err() {
+    if engine_tx.send(engine_req).await.is_err() {
         return Err((
             StatusCode::SERVICE_UNAVAILABLE,
             Json(serde_json::json!({"error": "engine unavailable"})),
@@ -2463,7 +2891,12 @@ async fn ollama_generate(
     let request_id = format!("gen-{}", uuid::Uuid::new_v4());
     let created_at = rfc3339_now();
 
-    let tokenizer = require_ollama_tokenizer(&state, &req.model)?;
+    let lm = load_model_on_demand(&state, &req.model, req.options.as_ref()).await?;
+
+    // Proxy mode: forward the request to the worker.
+    if let ModelBackend::Proxy { worker_url, .. } = &lm.backend {
+        return proxy_to_worker(&state.http_client, worker_url, "/api/generate", &req).await;
+    }
 
     let prompt = req.prompt.as_deref().unwrap_or("");
     if prompt.is_empty() {
@@ -2477,6 +2910,9 @@ async fn ollama_generate(
         }))
         .into_response());
     }
+
+    let (_, tokenizer, max_seq_len, _, _, _, _, _, _, _) = worker_fields(&lm)
+        .map_err(|(s, j)| (s, Json(serde_json::json!({"error": j.0.error.message}))))?;
 
     // Tokenize: apply the chat template by default; skip it only when raw=true.
     let is_raw = req.raw.unwrap_or(false);
@@ -2512,11 +2948,11 @@ async fn ollama_generate(
         )
     })?;
 
-    ollama_check_prompt(&prompt_tokens, state.max_seq_len)?;
+    ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
     let (temperature, top_p, top_k, repetition_penalty, max_tokens) =
         ollama_options_to_params(req.options.as_ref(), &state.default_params);
-    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), state.max_seq_len);
+    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
     let params = build_sampling_params(
         temperature,
         top_p,
@@ -2529,7 +2965,8 @@ async fn ollama_generate(
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
     if is_stream {
-        let token_rx = ollama_dispatch_stream(&state, &request_id, prompt_tokens, params).await?;
+        let token_rx =
+            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
         let stream = make_ollama_generate_stream(token_rx, model_name, created_at);
@@ -2539,7 +2976,8 @@ async fn ollama_generate(
         )
             .into_response())
     } else {
-        let result = ollama_dispatch_blocking(&state, request_id, prompt_tokens, params).await?;
+        let result =
+            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
 
         Ok(Json(OllamaGenerateResponse {
             model: req.model,
@@ -2610,7 +3048,15 @@ async fn ollama_chat(
     let request_id = format!("chat-{}", uuid::Uuid::new_v4());
     let created_at = rfc3339_now();
 
-    let tokenizer = require_ollama_tokenizer(&state, &req.model)?;
+    let lm = load_model_on_demand(&state, &req.model, req.options.as_ref()).await?;
+
+    // Proxy mode: forward to the worker.
+    if let ModelBackend::Proxy { worker_url, .. } = &lm.backend {
+        return proxy_to_worker(&state.http_client, worker_url, "/api/chat", &req).await;
+    }
+
+    let (_, tokenizer, max_seq_len, _, _, _, _, _, _, _) = worker_fields(&lm)
+        .map_err(|(s, j)| (s, Json(serde_json::json!({"error": j.0.error.message}))))?;
 
     // Convert Ollama messages to internal ChatMessage format.
     let chat_messages: Vec<ChatMessage> = req
@@ -2641,11 +3087,11 @@ async fn ollama_chat(
             )
         })?;
 
-    ollama_check_prompt(&prompt_tokens, state.max_seq_len)?;
+    ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
     let (temperature, top_p, top_k, repetition_penalty, max_tokens) =
         ollama_options_to_params(req.options.as_ref(), &state.default_params);
-    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), state.max_seq_len);
+    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
     let params = build_sampling_params(
         temperature,
         top_p,
@@ -2658,7 +3104,8 @@ async fn ollama_chat(
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
     if is_stream {
-        let token_rx = ollama_dispatch_stream(&state, &request_id, prompt_tokens, params).await?;
+        let token_rx =
+            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
         let stream = make_ollama_chat_stream(token_rx, model_name, created_at);
@@ -2668,7 +3115,8 @@ async fn ollama_chat(
         )
             .into_response())
     } else {
-        let result = ollama_dispatch_blocking(&state, request_id, prompt_tokens, params).await?;
+        let result =
+            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
 
         Ok(Json(OllamaChatResponse {
             model: req.model,


### PR DESCRIPTION
- inferrs serve (no model) acts as a persistent daemon on port 17434, mirroring ollama serve
- inferrs run talks to the daemon via the Ollama API; if no daemon is running it auto-starts one in the background with stdout/stderr suppressed
- On the first request the daemon spawns inferrs serve --port <N> <model> as an ephemeral worker child process and proxies all inference traffic to it, mirroring ollama's runner subprocess pattern
- Model-loading options (dtype, device, revision, paged-attention, turbo-quant, quantize) are passed from inferrs run to the daemon inside the Ollama API options field rather than as daemon CLI flags
- inferrs run enters the REPL immediately; model loading starts in a background task so the CLI is available while weights are downloading
- Loading state is shown in the prompt as (loading) > and the user is notified if they submit a message before loading completes
- Worker process lifecycle is managed correctly: killed on timeout, on replacement, and on daemon shutdown via Drop on ModelBackend
- Write lock is held only briefly to install a Loading sentinel; all I/O happens outside the lock so the daemon stays responsive during loads