### PR TITLE
feat: Ollama API parity — thinking mode + duration metrics

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -16,6 +16,7 @@
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
@@ -280,6 +281,15 @@ pub struct StreamToken {
     /// matching vllm's `--reasoning-parser` and llama-server's default behaviour.
     pub reasoning_content: String,
     pub finish_reason: Option<String>,
+    /// Wall time from request start to finish (nanoseconds).
+    /// Only populated on the final chunk (when `finish_reason.is_some()`).
+    pub total_duration_ns: Option<u128>,
+    /// Prefill (prompt evaluation) time in nanoseconds.
+    /// Only populated on the final chunk.
+    pub prompt_eval_duration_ns: Option<u128>,
+    /// Decode time for output tokens in nanoseconds.
+    /// Only populated on the final chunk.
+    pub eval_duration_ns: Option<u128>,
 }
 
 /// Classification of a single generated token with respect to the thinking block.
@@ -390,9 +400,18 @@ pub struct GenerationResult {
     #[allow(dead_code)]
     pub output_token_ids: Vec<u32>,
     pub output_text: String,
+    /// Reasoning/thinking text separated from the main content.
+    /// Empty when thinking is not active or the model produced no reasoning.
+    pub reasoning_content: String,
     pub finish_reason: String,
     pub prompt_tokens: usize,
     pub completion_tokens: usize,
+    /// Wall time from request start to finish (nanoseconds).
+    pub total_duration_ns: u128,
+    /// Prefill (prompt evaluation) time in nanoseconds.
+    pub prompt_eval_duration_ns: u128,
+    /// Decode time for output tokens in nanoseconds.
+    pub eval_duration_ns: u128,
 }
 
 // ---------------------------------------------------------------------------
@@ -442,7 +461,13 @@ impl TokenSink {
     }
 
     /// Send an error response appropriate to the channel type.
-    fn send_error(&mut self, error: &anyhow::Error, prompt_len: usize) {
+    fn send_error(
+        &mut self,
+        error: &anyhow::Error,
+        prompt_len: usize,
+        timing_ns: (u128, u128, u128),
+    ) {
+        let (total_duration_ns, prompt_eval_duration_ns, eval_duration_ns) = timing_ns;
         match self {
             TokenSink::Streaming {
                 request_id,
@@ -455,6 +480,9 @@ impl TokenSink {
                         text: format!("Error: {error}"),
                         reasoning_content: String::new(),
                         finish_reason: Some("error".to_string()),
+                        total_duration_ns: Some(total_duration_ns),
+                        prompt_eval_duration_ns: Some(prompt_eval_duration_ns),
+                        eval_duration_ns: Some(eval_duration_ns),
                     },
                 );
             }
@@ -463,9 +491,13 @@ impl TokenSink {
                     let _ = tx.send(GenerationResult {
                         output_token_ids: vec![],
                         output_text: format!("Error: {error}"),
+                        reasoning_content: String::new(),
                         finish_reason: "error".to_string(),
                         prompt_tokens: prompt_len,
                         completion_tokens: 0,
+                        total_duration_ns,
+                        prompt_eval_duration_ns,
+                        eval_duration_ns,
                     });
                 }
             }
@@ -495,6 +527,17 @@ struct ActiveSequence {
     finished: bool,
     /// Suppresses thinking-block tokens before they reach the client.
     think_filter: ThinkFilter,
+    /// Wall clock time when the sequence was admitted to the engine.
+    start_time: Instant,
+    /// Wall clock time when the prefill phase completed.  `None` until the
+    /// first decode step runs.
+    prefill_end: Option<Instant>,
+    /// Token IDs classified as reasoning (inside `<think>…</think>`).
+    /// Accumulated during decode for the non-streaming GenerationResult.
+    reasoning_tokens: Vec<u32>,
+    /// Token IDs classified as visible content.
+    /// Accumulated during decode for the non-streaming GenerationResult.
+    content_tokens: Vec<u32>,
 }
 
 impl ActiveSequence {
@@ -527,6 +570,10 @@ impl ActiveSequence {
                     prefilled: false,
                     finished: false,
                     think_filter: ThinkFilter::default(),
+                    start_time: Instant::now(),
+                    prefill_end: None,
+                    reasoning_tokens: Vec::new(),
+                    content_tokens: Vec::new(),
                 }
             }
             EngineRequest::GenerateStream {
@@ -554,6 +601,10 @@ impl ActiveSequence {
                     prefilled: false,
                     finished: false,
                     think_filter: ThinkFilter::default(),
+                    start_time: Instant::now(),
+                    prefill_end: None,
+                    reasoning_tokens: Vec::new(),
+                    content_tokens: Vec::new(),
                 }
             }
         }
@@ -576,16 +627,54 @@ impl ActiveSequence {
         if let (Some(bt), Some(pool)) = (&mut self.block_table, block_pool) {
             bt.free_all(pool);
         }
+        let (total_duration_ns, prompt_eval_duration_ns, eval_duration_ns) = self.timing_ns();
+        // Decode content and reasoning tokens separately so the blocking
+        // path gets the same structured separation that streaming gets via
+        // the per-token ThinkFilter classification.
+        let output_text = if self.content_tokens.is_empty() {
+            // No classification happened (e.g. no thinking model) — decode all.
+            tokenizer.decode(&self.output_tokens, true).unwrap_or_default()
+        } else {
+            tokenizer.decode(&self.content_tokens, true).unwrap_or_default()
+        };
+        let reasoning_content = if self.reasoning_tokens.is_empty() {
+            String::new()
+        } else {
+            tokenizer.decode(&self.reasoning_tokens, true).unwrap_or_default()
+        };
         self.sink.send_result(GenerationResult {
             output_token_ids: self.output_tokens.clone(),
-            output_text: tokenizer
-                .decode(&self.output_tokens, true)
-                .unwrap_or_default(),
+            output_text,
+            reasoning_content,
             finish_reason: finish_reason.to_string(),
             prompt_tokens: self.prompt_tokens.len(),
             completion_tokens: self.output_tokens.len(),
+            total_duration_ns,
+            prompt_eval_duration_ns,
+            eval_duration_ns,
         });
         self.finished = true;
+    }
+
+    /// Compute `(total, prompt_eval, eval)` wall times in nanoseconds from the
+    /// captured `start_time` / `prefill_end` instants.
+    ///
+    /// `prompt_eval_duration_ns` covers wall time from admission to the end of
+    /// prefill; `eval_duration_ns` covers the remaining decode time.  When
+    /// prefill never completed (e.g. the sequence failed during prefill), both
+    /// sub-durations are 0 and only `total_duration_ns` is populated.
+    fn timing_ns(&self) -> (u128, u128, u128) {
+        let now = Instant::now();
+        let total_duration_ns = now.duration_since(self.start_time).as_nanos();
+        let (prompt_eval_duration_ns, eval_duration_ns) = match self.prefill_end {
+            Some(end) => {
+                let pe = end.duration_since(self.start_time).as_nanos();
+                let ev = now.duration_since(end).as_nanos();
+                (pe, ev)
+            }
+            None => (0, 0),
+        };
+        (total_duration_ns, prompt_eval_duration_ns, eval_duration_ns)
     }
 
     /// Mark the sequence as failed, free its blocks, and send an error.
@@ -594,7 +683,9 @@ impl ActiveSequence {
         if let (Some(bt), Some(pool)) = (&mut self.block_table, block_pool) {
             bt.free_all(pool);
         }
-        self.sink.send_error(&error, self.prompt_tokens.len());
+        let timing = self.timing_ns();
+        self.sink
+            .send_error(&error, self.prompt_tokens.len(), timing);
         self.finished = true;
     }
 }
@@ -1333,6 +1424,7 @@ impl Engine {
 
                 if !seq.prefilled {
                     seq.prefilled = true;
+                    seq.prefill_end = Some(Instant::now());
                 }
 
                 let finish_reason = check_stop(
@@ -1342,7 +1434,24 @@ impl Engine {
                     &stop_token_ids,
                 );
 
+                // Populate timing on the final streaming chunk so the HTTP
+                // handler doesn't have to measure wall time itself (which
+                // would bake in queueing/transport delay).
+                let (total_ns, prompt_eval_ns, eval_ns) = if finish_reason.is_some() {
+                    let t = seq.timing_ns();
+                    (Some(t.0), Some(t.1), Some(t.2))
+                } else {
+                    (None, None, None)
+                };
+
                 let kind = seq.think_filter.classify(token_id);
+                // Accumulate token into the appropriate bucket for the
+                // non-streaming GenerationResult.
+                match kind {
+                    TokenKind::Reasoning => seq.reasoning_tokens.push(token_id),
+                    TokenKind::Content => seq.content_tokens.push(token_id),
+                    TokenKind::Delimiter => {} // delimiters are dropped
+                }
                 let client_gone = match kind {
                     TokenKind::Delimiter => {
                         // Opening/closing delimiter: drop text, but if this is
@@ -1353,6 +1462,9 @@ impl Engine {
                                 text: String::new(),
                                 reasoning_content: String::new(),
                                 finish_reason: finish_reason.clone(),
+                                total_duration_ns: total_ns,
+                                prompt_eval_duration_ns: prompt_eval_ns,
+                                eval_duration_ns: eval_ns,
                             });
                         }
                         false
@@ -1365,6 +1477,9 @@ impl Engine {
                             text: String::new(),
                             reasoning_content: text,
                             finish_reason: finish_reason.clone(),
+                            total_duration_ns: total_ns,
+                            prompt_eval_duration_ns: prompt_eval_ns,
+                            eval_duration_ns: eval_ns,
                         })
                     }
                     TokenKind::Content => {
@@ -1375,6 +1490,9 @@ impl Engine {
                             text,
                             reasoning_content: String::new(),
                             finish_reason: finish_reason.clone(),
+                            total_duration_ns: total_ns,
+                            prompt_eval_duration_ns: prompt_eval_ns,
+                            eval_duration_ns: eval_ns,
                         })
                     }
                 };
@@ -1599,6 +1717,9 @@ impl Engine {
                             text: format!("Error: {e}"),
                             reasoning_content: String::new(),
                             finish_reason: Some("error".to_string()),
+                            total_duration_ns: None,
+                            prompt_eval_duration_ns: None,
+                            eval_duration_ns: None,
                         });
                     }
                 }
@@ -1756,6 +1877,9 @@ impl Engine {
                     text: content,
                     reasoning_content: reasoning,
                     finish_reason: finish_reason.clone(),
+                    total_duration_ns: None,
+                    prompt_eval_duration_ns: None,
+                    eval_duration_ns: None,
                 }) {
                     self.free_paged_blocks();
                     return Ok(());
@@ -1767,6 +1891,9 @@ impl Engine {
                     text: String::new(),
                     reasoning_content: String::new(),
                     finish_reason: finish_reason.clone(),
+                    total_duration_ns: None,
+                    prompt_eval_duration_ns: None,
+                    eval_duration_ns: None,
                 });
             }
         }
@@ -1802,6 +1929,9 @@ impl Engine {
                         text: content,
                         reasoning_content: reasoning,
                         finish_reason: finish_reason.clone(),
+                        total_duration_ns: None,
+                        prompt_eval_duration_ns: None,
+                        eval_duration_ns: None,
                     }) {
                         break;
                     }
@@ -1811,6 +1941,9 @@ impl Engine {
                         text: String::new(),
                         reasoning_content: String::new(),
                         finish_reason: finish_reason.clone(),
+                        total_duration_ns: None,
+                        prompt_eval_duration_ns: None,
+                        eval_duration_ns: None,
                     });
                 }
             }
@@ -1837,8 +1970,6 @@ impl Engine {
         prompt_tokens: &[u32],
         sampling_params: &SamplingParams,
     ) -> Result<(GenerationResult, f64, f64)> {
-        use std::time::Instant;
-
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
@@ -1878,7 +2009,11 @@ impl Engine {
                 completion_tokens: output_tokens.len(),
                 output_token_ids: output_tokens,
                 output_text,
+                reasoning_content: String::new(),
                 finish_reason,
+                total_duration_ns: ((prefill_ms + decode_ms) * 1_000_000.0) as u128,
+                prompt_eval_duration_ns: (prefill_ms * 1_000_000.0) as u128,
+                eval_duration_ns: (decode_ms * 1_000_000.0) as u128,
             },
             prefill_ms,
             decode_ms,

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -366,7 +366,7 @@ impl ThinkFilter {
             for known_id in [98u32] {
                 if let Some(text) = tokenizer.id_to_token(known_id) {
                     if text.contains("think") {
-                        tracing::info!(
+                        tracing::debug!(
                             "ThinkFilter: found thinking token via fallback: '{}' = ID {}",
                             text,
                             known_id,
@@ -383,13 +383,13 @@ impl ThinkFilter {
         close_ids.dedup();
 
         if !open_ids.is_empty() {
-            tracing::info!(
+            tracing::debug!(
                 "ThinkFilter enabled: open_ids={:?} close_ids={:?}",
                 open_ids,
                 close_ids
             );
         } else {
-            tracing::info!("ThinkFilter: no thinking tokens found, filter disabled");
+            tracing::debug!("ThinkFilter: no thinking tokens found, filter disabled");
         }
         Self {
             think_token_ids: open_ids, // reused as open_ids
@@ -669,18 +669,24 @@ impl ActiveSequence {
         let output_text = if self.content_tokens.is_empty() {
             if self.reasoning_tokens.is_empty() {
                 // No classification happened (e.g. no thinking model) — decode all.
-                tokenizer.decode(&self.output_tokens, true).unwrap_or_default()
+                tokenizer
+                    .decode(&self.output_tokens, true)
+                    .unwrap_or_default()
             } else {
                 // All output was reasoning tokens (model never closed the thinking block).
                 String::new()
             }
         } else {
-            tokenizer.decode(&self.content_tokens, true).unwrap_or_default()
+            tokenizer
+                .decode(&self.content_tokens, true)
+                .unwrap_or_default()
         };
         let reasoning_content = if self.reasoning_tokens.is_empty() {
             String::new()
         } else {
-            tokenizer.decode(&self.reasoning_tokens, true).unwrap_or_default()
+            tokenizer
+                .decode(&self.reasoning_tokens, true)
+                .unwrap_or_default()
         };
         self.sink.send_result(GenerationResult {
             output_token_ids: self.output_tokens.clone(),

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -356,16 +356,40 @@ impl ThinkFilter {
                 close_ids.push(id);
             }
         }
+
+        // Fallback: some tokenizers (e.g. Gemma4 GGUF-loaded) don't expose
+        // added tokens via `token_to_id`.  Try looking up the token string
+        // from the vocab by ID for known positions.
+        if open_ids.is_empty() {
+            // Try well-known IDs for common thinking model families.
+            // Gemma4: <|think|> = 98
+            for known_id in [98u32] {
+                if let Some(text) = tokenizer.id_to_token(known_id) {
+                    if text.contains("think") {
+                        tracing::info!(
+                            "ThinkFilter: found thinking token via fallback: '{}' = ID {}",
+                            text,
+                            known_id,
+                        );
+                        open_ids.push(known_id);
+                        close_ids.push(known_id); // toggle style
+                    }
+                }
+            }
+        }
+
         // Deduplicate
         open_ids.dedup();
         close_ids.dedup();
 
         if !open_ids.is_empty() {
-            tracing::debug!(
-                "ThinkFilter: open_ids={:?} close_ids={:?}",
+            tracing::info!(
+                "ThinkFilter enabled: open_ids={:?} close_ids={:?}",
                 open_ids,
                 close_ids
             );
+        } else {
+            tracing::info!("ThinkFilter: no thinking tokens found, filter disabled");
         }
         Self {
             think_token_ids: open_ids, // reused as open_ids
@@ -391,6 +415,17 @@ impl ThinkFilter {
         } else {
             TokenKind::Content
         }
+    }
+
+    /// Check if a token ID is a thinking-block opening delimiter.
+    pub fn is_open_delimiter(&self, token_id: u32) -> bool {
+        self.think_token_ids.contains(&token_id)
+    }
+
+    /// Pre-set the thinking state (e.g. when the prompt already ends with
+    /// a `<|think|>` token, the model starts "inside" the thinking block).
+    pub fn set_in_think(&mut self, value: bool) {
+        self.in_think = value;
     }
 }
 
@@ -632,8 +667,13 @@ impl ActiveSequence {
         // path gets the same structured separation that streaming gets via
         // the per-token ThinkFilter classification.
         let output_text = if self.content_tokens.is_empty() {
-            // No classification happened (e.g. no thinking model) — decode all.
-            tokenizer.decode(&self.output_tokens, true).unwrap_or_default()
+            if self.reasoning_tokens.is_empty() {
+                // No classification happened (e.g. no thinking model) — decode all.
+                tokenizer.decode(&self.output_tokens, true).unwrap_or_default()
+            } else {
+                // All output was reasoning tokens (model never closed the thinking block).
+                String::new()
+            }
         } else {
             tokenizer.decode(&self.content_tokens, true).unwrap_or_default()
         };
@@ -1304,6 +1344,15 @@ impl Engine {
                     Ok(req) => {
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
+                        // If the prompt ends with a thinking delimiter (e.g. the
+                        // server injected <|think|> for think=true), the model
+                        // is already "inside" thinking and the first output token
+                        // will be reasoning content, not a delimiter.
+                        if let Some(&last) = seq.prompt_tokens.last() {
+                            if seq.think_filter.is_open_delimiter(last) {
+                                seq.think_filter.set_in_think(true);
+                            }
+                        }
                         tracing::debug!(
                             "Accepted request {} ({} prompt tokens, batch_size={})",
                             seq.request_id,
@@ -1322,6 +1371,11 @@ impl Engine {
                     Some(req) => {
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
+                        if let Some(&last) = seq.prompt_tokens.last() {
+                            if seq.think_filter.is_open_delimiter(last) {
+                                seq.think_filter.set_in_think(true);
+                            }
+                        }
                         tracing::debug!(
                             "Accepted request {} ({} prompt tokens)",
                             seq.request_id,

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -415,6 +415,10 @@ pub struct OllamaGenerateRequest {
     pub raw: Option<bool>,
     #[serde(default)]
     pub options: Option<OllamaOptions>,
+    /// When `true`, enable thinking/reasoning mode. The model's internal
+    /// chain-of-thought will be returned in the `thinking` field.
+    #[serde(default)]
+    pub think: Option<bool>,
 }
 
 /// Ollama `POST /api/chat` request.
@@ -426,6 +430,10 @@ pub struct OllamaChatRequest {
     pub stream: Option<bool>,
     #[serde(default)]
     pub options: Option<OllamaOptions>,
+    /// When `true`, enable thinking/reasoning mode. The model's internal
+    /// chain-of-thought will be returned in the `thinking` field.
+    #[serde(default)]
+    pub think: Option<bool>,
 }
 
 /// A single message in an Ollama chat request.
@@ -433,6 +441,9 @@ pub struct OllamaChatRequest {
 pub struct OllamaChatMessage {
     pub role: String,
     pub content: String,
+    /// Text from inside `<think>…</think>` tags when thinking is enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
 }
 
 /// Sampling options passed inside an Ollama request.
@@ -463,6 +474,13 @@ pub struct OllamaOptions {
     pub turbo_quant: Option<String>,
     /// GGUF quantization format, e.g. "Q4K"
     pub quantize: Option<String>,
+
+    // ── Extended sampling fields (not yet wired to sampler) ──────────────────
+    pub seed: Option<i64>,
+    pub min_p: Option<f64>,
+    pub stop: Option<Vec<String>>,
+    pub presence_penalty: Option<f64>,
+    pub frequency_penalty: Option<f64>,
 }
 
 /// Non-streaming `POST /api/generate` response.
@@ -476,6 +494,16 @@ pub struct OllamaGenerateResponse {
     pub done_reason: Option<String>,
     pub prompt_eval_count: usize,
     pub eval_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    /// Wall time from request start to done, in nanoseconds.
+    pub total_duration: u128,
+    /// Time to load / prepare the model (always 0 for pre-loaded models).
+    pub load_duration: u128,
+    /// Prompt prefill time in nanoseconds.
+    pub prompt_eval_duration: u128,
+    /// Decode time for output tokens, in nanoseconds.
+    pub eval_duration: u128,
 }
 
 /// Streaming chunk for `POST /api/generate`.
@@ -491,6 +519,17 @@ pub struct OllamaGenerateChunk {
     pub prompt_eval_count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eval_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    // Duration fields — only populated on the final (done=true) chunk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_eval_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_duration: Option<u128>,
 }
 
 /// Non-streaming `POST /api/chat` response.
@@ -504,6 +543,10 @@ pub struct OllamaChatResponse {
     pub done_reason: Option<String>,
     pub prompt_eval_count: usize,
     pub eval_count: usize,
+    pub total_duration: u128,
+    pub load_duration: u128,
+    pub prompt_eval_duration: u128,
+    pub eval_duration: u128,
 }
 
 /// Streaming chunk for `POST /api/chat`.
@@ -519,6 +562,15 @@ pub struct OllamaChatChunk {
     pub prompt_eval_count: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eval_count: Option<usize>,
+    // Duration fields — only populated on the final (done=true) chunk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub load_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_eval_duration: Option<u128>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eval_duration: Option<u128>,
 }
 
 /// `GET /api/tags` response.
@@ -2639,7 +2691,14 @@ fn secs_to_ymd_hms(mut secs: u64) -> (u64, u64, u64, u64, u64, u64) {
 fn ollama_options_to_params(
     opts: Option<&OllamaOptions>,
     defaults: &SamplingParams,
-) -> (Option<f64>, Option<f64>, Option<usize>, Option<f64>, usize) {
+) -> (
+    Option<f64>,
+    Option<f64>,
+    Option<usize>,
+    Option<f64>,
+    usize,
+    Vec<String>,
+) {
     let temperature = opts.and_then(|o| o.temperature);
     let top_p = opts.and_then(|o| o.top_p);
     let top_k = opts.and_then(|o| o.top_k);
@@ -2647,7 +2706,17 @@ fn ollama_options_to_params(
     let num_predict = opts
         .and_then(|o| o.num_predict)
         .unwrap_or(defaults.max_tokens);
-    (temperature, top_p, top_k, repetition_penalty, num_predict)
+    let stop = opts.and_then(|o| o.stop.clone()).unwrap_or_default();
+    // TODO(phase-3): wire seed / min_p / presence_penalty / frequency_penalty
+    // into the sampler (requires RNG refactor + new penalty stages).
+    (
+        temperature,
+        top_p,
+        top_k,
+        repetition_penalty,
+        num_predict,
+        stop,
+    )
 }
 
 /// Shared Ollama model/tokenizer validation.  Returns the tokenizer when the
@@ -2950,10 +3019,10 @@ async fn ollama_generate(
 
     ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
-    let (temperature, top_p, top_k, repetition_penalty, max_tokens) =
+    let (temperature, top_p, top_k, repetition_penalty, max_tokens, stop) =
         ollama_options_to_params(req.options.as_ref(), &state.default_params);
     let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
-    let params = build_sampling_params(
+    let mut params = build_sampling_params(
         temperature,
         top_p,
         top_k,
@@ -2961,15 +3030,20 @@ async fn ollama_generate(
         max_tokens,
         &state.default_params,
     );
+    params.extra_stop_token_ids = resolve_stop_token_ids(stop, tokenizer);
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
+
+    // Determine if thinking mode is active
+    let think_enabled = req.think.unwrap_or(false);
 
     if is_stream {
         let token_rx =
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
-        let stream = make_ollama_generate_stream(token_rx, model_name, created_at);
+        let stream =
+            make_ollama_generate_stream(token_rx, model_name, created_at, think_enabled);
         Ok((
             [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
             axum::body::Body::from_stream(stream),
@@ -2979,14 +3053,33 @@ async fn ollama_generate(
         let result =
             ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
 
+        // The engine's ThinkFilter has already separated reasoning and content
+        // at the token level.  Surface reasoning only when the client opted in.
+        let (thinking, content) = if think_enabled && !result.reasoning_content.is_empty() {
+            (Some(result.reasoning_content), result.output_text)
+        } else if !result.reasoning_content.is_empty() {
+            // Client didn't opt in — fold reasoning back into content.
+            (
+                None,
+                format!("{}{}", result.reasoning_content, result.output_text),
+            )
+        } else {
+            (None, result.output_text)
+        };
+
         Ok(Json(OllamaGenerateResponse {
             model: req.model,
             created_at,
-            response: result.output_text,
+            response: content,
             done: true,
             done_reason: Some(ollama_done_reason(&result.finish_reason)),
             prompt_eval_count: result.prompt_tokens,
             eval_count: result.completion_tokens,
+            thinking,
+            total_duration: result.total_duration_ns,
+            load_duration: 0,
+            prompt_eval_duration: result.prompt_eval_duration_ns,
+            eval_duration: result.eval_duration_ns,
         })
         .into_response())
     }
@@ -2996,37 +3089,71 @@ fn make_ollama_generate_stream(
     mut token_rx: mpsc::Receiver<StreamToken>,
     model_name: String,
     created_at: String,
+    think_enabled: bool,
 ) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
     async_stream::stream! {
         let mut eval_count: usize = 0;
+
         while let Some(token) = token_rx.recv().await {
             let is_final = token.finish_reason.is_some();
-            let text = if token.finish_reason.as_deref() == Some("stop") {
+            let content_text = if token.finish_reason.as_deref() == Some("stop") {
                 String::new()
             } else {
                 eval_count += 1;
                 token.text
             };
 
+            // The engine's ThinkFilter has already split content and reasoning
+            // for us at the token level (see engine.rs ThinkFilter + TokenKind).
+            // When the client opted into thinking mode, surface the reasoning
+            // chunk on Ollama's `thinking` field; otherwise fold it back into
+            // the main content so nothing is silently dropped.
+            let (thinking, content_text) = if think_enabled {
+                let thinking = if token.reasoning_content.is_empty() {
+                    None
+                } else {
+                    Some(token.reasoning_content.clone())
+                };
+                (thinking, content_text)
+            } else if !token.reasoning_content.is_empty() {
+                (None, format!("{}{}", token.reasoning_content, content_text))
+            } else {
+                (None, content_text)
+            };
+
             let chunk = if is_final {
+                // On the final chunk, Ollama always includes all four duration
+                // fields — keep `load_duration` pinned at 0 whenever any of the
+                // other timings are available.
+                let load_duration = token.total_duration_ns.map(|_| 0u128);
                 OllamaGenerateChunk {
                     model: model_name.clone(),
                     created_at: created_at.clone(),
-                    response: text,
+                    response: content_text,
                     done: true,
                     done_reason: token.finish_reason.as_deref().map(ollama_done_reason),
                     prompt_eval_count: None,
                     eval_count: Some(eval_count),
+                    thinking,
+                    total_duration: token.total_duration_ns,
+                    load_duration,
+                    prompt_eval_duration: token.prompt_eval_duration_ns,
+                    eval_duration: token.eval_duration_ns,
                 }
             } else {
                 OllamaGenerateChunk {
                     model: model_name.clone(),
                     created_at: created_at.clone(),
-                    response: text,
+                    response: content_text,
                     done: false,
                     done_reason: None,
                     prompt_eval_count: None,
                     eval_count: None,
+                    thinking,
+                    total_duration: None,
+                    load_duration: None,
+                    prompt_eval_duration: None,
+                    eval_duration: None,
                 }
             };
 
@@ -3089,10 +3216,10 @@ async fn ollama_chat(
 
     ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
-    let (temperature, top_p, top_k, repetition_penalty, max_tokens) =
+    let (temperature, top_p, top_k, repetition_penalty, max_tokens, stop) =
         ollama_options_to_params(req.options.as_ref(), &state.default_params);
     let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
-    let params = build_sampling_params(
+    let mut params = build_sampling_params(
         temperature,
         top_p,
         top_k,
@@ -3100,6 +3227,10 @@ async fn ollama_chat(
         max_tokens,
         &state.default_params,
     );
+    params.extra_stop_token_ids = resolve_stop_token_ids(stop, tokenizer);
+
+    // Determine if thinking mode is active: explicit think=true from request
+    let think_enabled = req.think.unwrap_or(false);
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
@@ -3108,7 +3239,7 @@ async fn ollama_chat(
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
-        let stream = make_ollama_chat_stream(token_rx, model_name, created_at);
+        let stream = make_ollama_chat_stream(token_rx, model_name, created_at, think_enabled);
         Ok((
             [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
             axum::body::Body::from_stream(stream),
@@ -3118,17 +3249,34 @@ async fn ollama_chat(
         let result =
             ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
 
+        // The engine's ThinkFilter has already separated reasoning and content.
+        let (thinking, content) = if think_enabled && !result.reasoning_content.is_empty() {
+            (Some(result.reasoning_content), result.output_text)
+        } else if !result.reasoning_content.is_empty() {
+            (
+                None,
+                format!("{}{}", result.reasoning_content, result.output_text),
+            )
+        } else {
+            (None, result.output_text)
+        };
+
         Ok(Json(OllamaChatResponse {
             model: req.model,
             created_at,
             message: OllamaChatMessage {
                 role: "assistant".to_string(),
-                content: result.output_text,
+                content,
+                thinking,
             },
             done: true,
             done_reason: Some(ollama_done_reason(&result.finish_reason)),
             prompt_eval_count: result.prompt_tokens,
             eval_count: result.completion_tokens,
+            total_duration: result.total_duration_ns,
+            load_duration: 0,
+            prompt_eval_duration: result.prompt_eval_duration_ns,
+            eval_duration: result.eval_duration_ns,
         })
         .into_response())
     }
@@ -3138,16 +3286,35 @@ fn make_ollama_chat_stream(
     mut token_rx: mpsc::Receiver<StreamToken>,
     model_name: String,
     created_at: String,
+    think_enabled: bool,
 ) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
     async_stream::stream! {
         let mut eval_count: usize = 0;
+
         while let Some(token) = token_rx.recv().await {
             let is_final = token.finish_reason.is_some();
-            let text = if token.finish_reason.as_deref() == Some("stop") {
+            let content_text = if token.finish_reason.as_deref() == Some("stop") {
                 String::new()
             } else {
                 eval_count += 1;
                 token.text
+            };
+
+            // The engine's ThinkFilter has already split content and reasoning
+            // at the token level.  Surface reasoning on Ollama's `thinking`
+            // field only when the client opted in; otherwise fold it back into
+            // content so nothing is silently dropped.
+            let (thinking, content_text) = if think_enabled {
+                let thinking = if token.reasoning_content.is_empty() {
+                    None
+                } else {
+                    Some(token.reasoning_content.clone())
+                };
+                (thinking, content_text)
+            } else if !token.reasoning_content.is_empty() {
+                (None, format!("{}{}", token.reasoning_content, content_text))
+            } else {
+                (None, content_text)
             };
 
             let chunk = if is_final {
@@ -3156,12 +3323,17 @@ fn make_ollama_chat_stream(
                     created_at: created_at.clone(),
                     message: OllamaChatMessage {
                         role: "assistant".to_string(),
-                        content: text,
+                        content: content_text,
+                        thinking,
                     },
                     done: true,
                     done_reason: token.finish_reason.as_deref().map(ollama_done_reason),
                     prompt_eval_count: None,
                     eval_count: Some(eval_count),
+                    total_duration: token.total_duration_ns,
+                    load_duration: token.total_duration_ns.map(|_| 0u128),
+                    prompt_eval_duration: token.prompt_eval_duration_ns,
+                    eval_duration: token.eval_duration_ns,
                 }
             } else {
                 OllamaChatChunk {
@@ -3169,12 +3341,17 @@ fn make_ollama_chat_stream(
                     created_at: created_at.clone(),
                     message: OllamaChatMessage {
                         role: "assistant".to_string(),
-                        content: text,
+                        content: content_text,
+                        thinking,
                     },
                     done: false,
                     done_reason: None,
                     prompt_eval_count: None,
                     eval_count: None,
+                    total_duration: None,
+                    load_duration: None,
+                    prompt_eval_duration: None,
+                    eval_duration: None,
                 }
             };
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -3037,6 +3037,23 @@ async fn ollama_generate(
     // Determine if thinking mode is active
     let think_enabled = req.think.unwrap_or(false);
 
+    // When thinking is enabled, append the thinking token to prompt.
+    let mut prompt_tokens = prompt_tokens;
+    if think_enabled {
+        let think_id = tokenizer
+            .token_to_id("<|think|>")
+            .or_else(|| tokenizer.token_to_id("<think>"))
+            .or_else(|| {
+                tokenizer
+                    .id_to_token(98)
+                    .filter(|t| t.contains("think"))
+                    .map(|_| 98u32)
+            });
+        if let Some(id) = think_id {
+            prompt_tokens.push(id);
+        }
+    }
+
     if is_stream {
         let token_rx =
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
@@ -3231,6 +3248,30 @@ async fn ollama_chat(
 
     // Determine if thinking mode is active: explicit think=true from request
     let think_enabled = req.think.unwrap_or(false);
+
+    // When thinking is enabled, append the <|think|> token to the prompt so the
+    // model enters thinking mode — matching Ollama's behavior where the think
+    // token is injected at the start of the assistant turn.
+    let mut prompt_tokens = prompt_tokens;
+    if think_enabled {
+        let think_id = tokenizer
+            .token_to_id("<|think|>")
+            .or_else(|| tokenizer.token_to_id("<think>"))
+            .or_else(|| {
+                // Fallback: check well-known ID 98 (Gemma4 <|think|>).
+                // Some tokenizers don't expose added tokens via token_to_id.
+                tokenizer
+                    .id_to_token(98)
+                    .filter(|t| t.contains("think"))
+                    .map(|_| 98u32)
+            });
+        if let Some(id) = think_id {
+            prompt_tokens.push(id);
+            tracing::info!("Think mode: injected token ID {} into prompt", id);
+        } else {
+            tracing::warn!("Think mode requested but no thinking token found in vocabulary");
+        }
+    }
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -2688,6 +2688,7 @@ fn secs_to_ymd_hms(mut secs: u64) -> (u64, u64, u64, u64, u64, u64) {
 }
 
 /// Extract sampling params from optional [`OllamaOptions`].
+#[allow(clippy::type_complexity)]
 fn ollama_options_to_params(
     opts: Option<&OllamaOptions>,
     defaults: &SamplingParams,
@@ -2707,8 +2708,24 @@ fn ollama_options_to_params(
         .and_then(|o| o.num_predict)
         .unwrap_or(defaults.max_tokens);
     let stop = opts.and_then(|o| o.stop.clone()).unwrap_or_default();
-    // TODO(phase-3): wire seed / min_p / presence_penalty / frequency_penalty
-    // into the sampler (requires RNG refactor + new penalty stages).
+
+    // Warn when the client sends sampling params that the engine doesn't
+    // support yet, so callers know they have no effect.
+    if let Some(o) = opts {
+        if o.seed.is_some() {
+            tracing::warn!("option 'seed' is not yet supported and will be ignored");
+        }
+        if o.min_p.is_some() {
+            tracing::warn!("option 'min_p' is not yet supported and will be ignored");
+        }
+        if o.presence_penalty.is_some() {
+            tracing::warn!("option 'presence_penalty' is not yet supported and will be ignored");
+        }
+        if o.frequency_penalty.is_some() {
+            tracing::warn!("option 'frequency_penalty' is not yet supported and will be ignored");
+        }
+    }
+
     (
         temperature,
         top_p,
@@ -3034,33 +3051,40 @@ async fn ollama_generate(
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
-    // Determine if thinking mode is active
+    let think_id = tokenizer
+        .token_to_id("<|think|>")
+        .or_else(|| tokenizer.token_to_id("<think>"))
+        .or_else(|| {
+            tokenizer
+                .id_to_token(98)
+                .filter(|t| t.contains("think"))
+                .map(|_| 98u32)
+        });
+
+    // For raw completions (/api/generate), defaulting to think=true and appending <|think|>
+    // can break unstructured prompts. Only enable if explicitly requested.
     let think_enabled = req.think.unwrap_or(false);
 
-    // When thinking is enabled, append the thinking token to prompt.
     let mut prompt_tokens = prompt_tokens;
     if think_enabled {
-        let think_id = tokenizer
-            .token_to_id("<|think|>")
-            .or_else(|| tokenizer.token_to_id("<think>"))
-            .or_else(|| {
-                tokenizer
-                    .id_to_token(98)
-                    .filter(|t| t.contains("think"))
-                    .map(|_| 98u32)
-            });
         if let Some(id) = think_id {
             prompt_tokens.push(id);
         }
     }
 
     if is_stream {
+        let prompt_eval_count = prompt_tokens.len();
         let token_rx =
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
-        let stream =
-            make_ollama_generate_stream(token_rx, model_name, created_at, think_enabled);
+        let stream = make_ollama_generate_stream(
+            token_rx,
+            model_name,
+            created_at,
+            think_enabled,
+            prompt_eval_count,
+        );
         Ok((
             [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
             axum::body::Body::from_stream(stream),
@@ -3107,6 +3131,7 @@ fn make_ollama_generate_stream(
     model_name: String,
     created_at: String,
     think_enabled: bool,
+    prompt_eval_count: usize,
 ) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
     async_stream::stream! {
         let mut eval_count: usize = 0;
@@ -3149,7 +3174,7 @@ fn make_ollama_generate_stream(
                     response: content_text,
                     done: true,
                     done_reason: token.finish_reason.as_deref().map(ollama_done_reason),
-                    prompt_eval_count: None,
+                    prompt_eval_count: Some(prompt_eval_count),
                     eval_count: Some(eval_count),
                     thinking,
                     total_duration: token.total_duration_ns,
@@ -3246,41 +3271,45 @@ async fn ollama_chat(
     );
     params.extra_stop_token_ids = resolve_stop_token_ids(stop, tokenizer);
 
-    // Determine if thinking mode is active: explicit think=true from request
-    let think_enabled = req.think.unwrap_or(false);
+    let think_id = tokenizer
+        .token_to_id("<|think|>")
+        .or_else(|| tokenizer.token_to_id("<think>"))
+        .or_else(|| {
+            // Fallback: check well-known ID 98 (Gemma4 <|think|>).
+            // Some tokenizers don't expose added tokens via token_to_id.
+            tokenizer
+                .id_to_token(98)
+                .filter(|t| t.contains("think"))
+                .map(|_| 98u32)
+        });
 
-    // When thinking is enabled, append the <|think|> token to the prompt so the
-    // model enters thinking mode — matching Ollama's behavior where the think
-    // token is injected at the start of the assistant turn.
+    let think_enabled = req.think.unwrap_or(think_id.is_some());
+
     let mut prompt_tokens = prompt_tokens;
     if think_enabled {
-        let think_id = tokenizer
-            .token_to_id("<|think|>")
-            .or_else(|| tokenizer.token_to_id("<think>"))
-            .or_else(|| {
-                // Fallback: check well-known ID 98 (Gemma4 <|think|>).
-                // Some tokenizers don't expose added tokens via token_to_id.
-                tokenizer
-                    .id_to_token(98)
-                    .filter(|t| t.contains("think"))
-                    .map(|_| 98u32)
-            });
         if let Some(id) = think_id {
             prompt_tokens.push(id);
-            tracing::info!("Think mode: injected token ID {} into prompt", id);
+            tracing::debug!("Think mode: injected token ID {} into prompt", id);
         } else {
-            tracing::warn!("Think mode requested but no thinking token found in vocabulary");
+            tracing::debug!("Think mode requested but no thinking token found in vocabulary");
         }
     }
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
     if is_stream {
+        let prompt_eval_count = prompt_tokens.len();
         let token_rx =
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
 
         let model_name = req.model.clone();
-        let stream = make_ollama_chat_stream(token_rx, model_name, created_at, think_enabled);
+        let stream = make_ollama_chat_stream(
+            token_rx,
+            model_name,
+            created_at,
+            think_enabled,
+            prompt_eval_count,
+        );
         Ok((
             [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
             axum::body::Body::from_stream(stream),
@@ -3328,6 +3357,7 @@ fn make_ollama_chat_stream(
     model_name: String,
     created_at: String,
     think_enabled: bool,
+    prompt_eval_count: usize,
 ) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
     async_stream::stream! {
         let mut eval_count: usize = 0;
@@ -3369,7 +3399,7 @@ fn make_ollama_chat_stream(
                     },
                     done: true,
                     done_reason: token.finish_reason.as_deref().map(ollama_done_reason),
-                    prompt_eval_count: None,
+                    prompt_eval_count: Some(prompt_eval_count),
                     eval_count: Some(eval_count),
                     total_duration: token.total_duration_ns,
                     load_duration: token.total_duration_ns.map(|_| 0u128),

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -377,6 +377,11 @@ impl Tokenizer {
         self.inner.token_to_id(token)
     }
 
+    /// Look up a token ID and return its string representation.
+    pub fn id_to_token(&self, id: u32) -> Option<String> {
+        self.inner.id_to_token(id)
+    }
+
     /// Encode text to token IDs.
     pub fn encode(&self, text: &str, add_special_tokens: bool) -> Result<Vec<u32>> {
         let encoding = self

--- a/tests/compare_ollama.sh
+++ b/tests/compare_ollama.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Reproducible comparison: inferrs vs ollama Ollama-compatible API.
+# Prerequisites: ollama serving gemma4:e2b on :11434, inferrs on :11435.
+set -uo pipefail
+
+OLLAMA="http://localhost:11434"
+INFERRS="http://localhost:11435"
+OLLAMA_MODEL="gemma4:e2b"
+INFERRS_MODEL="google/gemma-4-E2B-it"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass=0
+fail=0
+
+# ─── Test: Non-streaming /api/chat ───────────────────────────────────────────
+test_chat_nonstream() {
+  local label="$1"
+  local prompt="$2"
+  printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
+
+  local ollama_resp inferrs_resp
+  ollama_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
+    "${OLLAMA}/api/chat" -d "$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" \
+    '{model:$m,stream:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
+  inferrs_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
+    "${INFERRS}/api/chat" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" \
+    '{model:$m,stream:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
+
+  local o_content o_thinking i_content i_thinking
+  o_content=$(echo "$ollama_resp" | jq -r '.message.content // "(empty)"')
+  o_thinking=$(echo "$ollama_resp" | jq -r '.message.thinking // "(null)"' | head -c 120)
+  i_content=$(echo "$inferrs_resp" | jq -r '.message.content // "(empty)"')
+  i_thinking=$(echo "$inferrs_resp" | jq -r '.message.thinking // "(null)"' | head -c 120)
+
+  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 150)"
+  printf "           thinking=%s\n" "$o_thinking"
+  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 150)"
+  printf "           thinking=%s\n" "$i_thinking"
+
+  # Check 1: thinking field exists in ollama but missing in inferrs
+  if [[ "$o_thinking" != "(null)" && "$i_thinking" == "(null)" ]]; then
+    printf "  ${RED}FAIL${NC}: inferrs missing 'thinking' field (ollama has it)\n"
+    ((fail++))
+    return
+  fi
+
+  # Check 2: content quality — detect degeneration
+  local degen_count
+  degen_count=$(echo "$i_content" | grep -oP '\b(\w+)\b' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
+  if [[ "${degen_count:-0}" -gt 8 ]]; then
+    printf "  ${RED}FAIL${NC}: inferrs output degenerated\n"
+    ((fail++))
+    return
+  fi
+
+  printf "  ${GREEN}PASS${NC}\n"
+  ((pass++))
+}
+
+# ─── Test: Streaming /api/chat ───────────────────────────────────────────────
+test_chat_stream() {
+  local label="$1"
+  local prompt="$2"
+  printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
+
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  # Capture streaming NDJSON lines
+  curl -sN --max-time 30 -H "Content-Type: application/json" \
+    "${OLLAMA}/api/chat" -d "$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" \
+    '{model:$m,stream:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
+    > "$tmpdir/ollama_stream.ndjson" 2>&1 &
+  local ollama_pid=$!
+
+  curl -sN --max-time 30 -H "Content-Type: application/json" \
+    "${INFERRS}/api/chat" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" \
+    '{model:$m,stream:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
+    > "$tmpdir/inferrs_stream.ndjson" 2>&1 &
+  local inferrs_pid=$!
+
+  wait $ollama_pid 2>/dev/null || true
+  wait $inferrs_pid 2>/dev/null || true
+
+  # Reassemble content
+  local o_content o_thinking i_content i_thinking
+  o_content=$(jq -rj '.message.content // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null)
+  o_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null | head -c 120)
+  i_content=$(jq -rj '.message.content // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
+  i_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null | head -c 120)
+
+  # Check for thinking field in stream chunks
+  local o_has_thinking i_has_thinking
+  o_has_thinking=$(grep -c '"thinking"' "$tmpdir/ollama_stream.ndjson" 2>/dev/null || echo "0")
+  i_has_thinking=$(grep -c '"thinking"' "$tmpdir/inferrs_stream.ndjson" 2>/dev/null || echo "0")
+
+  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 150)"
+  printf "           thinking_chunks=%s, thinking=%s...\n" "$o_has_thinking" "$(echo "$o_thinking" | head -c 80)"
+  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 150)"
+  printf "           thinking_chunks=%s, thinking=%s...\n" "$i_has_thinking" "$(echo "$i_thinking" | head -c 80)"
+
+  local failures=0
+
+  # Check 1: thinking field present in stream
+  if [[ "$o_has_thinking" -gt 0 && "$i_has_thinking" -eq 0 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs stream missing 'thinking' field (ollama has %s chunks with it)\n" "$o_has_thinking"
+    ((failures++))
+  fi
+
+  # Check 2: degeneration
+  local degen_count
+  degen_count=$(echo "$i_content" | grep -oP '\b(\w+)\b' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
+  if [[ "${degen_count:-0}" -gt 8 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs stream output degenerated (repeated word %s times)\n" "$degen_count"
+    ((failures++))
+  fi
+
+  # Check 3: empty content
+  if [[ -z "$i_content" || "$i_content" == "(empty)" ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs returned empty content\n"
+    ((failures++))
+  fi
+
+  if [[ $failures -gt 0 ]]; then
+    printf "  ${RED}FAIL${NC} (%d issues)\n" "$failures"
+    ((fail++))
+  else
+    printf "  ${GREEN}PASS${NC}\n"
+    ((pass++))
+  fi
+
+  rm -rf "$tmpdir"
+}
+
+# ─── Test: /api/generate endpoint ────────────────────────────────────────────
+test_generate() {
+  local label="$1"
+  local prompt="$2"
+  local stream="$3"
+  printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
+
+  local inferrs_resp
+  inferrs_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
+    "${INFERRS}/api/generate" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" --argjson s "$stream" \
+    '{model:$m,stream:$s,prompt:$p,options:{temperature:0.01,num_predict:64}}')" 2>&1) || {
+    printf "  ${RED}FAIL${NC}: request failed (404 or error)\n"
+    ((fail++))
+    return
+  }
+
+  if [[ "$stream" == "false" ]]; then
+    local content
+    content=$(echo "$inferrs_resp" | jq -r '.response // "(empty)"')
+    printf "  Inferrs: %s\n" "$(echo "$content" | head -c 200)"
+    if [[ -z "$content" || "$content" == "(empty)" ]]; then
+      printf "  ${RED}FAIL${NC}: empty response\n"
+      ((fail++))
+    else
+      printf "  ${GREEN}PASS${NC}\n"
+      ((pass++))
+    fi
+  else
+    local content
+    content=$(echo "$inferrs_resp" | jq -rj '.response // empty' 2>/dev/null)
+    printf "  Inferrs: %s\n" "$(echo "$content" | head -c 200)"
+    if [[ -z "$content" ]]; then
+      printf "  ${RED}FAIL${NC}: empty streaming response\n"
+      ((fail++))
+    else
+      printf "  ${GREEN}PASS${NC}\n"
+      ((pass++))
+    fi
+  fi
+}
+
+echo "╔════════════════════════════════════════════════════════════╗"
+echo "║  inferrs vs ollama — Ollama API Compatibility Test Suite  ║"
+echo "║  Ollama:  ${OLLAMA}  model: ${OLLAMA_MODEL}              ║"
+echo "║  Inferrs: ${INFERRS}  model: ${INFERRS_MODEL}  ║"
+echo "╚════════════════════════════════════════════════════════════╝"
+
+# ── Non-streaming chat ───────────────────────────────────────────────────────
+test_chat_nonstream "CHAT non-stream: math"     "What is 2+2? Answer in one word."
+test_chat_nonstream "CHAT non-stream: greeting" "Hello, how are you today?"
+test_chat_nonstream "CHAT non-stream: code"     "Write a Python function that returns the factorial of n."
+
+# ── Streaming chat ───────────────────────────────────────────────────────────
+test_chat_stream "CHAT stream: math"     "What is 2+2? Answer in one word."
+test_chat_stream "CHAT stream: greeting" "Hello, how are you today?"
+test_chat_stream "CHAT stream: code"     "Write a Python function that returns the factorial of n."
+
+# ── Generate endpoint ────────────────────────────────────────────────────────
+test_generate "GENERATE non-stream" "What is 2+2?" false
+test_generate "GENERATE stream"     "What is 2+2?" true
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+printf "Results: ${GREEN}%d passed${NC}, ${RED}%d failed${NC}\n" "$pass" "$fail"
+echo "════════════════════════════════════════════════════════════"
+exit $fail

--- a/tests/compare_ollama.sh
+++ b/tests/compare_ollama.sh
@@ -24,12 +24,12 @@ test_chat_nonstream() {
   printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
 
   local ollama_resp inferrs_resp
-  ollama_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
+  ollama_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" \
     "${OLLAMA}/api/chat" -d "$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
-  inferrs_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
+    '{model:$m,stream:false,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
+  inferrs_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" \
     "${INFERRS}/api/chat" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
+    '{model:$m,stream:false,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
 
   local o_content o_thinking i_content i_thinking
   o_content=$(echo "$ollama_resp" | jq -r '.message.content // "(empty)"')
@@ -72,15 +72,15 @@ test_chat_stream() {
   tmpdir=$(mktemp -d)
 
   # Capture streaming NDJSON lines
-  curl -sN --max-time 30 -H "Content-Type: application/json" \
+  curl -sN --max-time 120 -H "Content-Type: application/json" \
     "${OLLAMA}/api/chat" -d "$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
+    '{model:$m,stream:true,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
     > "$tmpdir/ollama_stream.ndjson" 2>&1 &
   local ollama_pid=$!
 
-  curl -sN --max-time 30 -H "Content-Type: application/json" \
+  curl -sN --max-time 120 -H "Content-Type: application/json" \
     "${INFERRS}/api/chat" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
+    '{model:$m,stream:true,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:128}}')" \
     > "$tmpdir/inferrs_stream.ndjson" 2>&1 &
   local inferrs_pid=$!
 
@@ -120,9 +120,9 @@ test_chat_stream() {
     ((failures++))
   fi
 
-  # Check 3: empty content
-  if [[ -z "$i_content" || "$i_content" == "(empty)" ]]; then
-    printf "  ${RED}ISSUE${NC}: inferrs returned empty content\n"
+  # Check 3: empty content (only an issue if there's also no thinking output)
+  if [[ (-z "$i_content" || "$i_content" == "(empty)") && "$i_has_thinking" -eq 0 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs returned empty content (and no thinking)\n"
     ((failures++))
   fi
 

--- a/tests/compare_ollama.sh
+++ b/tests/compare_ollama.sh
@@ -3,10 +3,10 @@
 # Prerequisites: ollama serving gemma4:e2b on :11434, inferrs on :11435.
 set -uo pipefail
 
-OLLAMA="http://localhost:11434"
-INFERRS="http://localhost:11435"
-OLLAMA_MODEL="gemma4:e2b"
-INFERRS_MODEL="google/gemma-4-E2B-it"
+OLLAMA="${OLLAMA:-http://localhost:11434}"
+INFERRS="${INFERRS:-http://localhost:11435}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-gemma4:e2b}"
+INFERRS_MODEL="${INFERRS_MODEL:-google/gemma-4-E2B-it}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -17,49 +17,96 @@ NC='\033[0m'
 pass=0
 fail=0
 
+check_schema() {
+  local resp="$1"
+  local src="$2"
+  local d_reason e_count p_count total_d
+  d_reason=$(echo "$resp" | jq -r '.done_reason // ""')
+  e_count=$(echo "$resp" | jq -r '.eval_count // 0')
+  p_count=$(echo "$resp" | jq -r '.prompt_eval_count // 0')
+  total_d=$(echo "$resp" | jq -r '.total_duration // 0')
+  
+  if [[ -z "$d_reason" || "$e_count" == "0" || "$p_count" == "0" || "$total_d" == "0" ]]; then
+    printf "  ${RED}ISSUE${NC}: %s missing/zero metrics fields (d_reason='%s', e_count=%s, p_count=%s, total_d=%s)\n" "$src" "$d_reason" "$e_count" "$p_count" "$total_d"
+    return 1
+  fi
+  return 0
+}
+
 # ─── Test: Non-streaming /api/chat ───────────────────────────────────────────
 test_chat_nonstream() {
   local label="$1"
   local prompt="$2"
+  local think_flag="$3"
   printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
 
+  local filter
+  if [[ "$think_flag" == "default" ]]; then
+    filter='{model:$m,stream:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}'
+  elif [[ "$think_flag" == "true" ]]; then
+    filter='{model:$m,stream:false,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}'
+  else
+    filter='{model:$m,stream:false,think:false,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}'
+  fi
+
+  local o_req i_req
+  o_req=$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" "$filter")
+  i_req=$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" "$filter")
+
   local ollama_resp inferrs_resp
-  ollama_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" \
-    "${OLLAMA}/api/chat" -d "$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:false,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
-  inferrs_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" \
-    "${INFERRS}/api/chat" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" \
-    '{model:$m,stream:false,think:true,messages:[{role:"user",content:$p}],options:{temperature:0.01,num_predict:256}}')" 2>&1)
+  ollama_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" "${OLLAMA}/api/chat" -d "$o_req" 2>&1)
+  inferrs_resp=$(curl -sf --max-time 120 -H "Content-Type: application/json" "${INFERRS}/api/chat" -d "$i_req" 2>&1)
 
   local o_content o_thinking i_content i_thinking
   o_content=$(echo "$ollama_resp" | jq -r '.message.content // "(empty)"')
-  o_thinking=$(echo "$ollama_resp" | jq -r '.message.thinking // "(null)"' | head -c 120)
+  o_thinking=$(echo "$ollama_resp" | jq -r '.message.thinking // "(null)"')
   i_content=$(echo "$inferrs_resp" | jq -r '.message.content // "(empty)"')
-  i_thinking=$(echo "$inferrs_resp" | jq -r '.message.thinking // "(null)"' | head -c 120)
+  i_thinking=$(echo "$inferrs_resp" | jq -r '.message.thinking // "(null)"')
 
-  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 150)"
-  printf "           thinking=%s\n" "$o_thinking"
-  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 150)"
-  printf "           thinking=%s\n" "$i_thinking"
+  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 100)"
+  printf "           thinking=%s\n" "$(echo "$o_thinking" | head -c 100 | tr '\n' ' ')"
+  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 100)"
+  printf "           thinking=%s\n" "$(echo "$i_thinking" | head -c 100 | tr '\n' ' ')"
 
-  # Check 1: thinking field exists in ollama but missing in inferrs
-  if [[ "$o_thinking" != "(null)" && "$i_thinking" == "(null)" ]]; then
-    printf "  ${RED}FAIL${NC}: inferrs missing 'thinking' field (ollama has it)\n"
-    ((fail++))
-    return
+  local failures=0
+
+  # Check 1: Valid schema metrics
+  if ! check_schema "$inferrs_resp" "inferrs"; then
+    ((failures++))
   fi
 
-  # Check 2: content quality — detect degeneration
+  # Check 2: Thinking field logic
+  if [[ "$think_flag" == "true" || "$think_flag" == "default" ]]; then
+    # In ollama, default behavior is to extract thinking if the model produces it (e2b always does for math)
+    if [[ "$o_thinking" != "(null)" && "$i_thinking" == "(null)" ]]; then
+      printf "  ${RED}ISSUE${NC}: inferrs missing 'thinking' field (ollama has it)\n"
+      ((failures++))
+    elif [[ "$i_thinking" != "(null)" && ${#i_thinking} -lt 15 ]]; then
+      printf "  ${RED}ISSUE${NC}: inferrs thinking field is suspiciously short (%d chars). Did it really think?\n" "${#i_thinking}"
+      ((failures++))
+    fi
+  elif [[ "$think_flag" == "false" ]]; then
+    if [[ "$i_thinking" != "(null)" && -n "$i_thinking" ]]; then
+      printf "  ${RED}ISSUE${NC}: inferrs returned 'thinking' field despite think:false\n"
+      ((failures++))
+    fi
+  fi
+
+  # Check 3: Content quality (detect degeneration)
   local degen_count
-  degen_count=$(echo "$i_content" | grep -oP '\b(\w+)\b' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
-  if [[ "${degen_count:-0}" -gt 8 ]]; then
-    printf "  ${RED}FAIL${NC}: inferrs output degenerated\n"
-    ((fail++))
-    return
+  degen_count=$(printf '%s\n' "$i_content" | tr -cs '[:alnum:]_' '\n' | grep -E '.' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
+  if [[ "${degen_count:-0}" -gt 40 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs output degenerated (repeated word %s times)\n" "$degen_count"
+    ((failures++))
   fi
 
-  printf "  ${GREEN}PASS${NC}\n"
-  ((pass++))
+  if [[ $failures -gt 0 ]]; then
+    printf "  ${RED}FAIL${NC} (%d issues)\n" "$failures"
+    ((fail++))
+  else
+    printf "  ${GREEN}PASS${NC}\n"
+    ((pass++))
+  fi
 }
 
 # ─── Test: Streaming /api/chat ───────────────────────────────────────────────
@@ -90,37 +137,47 @@ test_chat_stream() {
   # Reassemble content
   local o_content o_thinking i_content i_thinking
   o_content=$(jq -rj '.message.content // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null)
-  o_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null | head -c 120)
+  o_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null)
   i_content=$(jq -rj '.message.content // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
-  i_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null | head -c 120)
+  i_thinking=$(jq -rj '.message.thinking // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
 
   # Check for thinking field in stream chunks
   local o_has_thinking i_has_thinking
   o_has_thinking=$(grep -c '"thinking"' "$tmpdir/ollama_stream.ndjson" 2>/dev/null || echo "0")
   i_has_thinking=$(grep -c '"thinking"' "$tmpdir/inferrs_stream.ndjson" 2>/dev/null || echo "0")
 
-  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 150)"
-  printf "           thinking_chunks=%s, thinking=%s...\n" "$o_has_thinking" "$(echo "$o_thinking" | head -c 80)"
-  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 150)"
-  printf "           thinking_chunks=%s, thinking=%s...\n" "$i_has_thinking" "$(echo "$i_thinking" | head -c 80)"
+  printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 100)"
+  printf "           thinking_chunks=%s, thinking=%s\n" "$o_has_thinking" "$(echo "$o_thinking" | head -c 50 | tr '\n' ' ')"
+  printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 100)"
+  printf "           thinking_chunks=%s, thinking=%s\n" "$i_has_thinking" "$(echo "$i_thinking" | head -c 50 | tr '\n' ' ')"
 
   local failures=0
 
-  # Check 1: thinking field present in stream
-  if [[ "$o_has_thinking" -gt 0 && "$i_has_thinking" -eq 0 ]]; then
-    printf "  ${RED}ISSUE${NC}: inferrs stream missing 'thinking' field (ollama has %s chunks with it)\n" "$o_has_thinking"
+  # Check 1: Final token schema
+  local last_token
+  last_token=$(tail -n 1 "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
+  if ! check_schema "$last_token" "inferrs (stream final)"; then
     ((failures++))
   fi
 
-  # Check 2: degeneration
+  # Check 2: thinking field present in stream and sane length
+  if [[ "$o_has_thinking" -gt 0 && "$i_has_thinking" -eq 0 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs stream missing 'thinking' field (ollama has %s chunks with it)\n" "$o_has_thinking"
+    ((failures++))
+  elif [[ "$i_has_thinking" -gt 0 && "$i_has_thinking" -lt 5 ]]; then
+    printf "  ${RED}ISSUE${NC}: inferrs thinking stream suspiciously short (%d chunks). Real reasoning expected.\n" "$i_has_thinking"
+    ((failures++))
+  fi
+
+  # Check 3: degeneration
   local degen_count
-  degen_count=$(echo "$i_content" | grep -oP '\b(\w+)\b' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
-  if [[ "${degen_count:-0}" -gt 8 ]]; then
+  degen_count=$(printf '%s\n' "$i_content" | tr -cs '[:alnum:]_' '\n' | grep -E '.' | sort | uniq -c | sort -rn | head -1 | awk '{print $1}')
+  if [[ "${degen_count:-0}" -gt 40 ]]; then
     printf "  ${RED}ISSUE${NC}: inferrs stream output degenerated (repeated word %s times)\n" "$degen_count"
     ((failures++))
   fi
 
-  # Check 3: empty content (only an issue if there's also no thinking output)
+  # Check 4: empty content (only an issue if there's also no thinking output)
   if [[ (-z "$i_content" || "$i_content" == "(empty)") && "$i_has_thinking" -eq 0 ]]; then
     printf "  ${RED}ISSUE${NC}: inferrs returned empty content (and no thinking)\n"
     ((failures++))
@@ -144,37 +201,58 @@ test_generate() {
   local stream="$3"
   printf "\n${YELLOW}━━━ %s ━━━${NC}\n" "$label"
 
-  local inferrs_resp
-  inferrs_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" \
-    "${INFERRS}/api/generate" -d "$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" --argjson s "$stream" \
-    '{model:$m,stream:$s,prompt:$p,options:{temperature:0.01,num_predict:64}}')" 2>&1) || {
-    printf "  ${RED}FAIL${NC}: request failed (404 or error)\n"
-    ((fail++))
-    return
-  }
+  local o_req i_req
+  o_req=$(jq -nc --arg m "$OLLAMA_MODEL" --arg p "$prompt" --argjson s "$stream" '{model:$m,stream:$s,prompt:$p,options:{temperature:0.01,num_predict:64}}')
+  i_req=$(jq -nc --arg m "$INFERRS_MODEL" --arg p "$prompt" --argjson s "$stream" '{model:$m,stream:$s,prompt:$p,options:{temperature:0.01,num_predict:64}}')
 
+  local ollama_resp inferrs_resp
   if [[ "$stream" == "false" ]]; then
-    local content
-    content=$(echo "$inferrs_resp" | jq -r '.response // "(empty)"')
-    printf "  Inferrs: %s\n" "$(echo "$content" | head -c 200)"
-    if [[ -z "$content" || "$content" == "(empty)" ]]; then
-      printf "  ${RED}FAIL${NC}: empty response\n"
-      ((fail++))
-    else
-      printf "  ${GREEN}PASS${NC}\n"
-      ((pass++))
+    ollama_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" "${OLLAMA}/api/generate" -d "$o_req" 2>&1)
+    inferrs_resp=$(curl -sf --max-time 60 -H "Content-Type: application/json" "${INFERRS}/api/generate" -d "$i_req" 2>&1)
+
+    local o_content i_content failures=0
+    o_content=$(echo "$ollama_resp" | jq -r '.response // "(empty)"')
+    i_content=$(echo "$inferrs_resp" | jq -r '.response // "(empty)"')
+    
+    printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 100)"
+    printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 100)"
+
+    if ! check_schema "$inferrs_resp" "inferrs (generate)"; then ((failures++)); fi
+    if [[ -z "$i_content" || "$i_content" == "(empty)" ]]; then
+      printf "  ${RED}ISSUE${NC}: inferrs returned empty response\n"
+      ((failures++))
     fi
+
+    if [[ $failures -gt 0 ]]; then ((fail++)); printf "  ${RED}FAIL${NC} (%d issues)\n" "$failures"; else ((pass++)); printf "  ${GREEN}PASS${NC}\n"; fi
   else
-    local content
-    content=$(echo "$inferrs_resp" | jq -rj '.response // empty' 2>/dev/null)
-    printf "  Inferrs: %s\n" "$(echo "$content" | head -c 200)"
-    if [[ -z "$content" ]]; then
-      printf "  ${RED}FAIL${NC}: empty streaming response\n"
-      ((fail++))
-    else
-      printf "  ${GREEN}PASS${NC}\n"
-      ((pass++))
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    curl -sN --max-time 60 -H "Content-Type: application/json" "${OLLAMA}/api/generate" -d "$o_req" > "$tmpdir/ollama_stream.ndjson" 2>&1 &
+    local ollama_pid=$!
+    curl -sN --max-time 60 -H "Content-Type: application/json" "${INFERRS}/api/generate" -d "$i_req" > "$tmpdir/inferrs_stream.ndjson" 2>&1 &
+    local inferrs_pid=$!
+    
+    wait $ollama_pid 2>/dev/null || true
+    wait $inferrs_pid 2>/dev/null || true
+
+    local o_content i_content failures=0
+    o_content=$(jq -rj '.response // empty' < "$tmpdir/ollama_stream.ndjson" 2>/dev/null)
+    i_content=$(jq -rj '.response // empty' < "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
+
+    printf "  ${CYAN}Ollama${NC}:  content=%s\n" "$(echo "$o_content" | head -c 100)"
+    printf "  ${CYAN}Inferrs${NC}: content=%s\n" "$(echo "$i_content" | head -c 100)"
+
+    local last_token
+    last_token=$(tail -n 1 "$tmpdir/inferrs_stream.ndjson" 2>/dev/null)
+    if ! check_schema "$last_token" "inferrs (generate stream final)"; then ((failures++)); fi
+    if [[ -z "$i_content" ]]; then
+      printf "  ${RED}ISSUE${NC}: inferrs empty streaming response\n"
+      ((failures++))
     fi
+
+    if [[ $failures -gt 0 ]]; then ((fail++)); printf "  ${RED}FAIL${NC} (%d issues)\n" "$failures"; else ((pass++)); printf "  ${GREEN}PASS${NC}\n"; fi
+    rm -rf "$tmpdir"
   fi
 }
 
@@ -185,18 +263,19 @@ echo "║  Inferrs: ${INFERRS}  model: ${INFERRS_MODEL}  ║"
 echo "╚════════════════════════════════════════════════════════════╝"
 
 # ── Non-streaming chat ───────────────────────────────────────────────────────
-test_chat_nonstream "CHAT non-stream: math"     "What is 2+2? Answer in one word."
-test_chat_nonstream "CHAT non-stream: greeting" "Hello, how are you today?"
-test_chat_nonstream "CHAT non-stream: code"     "Write a Python function that returns the factorial of n."
+test_chat_nonstream "CHAT non-stream: default logic (math)" "What is 2+2? Explain your reasoning." "default"
+test_chat_nonstream "CHAT non-stream: think=true (math)" "Solve step by step: What is the derivative of f(x) = x^3 + 2x^2 - 5x + 3?" "true"
+test_chat_nonstream "CHAT non-stream: think=false (math)" "Solve step by step: What is the integral of 2x?" "false"
+test_chat_nonstream "CHAT non-stream: think=true (greeting)" "Hello, how are you today?" "true"
+test_chat_nonstream "CHAT non-stream: think=false (code)" "Write a Python function that returns the factorial of n." "false"
 
 # ── Streaming chat ───────────────────────────────────────────────────────────
-test_chat_stream "CHAT stream: math"     "What is 2+2? Answer in one word."
-test_chat_stream "CHAT stream: greeting" "Hello, how are you today?"
-test_chat_stream "CHAT stream: code"     "Write a Python function that returns the factorial of n."
+test_chat_stream "CHAT stream: math" "Solve step by step: What is the derivative of x^2?"
+test_chat_stream "CHAT stream: code" "Write a fast inverse square root in C."
 
 # ── Generate endpoint ────────────────────────────────────────────────────────
 test_generate "GENERATE non-stream" "What is 2+2?" false
-test_generate "GENERATE stream"     "What is 2+2?" true
+test_generate "GENERATE stream"     "Write a greeting to a user." true
 
 echo ""
 echo "════════════════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Full Ollama API parity for thinking/reasoning models and duration metrics.

### What this PR does

**1. Thinking mode (`think: true/false`)**
- Auto-detects thinking-capable models (e.g. Gemma4) via `<|think|>` token presence in the vocabulary
- `/api/chat` defaults to `think=true` when the model supports it, matching Ollama behavior
- `/api/generate` keeps `think=false` default to avoid breaking raw prompts
- When `think=true`: reasoning surfaces in a separate `thinking` field
- When `think=false`: reasoning tokens fold back into `content` (nothing silently dropped)
- Engine-level `ThinkFilter` classifies tokens at the token ID level — both streaming and blocking paths share the same code

**2. Duration metrics**
- `total_duration`, `load_duration`, `prompt_eval_duration`, `eval_duration` on all `/api/generate` and `/api/chat` responses (streaming + non-streaming)
- `prompt_eval_count` and `eval_count` populated correctly on streaming final chunks
- Timings measured at the engine level using wall-clock `Instant` to avoid HTTP/queue transport delay

**3. OllamaOptions extensions**
- Accepts `seed`, `min_p`, `stop`, `presence_penalty`, `frequency_penalty`
- `stop` tokens are resolved via tokenizer and wired to `extra_stop_token_ids`

**4. Test suite**
- `tests/compare_ollama.sh`: 9-test parity suite covering:
  - Non-streaming chat with default/think=true/think=false
  - Streaming chat with thinking chunk validation
  - Non-streaming and streaming `/api/generate`
  - Schema metric checks (done_reason, eval_count, prompt_eval_count, total_duration)
  - Degeneration detection
  - Thinking field quality (minimum length check)

### Tested with
- `gemma4:e2b` (Ollama) vs `google/gemma-4-E2B-it` Q4K (inferrs)
- **9/9 tests pass** with full schema and behavioral parity

### Commits
1. `feat: ollama duration timings + thinking/reasoning mode` — core implementation
2. `fix: think mode activation and ThinkFilter token detection` — Gemma4 tokenizer fallbacks
3. `feat: auto-detect thinking models + streaming metrics parity` — default think=true for capable models