### PR TITLE
Split VisionConfig into enum with per-family variants to handle Qwen 3.5

### DIFF
--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -66,9 +66,49 @@ pub struct TextConfig {
 }
 
 /// Vision encoder configuration from `vision_config` in `config.json`.
+///
+/// Different model families ship different vision encoders, each with its own
+/// config shape.  The `model_type` field inside `vision_config` is used to
+/// dispatch to the right variant at deserialization time.
+#[derive(Debug, Clone)]
+pub enum VisionConfig {
+    Gemma4(Gemma4VisionConfig),
+    Qwen(QwenVisionConfig),
+}
+
+/// Parameters the server needs for image preprocessing, regardless of encoder
+/// architecture.
+pub struct VisionPreprocessParams {
+    pub patch_size: usize,
+    pub pooling_kernel_size: usize,
+    pub default_output_length: usize,
+}
+
+impl VisionConfig {
+    pub fn preprocess_params(&self) -> VisionPreprocessParams {
+        match self {
+            VisionConfig::Gemma4(c) => VisionPreprocessParams {
+                patch_size: c.patch_size,
+                pooling_kernel_size: c.pooling_kernel_size,
+                default_output_length: c.default_output_length,
+            },
+            VisionConfig::Qwen(c) => VisionPreprocessParams {
+                patch_size: c.patch_size,
+                pooling_kernel_size: if c.spatial_merge_size > 0 {
+                    c.spatial_merge_size
+                } else {
+                    3
+                },
+                default_output_length: 280,
+            },
+        }
+    }
+}
+
+/// SigLIP2 ViT vision encoder configuration (Gemma4).
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
-pub struct VisionConfig {
+pub struct Gemma4VisionConfig {
     pub hidden_size: usize,
     pub num_hidden_layers: usize,
     pub num_attention_heads: usize,
@@ -84,12 +124,29 @@ pub struct VisionConfig {
     pub rms_norm_eps: f64,
     #[serde(default = "default_vision_rope_theta")]
     pub rope_theta: f64,
-    #[serde(default)]
     pub use_clipped_linears: bool,
-    #[serde(default)]
     pub standardize: bool,
     #[serde(default = "default_vision_hidden_activation")]
     pub hidden_activation: String,
+}
+
+/// Qwen vision encoder configuration (shared by Qwen3.5 and Qwen3-VL).
+#[derive(Debug, Deserialize, Clone, Default)]
+#[serde(default)]
+#[allow(dead_code)]
+pub struct QwenVisionConfig {
+    pub depth: usize,
+    pub hidden_size: usize,
+    pub num_heads: usize,
+    pub num_position_embeddings: usize,
+    pub intermediate_size: usize,
+    pub patch_size: usize,
+    pub in_channels: usize,
+    pub out_hidden_size: usize,
+    pub spatial_merge_size: usize,
+    pub temporal_patch_size: usize,
+    pub initializer_range: f64,
+    pub deepstack_visual_indexes: Vec<usize>,
 }
 
 fn default_vision_head_dim() -> usize {
@@ -100,6 +157,25 @@ fn default_vision_rope_theta() -> f64 {
 }
 fn default_vision_hidden_activation() -> String {
     "gelu_pytorch_tanh".to_string()
+}
+
+impl<'de> serde::Deserialize<'de> for VisionConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> std::result::Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(de)?;
+        let model_type = raw.get("model_type").and_then(|v| v.as_str()).unwrap_or("");
+        match model_type {
+            "qwen3_5" | "qwen3_vl" => {
+                let cfg: QwenVisionConfig =
+                    serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+                Ok(VisionConfig::Qwen(cfg))
+            }
+            _ => {
+                let cfg: Gemma4VisionConfig =
+                    serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+                Ok(VisionConfig::Gemma4(cfg))
+            }
+        }
+    }
 }
 
 /// Audio encoder configuration from `audio_config` in `config.json`.

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -15,7 +15,7 @@ use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use std::path::Path;
 
-use crate::config::{ModelArchitecture, RawConfig};
+use crate::config::{ModelArchitecture, RawConfig, VisionConfig};
 use crate::kv_cache::{BlockTable, PagedKvStore};
 use gemma4::QGgufVarBuilder;
 
@@ -634,23 +634,33 @@ pub fn load_model(
 
             // Load vision encoder if vision_config is present in the model config.
             let vision_encoder = if let Some(vision_cfg) = &raw_config.vision_config {
-                tracing::info!(
-                    "Gemma4 vision encoder: {} layers, hidden={}, patch_size={}, output_length={}",
-                    vision_cfg.num_hidden_layers,
-                    vision_cfg.hidden_size,
-                    vision_cfg.patch_size,
-                    vision_cfg.default_output_length,
-                );
-                let enc = vision_encoder::VisionEncoder::load(
-                    vb.pp("model"),
-                    vision_cfg,
-                    config.hidden_size,
-                    device,
-                    dtype,
-                )
-                .context("Failed to load Gemma4 vision encoder")?;
-                tracing::info!("Vision encoder loaded successfully");
-                Some(enc)
+                match vision_cfg {
+                    VisionConfig::Gemma4(cfg) => {
+                        tracing::info!(
+                            "Gemma4 vision encoder: {} layers, hidden={}, patch_size={}, output_length={}",
+                            cfg.num_hidden_layers,
+                            cfg.hidden_size,
+                            cfg.patch_size,
+                            cfg.default_output_length,
+                        );
+                        let enc = vision_encoder::VisionEncoder::load(
+                            vb.pp("model"),
+                            cfg,
+                            config.hidden_size,
+                            device,
+                            dtype,
+                        )
+                        .context("Failed to load Gemma4 vision encoder")?;
+                        tracing::info!("Vision encoder loaded successfully");
+                        Some(enc)
+                    }
+                    VisionConfig::Qwen(_) => {
+                        tracing::info!(
+                            "Qwen vision encoder detected but not yet supported, skipping"
+                        );
+                        None
+                    }
+                }
             } else {
                 None
             };

--- a/inferrs/src/models/vision_encoder.rs
+++ b/inferrs/src/models/vision_encoder.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor, D};
 use candle_nn::{linear_no_bias, rms_norm, Linear, RmsNorm, VarBuilder};
 
-use crate::config::VisionConfig;
+use crate::config::Gemma4VisionConfig;
 use crate::models::audio_encoder::ClipLinear;
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ struct PatchEmbedder {
 }
 
 impl PatchEmbedder {
-    fn load(vb: VarBuilder, cfg: &VisionConfig) -> Result<Self> {
+    fn load(vb: VarBuilder, cfg: &Gemma4VisionConfig) -> Result<Self> {
         let patch_pixels = cfg.patch_size * cfg.patch_size * 3;
         let input_proj = linear_no_bias(patch_pixels, cfg.hidden_size, vb.pp("input_proj"))?;
         let position_embedding_table = vb.get(
@@ -155,7 +155,7 @@ struct VisionAttention {
 }
 
 impl VisionAttention {
-    fn load(vb: VarBuilder, cfg: &VisionConfig) -> Result<Self> {
+    fn load(vb: VarBuilder, cfg: &Gemma4VisionConfig) -> Result<Self> {
         let h = cfg.hidden_size;
         let nh = cfg.num_attention_heads;
         let nkv = cfg.num_key_value_heads;
@@ -267,7 +267,7 @@ struct VisionMlp {
 }
 
 impl VisionMlp {
-    fn load(vb: VarBuilder, cfg: &VisionConfig) -> Result<Self> {
+    fn load(vb: VarBuilder, cfg: &Gemma4VisionConfig) -> Result<Self> {
         let mlp_vb = vb.pp("mlp");
         let gate_proj = ClipLinear::load(
             mlp_vb.pp("gate_proj"),
@@ -310,7 +310,7 @@ struct VisionEncoderLayer {
 }
 
 impl VisionEncoderLayer {
-    fn load(vb: VarBuilder, cfg: &VisionConfig) -> Result<Self> {
+    fn load(vb: VarBuilder, cfg: &Gemma4VisionConfig) -> Result<Self> {
         let input_layernorm =
             rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let post_attention_layernorm = rms_norm(
@@ -364,7 +364,7 @@ impl VisionEncoderLayer {
 struct VisionPooler {}
 
 impl VisionPooler {
-    fn new(_cfg: &VisionConfig) -> Self {
+    fn new(_cfg: &Gemma4VisionConfig) -> Self {
         Self {}
     }
 
@@ -475,7 +475,7 @@ impl VisionEncoder {
     /// Expected call site: `VisionEncoder::load(vb.pp("model"), cfg, lm_hidden_size, device, dtype)`
     pub fn load(
         vb: VarBuilder,
-        cfg: &VisionConfig,
+        cfg: &Gemma4VisionConfig,
         lm_hidden_size: usize,
         _device: &Device,
         dtype: DType,

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -916,10 +916,11 @@ fn loaded_model_from_ctx(
     let eoi_token_id = ctx.raw_config.eoi_token_id;
     let (vision_patch_size, vision_pooling_kernel, vision_default_output_length) =
         if let Some(vc) = &ctx.raw_config.vision_config {
+            let p = vc.preprocess_params();
             (
-                Some(vc.patch_size),
-                Some(vc.pooling_kernel_size),
-                Some(vc.default_output_length),
+                Some(p.patch_size),
+                Some(p.pooling_kernel_size),
+                Some(p.default_output_length),
             )
         } else {
             (None, None, None)


### PR DESCRIPTION
After reviewing https://github.com/ericcurtin/inferrs/pull/157, Fixes a crash when loading Qwen3.5 models by refactoring `VisionConfig` from a single flat struct into an enum with per-family variants (`Gemma4` / `Qwen`), enabling proper support for Qwen3.5's different vision encoder config shape.

### Problem

On `main`, loading a Qwen3.5 model would crash because `vision_config` in Qwen3.5's `config.json` has a completely different schema than Gemma4's (e.g. `depth` instead of `num_hidden_layers`, no `pooling_kernel_size`, etc.). The single `VisionConfig` struct couldn't deserialize it.

**Broken on `main`:**
```bash
./target/release/inferrs run Qwen/Qwen3.5-0.8B "Describe docker company in one sentence" --device=cuda
```

> Docker is a software development platform that enables developers to build, run, and deploy applications across multiple environments using containerized code.
