### PR TITLE
restore: re-add co-esquie contributions lost in Gemma4 merge

### DIFF
--- a/candle-core/benches/bench_main.rs
+++ b/candle-core/benches/bench_main.rs
@@ -7,6 +7,7 @@ criterion_main!(
     benchmarks::binary::benches,
     benchmarks::broadcast::benches,
     benchmarks::copy::benches,
+    benchmarks::conv1d_depthwise::benches,
     benchmarks::conv_transpose2d::benches,
     benchmarks::matmul::benches,
     benchmarks::qmatmul::benches,

--- a/candle-core/benches/benchmarks/conv1d_depthwise.rs
+++ b/candle-core/benches/benchmarks/conv1d_depthwise.rs
@@ -1,0 +1,54 @@
+use crate::benchmarks::{BenchDevice, BenchDeviceHandler};
+use candle_core::{DType, Device, Tensor};
+use criterion::{criterion_group, Criterion, Throughput};
+use std::hint::black_box;
+use std::time::Instant;
+
+/// Benchmark shapes for depthwise conv1d.
+/// Tuple: (name, channels, seq_len, kernel_size)
+/// The "decode_1tok" shape matches Qwen3.5-2B during single-token decode,
+/// which was the original bottleneck (6144 serial CUDA launches → 1 launch).
+const BENCH_SHAPES: &[(&str, usize, usize, usize)] = &[
+    ("decode_1tok", 6144, 1, 4),   // Qwen3.5-2B single-token decode
+    ("decode_8tok", 6144, 8, 4),   // small batch
+    ("prefill_128", 6144, 128, 4), // short prefill
+    ("small_c64", 64, 32, 3),      // sanity / CPU baseline
+];
+
+fn run(x: &Tensor, w: &Tensor, padding: usize, groups: usize) {
+    x.conv1d(w, padding, 1, 1, groups).unwrap();
+}
+
+fn run_bench(c: &mut Criterion, device: &Device, name: &str, channels: usize, t: usize, k: usize) {
+    let dtype = DType::BF16;
+    let x = Tensor::zeros(&[1usize, channels, t], dtype, device).unwrap();
+    let w = Tensor::zeros(&[channels, 1usize, k], dtype, device).unwrap();
+    let padding = k - 1;
+    // MAC ops per output element = k; total = channels * t_out * k ≈ channels * t * k
+    let flops = channels * t * k;
+
+    let mut group = c.benchmark_group(device.bench_name(format!("conv1d_depthwise_{name}")));
+    group.throughput(Throughput::Bytes(flops as u64));
+    group.bench_function("iter", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            for _ in 0..iters {
+                run(black_box(&x), black_box(&w), padding, channels);
+            }
+            device.sync().unwrap();
+            start.elapsed()
+        })
+    });
+    group.finish();
+}
+
+fn conv1d_depthwise_benchmark(c: &mut Criterion) {
+    let handler = BenchDeviceHandler::new().unwrap();
+    for device in handler.devices {
+        for &(name, channels, t, k) in BENCH_SHAPES {
+            run_bench(c, &device, name, channels, t, k);
+        }
+    }
+}
+
+criterion_group!(benches, conv1d_depthwise_benchmark);

--- a/candle-core/benches/benchmarks/mod.rs
+++ b/candle-core/benches/benchmarks/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod affine;
 pub(crate) mod binary;
 pub(crate) mod broadcast;
+pub(crate) mod conv1d_depthwise;
 pub(crate) mod conv_transpose2d;
 pub(crate) mod copy;
 pub(crate) mod matmul;

--- a/candle-core/src/conv.rs
+++ b/candle-core/src/conv.rs
@@ -55,6 +55,30 @@ impl ParamsConvTranspose1D {
     }
 }
 
+/// Parameters for depthwise conv1d (groups == c_in, c_in_k == 1).
+/// Stored separately from `ParamsConv1D` to avoid threading `groups` through the
+/// generic single-group path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamsConv1DDepthwise {
+    pub(crate) b_size: usize,
+    pub(crate) c_size: usize, // total channels (== groups)
+    pub(crate) l_in: usize,
+    pub(crate) k_size: usize,
+    pub(crate) padding: usize,
+    pub(crate) stride: usize,
+    pub(crate) dilation: usize,
+}
+
+impl ParamsConv1DDepthwise {
+    pub(crate) fn l_out(&self) -> usize {
+        (self.l_in + 2 * self.padding - self.dilation * (self.k_size - 1) - 1) / self.stride + 1
+    }
+
+    pub(crate) fn out_dims(&self) -> Vec<usize> {
+        vec![self.b_size, self.c_size, self.l_out()]
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CudnnFwdAlgo {
     ImplicitGemm,
@@ -129,6 +153,26 @@ impl ParamsConvTranspose2D {
 }
 
 impl Tensor {
+    fn conv1d_depthwise_path(&self, kernel: &Self, params: &ParamsConv1DDepthwise) -> Result<Self> {
+        // Squeeze kernel from [c, 1, k] to [c, k] so the CUDA backend receives a
+        // contiguous 2-D layout and doesn't need to reason about the extra dim.
+        let kernel_sq = kernel.squeeze(1)?.contiguous()?;
+        let storage = self.storage().conv1d_depthwise(
+            self.layout(),
+            &kernel_sq.storage(),
+            kernel_sq.layout(),
+            params,
+        )?;
+        // TODO: Op::Conv1D does not carry a `groups` field, so the existing
+        // backprop path would reconstruct the input gradient with groups=1,
+        // producing shape [b, 1, l_in] instead of [b, c, l_in].  Until
+        // Op::Conv1D is extended and backprop.rs updated accordingly, we
+        // disable autograd for this path to avoid silently wrong gradients.
+        let op = BackpropOp::none();
+        let out_dims = params.out_dims();
+        Ok(crate::tensor::from_storage(storage, out_dims, op, false))
+    }
+
     fn conv1d_single_group(&self, kernel: &Self, params: &ParamsConv1D) -> Result<Self> {
         let storage =
             self.storage()
@@ -192,6 +236,21 @@ impl Tensor {
         };
         if groups == 1 {
             self.conv1d_single_group(kernel, &params)
+        } else if c_in_k == 1 && c_out == groups && matches!(self.device(), crate::Device::Cuda(_))
+        {
+            // Depthwise case on CUDA: groups == c_in == c_out, one weight per channel.
+            // A single CUDA kernel handles all channels; avoids N_groups serial launches.
+            // CPU and Metal keep the existing chunk-loop path below (no regression).
+            let dw_params = ParamsConv1DDepthwise {
+                b_size,
+                c_size: c_in,
+                l_in,
+                k_size,
+                padding,
+                stride,
+                dilation,
+            };
+            self.conv1d_depthwise_path(kernel, &dw_params)
         } else {
             let blocks = self.chunk(groups, 1)?;
             let kernel = kernel.chunk(groups, 0)?;

--- a/candle-core/src/cuda_backend/mod.rs
+++ b/candle-core/src/cuda_backend/mod.rs
@@ -715,6 +715,63 @@ impl Map2 for Conv1D<'_> {
     }
 }
 
+struct Conv1DDepthwise<'a>(&'a crate::conv::ParamsConv1DDepthwise);
+impl Map2 for Conv1DDepthwise<'_> {
+    fn f<T: DeviceRepr + WithDType + ValidAsZeroBits>(
+        &self,
+        inp: &CudaSlice<T>,
+        inp_l: &Layout,
+        k: &CudaSlice<T>,
+        k_l: &Layout,
+        dev: &CudaDevice,
+    ) -> Result<CudaSlice<T>> {
+        // inp: [b, c, l_in]  (possibly non-contiguous strides)
+        // k:   [c, k_size]   (contiguous — squeezed at Tensor level before dispatch)
+        let p = &self.0;
+        let l_out = p.l_out();
+        let dst_el = p.b_size * p.c_size * l_out;
+        let cfg = LaunchConfig::for_num_elems(dst_el as u32);
+        let func = dev.get_or_load_func(&kernel_name::<T>("conv1d_depthwise"), &kernels::CONV)?;
+
+        let inp = &inp.slice(inp_l.start_offset()..);
+        let k = &k.slice(k_l.start_offset()..);
+
+        let src_strides = inp_l.stride();
+        if src_strides.len() != 3 {
+            crate::bail!(
+                "conv1d_depthwise: expected 3-D input, got strides {:?}",
+                src_strides
+            );
+        }
+        let (src_b_stride, src_c_stride, src_l_stride) =
+            (src_strides[0], src_strides[1], src_strides[2]);
+
+        // SAFETY: Set later by running the kernel.
+        let out = unsafe { dev.alloc::<T>(dst_el)? };
+        let mut builder = func.builder();
+        barg!(
+            builder,
+            p.b_size,
+            p.c_size,
+            p.l_in,
+            l_out,
+            p.k_size,
+            p.stride,
+            p.padding,
+            p.dilation,
+            src_b_stride,
+            src_c_stride,
+            src_l_stride
+        );
+        builder.arg(inp);
+        builder.arg(k);
+        builder.arg(&out);
+        // SAFETY: ffi.
+        unsafe { builder.launch(cfg) }.w()?;
+        Ok(out)
+    }
+}
+
 struct Conv2D<'a>(&'a crate::conv::ParamsConv2D);
 impl Map2 for Conv2D<'_> {
     fn f<T: DeviceRepr + WithDType + ValidAsZeroBits>(
@@ -1430,6 +1487,21 @@ fn gemm_config<T>(
         stride_b: stride_b as i64,
         stride_c: (m * n) as i64,
     })
+}
+
+impl CudaStorage {
+    pub(crate) fn conv1d_depthwise(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv1DDepthwise,
+    ) -> Result<Self> {
+        let device = self.device().clone();
+        let slice =
+            Conv1DDepthwise(params).map(&self.slice, l, &kernel.slice, kernel_l, &device)?;
+        Ok(Self { slice, device })
+    }
 }
 
 impl BackendStorage for CudaStorage {

--- a/candle-core/src/storage.rs
+++ b/candle-core/src/storage.rs
@@ -399,6 +399,28 @@ impl Storage {
         }
     }
 
+    /// Depthwise conv1d optimised path (CUDA only).
+    /// Only called when `matches!(device, Device::Cuda(_))` so the CPU/Metal
+    /// branches are unreachable in practice; they bail with a clear message.
+    #[allow(unused_variables)]
+    pub(crate) fn conv1d_depthwise(
+        &self,
+        l: &Layout,
+        kernel: &Self,
+        kernel_l: &Layout,
+        params: &crate::conv::ParamsConv1DDepthwise,
+    ) -> Result<Self> {
+        self.same_device(kernel, "conv1d_depthwise")?;
+        self.same_dtype(kernel, "conv1d_depthwise")?;
+        match (self, kernel) {
+            #[cfg(feature = "cuda")]
+            (Storage::Cuda(inp), Storage::Cuda(k)) => {
+                Ok(Self::Cuda(inp.conv1d_depthwise(l, k, kernel_l, params)?))
+            }
+            _ => crate::bail!("conv1d_depthwise is only supported on CUDA"),
+        }
+    }
+
     pub(crate) fn conv_transpose1d(
         &self,
         l: &Layout,

--- a/candle-core/tests/conv_tests.rs
+++ b/candle-core/tests/conv_tests.rs
@@ -860,12 +860,65 @@ fn conv2d_grad(dev: &Device) -> Result<()> {
     Ok(())
 }
 
+/// Depthwise conv1d (groups == c_in) with ones kernel and zero padding.
+/// Expected values computed analytically: each output element is the sum of
+/// the 3 nearest input values (with zero-padding on boundaries).
+///
+/// Input x: arange(20).reshape(1, 4, 5) — channel c has values [c*5, c*5+1, ..., c*5+4]
+/// Kernel w: ones(4, 1, 3)
+/// Conv1d(x, w, padding=1, stride=1, groups=4) → shape [1, 4, 5]
+fn conv1d_depthwise(dev: &Device) -> Result<()> {
+    let x = Tensor::arange(0f32, 20f32, dev)?.reshape((1usize, 4usize, 5usize))?;
+    let w = Tensor::ones((4usize, 1usize, 3usize), candle_core::DType::F32, dev)?;
+    let out = x.conv1d(
+        &w, /*padding=*/ 1, /*stride=*/ 1, /*dilation=*/ 1, /*groups=*/ 4,
+    )?;
+    assert_eq!(out.dims(), [1, 4, 5]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 4)?,
+        [
+            1., 3., 6., 9., 7., 11., 18., 21., 24., 17., 21., 33., 36., 39., 27., 31., 48., 51.,
+            54., 37.,
+        ]
+    );
+    Ok(())
+}
+
+/// Same as above but with stride=2.
+/// Input x: arange(24).reshape(1, 4, 6), w: ones(4, 1, 3)
+/// Conv1d(x, w, padding=1, stride=2, groups=4) → shape [1, 4, 3]
+fn conv1d_depthwise_stride2(dev: &Device) -> Result<()> {
+    let x = Tensor::arange(0f32, 24f32, dev)?.reshape((1usize, 4usize, 6usize))?;
+    let w = Tensor::ones((4usize, 1usize, 3usize), candle_core::DType::F32, dev)?;
+    let out = x.conv1d(
+        &w, /*padding=*/ 1, /*stride=*/ 2, /*dilation=*/ 1, /*groups=*/ 4,
+    )?;
+    assert_eq!(out.dims(), [1, 4, 3]);
+    assert_eq!(
+        test_utils::to_vec1_round(&out.flatten_all()?, 4)?,
+        [1., 6., 12., 13., 24., 30., 25., 42., 48., 37., 60., 66.,]
+    );
+    Ok(())
+}
+
 test_device!(conv1d, conv1d_cpu, conv1d_gpu, conv1d_metal);
 test_device!(
     conv1d_small,
     conv1d_small_cpu,
     conv1d_small_gpu,
     conv1d_small_metal
+);
+test_device!(
+    conv1d_depthwise,
+    conv1d_depthwise_cpu,
+    conv1d_depthwise_gpu,
+    conv1d_depthwise_metal
+);
+test_device!(
+    conv1d_depthwise_stride2,
+    conv1d_depthwise_stride2_cpu,
+    conv1d_depthwise_stride2_gpu,
+    conv1d_depthwise_stride2_metal
 );
 test_device!(conv2d, conv2d_cpu, conv2d_gpu, conv2d_metal);
 test_device!(

--- a/candle-kernels/src/conv.cu
+++ b/candle-kernels/src/conv.cu
@@ -51,6 +51,49 @@ __device__ void conv1d(
   dst[dst_i] = static_cast<T>(d);
 }
 
+// Depthwise conv1d: one thread per output element (b, c, l_out).
+// Input  [b, c, l_in]  — strides passed explicitly to support non-contiguous layouts.
+// Kernel [c, k_size]   — contiguous (squeezed from [c, 1, k_size] at Rust level).
+// Output [b, c, l_out] — contiguous.
+// Replaces N_groups sequential single-channel launches with a single kernel.
+template <typename T, typename A>
+__device__ void conv1d_depthwise(
+    const size_t b_size,
+    const size_t c_size,
+    const size_t l_in,
+    const size_t l_out,
+    const size_t k_size,
+    const size_t stride,
+    const size_t padding,
+    const size_t dilation,
+    const size_t src_b_stride,
+    const size_t src_c_stride,
+    const size_t src_l_stride,
+    const T *src,
+    const T *kernel,
+    T *dst
+) {
+    const size_t dst_i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (dst_i >= b_size * c_size * l_out) return;
+
+    const size_t l_idx = dst_i % l_out;
+    const size_t c_idx = (dst_i / l_out) % c_size;
+    const size_t b_idx = dst_i / (l_out * c_size);
+
+    A d = 0;
+    for (size_t k = 0; k < k_size; k++) {
+        const size_t src_l_raw = l_idx * stride + k * dilation;
+        if (src_l_raw < padding || src_l_raw >= padding + l_in) continue;
+        const size_t src_l = src_l_raw - padding;
+        const size_t src_idx = b_idx * src_b_stride
+                             + c_idx * src_c_stride
+                             + src_l * src_l_stride;
+        const size_t k_idx = c_idx * k_size + k;
+        d += static_cast<A>(src[src_idx]) * static_cast<A>(kernel[k_idx]);
+    }
+    dst[dst_i] = static_cast<T>(d);
+}
+
 template <typename T>
 __device__ void im2col1d(
     const size_t numel,
@@ -648,6 +691,28 @@ extern "C" __global__ void FN_NAME(  \
   conv1d<TYPENAME, TYPEACC>(src_numel, num_dims, stride, padding, dilation, info, src, kernel, dst); \
 } \
 
+#define CONV1D_DEPTHWISE_OP(TYPENAME, TYPEACC, FN_NAME) \
+extern "C" __global__ void FN_NAME( \
+    const size_t b_size, \
+    const size_t c_size, \
+    const size_t l_in, \
+    const size_t l_out, \
+    const size_t k_size, \
+    const size_t stride, \
+    const size_t padding, \
+    const size_t dilation, \
+    const size_t src_b_stride, \
+    const size_t src_c_stride, \
+    const size_t src_l_stride, \
+    const TYPENAME *src, \
+    const TYPENAME *kernel, \
+    TYPENAME *dst \
+) { \
+  conv1d_depthwise<TYPENAME, TYPEACC>( \
+    b_size, c_size, l_in, l_out, k_size, stride, padding, dilation, \
+    src_b_stride, src_c_stride, src_l_stride, src, kernel, dst); \
+} \
+
 #define CONV2D_OP(TYPENAME, TYPEACC, FN_NAME) \
 extern "C" __global__ void FN_NAME(  \
     const size_t src_numel, \
@@ -802,6 +867,7 @@ extern "C" __global__ void FN_NAME(  \
 
 #if __CUDA_ARCH__ >= 800
 CONV1D_OP(__nv_bfloat16, float, conv1d_bf16)
+CONV1D_DEPTHWISE_OP(__nv_bfloat16, float, conv1d_depthwise_bf16)
 CONV2D_OP(__nv_bfloat16, float, conv2d_bf16)
 CONVT1D_OP(__nv_bfloat16, float, conv_transpose1d_bf16)
 CONVT2D_OP(__nv_bfloat16, float, conv_transpose2d_bf16)
@@ -828,6 +894,7 @@ COL2IM1D_OP(__nv_bfloat16, col2im1d_bf16)
 
 #if __CUDA_ARCH__ >= 530
 CONV1D_OP(__half, float, conv1d_f16)
+CONV1D_DEPTHWISE_OP(__half, float, conv1d_depthwise_f16)
 CONV2D_OP(__half, float, conv2d_f16)
 CONVT1D_OP(__half, float, conv_transpose1d_f16)
 CONVT2D_OP(__half, float, conv_transpose2d_f16)
@@ -841,9 +908,13 @@ COL2IM1D_OP(__half, col2im1d_f16)
 #endif
 
 CONV1D_OP(float, float, conv1d_f32)
+CONV1D_DEPTHWISE_OP(float, float, conv1d_depthwise_f32)
 CONV1D_OP(double, double, conv1d_f64)
+CONV1D_DEPTHWISE_OP(double, double, conv1d_depthwise_f64)
 CONV1D_OP(uint8_t, uint8_t, conv1d_u8)
+CONV1D_DEPTHWISE_OP(uint8_t, uint8_t, conv1d_depthwise_u8)
 CONV1D_OP(uint32_t, uint32_t, conv1d_u32)
+CONV1D_DEPTHWISE_OP(uint32_t, uint32_t, conv1d_depthwise_u32)
 
 CONV2D_OP(float, float, conv2d_f32)
 CONV2D_OP(double, double, conv2d_f64)

--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -484,6 +484,7 @@ impl RawConfig {
         &self,
         dtype: DType,
         device: Device,
+        turbo_quant_bits: Option<u8>,
     ) -> crate::models::qwen3_5::Qwen35Config {
         use crate::models::qwen3_5::{LayerType, Qwen35Config};
 
@@ -554,6 +555,7 @@ impl RawConfig {
             tie_word_embeddings,
             dtype,
             device,
+            turbo_quant_bits,
         }
     }
 

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -137,7 +137,11 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
     let arch = raw_config.detect_architecture()?;
     tracing::info!("Detected architecture: {:?}", arch);
 
-    let max_seq_len = raw_config.effective_max_seq_len(&arch);
+    let max_seq_len = if args.max_seq_len > 0 {
+        args.max_seq_len
+    } else {
+        raw_config.effective_max_seq_len(&arch)
+    };
     if max_seq_len < usize::MAX {
         tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
     }

--- a/inferrs/src/models/attention_utils.rs
+++ b/inferrs/src/models/attention_utils.rs
@@ -5,6 +5,7 @@ use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{linear_no_bias, ops, rotary_emb, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
+use crate::turbo_quant::TurboQuantKvCache;
 
 /// Paged-attention context passed to each layer's `forward_paged` call.
 ///
@@ -411,6 +412,40 @@ pub fn concat_kv_cache(
     };
     *kv_cache = Some((k.clone(), v.clone()));
     Ok((k, v))
+}
+
+/// Append `k`/`v` to the per-layer KV cache, with optional TurboQuant compression.
+///
+/// Three-path strategy:
+/// - **Prefill** (`seqlen_offset == 0 && t > 1`): plain concat — avoids the TQ
+///   overhead during the long prompt phase.
+/// - **First decode step** (TQ enabled, cache empty): adopt the prefill tensors into
+///   TQ's warmup buffer (zero-copy), then append + dequantize.
+/// - **Subsequent decode / no TQ**: plain concat.
+///
+/// Returns the full `(k, v)` to use for attention, shaped
+/// `[b, num_kv_heads, total_seq_len, head_dim]`.
+pub fn append_kv_tq(
+    k: Tensor,
+    v: Tensor,
+    seqlen_offset: usize,
+    t: usize,
+    kv_cache: &mut Option<(Tensor, Tensor)>,
+    tq_cache: &mut Option<TurboQuantKvCache>,
+) -> Result<(Tensor, Tensor)> {
+    if seqlen_offset == 0 && t > 1 {
+        concat_kv_cache(k, v, kv_cache)
+    } else if let Some(tq) = tq_cache {
+        if tq.is_empty() {
+            if let Some((k_cache, v_cache)) = kv_cache.take() {
+                tq.adopt_warmup_buffer(k_cache, v_cache)?;
+            }
+        }
+        tq.append(&k, &v)?;
+        tq.dequantize()
+    } else {
+        concat_kv_cache(k, v, kv_cache)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -586,7 +586,7 @@ pub fn load_model(
             })
         }
         ModelArchitecture::Qwen35 => {
-            let config = raw_config.to_qwen35_config(dtype, device.clone());
+            let config = raw_config.to_qwen35_config(dtype, device.clone(), turbo_quant_bits);
             tracing::info!(
                 "Qwen3.5 config: {} layers, {} attn heads, {} hidden, {} kv_heads",
                 config.num_hidden_layers,

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -9,14 +9,20 @@
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::{embedding, linear_no_bias, rms_norm, Embedding, Linear, RmsNorm, VarBuilder};
+use candle_nn::{embedding, linear_no_bias, Embedding, Init, Linear, RmsNorm, VarBuilder};
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use crate::models::attention_utils::{
-    apply_output_gate, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
-    concat_kv_cache, paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx,
-    PagedPassCache,
+    append_kv_tq, apply_output_gate, apply_rms_norm_heads, apply_rope, causal_mask, compute_logits,
+    paged_write_gather_sdpa, precompute_rope, repeat_kv, AttnDims, Mlp, PagedCtx, PagedPassCache,
 };
+use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
+
+fn rms_norm_with_offset(size: usize, eps: f64, vb: VarBuilder, offset: f64) -> Result<RmsNorm> {
+    let weight = vb.get_with_hints(size, "weight", Init::Const(0.0))?;
+    let adjusted = weight.affine(1.0, offset)?;
+    Ok(RmsNorm::new(adjusted, eps))
+}
 
 // ---------------------------------------------------------------------------
 // Config
@@ -52,6 +58,7 @@ pub struct Qwen35Config {
     pub tie_word_embeddings: bool,
     pub dtype: DType,
     pub device: Device,
+    pub turbo_quant_bits: Option<u8>,
 }
 
 // ---------------------------------------------------------------------------
@@ -74,10 +81,11 @@ struct FullAttention {
     head_dim: usize,
     // KV cache: Option<(k_cache, v_cache)> accumulated across calls
     kv_cache: Option<(Tensor, Tensor)>,
+    tq_cache: Option<TurboQuantKvCache>,
 }
 
 impl FullAttention {
-    fn new(cfg: &Qwen35Config, vb: VarBuilder) -> Result<Self> {
+    fn new(cfg: &Qwen35Config, vb: VarBuilder, tq_cfg: Option<&TurboQuantConfig>) -> Result<Self> {
         // q_proj outputs num_heads * head_dim * 2: first half is query, second half is the
         // output gate (attn_output_gate). The o_proj then takes num_heads * head_dim.
         let q_proj_out = cfg.num_attention_heads * cfg.head_dim * 2;
@@ -88,8 +96,12 @@ impl FullAttention {
         let k_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("k_proj"))?;
         let v_proj = linear_no_bias(cfg.hidden_size, kv_out, vb.pp("v_proj"))?;
         let o_proj = linear_no_bias(attn_out, cfg.hidden_size, vb.pp("o_proj"))?;
-        let q_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
-        let k_norm = rms_norm(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+        let q_norm = rms_norm_with_offset(cfg.head_dim, cfg.rms_norm_eps, vb.pp("q_norm"), 1.0)?;
+        let k_norm = rms_norm_with_offset(cfg.head_dim, cfg.rms_norm_eps, vb.pp("k_norm"), 1.0)?;
+
+        let tq_cache = tq_cfg.map(|c| {
+            TurboQuantKvCache::new(c, cfg.num_key_value_heads, cfg.dtype, cfg.device.clone())
+        });
 
         Ok(Self {
             q_proj,
@@ -102,6 +114,7 @@ impl FullAttention {
             num_kv_heads: cfg.num_key_value_heads,
             head_dim: cfg.head_dim,
             kv_cache: None,
+            tq_cache,
         })
     }
 
@@ -150,8 +163,15 @@ impl FullAttention {
         let q = apply_rope(&q, &cos_slice, &sin_slice)?;
         let k = apply_rope(&k, &cos_slice, &sin_slice)?;
 
-        // Append to KV cache
-        let (k, v) = concat_kv_cache(k, v, &mut self.kv_cache)?;
+        // Append to KV cache (with optional TurboQuant compression).
+        let (k, v) = append_kv_tq(
+            k,
+            v,
+            seqlen_offset,
+            t,
+            &mut self.kv_cache,
+            &mut self.tq_cache,
+        )?;
 
         let kv_len = k.dim(2)?;
 
@@ -193,6 +213,9 @@ impl FullAttention {
 
     fn clear_kv_cache(&mut self) {
         self.kv_cache = None;
+        if let Some(tq) = &mut self.tq_cache {
+            tq.clear();
+        }
     }
 
     /// Paged-attention forward pass.
@@ -634,7 +657,7 @@ fn rms_norm_tensor(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
 // ---------------------------------------------------------------------------
 
 enum LayerAttn {
-    Full(FullAttention),
+    Full(Box<FullAttention>),
     Linear(LinearAttn),
 }
 
@@ -646,20 +669,35 @@ struct DecoderLayer {
 }
 
 impl DecoderLayer {
-    fn new(cfg: &Qwen35Config, vb: VarBuilder, is_full_attention: bool) -> Result<Self> {
+    fn new(
+        cfg: &Qwen35Config,
+        vb: VarBuilder,
+        is_full_attention: bool,
+        tq_cfg: Option<&TurboQuantConfig>,
+    ) -> Result<Self> {
         let attn = if is_full_attention {
-            LayerAttn::Full(FullAttention::new(cfg, vb.pp("self_attn"))?)
+            LayerAttn::Full(Box::new(FullAttention::new(
+                cfg,
+                vb.pp("self_attn"),
+                tq_cfg,
+            )?))
         } else {
             LayerAttn::Linear(LinearAttn::new(cfg, vb.pp("linear_attn"))?)
         };
         Ok(Self {
             attn,
             mlp: Mlp::new(cfg.hidden_size, cfg.intermediate_size, vb.pp("mlp"))?,
-            input_layernorm: rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
-            post_attention_layernorm: rms_norm(
+            input_layernorm: rms_norm_with_offset(
+                cfg.hidden_size,
+                cfg.rms_norm_eps,
+                vb.pp("input_layernorm"),
+                1.0,
+            )?,
+            post_attention_layernorm: rms_norm_with_offset(
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
                 vb.pp("post_attention_layernorm"),
+                1.0,
             )?,
         })
     }
@@ -746,15 +784,24 @@ impl Qwen35Model {
 
         let embed_tokens = embedding(cfg.vocab_size, cfg.hidden_size, lm_vb.pp("embed_tokens"))?;
 
+        let tq_cfg: Option<TurboQuantConfig> = cfg.turbo_quant_bits.map(|bits| {
+            tracing::info!("TurboQuant KV cache enabled: {bits} bits/coord, absmax quantization");
+            TurboQuantConfig {
+                bits,
+                head_dim: cfg.head_dim,
+            }
+        });
+
         let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
         for (i, layer_type) in cfg.layer_types.iter().enumerate() {
             let layer_vb = lm_vb.pp("layers").pp(i.to_string());
-            let layer = DecoderLayer::new(cfg, layer_vb, layer_type.is_full_attention)
-                .with_context(|| format!("loading layer {i}"))?;
+            let layer =
+                DecoderLayer::new(cfg, layer_vb, layer_type.is_full_attention, tq_cfg.as_ref())
+                    .with_context(|| format!("loading layer {i}"))?;
             layers.push(layer);
         }
 
-        let norm = rms_norm(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"))?;
+        let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"), 1.0)?;
 
         // Tied weights: lm_head = embed_tokens.weight transposed
         let lm_head_weight = embed_tokens.embeddings().clone();

--- a/inferrs/src/turbo_quant.rs
+++ b/inferrs/src/turbo_quant.rs
@@ -556,8 +556,8 @@ impl TurboQuantKvCache {
                 // Copy existing valid tokens into the new buffer.
                 if self.warmup_kv_buf_len > 0 {
                     if let Some((kb_old, vb_old)) = &self.warmup_kv_buf {
-                        let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?;
-                        let v_valid = vb_old.narrow(2, 0, self.warmup_kv_buf_len)?;
+                        let k_valid = kb_old.narrow(2, 0, self.warmup_kv_buf_len)?.contiguous()?;
+                        let v_valid = vb_old.narrow(2, 0, self.warmup_kv_buf_len)?.contiguous()?;
                         new_k_buf.slice_set(&k_valid, 2, 0)?;
                         new_v_buf.slice_set(&v_valid, 2, 0)?;
                     }
@@ -769,8 +769,8 @@ impl TurboQuantKvCache {
             // Copy existing valid data into the new (larger) buffer.
             if self.cached_seq_len > 0 {
                 if let Some((k_old, v_old)) = &self.kv_buffer {
-                    k_buf.slice_set(k_old, 2, 0)?;
-                    v_buf.slice_set(v_old, 2, 0)?;
+                    k_buf.slice_set(&k_old.contiguous()?, 2, 0)?;
+                    v_buf.slice_set(&v_old.contiguous()?, 2, 0)?;
                 }
             }
             self.kv_buffer = Some((k_buf, v_buf));
@@ -780,8 +780,8 @@ impl TurboQuantKvCache {
         // Write the new delta tokens into the buffer at position `cached_seq_len`.
         // `slice_set` is an in-place write — no allocation, no copy of previous data.
         let (k_buf, v_buf) = self.kv_buffer.as_mut().expect("kv_buffer allocated above");
-        k_buf.slice_set(&k_new, 2, self.cached_seq_len)?;
-        v_buf.slice_set(&v_new, 2, self.cached_seq_len)?;
+        k_buf.slice_set(&k_new.contiguous()?, 2, self.cached_seq_len)?;
+        v_buf.slice_set(&v_new.contiguous()?, 2, self.cached_seq_len)?;
 
         // Update the cached sequence length.
         self.cached_seq_len = self.seq_len;
@@ -1325,5 +1325,46 @@ mod tests {
              if they match, TurboQuant now caps at the window and this test should be updated",
             k_out.dim(2).unwrap()
         );
+    }
+
+    /// Regression test: buffer reallocation with non-contiguous narrow views.
+    ///
+    /// When the warmup buffer grows (lines 559-562), the existing data is copied via
+    /// `narrow(2, 0, len)` then `slice_set`. The narrow produces a non-contiguous view
+    /// that `slice_set` cannot handle directly. This test verifies the `.contiguous()`
+    /// fix prevents the "slice-set only supports contiguous tensors" error.
+    #[test]
+    fn buffer_realloc_with_narrow_non_contiguous() {
+        let head_dim = 128usize;
+        let n_kv_heads = 4usize;
+        let device = test_device();
+        let dtype = test_dtype(&device);
+
+        // Create cache WITH warmup enabled (not calling .without_warmup())
+        // This exercises the warmup buffer path that has the narrow+slice_set pattern.
+        let mut cache = TurboQuantKvCache::new(
+            &TurboQuantConfig { bits: 8, head_dim },
+            n_kv_heads,
+            dtype,
+            device.clone(),
+        );
+
+        // Append tokens gradually to trigger multiple buffer growths.
+        // The warmup buffer starts small and doubles when needed.
+        // Each growth copies existing data via narrow+slice_set.
+        for step in 0..300usize {
+            let k_data: Vec<f32> = (0..n_kv_heads * head_dim)
+                .map(|i| {
+                    let h = i / head_dim;
+                    let d = i % head_dim;
+                    ((step as f32 * 0.37 + h as f32 * 1.1 + d as f32 * 0.07) * 0.5).sin()
+                })
+                .collect();
+            let k_t = Tensor::from_slice(&k_data, (1, n_kv_heads, 1, head_dim), &device).unwrap();
+            // This must not fail with "slice-set only supports contiguous tensors"
+            cache.append(&k_t, &k_t).unwrap_or_else(|e| {
+                panic!("append step {step} should work with contiguous narrow fix: {e}")
+            });
+        }
     }
 }


### PR DESCRIPTION
Commit 8ae9634 accidentally reverted four previously merged PRs from
co-esquie (#142, #144, #146, #151) while resolving merge conflicts.

## PR #144 — optimised depthwise conv1d CUDA fast path

- `candle-kernels/src/conv.cu`: add `conv1d_depthwise` device function and `CONV1D_DEPTHWISE_OP` macro; instantiate for bf16, f16, f32, f64, u8, u32 to match coverage of the regular `CONV1D_OP` variants
- `candle-core/src/conv.rs`: add `ParamsConv1DDepthwise` struct and `conv1d_depthwise_path`; dispatch to it when `c_in_k == 1` and `c_out == groups` on CUDA (true depthwise case), falling back to the existing chunk-loop on CPU and Metal
- `candle-core/src/cuda_backend/mod.rs`: add `Conv1DDepthwise` `Map2` impl and `CudaStorage::conv1d_depthwise`
- `candle-core/src/storage.rs`: add `Storage::conv1d_depthwise` dispatch
- `candle-core/tests/conv_tests.rs`: restore `conv1d_depthwise` and `conv1d_depthwise_stride2` correctness tests across all backends
- `candle-core/benches/benchmarks/conv1d_depthwise.rs`: restore Criterion benchmark for the four representative Qwen3.5 decode/prefill shapes

## PR #142 — honor `--max-seq-len` and fix non-contiguous KV tensors

- `inferrs/src/engine.rs`: respect `args.max_seq_len` when `> 0` instead of always using the model default
- `inferrs/src/turbo_quant.rs`: add `.contiguous()` at three `narrow+slice_set` sites that produced "slice-set only supports contiguous tensors" warnings during buffer reallocation; restore regression test

## PR #146 — Qwen3.5 TurboQuant KV cache support

- `inferrs/src/models/attention_utils.rs`: restore `append_kv_tq` helper (prefill bypass + zero-copy warmup buffer adoption on first decode step)
- `inferrs/src/models/qwen3_5.rs`: restore `tq_cache` in `FullAttention`, `turbo_quant_bits` in `Qwen35Config`, `Box<FullAttention>` in `LayerAttn`, full `tq_cfg` threading through `DecoderLayer` and `Qwen35Model`
- `inferrs/src/config.rs`: add `turbo_quant_bits` param to `to_qwen35_config`
- `inferrs/src/models/mod.rs`: pass `turbo_quant_bits` through to `to_qwen35_config`

## PR #151 — Qwen3.5 RMSNorm weight convention fix

- `inferrs/src/models/qwen3_5.rs`: restore `rms_norm_with_offset` (adds 1.0 offset to convert zero-initialised residual weights to direct multipliers); apply to `q_norm`, `k_norm`, `input_layernorm`, `post_attention_layernorm`, and the final `norm` — fixes the endless-whitespace output bug on Qwen3.5 models