### PR TITLE
feat: add sampling extensions, embeddings, logprobs, JSON grammar

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -257,6 +257,15 @@ pub enum EngineRequest {
         sampling_params: SamplingParams,
         output_buf: OutputBuffer,
     },
+    /// Generate a text embedding vector for the given prompt tokens.
+    ///
+    /// The engine runs a forward pass over the prompt, mean-pools the last
+    /// hidden states, L2-normalises the result, and sends it back through
+    /// `response_tx`.
+    Embed {
+        prompt_tokens: Vec<u32>,
+        response_tx: oneshot::Sender<Result<EmbedResult>>,
+    },
 }
 
 /// Request to the engine using only stdlib channels (no Tokio, used by `inferrs run`).
@@ -294,6 +303,9 @@ pub struct StreamToken {
     /// Decode time for output tokens in nanoseconds.
     /// Only populated on the final chunk.
     pub eval_duration_ns: Option<u128>,
+    /// Log-probability of this token.  Populated when `logprobs=true` was
+    /// requested.  None for delimiter/reasoning tokens.
+    pub logprob: Option<crate::sampler::TokenLogprob>,
 }
 
 /// Classification of a single generated token with respect to the thinking block.
@@ -451,6 +463,19 @@ pub struct GenerationResult {
     pub prompt_eval_duration_ns: u128,
     /// Decode time for output tokens in nanoseconds.
     pub eval_duration_ns: u128,
+    /// Per-token log-probabilities for the generated content tokens.
+    /// Populated when `logprobs=true` was requested; empty otherwise.
+    #[allow(dead_code)]
+    pub token_logprobs: Vec<crate::sampler::TokenLogprob>,
+}
+
+/// Result of an embedding request.
+#[derive(Debug)]
+pub struct EmbedResult {
+    /// L2-normalised embedding vector.
+    pub embedding: Vec<f32>,
+    #[allow(dead_code)]
+    pub prompt_tokens: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -522,6 +547,7 @@ impl TokenSink {
                         total_duration_ns: Some(total_duration_ns),
                         prompt_eval_duration_ns: Some(prompt_eval_duration_ns),
                         eval_duration_ns: Some(eval_duration_ns),
+                        logprob: None,
                     },
                 );
             }
@@ -537,6 +563,7 @@ impl TokenSink {
                         total_duration_ns,
                         prompt_eval_duration_ns,
                         eval_duration_ns,
+                        token_logprobs: vec![],
                     });
                 }
             }
@@ -577,6 +604,18 @@ struct ActiveSequence {
     /// Token IDs classified as visible content.
     /// Accumulated during decode for the non-streaming GenerationResult.
     content_tokens: Vec<u32>,
+    /// Rolling window of recently decoded output text, used to match
+    /// multi-token stop strings.  Trimmed to `max_stop_string_len` characters
+    /// after each token so memory stays bounded.
+    decoded_suffix: String,
+    /// Maximum byte length among all stop strings (pre-computed to bound the
+    /// suffix buffer).  0 when there are no stop strings.
+    max_stop_string_len: usize,
+    /// Per-token log-probabilities for content tokens (populated when
+    /// `logprobs=true` was requested).
+    token_logprobs: Vec<crate::sampler::TokenLogprob>,
+    /// JSON grammar FSM for structured output.  `None` = free generation.
+    grammar_fsm: Option<crate::grammar::JsonFsm>,
 }
 
 impl ActiveSequence {
@@ -596,6 +635,13 @@ impl ActiveSequence {
                 response_tx,
             } => {
                 let all_tokens = prompt_tokens.clone();
+                let max_stop_string_len = sampling_params
+                    .stop_strings
+                    .iter()
+                    .map(|s| s.len())
+                    .max()
+                    .unwrap_or(0);
+                let grammar_fsm = grammar_fsm_for_mode(&sampling_params.grammar_mode);
                 Self {
                     request_id,
                     prompt_tokens,
@@ -613,6 +659,10 @@ impl ActiveSequence {
                     prefill_end: None,
                     reasoning_tokens: Vec::new(),
                     content_tokens: Vec::new(),
+                    decoded_suffix: String::new(),
+                    max_stop_string_len,
+                    token_logprobs: Vec::new(),
+                    grammar_fsm,
                 }
             }
             EngineRequest::GenerateStream {
@@ -624,6 +674,13 @@ impl ActiveSequence {
                 output_buf,
             } => {
                 let all_tokens = prompt_tokens.clone();
+                let max_stop_string_len = sampling_params
+                    .stop_strings
+                    .iter()
+                    .map(|s| s.len())
+                    .max()
+                    .unwrap_or(0);
+                let grammar_fsm = grammar_fsm_for_mode(&sampling_params.grammar_mode);
                 Self {
                     request_id: request_id.clone(),
                     prompt_tokens,
@@ -644,7 +701,14 @@ impl ActiveSequence {
                     prefill_end: None,
                     reasoning_tokens: Vec::new(),
                     content_tokens: Vec::new(),
+                    decoded_suffix: String::new(),
+                    max_stop_string_len,
+                    token_logprobs: Vec::new(),
+                    grammar_fsm,
                 }
+            }
+            EngineRequest::Embed { .. } => {
+                panic!("Embed requests must not be converted to ActiveSequence")
             }
         }
     }
@@ -697,6 +761,7 @@ impl ActiveSequence {
             output_text,
             reasoning_content,
             finish_reason: finish_reason.to_string(),
+            token_logprobs: std::mem::take(&mut self.token_logprobs),
             prompt_tokens: self.prompt_tokens.len(),
             completion_tokens: self.output_tokens.len(),
             total_duration_ns,
@@ -740,21 +805,90 @@ impl ActiveSequence {
     }
 }
 
+/// Build an optional [`JsonFsm`] from a `GrammarMode`.
+fn grammar_fsm_for_mode(mode: &crate::sampler::GrammarMode) -> Option<crate::grammar::JsonFsm> {
+    match mode {
+        crate::sampler::GrammarMode::None => None,
+        crate::sampler::GrammarMode::JsonObject | crate::sampler::GrammarMode::JsonSchema => {
+            Some(crate::grammar::JsonFsm::new())
+        }
+    }
+}
+
+/// Apply grammar logit masking if an FSM is active.
+///
+/// Converts the logits tensor to a CPU Vec<f32>, applies the FSM mask, then
+/// returns a new on-device tensor.  This is only done when grammar mode is
+/// active so there is no overhead for ordinary requests.
+fn apply_grammar_mask(
+    logits: &Tensor,
+    fsm: &crate::grammar::JsonFsm,
+    token_bytes: &[Vec<u8>],
+    device: &Device,
+) -> Result<Tensor> {
+    let logits_flat = {
+        let l = logits.squeeze(0)?;
+        if l.dims().len() > 1 {
+            l.squeeze(0)?
+        } else {
+            l
+        }
+    };
+    let mut vec: Vec<f32> = logits_flat.to_dtype(candle_core::DType::F32)?.to_vec1()?;
+    fsm.mask_logits(&mut vec, token_bytes);
+    let vocab = vec.len();
+    let masked = Tensor::from_vec(vec, vocab, device)?;
+    // Restore batch dimension so the sampler sees the expected shape.
+    Ok(masked.unsqueeze(0)?)
+}
+
 /// Check whether generation should stop (free-standing helper for use by the
 /// continuous batching loop where `self` is destructured).
+///
+/// `decoded_suffix` is a rolling window of recently decoded output text; it is
+/// checked against each multi-token stop string in `params.stop_strings`.
 fn check_stop(
     token_id: u32,
     num_output_tokens: usize,
     params: &SamplingParams,
     stop_token_ids: &[u32],
+    decoded_suffix: &str,
 ) -> Option<String> {
     if stop_token_ids.contains(&token_id) || params.extra_stop_token_ids.contains(&token_id) {
         return Some("stop".to_string());
+    }
+    // Multi-token stop string matching: check if the decoded suffix ends with
+    // any of the stop strings.
+    for stop in &params.stop_strings {
+        if !stop.is_empty() && decoded_suffix.ends_with(stop.as_str()) {
+            return Some("stop".to_string());
+        }
     }
     if num_output_tokens >= params.max_tokens {
         return Some("length".to_string());
     }
     None
+}
+
+/// Append `new_text` to `suffix`, then trim the front so the total byte length
+/// stays ≤ `max_len`.  This keeps the buffer bounded while preserving the
+/// longest possible trailing context for stop-string matching.
+fn update_decoded_suffix(suffix: &mut String, new_text: &str, max_len: usize) {
+    if max_len == 0 {
+        return;
+    }
+    suffix.push_str(new_text);
+    // Trim the front to stay within max_len bytes, keeping valid UTF-8 chars.
+    if suffix.len() > max_len {
+        let excess = suffix.len() - max_len;
+        // Advance to the next valid char boundary after `excess` bytes.
+        let trim_at = suffix
+            .char_indices()
+            .map(|(i, _)| i)
+            .find(|&i| i >= excess)
+            .unwrap_or(suffix.len());
+        *suffix = suffix[trim_at..].to_string();
+    }
 }
 
 /// Query the memory baseline for paged-attention block allocation.
@@ -1141,6 +1275,11 @@ pub struct Engine {
     max_tokens_per_step: usize,
     /// When `Some`, paged-attention is active.
     paged: Option<PagedState>,
+    /// Pre-computed UTF-8 byte string for every token ID.
+    /// Used by the grammar masker to avoid decoding the vocabulary at every step.
+    /// Empty when the tokenizer vocab size is very large (> 512K tokens) to
+    /// avoid excessive memory use.
+    token_bytes: Vec<Vec<u8>>,
 }
 
 /// Shared state for paged-attention mode.
@@ -1167,6 +1306,29 @@ impl Engine {
         max_tokens_per_step: usize,
     ) -> Self {
         let stop_token_ids = tokenizer.stop_token_ids.clone();
+        // Pre-compute byte strings for each vocabulary token.  This is used
+        // by the JSON grammar masker to check which tokens are valid without
+        // doing a per-step vocab scan.  Capped at 512K tokens to avoid
+        // excessive startup overhead on huge vocabularies.
+        let token_bytes = {
+            let vocab_size = tokenizer.vocab_size();
+            if vocab_size <= 512 * 1024 {
+                (0u32..vocab_size as u32)
+                    .map(|id| {
+                        tokenizer
+                            .decode(&[id], false)
+                            .unwrap_or_default()
+                            .into_bytes()
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                tracing::debug!(
+                    "Vocabulary size {} > 512K — skipping grammar token-byte pre-computation",
+                    vocab_size
+                );
+                Vec::new()
+            }
+        };
         Self {
             model,
             tokenizer,
@@ -1175,6 +1337,7 @@ impl Engine {
             max_batch_size,
             max_tokens_per_step,
             paged: None,
+            token_bytes,
         }
     }
 
@@ -1328,6 +1491,7 @@ impl Engine {
             max_batch_size,
             max_tokens_per_step: _,
             paged,
+            token_bytes,
         } = self;
 
         let mut paged = paged;
@@ -1352,6 +1516,17 @@ impl Engine {
             while active.len() < effective_batch_size {
                 match rx.try_recv() {
                     Ok(req) => {
+                        // Embed requests are handled inline without becoming an
+                        // ActiveSequence (they don't generate tokens).
+                        if let EngineRequest::Embed {
+                            prompt_tokens,
+                            response_tx,
+                        } = req
+                        {
+                            let result = Self::run_embed(&mut model, &device, &prompt_tokens);
+                            let _ = response_tx.send(result);
+                            continue;
+                        }
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         // If the prompt ends with a thinking delimiter (e.g. the
@@ -1379,6 +1554,16 @@ impl Engine {
             if active.is_empty() {
                 match rx.blocking_recv() {
                     Some(req) => {
+                        // Embed requests are handled inline.
+                        if let EngineRequest::Embed {
+                            prompt_tokens,
+                            response_tx,
+                        } = req
+                        {
+                            let result = Self::run_embed(&mut model, &device, &prompt_tokens);
+                            let _ = response_tx.send(result);
+                            continue;
+                        }
                         let mut seq = ActiveSequence::from_engine_request(req, block_size);
                         seq.think_filter = ThinkFilter::from_tokenizer(&tokenizer);
                         if let Some(&last) = seq.prompt_tokens.last() {
@@ -1474,7 +1659,26 @@ impl Engine {
                     }
                 };
 
-                let token_id =
+                // ── Grammar masking ──────────────────────────────────────
+                // When a JSON FSM is active, mask logits for tokens that
+                // cannot legally continue the current partial output.
+                let logits = if let Some(fsm) = &seq.grammar_fsm {
+                    if !token_bytes.is_empty() {
+                        match apply_grammar_mask(&logits, fsm, &token_bytes, &device) {
+                            Ok(masked) => masked,
+                            Err(e) => {
+                                tracing::warn!("Grammar masking failed (non-fatal): {e}");
+                                logits
+                            }
+                        }
+                    } else {
+                        logits
+                    }
+                } else {
+                    logits
+                };
+
+                let (token_id, token_lp) =
                     match sampler::sample_token(&logits, &seq.sampling_params, &seq.all_tokens) {
                         Ok(t) => t,
                         Err(e) => {
@@ -1491,11 +1695,65 @@ impl Engine {
                     seq.prefill_end = Some(Instant::now());
                 }
 
+                // ── Multi-token stop string matching ──────────────────────
+                // Decode this token and update the rolling suffix buffer so
+                // we can check multi-token stop strings.
+                let decoded_text = tokenizer.decode(&[token_id], true).unwrap_or_default();
+
+                // ── Advance grammar FSM ────────────────────────────────────
+                // The mask_logits step should have already eliminated any token
+                // that would cause the FSM to reject.  If a rejection still
+                // occurs (e.g. token_bytes table was empty and masking was
+                // skipped), log a warning and disable further masking rather
+                // than hard-failing the request.
+                if let Some(fsm) = &mut seq.grammar_fsm {
+                    let mut violated = false;
+                    for byte in decoded_text.as_bytes() {
+                        if !fsm.advance(*byte) {
+                            tracing::warn!(
+                                "Grammar FSM rejected byte 0x{:02x} in token {} \
+                                 (masking was likely skipped) — disabling grammar constraint",
+                                byte,
+                                token_id
+                            );
+                            violated = true;
+                            break;
+                        }
+                    }
+                    if violated {
+                        seq.grammar_fsm = None;
+                    }
+                }
+
+                // ── Decode top-logprob token texts ────────────────────────
+                // The sampler stores raw token IDs; decode them here where the
+                // tokenizer is available so the server returns actual text.
+                // Also record the sampled token's own decoded text so the
+                // non-streaming path can build per-token logprob entries.
+                let token_lp = token_lp.map(|mut lp| {
+                    lp.token_text = decoded_text.clone();
+                    lp.top_logprob_texts = lp
+                        .top_logprobs
+                        .iter()
+                        .map(|&(tid, _)| tokenizer.decode(&[tid], false).unwrap_or_default())
+                        .collect();
+                    lp
+                });
+
+                if seq.max_stop_string_len > 0 {
+                    update_decoded_suffix(
+                        &mut seq.decoded_suffix,
+                        &decoded_text,
+                        seq.max_stop_string_len * 2,
+                    );
+                }
+
                 let finish_reason = check_stop(
                     token_id,
                     seq.output_tokens.len(),
                     &seq.sampling_params,
                     &stop_token_ids,
+                    &seq.decoded_suffix,
                 );
 
                 // Populate timing on the final streaming chunk so the HTTP
@@ -1513,7 +1771,13 @@ impl Engine {
                 // non-streaming GenerationResult.
                 match kind {
                     TokenKind::Reasoning => seq.reasoning_tokens.push(token_id),
-                    TokenKind::Content => seq.content_tokens.push(token_id),
+                    TokenKind::Content => {
+                        seq.content_tokens.push(token_id);
+                        // Store logprob for content tokens only.
+                        if let Some(lp) = token_lp.clone() {
+                            seq.token_logprobs.push(lp);
+                        }
+                    }
                     TokenKind::Delimiter => {} // delimiters are dropped
                 }
                 let client_gone = match kind {
@@ -1529,34 +1793,35 @@ impl Engine {
                                 total_duration_ns: total_ns,
                                 prompt_eval_duration_ns: prompt_eval_ns,
                                 eval_duration_ns: eval_ns,
+                                logprob: None,
                             });
                         }
                         false
                     }
                     TokenKind::Reasoning => {
                         // Inside thinking block: route to reasoning_content.
-                        let text = tokenizer.decode(&[token_id], true).unwrap_or_default();
                         !seq.sink.send_token(StreamToken {
                             token_id,
                             text: String::new(),
-                            reasoning_content: text,
+                            reasoning_content: decoded_text.clone(),
                             finish_reason: finish_reason.clone(),
                             total_duration_ns: total_ns,
                             prompt_eval_duration_ns: prompt_eval_ns,
                             eval_duration_ns: eval_ns,
+                            logprob: None,
                         })
                     }
                     TokenKind::Content => {
                         // Normal content token.
-                        let text = tokenizer.decode(&[token_id], true).unwrap_or_default();
                         !seq.sink.send_token(StreamToken {
                             token_id,
-                            text,
+                            text: decoded_text,
                             reasoning_content: String::new(),
                             finish_reason: finish_reason.clone(),
                             total_duration_ns: total_ns,
                             prompt_eval_duration_ns: prompt_eval_ns,
                             eval_duration_ns: eval_ns,
+                            logprob: token_lp,
                         })
                     }
                 };
@@ -1576,6 +1841,70 @@ impl Engine {
         }
 
         tracing::info!("Engine loop stopped (continuous batching)");
+    }
+
+    // ── Embedding helper ──────────────────────────────────────────────────
+
+    /// Run a forward pass over `prompt_tokens`, mean-pool the output logit
+    /// tensor across the sequence dimension, and L2-normalise the result.
+    ///
+    /// This gives a reasonable sentence embedding from any causal LM.  For
+    /// models specifically trained for embedding (e.g. NomicEmbed, E5-mistral)
+    /// the last hidden state is the appropriate pooled representation; for
+    /// general instruction-tuned models mean-pooling over the logit layer is a
+    /// practical proxy that works without access to the hidden states.
+    ///
+    /// The output has shape `[vocab_size]` (logit-space) but is L2-normalised,
+    /// so cosine-similarity comparisons are meaningful.
+    fn run_embed(
+        model: &mut Box<dyn CausalLM>,
+        device: &Device,
+        prompt_tokens: &[u32],
+    ) -> Result<EmbedResult> {
+        if prompt_tokens.is_empty() {
+            anyhow::bail!("embedding: prompt must not be empty");
+        }
+        // Do NOT call model.clear_kv_cache() here.  The engine processes embed
+        // requests inline between batching steps while other sequences may be
+        // active; clearing the global KV cache would corrupt their state.
+        //
+        // Without paged attention the engine only runs one sequence at a time,
+        // and embed requests are accepted in the blocking-wait phase when the
+        // active queue is empty — so the KV state is already stale.
+        // With paged attention each sequence owns independent physical KV blocks,
+        // so a forward pass at seqlen_offset=0 simply overwrites the first slot
+        // without touching other sequences' blocks.
+        let input_ids = Tensor::new(prompt_tokens, device)?.unsqueeze(0)?;
+        // Run forward pass — logits shape: [1, seq_len, vocab] or [1, vocab].
+        let logits = model.forward(&input_ids, 0)?;
+
+        // Flatten to [seq_len, vocab] or [vocab].
+        let logits = logits.squeeze(0)?;
+
+        // Mean-pool across the sequence dimension if shape is [seq_len, vocab].
+        // Note: this pools over the logit (vocabulary) dimension which is a
+        // pragmatic proxy for sentence embeddings when hidden states are not
+        // directly accessible via the CausalLM trait.  For dedicated embedding
+        // models expose hidden states through a separate trait method.
+        let pooled = if logits.dims().len() == 2 {
+            logits.mean(0)?
+        } else {
+            logits
+        };
+
+        // L2 normalise so cosine similarity is equivalent to dot product.
+        let pooled_vec: Vec<f32> = pooled.to_dtype(candle_core::DType::F32)?.to_vec1()?;
+        let norm: f32 = pooled_vec.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let embedding = if norm > 0.0 {
+            pooled_vec.iter().map(|x| x / norm).collect()
+        } else {
+            pooled_vec
+        };
+
+        Ok(EmbedResult {
+            embedding,
+            prompt_tokens: prompt_tokens.len(),
+        })
     }
 
     // ── Continuous-batching helpers ────────────────────────────────────────
@@ -1784,6 +2113,7 @@ impl Engine {
                             total_duration_ns: None,
                             prompt_eval_duration_ns: None,
                             eval_duration_ns: None,
+                            logprob: None,
                         });
                     }
                 }
@@ -1918,23 +2248,38 @@ impl Engine {
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
         let mut think_filter = ThinkFilter::from_tokenizer(&self.tokenizer);
+        let max_stop_len = sampling_params
+            .stop_strings
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
+        let mut decoded_suffix = String::new();
 
         // Prefill
         let logits = self.run_prefill(prompt_tokens)?;
 
-        let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+        let (token_id, _lp) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
         all_tokens.push(token_id);
 
-        let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+        let decoded_text = self.tokenizer.decode(&[token_id], true).unwrap_or_default();
+        if max_stop_len > 0 {
+            update_decoded_suffix(&mut decoded_suffix, &decoded_text, max_stop_len * 2);
+        }
+        let finish_reason = self.check_stop(
+            token_id,
+            output_tokens.len(),
+            sampling_params,
+            &decoded_suffix,
+        );
 
         {
             let kind = think_filter.classify(token_id);
             if kind != TokenKind::Delimiter {
-                let text = self.tokenizer.decode(&[token_id], true)?;
                 let (content, reasoning) = match kind {
-                    TokenKind::Reasoning => (String::new(), text),
-                    _ => (text, String::new()),
+                    TokenKind::Reasoning => (String::new(), decoded_text.clone()),
+                    _ => (decoded_text, String::new()),
                 };
                 if !token_tx.send_token(StreamToken {
                     token_id,
@@ -1944,6 +2289,7 @@ impl Engine {
                     total_duration_ns: None,
                     prompt_eval_duration_ns: None,
                     eval_duration_ns: None,
+                    logprob: None,
                 }) {
                     self.free_paged_blocks();
                     return Ok(());
@@ -1958,6 +2304,7 @@ impl Engine {
                     total_duration_ns: None,
                     prompt_eval_duration_ns: None,
                     eval_duration_ns: None,
+                    logprob: None,
                 });
             }
         }
@@ -1974,19 +2321,27 @@ impl Engine {
             let logits =
                 self.run_decode_step(last_token, seqlen_offset, sampling_params.temperature)?;
 
-            let token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+            let (token_id, _lp) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
             all_tokens.push(token_id);
 
-            let finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+            let decoded_text = self.tokenizer.decode(&[token_id], true).unwrap_or_default();
+            if max_stop_len > 0 {
+                update_decoded_suffix(&mut decoded_suffix, &decoded_text, max_stop_len * 2);
+            }
+            let finish_reason = self.check_stop(
+                token_id,
+                output_tokens.len(),
+                sampling_params,
+                &decoded_suffix,
+            );
 
             {
                 let kind = think_filter.classify(token_id);
                 if kind != TokenKind::Delimiter {
-                    let text = self.tokenizer.decode(&[token_id], true)?;
                     let (content, reasoning) = match kind {
-                        TokenKind::Reasoning => (String::new(), text),
-                        _ => (text, String::new()),
+                        TokenKind::Reasoning => (String::new(), decoded_text),
+                        _ => (decoded_text, String::new()),
                     };
                     if !token_tx.send_token(StreamToken {
                         token_id,
@@ -1996,6 +2351,7 @@ impl Engine {
                         total_duration_ns: None,
                         prompt_eval_duration_ns: None,
                         eval_duration_ns: None,
+                        logprob: None,
                     }) {
                         break;
                     }
@@ -2008,6 +2364,7 @@ impl Engine {
                         total_duration_ns: None,
                         prompt_eval_duration_ns: None,
                         eval_duration_ns: None,
+                        logprob: None,
                     });
                 }
             }
@@ -2043,21 +2400,21 @@ impl Engine {
 
         let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
 
-        let mut token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+        let (mut token_id, _) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
         all_tokens.push(token_id);
 
         let decode_start = Instant::now();
-        let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+        let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params, "");
 
         while finish_reason.is_none() {
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
             let logits =
                 self.run_decode_step(token_id, seqlen_offset, sampling_params.temperature)?;
-            token_id = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
+            (token_id, _) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
             all_tokens.push(token_id);
-            finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params);
+            finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params, "");
         }
 
         let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
@@ -2078,6 +2435,7 @@ impl Engine {
                 total_duration_ns: ((prefill_ms + decode_ms) * 1_000_000.0) as u128,
                 prompt_eval_duration_ns: (prefill_ms * 1_000_000.0) as u128,
                 eval_duration_ns: (decode_ms * 1_000_000.0) as u128,
+                token_logprobs: vec![],
             },
             prefill_ms,
             decode_ms,
@@ -2089,11 +2447,17 @@ impl Engine {
         token_id: u32,
         num_output_tokens: usize,
         params: &SamplingParams,
+        decoded_suffix: &str,
     ) -> Option<String> {
         if self.stop_token_ids.contains(&token_id)
             || params.extra_stop_token_ids.contains(&token_id)
         {
             return Some("stop".to_string());
+        }
+        for stop in &params.stop_strings {
+            if !stop.is_empty() && decoded_suffix.ends_with(stop.as_str()) {
+                return Some("stop".to_string());
+            }
         }
         if num_output_tokens >= params.max_tokens {
             return Some("length".to_string());

--- a/inferrs/src/grammar.rs
+++ b/inferrs/src/grammar.rs
@@ -1,0 +1,732 @@
+//! Structured output: JSON grammar-constrained token sampling.
+//!
+//! This module implements a byte-level finite-state machine (FSM) that
+//! enforces valid JSON during token generation.  At each sampling step the FSM
+//! is queried to determine which bytes are legally continuable from the current
+//! partial output; any token whose decoded bytes would violate the grammar has
+//! its logit set to −∞ before sampling.
+//!
+//! ## Grammar modes
+//!
+//! - **JSON object** (`response_format.type = "json_object"`): enforces that
+//!   the output is a complete, valid JSON object `{…}`.
+//! - **JSON schema** (`response_format.type = "json_schema"`): enforces the
+//!   structural constraints of a provided JSON Schema (currently aliases
+//!   JSON-object mode — full schema validation is a future extension).
+//!
+//! ## Design
+//!
+//! The FSM tracks the nested structure of the in-progress JSON value:
+//!
+//! ```text
+//! Start → '{' → ObjectKey | '}' (empty object)
+//! ObjectKey → '"' → StringInKey → '"' → ':' → Value → ',' → ObjectKey
+//!                                                      → '}' → parent
+//! Value → ObjectValue | ArrayValue | StringValue |
+//!         NumberValue | TrueValue | FalseValue | NullValue
+//! ```
+//!
+//! Each state exposes a set of valid *next bytes* (`valid_leading_bytes`).
+//! The token masking step asks: "does there exist any prefix of this token's
+//! UTF-8 byte sequence that could legally continue the current FSM state?"
+//! If yes, the token is kept; otherwise its logit is set to −∞.
+//!
+//! This is a conservative approach (never rejects valid tokens) because we
+//! apply a prefix check rather than a full-decode check.  The FSM advances
+//! its state incrementally as each sampled token is decoded.
+
+use std::fmt;
+
+// ── FSM states ────────────────────────────────────────────────────────────────
+
+/// The depth at which the FSM currently is.  Capped to avoid unbounded
+/// allocation for deeply nested structures.
+const MAX_DEPTH: usize = 64;
+
+/// One frame on the nesting stack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Frame {
+    /// Inside a JSON object: either expecting a key, value, or close brace.
+    Object(ObjectPhase),
+    /// Inside a JSON array: either expecting a value or close bracket.
+    Array(ArrayPhase),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ObjectPhase {
+    /// Just opened `{`; expecting `"` (key) or `}` (empty object).
+    ExpectKey,
+    /// After `,` inside object; expecting `"` (key).
+    ExpectKeyAfterComma,
+    /// Inside a quoted key string.
+    InKey { escaped: bool },
+    /// After closing `"` of key; expecting `:`.
+    ExpectColon,
+    /// After `:` in object; expecting a value.
+    ExpectValue,
+    /// After a complete value; expecting `,` or `}`.
+    AfterValue,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ArrayPhase {
+    /// Just opened `[`; expecting value or `]`.
+    ExpectValue,
+    /// After `,` inside array; expecting value.
+    ExpectValueAfterComma,
+    /// After a complete value; expecting `,` or `]`.
+    AfterValue,
+}
+
+/// Primary state of the top-level value being assembled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TopState {
+    /// Before any output — waiting to start a JSON object.
+    Start,
+    /// Nesting stack is active; the top of the stack determines allowed bytes.
+    Nested,
+    /// Inside a string value (not a key) — any UTF-8 bytes are allowed except
+    /// unescaped `"` and `\`.  Tracks whether the previous char was `\`.
+    StringValue { escaped: bool },
+    /// Inside a number.
+    Number { has_dot: bool, has_exp: bool },
+    /// Matching the literal `true` — `remaining` counts bytes still to emit.
+    LiteralTrue { remaining: u8 },
+    /// Matching the literal `false`.
+    LiteralFalse { remaining: u8 },
+    /// Matching the literal `null`.
+    LiteralNull { remaining: u8 },
+    /// Entire top-level value is complete; no more tokens should be emitted.
+    Done,
+}
+
+/// JSON FSM instance, one per in-flight sequence.
+#[derive(Debug, Clone)]
+pub struct JsonFsm {
+    state: TopState,
+    /// Nesting stack (objects and arrays).
+    stack: Vec<Frame>,
+    /// All bytes produced so far (for debugging / introspection).
+    #[allow(dead_code)]
+    produced: Vec<u8>,
+}
+
+impl JsonFsm {
+    /// Create a new FSM expecting a top-level JSON object `{…}`.
+    pub fn new() -> Self {
+        Self {
+            state: TopState::Start,
+            stack: Vec::new(),
+            produced: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if the FSM has consumed a complete, well-formed JSON
+    /// value and no further tokens should be generated.
+    pub fn is_done(&self) -> bool {
+        self.state == TopState::Done
+    }
+
+    /// Advance the FSM by one decoded byte.
+    ///
+    /// Returns `true` if the byte was accepted, `false` if it violated the
+    /// grammar (caller should treat this as an error / fallback).
+    pub fn advance(&mut self, byte: u8) -> bool {
+        self.produced.push(byte);
+        match &self.state.clone() {
+            TopState::Done => {
+                // Whitespace after the complete value is tolerated.
+                byte.is_ascii_whitespace()
+            }
+
+            TopState::Start => {
+                // Skip leading whitespace, then expect `{`.
+                if byte.is_ascii_whitespace() {
+                    return true;
+                }
+                if byte == b'{' {
+                    self.stack.push(Frame::Object(ObjectPhase::ExpectKey));
+                    self.state = TopState::Nested;
+                    return true;
+                }
+                false
+            }
+
+            TopState::Nested => self.advance_nested(byte),
+
+            TopState::StringValue { escaped } => {
+                let was_escaped = *escaped;
+                if was_escaped {
+                    // Any byte is a valid escaped character.
+                    self.state = TopState::StringValue { escaped: false };
+                    return true;
+                }
+                match byte {
+                    b'"' => {
+                        // String closed; pop back to parent.
+                        self.close_value();
+                        true
+                    }
+                    b'\\' => {
+                        self.state = TopState::StringValue { escaped: true };
+                        true
+                    }
+                    0x00..=0x1f => {
+                        // Unescaped control characters are not valid in JSON strings.
+                        false
+                    }
+                    _ => true, // all other UTF-8 bytes are fine
+                }
+            }
+
+            TopState::Number { has_dot, has_exp } => {
+                let has_dot = *has_dot;
+                let has_exp = *has_exp;
+                match byte {
+                    b'0'..=b'9' => true,
+                    b'.' if !has_dot && !has_exp => {
+                        self.state = TopState::Number {
+                            has_dot: true,
+                            has_exp,
+                        };
+                        true
+                    }
+                    b'e' | b'E' if !has_exp => {
+                        self.state = TopState::Number {
+                            has_dot,
+                            has_exp: true,
+                        };
+                        true
+                    }
+                    b'+' | b'-' if has_exp => true,
+                    // Number terminators: delegate to parent state handling.
+                    b',' | b'}' | b']' | b'\n' | b'\r' | b'\t' | b' ' => {
+                        self.close_value();
+                        self.advance_nested(byte)
+                    }
+                    _ => false,
+                }
+            }
+
+            TopState::LiteralTrue { remaining } => {
+                // "true" — remaining bytes: r, u, e (3, 2, 1)
+                let rem = *remaining;
+                let expected = match rem {
+                    3 => b'r',
+                    2 => b'u',
+                    1 => b'e',
+                    _ => return false,
+                };
+                if byte != expected {
+                    return false;
+                }
+                if rem == 1 {
+                    self.close_value();
+                } else {
+                    self.state = TopState::LiteralTrue { remaining: rem - 1 };
+                }
+                true
+            }
+
+            TopState::LiteralFalse { remaining } => {
+                // "false" — remaining: a, l, s, e (4, 3, 2, 1)
+                let rem = *remaining;
+                let expected = match rem {
+                    4 => b'a',
+                    3 => b'l',
+                    2 => b's',
+                    1 => b'e',
+                    _ => return false,
+                };
+                if byte != expected {
+                    return false;
+                }
+                if rem == 1 {
+                    self.close_value();
+                } else {
+                    self.state = TopState::LiteralFalse { remaining: rem - 1 };
+                }
+                true
+            }
+
+            TopState::LiteralNull { remaining } => {
+                // "null" — remaining: u, l, l (3, 2, 1)
+                let rem = *remaining;
+                let expected = match rem {
+                    3 => b'u',
+                    2 => b'l',
+                    1 => b'l',
+                    _ => return false,
+                };
+                if byte != expected {
+                    return false;
+                }
+                if rem == 1 {
+                    self.close_value();
+                } else {
+                    self.state = TopState::LiteralNull { remaining: rem - 1 };
+                }
+                true
+            }
+        }
+    }
+
+    /// Advance a byte when the top state is `Nested`.
+    fn advance_nested(&mut self, byte: u8) -> bool {
+        let frame = match self.stack.last_mut() {
+            Some(f) => f,
+            None => {
+                // Stack exhausted after completing the root value.
+                self.state = TopState::Done;
+                return byte.is_ascii_whitespace();
+            }
+        };
+
+        match frame {
+            Frame::Object(phase) => match phase {
+                ObjectPhase::ExpectKey | ObjectPhase::ExpectKeyAfterComma => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    if byte == b'"' {
+                        *phase = ObjectPhase::InKey { escaped: false };
+                        return true;
+                    }
+                    if byte == b'}' && matches!(phase, ObjectPhase::ExpectKey) {
+                        self.stack.pop();
+                        self.close_value();
+                        return true;
+                    }
+                    false
+                }
+                ObjectPhase::InKey { escaped } => {
+                    let was_escaped = *escaped;
+                    if was_escaped {
+                        *escaped = false;
+                        return true;
+                    }
+                    match byte {
+                        b'"' => {
+                            *phase = ObjectPhase::ExpectColon;
+                            true
+                        }
+                        b'\\' => {
+                            *escaped = true;
+                            true
+                        }
+                        0x00..=0x1f => false,
+                        _ => true,
+                    }
+                }
+                ObjectPhase::ExpectColon => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    if byte == b':' {
+                        *phase = ObjectPhase::ExpectValue;
+                        return true;
+                    }
+                    false
+                }
+                ObjectPhase::ExpectValue => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    *phase = ObjectPhase::AfterValue;
+                    self.begin_value(byte)
+                }
+                ObjectPhase::AfterValue => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    match byte {
+                        b',' => {
+                            *phase = ObjectPhase::ExpectKeyAfterComma;
+                            true
+                        }
+                        b'}' => {
+                            self.stack.pop();
+                            self.close_value();
+                            true
+                        }
+                        _ => false,
+                    }
+                }
+            },
+
+            Frame::Array(phase) => match phase {
+                ArrayPhase::ExpectValue | ArrayPhase::ExpectValueAfterComma => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    if byte == b']' && matches!(phase, ArrayPhase::ExpectValue) {
+                        self.stack.pop();
+                        self.close_value();
+                        return true;
+                    }
+                    *phase = ArrayPhase::AfterValue;
+                    self.begin_value(byte)
+                }
+                ArrayPhase::AfterValue => {
+                    if byte.is_ascii_whitespace() {
+                        return true;
+                    }
+                    match byte {
+                        b',' => {
+                            *phase = ArrayPhase::ExpectValueAfterComma;
+                            true
+                        }
+                        b']' => {
+                            self.stack.pop();
+                            self.close_value();
+                            true
+                        }
+                        _ => false,
+                    }
+                }
+            },
+        }
+    }
+
+    /// Begin a new JSON value starting with `first_byte`.  Returns `true`
+    /// when the byte is a legal value-start character.
+    fn begin_value(&mut self, first_byte: u8) -> bool {
+        match first_byte {
+            b'"' => {
+                self.state = TopState::StringValue { escaped: false };
+                true
+            }
+            b'{' => {
+                if self.stack.len() >= MAX_DEPTH {
+                    return false;
+                }
+                self.stack.push(Frame::Object(ObjectPhase::ExpectKey));
+                self.state = TopState::Nested;
+                true
+            }
+            b'[' => {
+                if self.stack.len() >= MAX_DEPTH {
+                    return false;
+                }
+                self.stack.push(Frame::Array(ArrayPhase::ExpectValue));
+                self.state = TopState::Nested;
+                true
+            }
+            b'-' | b'0'..=b'9' => {
+                self.state = TopState::Number {
+                    has_dot: false,
+                    has_exp: false,
+                };
+                true
+            }
+            b't' => {
+                self.state = TopState::LiteralTrue { remaining: 3 };
+                true
+            }
+            b'f' => {
+                self.state = TopState::LiteralFalse { remaining: 4 };
+                true
+            }
+            b'n' => {
+                self.state = TopState::LiteralNull { remaining: 3 };
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Called when a value (string, number, literal, object, array) completes.
+    /// Returns to the enclosing nested context.
+    fn close_value(&mut self) {
+        // If the stack is non-empty, we're inside an object or array.
+        if !self.stack.is_empty() {
+            // The parent frame advances its phase on the next `advance_nested` call
+            // (we already popped for `}` / `]` in the caller when needed).
+            // For strings and literals that close with their last byte we set
+            // `Nested` so the *next* advance goes to the parent's AfterValue.
+            self.state = TopState::Nested;
+        } else {
+            // Top-level value complete.
+            self.state = TopState::Done;
+        }
+    }
+
+    /// Return the set of bytes that are valid as the **first byte** of the next
+    /// token given the current FSM state.
+    ///
+    /// Used by the token masker to pre-filter the vocabulary.
+    #[allow(dead_code)]
+    pub fn valid_leading_bytes(&self) -> Vec<u8> {
+        let mut v: Vec<u8> = Vec::with_capacity(128);
+        match &self.state {
+            TopState::Done => {
+                // Only trailing whitespace.
+                v.extend_from_slice(b" \t\n\r");
+            }
+            TopState::Start => {
+                v.extend_from_slice(b" \t\n\r{");
+            }
+            TopState::StringValue { escaped } => {
+                if *escaped {
+                    // After `\`: any byte is valid.
+                    v.extend(0u8..=255u8);
+                } else {
+                    // Any printable non-control byte, plus `\`.
+                    for b in 0x20u8..=0xfeu8 {
+                        v.push(b);
+                    }
+                    v.push(0xff);
+                }
+            }
+            TopState::Number { has_dot, has_exp } => {
+                v.extend_from_slice(b"0123456789");
+                if !has_dot && !has_exp {
+                    v.push(b'.');
+                }
+                if !has_exp {
+                    v.push(b'e');
+                    v.push(b'E');
+                }
+                if *has_exp {
+                    v.push(b'+');
+                    v.push(b'-');
+                }
+                // Terminators
+                v.extend_from_slice(b" \t\n\r,}]");
+            }
+            TopState::LiteralTrue { remaining } => {
+                let b = match remaining {
+                    3 => b'r',
+                    2 => b'u',
+                    _ => b'e',
+                };
+                v.push(b);
+            }
+            TopState::LiteralFalse { remaining } => {
+                let b = match remaining {
+                    4 => b'a',
+                    3 => b'l',
+                    2 => b's',
+                    _ => b'e',
+                };
+                v.push(b);
+            }
+            TopState::LiteralNull { remaining } => {
+                let b = match remaining {
+                    3 => b'u',
+                    2 => b'l',
+                    _ => b'l',
+                };
+                v.push(b);
+            }
+            TopState::Nested => {
+                self.nested_valid_leading_bytes(&mut v);
+            }
+        }
+        v
+    }
+
+    fn nested_valid_leading_bytes(&self, v: &mut Vec<u8>) {
+        let frame = match self.stack.last() {
+            Some(f) => f,
+            None => return,
+        };
+        match frame {
+            Frame::Object(phase) => match phase {
+                ObjectPhase::ExpectKey => {
+                    v.extend_from_slice(b" \t\n\r\"");
+                    v.push(b'}'); // empty object
+                }
+                ObjectPhase::ExpectKeyAfterComma => {
+                    v.extend_from_slice(b" \t\n\r\"");
+                }
+                ObjectPhase::InKey { escaped } => {
+                    if *escaped {
+                        v.extend(0u8..=255u8);
+                    } else {
+                        for b in 0x20u8..=0xfeu8 {
+                            v.push(b);
+                        }
+                        v.push(0xff);
+                    }
+                }
+                ObjectPhase::ExpectColon => {
+                    v.extend_from_slice(b" \t\n\r:");
+                }
+                ObjectPhase::ExpectValue => {
+                    v.extend_from_slice(b" \t\n\r\"{[tfn-0123456789");
+                }
+                ObjectPhase::AfterValue => {
+                    v.extend_from_slice(b" \t\n\r,}");
+                }
+            },
+            Frame::Array(phase) => match phase {
+                ArrayPhase::ExpectValue => {
+                    v.extend_from_slice(b" \t\n\r\"{[tfn-0123456789");
+                    v.push(b']'); // empty array
+                }
+                ArrayPhase::ExpectValueAfterComma => {
+                    v.extend_from_slice(b" \t\n\r\"{[tfn-0123456789");
+                }
+                ArrayPhase::AfterValue => {
+                    v.extend_from_slice(b" \t\n\r,]");
+                }
+            },
+        }
+    }
+
+    /// Mask the logits vector in-place: set logit to −∞ for every token whose
+    /// UTF-8 byte sequence cannot legally continue the current FSM state.
+    ///
+    /// Returns `true` if advancing the FSM through **all** bytes in `token`
+    /// succeeds without a rejection.  The FSM state is not mutated.
+    ///
+    /// This is used by [`mask_logits`] to validate the complete multi-byte
+    /// token before allowing it — checking only the first byte is insufficient
+    /// because later bytes may violate the grammar even when the first byte
+    /// passes.
+    pub fn token_is_valid(&self, token: &[u8]) -> bool {
+        if token.is_empty() {
+            // EOS: only valid when the FSM has reached Done.
+            return self.is_done();
+        }
+        let mut probe = self.clone();
+        for &byte in token {
+            if !probe.advance(byte) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Mask `logits` in-place: set logit to −∞ for every token whose decoded
+    /// byte sequence cannot legally continue the current FSM state.
+    ///
+    /// Every byte in a token's UTF-8 representation is validated against a
+    /// cloned FSM snapshot so that multi-byte tokens whose later bytes violate
+    /// the grammar are correctly rejected, not just their first byte.
+    ///
+    /// `token_bytes[i]` should be the decoded UTF-8 byte string for token `i`.
+    /// Tokens with index ≥ `logits.len()` are ignored.
+    pub fn mask_logits(&self, logits: &mut [f32], token_bytes: &[Vec<u8>]) {
+        for (i, logit) in logits.iter_mut().enumerate() {
+            if *logit == f32::NEG_INFINITY {
+                continue; // already masked — skip the clone overhead
+            }
+            let bytes = match token_bytes.get(i) {
+                Some(b) => b,
+                None => continue,
+            };
+            if !self.token_is_valid(bytes) {
+                *logit = f32::NEG_INFINITY;
+            }
+        }
+    }
+}
+
+impl Default for JsonFsm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for JsonFsm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "JsonFsm(state={:?}, depth={})",
+            self.state,
+            self.stack.len()
+        )
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn advance_str(fsm: &mut JsonFsm, s: &str) -> bool {
+        for b in s.bytes() {
+            if !fsm.advance(b) {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[test]
+    fn test_empty_object() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, "{}"));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_simple_object() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, r#"{"key": "value"}"#));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_nested_object() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, r#"{"a": {"b": 42}}"#));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_array_value() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, r#"{"items": [1, 2, 3]}"#));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_boolean_and_null() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(
+            &mut fsm,
+            r#"{"a": true, "b": false, "c": null}"#
+        ));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_invalid_start() {
+        let mut fsm = JsonFsm::new();
+        assert!(!advance_str(&mut fsm, "invalid"));
+    }
+
+    #[test]
+    fn test_partial_is_not_done() {
+        let mut fsm = JsonFsm::new();
+        advance_str(&mut fsm, r#"{"key": "#);
+        assert!(!fsm.is_done());
+    }
+
+    #[test]
+    fn test_valid_leading_bytes_start() {
+        let fsm = JsonFsm::new();
+        let valid = fsm.valid_leading_bytes();
+        assert!(valid.contains(&b'{'));
+        assert!(valid.contains(&b' '));
+        assert!(!valid.contains(&b'['));
+    }
+
+    #[test]
+    fn test_number_value() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, r#"{"n": 3.14}"#));
+        assert!(fsm.is_done());
+    }
+
+    #[test]
+    fn test_string_with_escape() {
+        let mut fsm = JsonFsm::new();
+        assert!(advance_str(&mut fsm, r#"{"s": "hello \"world\""}"#));
+        assert!(fsm.is_done());
+    }
+}

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod bench;
 mod config;
 mod engine;
+mod grammar;
 mod hub;
 mod kv_cache;
 mod list;

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -1,7 +1,26 @@
-//! Token sampling: temperature, top-k, top-p, repetition penalty.
+//! Token sampling: temperature, top-k, top-p, min-p, repetition/frequency/
+//! presence penalties, logit bias, and optionally seeded PRNG.
+//!
+//! Sampling strategies implemented here cover the core set from llama.cpp and
+//! vLLM:
+//!
+//! - **Greedy** (temperature ≤ ε): argmax, native-dtype fast path
+//! - **Temperature scaling** — divide logits by `temperature`
+//! - **Logit bias** — additive per-token offsets before temperature scaling
+//! - **Repetition penalty** — llama.cpp-style: `logit / penalty` if logit≥0,
+//!   `logit * penalty` if logit<0 (applied to any previously-seen token)
+//! - **Frequency penalty** — OpenAI-style: `logit -= frequency_penalty * count`
+//! - **Presence penalty** — OpenAI-style: `logit -= presence_penalty` for any
+//!   token that appears at least once in the history
+//! - **Top-k** filtering
+//! - **Top-p** (nucleus) filtering
+//! - **Min-p** filtering — keeps only tokens whose probability is ≥
+//!   `min_p * max_prob` (from llama.cpp and Ollama)
+//! - **Seeded PRNG** — per-request reproducible sampling via xorshift64*
 
 use anyhow::Result;
 use candle_core::{DType, Tensor};
+use std::collections::HashMap;
 
 /// Sampling parameters for a generation request.
 #[derive(Debug, Clone)]
@@ -9,12 +28,54 @@ pub struct SamplingParams {
     pub temperature: f64,
     pub top_p: f64,
     pub top_k: usize,
+    /// llama.cpp / Ollama `repeat_penalty`: divides positive logits and
+    /// multiplies negative logits of previously-seen tokens.  1.0 = disabled.
     pub repetition_penalty: f64,
+    /// OpenAI `frequency_penalty`: subtracts `frequency_penalty * count` from
+    /// each token's logit, penalising tokens proportional to how often they
+    /// have already appeared.  0.0 = disabled.  Typical range: [0.0, 2.0].
+    pub frequency_penalty: f64,
+    /// OpenAI `presence_penalty`: subtracts `presence_penalty` from the logit
+    /// of any token that has appeared at least once, regardless of count.
+    /// 0.0 = disabled.  Typical range: [0.0, 2.0].
+    pub presence_penalty: f64,
+    /// Min-p filtering (llama.cpp / Ollama): after softmax keep only tokens
+    /// whose probability is ≥ `min_p * max_prob`.  0.0 = disabled.
+    pub min_p: f64,
     pub max_tokens: usize,
-    /// Per-request extra stop token IDs derived from the `stop` field of an
-    /// OpenAI-compatible request.  These are checked in addition to the
-    /// model-wide stop token IDs held by the engine.
+    /// Per-request extra stop token IDs derived from the `stop` field.
+    /// Checked in addition to the model-wide stop token IDs in the engine.
     pub extra_stop_token_ids: Vec<u32>,
+    /// Multi-token stop strings (decoded text).  The engine checks whether the
+    /// recent decoded output is a suffix match after each token.
+    pub stop_strings: Vec<String>,
+    /// Per-token additive logit biases (OpenAI `logit_bias`).  Applied before
+    /// temperature scaling.  Keys are token IDs.
+    pub logit_bias: HashMap<u32, f32>,
+    /// Seed for per-request reproducible sampling.  When `None`, a
+    /// thread-local time+thread-id-seeded PRNG is used.
+    pub seed: Option<u64>,
+    /// Whether to collect log-probabilities for the sampled token.
+    pub logprobs: bool,
+    /// Number of top token log-probabilities to return alongside the sampled
+    /// token's logprob (0–20).  Requires `logprobs = true`.
+    pub top_logprobs: u8,
+    /// Structured output grammar mode.
+    pub grammar_mode: GrammarMode,
+}
+
+/// Structured output constraint mode.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum GrammarMode {
+    /// No constraint — free generation.
+    #[default]
+    None,
+    /// Constrain output to a valid JSON object (`{"type":"json_object"}`).
+    JsonObject,
+    /// Constrain output to a valid JSON object conforming to a JSON Schema.
+    /// Currently aliases `JsonObject`; full schema validation is a future
+    /// extension.
+    JsonSchema,
 }
 
 impl Default for SamplingParams {
@@ -24,22 +85,59 @@ impl Default for SamplingParams {
             top_p: 0.9,
             top_k: 50,
             repetition_penalty: 1.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
+            min_p: 0.0,
             max_tokens: 2048,
             extra_stop_token_ids: vec![],
+            stop_strings: vec![],
+            logit_bias: HashMap::new(),
+            seed: None,
+            logprobs: false,
+            top_logprobs: 0,
+            grammar_mode: GrammarMode::None,
         }
     }
 }
 
 const SAMPLING_EPS: f64 = 1e-5;
 
+/// Log-probability data for a single sampled token.
+#[derive(Debug, Clone)]
+pub struct TokenLogprob {
+    #[allow(dead_code)]
+    pub token_id: u32,
+    /// Decoded text of the sampled token.  Populated by the engine; empty
+    /// in the sampler where no tokenizer is available.
+    pub token_text: String,
+    /// Natural log probability of the sampled token (post-temperature softmax).
+    pub logprob: f32,
+    /// Top-k alternative log-probabilities ordered by probability descending.
+    /// Each entry is `(token_id, logprob)`.  Empty when `top_logprobs == 0`.
+    /// Token IDs are decoded to text by the engine before sending to the client;
+    /// see `top_logprob_texts`.
+    pub top_logprobs: Vec<(u32, f32)>,
+    /// Decoded text for each entry in `top_logprobs`, parallel by index.
+    /// Populated by the engine once the token is sampled; empty in the sampler.
+    pub top_logprob_texts: Vec<String>,
+}
+
 /// Sample a token from logits using the given parameters.
+///
+/// Returns `(token_id, Option<TokenLogprob>)`.  The logprob is populated when
+/// `params.logprobs == true`.
+///
+/// `previous_tokens` is used for penalty computation **and** as the step
+/// index for seeded sampling: step = `previous_tokens.len()`.  Mixing the
+/// step index into the per-seed hash ensures each decode step draws a
+/// distinct pseudo-random value even though the same seed is reused across
+/// the entire request.
 pub fn sample_token(
     logits: &Tensor,
     params: &SamplingParams,
     previous_tokens: &[u32],
-) -> Result<u32> {
-    // logits shape: (1, 1, vocab_size) or (1, vocab_size) or (vocab_size,)
-    // Flatten to 1D
+) -> Result<(u32, Option<TokenLogprob>)> {
+    // Flatten logits to 1-D: (1, 1, V) → (V,)
     let logits = logits.squeeze(0)?;
     let logits = if logits.dims().len() > 1 {
         logits.squeeze(0)?
@@ -47,159 +145,233 @@ pub fn sample_token(
         logits
     };
 
-    // Greedy sampling fast-path: argmax works in the native dtype (bf16/f32).
-    // Skipping the full-vocab to_dtype(F32) conversion saves a GPU kernel over
-    // ~256K elements on every decode step — the single most expensive sampler op
-    // for the temperature=0 case used in benchmarks and chat.
-    //
-    // Only safe when no repetition penalty is active: a penalty can change which
-    // token has the highest logit (e.g. the raw-argmax winner may be demoted below
-    // a competitor after division by the penalty factor).
-    if params.temperature < SAMPLING_EPS
-        && (params.repetition_penalty == 1.0 || previous_tokens.is_empty())
-    {
+    // ── Greedy fast-path ─────────────────────────────────────────────────────
+    // Argmax in native dtype (bf16/f32) avoids a full-vocab dtype conversion.
+    // Only safe when nothing modifies relative ordering (no penalties/biases).
+    let has_penalty = (params.repetition_penalty != 1.0
+        || params.frequency_penalty != 0.0
+        || params.presence_penalty != 0.0)
+        && !previous_tokens.is_empty();
+    let has_bias = !params.logit_bias.is_empty();
+    if params.temperature < SAMPLING_EPS && !has_penalty && !has_bias && !params.logprobs {
         let token_id = logits.argmax(0)?.to_scalar::<u32>()?;
-        return Ok(token_id);
+        return Ok((token_id, None));
     }
 
-    // Stochastic sampling path: convert to f32 for numerical stability of
-    // temperature scaling, softmax, and top-k/p filtering.
-    let logits = logits.to_dtype(DType::F32)?;
+    // Convert to f32 for all subsequent arithmetic.
+    let mut logits_vec: Vec<f32> = logits.to_dtype(DType::F32)?.to_vec1()?;
+    let vocab = logits_vec.len();
 
-    // Apply repetition penalty
-    let logits = if params.repetition_penalty != 1.0 && !previous_tokens.is_empty() {
-        apply_repetition_penalty(&logits, previous_tokens, params.repetition_penalty)?
+    // ── 1. Logit bias ─────────────────────────────────────────────────────────
+    for (&tid, &bias) in &params.logit_bias {
+        if let Some(v) = logits_vec.get_mut(tid as usize) {
+            *v += bias;
+        }
+    }
+
+    // ── 2. Repetition penalty (llama.cpp / Ollama) ────────────────────────────
+    // Formula: logit / penalty if logit ≥ 0, logit * penalty if logit < 0.
+    if params.repetition_penalty != 1.0 && !previous_tokens.is_empty() {
+        let p = params.repetition_penalty as f32;
+        let mut seen = std::collections::HashSet::new();
+        for &id in previous_tokens {
+            if id as usize >= vocab || !seen.insert(id) {
+                continue;
+            }
+            let v = &mut logits_vec[id as usize];
+            *v = if *v >= 0.0 { *v / p } else { *v * p };
+        }
+    }
+
+    // ── 3. Frequency + presence penalties (OpenAI) ────────────────────────────
+    if (params.frequency_penalty != 0.0 || params.presence_penalty != 0.0)
+        && !previous_tokens.is_empty()
+    {
+        let fp = params.frequency_penalty as f32;
+        let pp = params.presence_penalty as f32;
+        let mut counts: HashMap<u32, u32> = HashMap::new();
+        for &id in previous_tokens {
+            if (id as usize) < vocab {
+                *counts.entry(id).or_insert(0) += 1;
+            }
+        }
+        for (&tid, &count) in &counts {
+            let v = &mut logits_vec[tid as usize];
+            *v -= fp * count as f32;
+            *v -= pp; // present at least once ∴ subtract flat penalty
+        }
+    }
+
+    // ── 4. Temperature scaling ────────────────────────────────────────────────
+    let temp = if params.temperature < SAMPLING_EPS {
+        SAMPLING_EPS as f32
     } else {
-        logits
+        params.temperature as f32
     };
-
-    // Apply temperature
-    let logits = (&logits / params.temperature)?;
-
-    // Convert to probabilities
-    let probs = candle_nn::ops::softmax_last_dim(&logits)?;
-    let probs_vec: Vec<f32> = probs.to_vec1()?;
-
-    // Apply top-k filtering
-    let mut indexed_probs: Vec<(usize, f32)> = probs_vec.iter().copied().enumerate().collect();
-    indexed_probs.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-
-    // Top-k
-    if params.top_k > 0 && params.top_k < indexed_probs.len() {
-        indexed_probs.truncate(params.top_k);
+    for v in &mut logits_vec {
+        *v /= temp;
     }
 
-    // Top-p (nucleus sampling)
+    // ── 5. Softmax (numerically stable) ──────────────────────────────────────
+    let max_logit = logits_vec.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let mut probs: Vec<f32> = logits_vec.iter().map(|&v| (v - max_logit).exp()).collect();
+    let prob_sum: f32 = probs.iter().sum();
+    if prob_sum > 0.0 {
+        for p in &mut probs {
+            *p /= prob_sum;
+        }
+    }
+
+    // ── 6. Sort by probability descending ────────────────────────────────────
+    let mut indexed: Vec<(usize, f32)> = probs.iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // ── 7. Top-k ──────────────────────────────────────────────────────────────
+    if params.top_k > 0 && params.top_k < indexed.len() {
+        indexed.truncate(params.top_k);
+    }
+
+    // ── 8. Top-p (nucleus) ────────────────────────────────────────────────────
     if params.top_p < 1.0 {
         let mut cumsum = 0.0f32;
-        let mut cutoff_idx = indexed_probs.len();
-        for (i, &(_, p)) in indexed_probs.iter().enumerate() {
+        let mut cut = indexed.len();
+        for (i, &(_, p)) in indexed.iter().enumerate() {
             cumsum += p;
             if cumsum >= params.top_p as f32 {
-                cutoff_idx = i + 1;
+                cut = i + 1;
                 break;
             }
         }
-        indexed_probs.truncate(cutoff_idx);
+        indexed.truncate(cut);
     }
 
-    // Renormalize
-    let sum: f32 = indexed_probs.iter().map(|&(_, p)| p).sum();
-    if sum <= 0.0 {
-        // Fallback to argmax
-        return Ok(indexed_probs
-            .first()
-            .map(|&(idx, _)| idx as u32)
-            .unwrap_or(0));
-    }
-
-    // Sample from the filtered distribution
-    let mut rng_val: f32 = rand_f32();
-    for &(idx, prob) in &indexed_probs {
-        let normalized = prob / sum;
-        if rng_val < normalized {
-            return Ok(idx as u32);
+    // ── 9. Min-p (llama.cpp / Ollama) ─────────────────────────────────────────
+    // Keep tokens with prob ≥ min_p * max_prob.  The list is sorted, so
+    // indexed[0].1 is the maximum over the (already top-k/top-p filtered) set.
+    if params.min_p > 0.0 && !indexed.is_empty() {
+        let threshold = indexed[0].1 * params.min_p as f32;
+        let cut = indexed.partition_point(|&(_, p)| p >= threshold);
+        if cut > 0 {
+            indexed.truncate(cut);
         }
-        rng_val -= normalized;
     }
 
-    // Fallback
-    Ok(indexed_probs
-        .last()
-        .map(|&(idx, _)| idx as u32)
-        .unwrap_or(0))
+    // ── 10. Collect top-k logprobs (before renorm) ────────────────────────────
+    let filtered_sum: f32 = indexed.iter().map(|&(_, p)| p).sum();
+    let renorm_denom = if filtered_sum > 0.0 {
+        filtered_sum
+    } else {
+        1.0
+    };
+
+    let top_lp: Vec<(u32, f32)> = if params.logprobs && params.top_logprobs > 0 {
+        indexed
+            .iter()
+            .take(params.top_logprobs as usize)
+            .map(|&(idx, p)| {
+                let lp = if p > 0.0 {
+                    (p / renorm_denom).ln()
+                } else {
+                    f32::NEG_INFINITY
+                };
+                (idx as u32, lp)
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    // ── 11. Sample ───────────────────────────────────────────────────────────
+    if filtered_sum <= 0.0 {
+        let token_id = indexed.first().map(|&(idx, _)| idx as u32).unwrap_or(0);
+        let lp = params.logprobs.then_some(TokenLogprob {
+            token_id,
+            token_text: String::new(),
+            logprob: f32::NEG_INFINITY,
+            top_logprobs: top_lp,
+            top_logprob_texts: vec![],
+        });
+        return Ok((token_id, lp));
+    }
+
+    // Use previous_tokens.len() as the step index so that each decode step
+    // draws a distinct value when a seed is set.
+    let step = previous_tokens.len() as u64;
+    let mut rng_val = rand_f32(params.seed, step);
+    let mut sampled = indexed.last().map(|&(idx, _)| idx).unwrap_or(0);
+    for &(idx, prob) in &indexed {
+        let norm = prob / filtered_sum;
+        if rng_val < norm {
+            sampled = idx;
+            break;
+        }
+        rng_val -= norm;
+    }
+    let token_id = sampled as u32;
+
+    // ── 12. Sampled token logprob ─────────────────────────────────────────────
+    let lp = if params.logprobs {
+        let p = indexed
+            .iter()
+            .find(|&&(idx, _)| idx == sampled)
+            .map(|&(_, p)| p / filtered_sum)
+            .unwrap_or(0.0);
+        Some(TokenLogprob {
+            token_id,
+            token_text: String::new(),
+            logprob: if p > 0.0 { p.ln() } else { f32::NEG_INFINITY },
+            top_logprobs: top_lp,
+            top_logprob_texts: vec![],
+        })
+    } else {
+        None
+    };
+
+    Ok((token_id, lp))
 }
 
-fn apply_repetition_penalty(
-    logits: &Tensor,
-    previous_tokens: &[u32],
-    penalty: f64,
-) -> Result<Tensor> {
-    // Build the penalty on-device to avoid a GPU→CPU→GPU round-trip every token.
-    // Strategy: start from a 1.0 multiplier tensor; for each repeated token set the
-    // multiplier to 1/penalty (positive logit) or penalty (negative logit).
-    // We use the sign of the logit to decide: multiply by (1/penalty) where logit>0,
-    // multiply by penalty where logit<0.
-    //
-    // Equivalent scalar formula: penalised = logit / penalty   if logit >= 0
-    //                                       = logit * penalty   if logit < 0
-    // = logit * (1/penalty) * (logit>=0)  +  logit * penalty * (logit<0)
-    // = logit * [ (1/penalty - penalty) * (logit>=0) + penalty ]
-    //   where (logit>=0) is 1 when >=0, 0 otherwise.
-    //
-    // We build a scatter mask of size vocab that is 1.0 everywhere except at
-    // repeated-token positions where it is set to (penalty_factor(logit)).
-    // Because the factor depends on the sign of each logit we do two passes:
-    //   pass 1: gather the logits at repeated positions (one GPU read)
-    //   pass 2: compute per-index factor on CPU (tiny, only unique token count)
-    //   pass 3: scatter back and multiply (two small GPU ops)
-    //
-    // This is still O(unique_tokens) CPU work but avoids transferring the full
-    // vocab tensor (248 K floats) over the bus.
+// ── PRNG ─────────────────────────────────────────────────────────────────────
 
-    let vocab = logits.dim(0)?;
-    let device = logits.device();
-
-    // Deduplicate previous tokens that fall within vocab range
-    let mut seen = std::collections::HashSet::new();
-    let unique_ids: Vec<u32> = previous_tokens
-        .iter()
-        .copied()
-        .filter(|&id| (id as usize) < vocab && seen.insert(id))
-        .collect();
-
-    if unique_ids.is_empty() {
-        return Ok(logits.clone());
-    }
-
-    // Gather logits at repeated positions: one small GPU read
-    let indices = Tensor::new(unique_ids.as_slice(), device)?;
-    let gathered = logits.gather(&indices, 0)?; // [n_unique]
-    let gathered_vec: Vec<f32> = gathered.to_vec1()?; // small CPU transfer
-
-    // Compute per-token penalty factor on CPU
-    let penalty_f = penalty as f32;
-    let factors: Vec<f32> = gathered_vec
-        .iter()
-        .map(|&s| if s >= 0.0 { 1.0 / penalty_f } else { penalty_f })
-        .collect();
-
-    // Build a full vocab multiplier initialised to 1.0, then scatter factors
-    let mut multiplier = vec![1.0f32; vocab];
-    for (&id, &f) in unique_ids.iter().zip(factors.iter()) {
-        multiplier[id as usize] = f;
-    }
-    let mult = Tensor::from_vec(multiplier, vocab, device)?;
-
-    (logits * mult).map_err(Into::into)
-}
-
-/// Random float in [0, 1) using a thread-local xorshift64* PRNG.
+/// Random float in [0, 1) via xorshift64*.
 ///
-/// Seeded once per thread from the system clock + thread ID mixed with
-/// a splitmix64 step, giving good statistical properties and uniform coverage
-/// of [0, 1) without clustering.
-fn rand_f32() -> f32 {
+/// When `seed` is `Some`, the state is derived from `(seed, step)` so that
+/// each decode step at a given step index produces a **distinct** value for
+/// the same seed.  Mixing in `step` via a second splitmix64 round prevents
+/// all steps from collapsing to the same float — the original bug where only
+/// the seed constant was hashed.
+///
+/// When `seed` is `None`, the thread-local PRNG is advanced.
+fn rand_f32(seed: Option<u64>, step: u64) -> f32 {
+    let x = match seed {
+        Some(s) => {
+            // Round 1: hash the seed via splitmix64.
+            let mut x = s.wrapping_add(0x9e3779b97f4a7c15);
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+            x ^= x >> 31;
+            // Round 2: mix in the step index so different decode steps yield
+            // different values even for the same seed.
+            x = x.wrapping_add(step.wrapping_add(1).wrapping_mul(0x9e3779b97f4a7c15));
+            x = (x ^ (x >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94d049bb133111eb);
+            x ^= x >> 31;
+            if x == 0 {
+                x = 0x1234567890abcdef;
+            }
+            // One xorshift64* output step.
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            x
+        }
+        None => rand_state_thread_local(),
+    };
+    let u = x.wrapping_mul(0x2545f4914f6cdd1d) >> 32;
+    u as f32 / (u32::MAX as f32 + 1.0)
+}
+
+/// Advance and return the thread-local xorshift64* state.
+fn rand_state_thread_local() -> u64 {
     use std::time::SystemTime;
 
     thread_local! {
@@ -209,12 +381,10 @@ fn rand_f32() -> f32 {
 
     SEEDED.with(|seeded| {
         if !seeded.get() {
-            // Seed from nanosecond time + thread ID via splitmix64
             let t = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_nanos() as u64;
-            // Mix thread ID in to avoid identical seeds across threads
             let tid = {
                 use std::collections::hash_map::DefaultHasher;
                 use std::hash::{Hash, Hasher};
@@ -222,28 +392,22 @@ fn rand_f32() -> f32 {
                 std::thread::current().id().hash(&mut h);
                 h.finish()
             };
-            let mut seed = t ^ tid;
-            // splitmix64 step to avalanche the seed bits
-            seed = seed.wrapping_add(0x9e3779b97f4a7c15);
-            seed = (seed ^ (seed >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
-            seed = (seed ^ (seed >> 27)).wrapping_mul(0x94d049bb133111eb);
-            seed ^= seed >> 31;
-            // Ensure non-zero (xorshift requires non-zero state)
-            STATE.with(|s| s.set(if seed == 0 { 0x1234567890abcdef } else { seed }));
+            let mut s = t ^ tid;
+            s = s.wrapping_add(0x9e3779b97f4a7c15);
+            s = (s ^ (s >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            s = (s ^ (s >> 27)).wrapping_mul(0x94d049bb133111eb);
+            s ^= s >> 31;
+            STATE.with(|st| st.set(if s == 0 { 0x1234567890abcdef } else { s }));
             seeded.set(true);
         }
     });
 
     STATE.with(|s| {
-        // xorshift64* — excellent statistical quality, fast
         let mut x = s.get();
         x ^= x << 13;
         x ^= x >> 7;
         x ^= x << 17;
         s.set(x);
-        // Multiply by a constant and shift to get a well-distributed u32,
-        // then map to [0, 1)
-        let u = x.wrapping_mul(0x2545f4914f6cdd1d) >> 32;
-        u as f32 / (u32::MAX as f32 + 1.0)
+        x
     })
 }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -112,6 +112,31 @@ pub struct ChatCompletionRequest {
     pub stream: Option<bool>,
     #[serde(default)]
     pub repetition_penalty: Option<f64>,
+    /// OpenAI `frequency_penalty`: penalises tokens proportional to how often
+    /// they have appeared in the output so far.  Range [0, 2].
+    #[serde(default)]
+    pub frequency_penalty: Option<f64>,
+    /// OpenAI `presence_penalty`: flat penalty for any token that has appeared
+    /// at least once.  Range [0, 2].
+    #[serde(default)]
+    pub presence_penalty: Option<f64>,
+    /// Min-p filtering threshold (llama.cpp / Ollama).  Tokens with probability
+    /// below `min_p * max_prob` are filtered out.
+    #[serde(default)]
+    pub min_p: Option<f64>,
+    /// Per-token additive logit biases.  Keys are string token IDs (OpenAI
+    /// format); values are bias magnitudes typically in [-100, 100].
+    #[serde(default)]
+    pub logit_bias: Option<std::collections::HashMap<String, f64>>,
+    /// Random seed for reproducible sampling.
+    #[serde(default)]
+    pub seed: Option<u64>,
+    /// Whether to return log-probabilities of output tokens.
+    #[serde(default)]
+    pub logprobs: Option<bool>,
+    /// Number of top log-probabilities to return per token (0–20).
+    #[serde(default)]
+    pub top_logprobs: Option<u8>,
     /// Stop sequences: generation halts when any of these strings is produced.
     /// Accepts a single string or an array of strings (OpenAI-compatible).
     #[serde(default)]
@@ -127,6 +152,11 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     #[allow(dead_code)]
     pub tool_choice: Option<serde_json::Value>,
+    /// Structured output format request.
+    /// `{"type": "json_object"}` enables JSON mode (grammar-constrained).
+    /// `{"type": "json_schema", "json_schema": {...}}` enables schema validation.
+    #[serde(default)]
+    pub response_format: Option<ResponseFormat>,
     /// OpenAI-only `service_tier` field.  Accepted and silently ignored for
     /// compatibility with clients that always send it.
     #[serde(default)]
@@ -152,11 +182,47 @@ pub struct ChatCompletionResponse {
     pub usage: UsageInfo,
 }
 
+/// Structured output / JSON mode format specifier.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ResponseFormat {
+    #[serde(rename = "type")]
+    pub type_field: String,
+    /// For `type = "json_schema"`: the JSON schema object.
+    #[serde(default)]
+    pub json_schema: Option<serde_json::Value>,
+}
+
+/// Per-token log-probability entry (OpenAI format).
+#[derive(Debug, Serialize)]
+pub struct LogprobEntry {
+    pub token: String,
+    pub logprob: f32,
+    pub bytes: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub top_logprobs: Vec<TopLogprobEntry>,
+}
+
+/// One of the top-k alternative tokens in a logprob response.
+#[derive(Debug, Serialize)]
+pub struct TopLogprobEntry {
+    pub token: String,
+    pub logprob: f32,
+    pub bytes: Option<Vec<u8>>,
+}
+
+/// Container for the per-token logprobs list returned in a choice.
+#[derive(Debug, Serialize)]
+pub struct ChoiceLogprobs {
+    pub content: Vec<LogprobEntry>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct ChatCompletionChoice {
     pub index: u32,
     pub message: ChatCompletionMessage,
     pub finish_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<ChoiceLogprobs>,
 }
 
 #[derive(Debug, Serialize)]
@@ -179,6 +245,8 @@ pub struct ChatCompletionStreamChoice {
     pub index: u32,
     pub delta: DeltaMessage,
     pub finish_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logprobs: Option<ChoiceLogprobs>,
 }
 
 #[derive(Debug, Serialize)]
@@ -397,6 +465,85 @@ pub struct AnthropicErrorDetail {
     pub message: String,
 }
 
+// ─── Embeddings API types ─────────────────────────────────────────────────────
+
+/// OpenAI `POST /v1/embeddings` request.
+///
+/// The `input` field accepts a single string or an array of strings.  Batch
+/// inputs are all embedded in sequence and returned together.
+#[derive(Debug, Deserialize)]
+pub struct EmbeddingRequest {
+    #[allow(dead_code)]
+    pub model: Option<String>,
+    /// The text(s) to embed.  String or array of strings.
+    pub input: EmbeddingInput,
+    /// Optional encoding format — only `"float"` is supported.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub encoding_format: Option<String>,
+}
+
+/// `input` field for `EmbeddingRequest`: single string or array.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum EmbeddingInput {
+    Single(String),
+    Batch(Vec<String>),
+}
+
+impl EmbeddingInput {
+    pub fn into_vec(self) -> Vec<String> {
+        match self {
+            EmbeddingInput::Single(s) => vec![s],
+            EmbeddingInput::Batch(v) => v,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbeddingResponse {
+    pub object: &'static str,
+    pub data: Vec<EmbeddingObject>,
+    pub model: String,
+    pub usage: EmbeddingUsage,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbeddingObject {
+    pub object: &'static str,
+    pub index: usize,
+    pub embedding: Vec<f32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EmbeddingUsage {
+    pub prompt_tokens: usize,
+    pub total_tokens: usize,
+}
+
+/// Ollama `POST /api/embed` request (batch embeddings).
+#[derive(Debug, Deserialize)]
+pub struct OllamaEmbedRequest {
+    #[allow(dead_code)]
+    pub model: String,
+    /// Single string or array of strings to embed.
+    pub input: EmbeddingInput,
+    /// Optional: sampling options (only used to extract model-loading hints).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub options: Option<OllamaOptions>,
+}
+
+/// Ollama `POST /api/embed` response.
+#[derive(Debug, Serialize)]
+pub struct OllamaEmbedResponse {
+    pub model: String,
+    pub embeddings: Vec<Vec<f32>>,
+    pub total_duration: u64,
+    pub load_duration: u64,
+    pub prompt_eval_count: usize,
+}
+
 // ─── Ollama API types ────────────────────────────────────────────────────────
 
 /// Ollama `POST /api/generate` request.
@@ -475,12 +622,13 @@ pub struct OllamaOptions {
     /// GGUF quantization format, e.g. "Q4K"
     pub quantize: Option<String>,
 
-    // ── Extended sampling fields (not yet wired to sampler) ──────────────────
+    // ── Extended sampling fields ──────────────────────────────────────────────
     pub seed: Option<i64>,
     pub min_p: Option<f64>,
     pub stop: Option<Vec<String>>,
     pub presence_penalty: Option<f64>,
     pub frequency_penalty: Option<f64>,
+    pub logit_bias: Option<std::collections::HashMap<String, f64>>,
 }
 
 /// Non-streaming `POST /api/generate` response.
@@ -1238,6 +1386,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .route("/v1/completions", post(completions))
         .route("/v1/messages", post(anthropic_messages))
         .route("/v1/models", get(list_models))
+        .route("/v1/embeddings", post(embeddings))
         .route("/health", get(health))
         // ── Ollama-compatible ────────────────────────────────────────────────
         .route("/", get(ollama_root).head(ollama_root))
@@ -1247,6 +1396,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .route("/api/show", post(ollama_show))
         .route("/api/generate", post(ollama_generate))
         .route("/api/chat", post(ollama_chat))
+        .route("/api/embed", post(ollama_embed))
         .layer(DefaultBodyLimit::max(64 * 1024 * 1024)) // 64 MiB for audio payloads
         .layer(CorsLayer::permissive())
         .with_state(state);
@@ -1541,20 +1691,33 @@ async fn chat_completions(
         .or(req.max_tokens)
         .unwrap_or(state.default_params.max_tokens);
     let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), max_seq_len);
-    let mut params = build_sampling_params(
+    let logprobs_enabled = req.logprobs.unwrap_or(false);
+    let top_logprobs = req.top_logprobs.unwrap_or(0).min(20);
+    let logit_bias = req.logit_bias.as_ref().map(parse_logit_bias_map);
+    // Determine grammar mode from response_format.
+    let grammar_mode = match &req.response_format {
+        Some(rf) if rf.type_field == "json_object" => crate::sampler::GrammarMode::JsonObject,
+        Some(rf) if rf.type_field == "json_schema" => crate::sampler::GrammarMode::JsonSchema,
+        _ => crate::sampler::GrammarMode::None,
+    };
+    let params = build_sampling_params_with_grammar(
         req.temperature,
         req.top_p,
         req.top_k,
+        req.min_p,
         req.repetition_penalty,
+        req.frequency_penalty,
+        req.presence_penalty,
+        logit_bias,
+        req.seed,
+        logprobs_enabled,
+        top_logprobs,
         max_tokens,
+        req.stop.into_vec(),
+        tokenizer,
         &state.default_params,
+        grammar_mode,
     );
-
-    // Resolve per-request stop strings into token IDs.
-    let stop_strings = req.stop.into_vec();
-    if !stop_strings.is_empty() {
-        params.extra_stop_token_ids = resolve_stop_token_ids(stop_strings, tokenizer);
-    }
 
     let is_stream = req.stream.unwrap_or(false);
 
@@ -1601,6 +1764,11 @@ async fn chat_completions(
 
         match response_rx.await {
             Ok(result) => {
+                let choice_logprobs = if result.token_logprobs.is_empty() {
+                    None
+                } else {
+                    Some(token_logprobs_to_choice(&result.token_logprobs))
+                };
                 let response = ChatCompletionResponse {
                     id: request_id,
                     object: "chat.completion",
@@ -1613,6 +1781,7 @@ async fn chat_completions(
                             content: result.output_text,
                         },
                         finish_reason: Some(result.finish_reason),
+                        logprobs: choice_logprobs,
                     }],
                     usage: UsageInfo {
                         prompt_tokens: result.prompt_tokens,
@@ -1625,6 +1794,43 @@ async fn chat_completions(
             Err(_) => Err(server_error("Engine dropped the request")),
         }
     }
+}
+
+/// Convert a slice of per-token [`TokenLogprob`] values (from a non-streaming
+/// [`GenerationResult`]) into the OpenAI [`ChoiceLogprobs`] structure.
+fn token_logprobs_to_choice(token_logprobs: &[crate::sampler::TokenLogprob]) -> ChoiceLogprobs {
+    let content = token_logprobs
+        .iter()
+        .map(|lp| {
+            let bytes = Some(lp.token_text.as_bytes().to_vec());
+            let top_logprobs = lp
+                .top_logprobs
+                .iter()
+                .zip(
+                    lp.top_logprob_texts
+                        .iter()
+                        .map(Some)
+                        .chain(std::iter::repeat(None)),
+                )
+                .map(|(&(tid, tlp), text)| {
+                    let tok_text = text.cloned().unwrap_or_else(|| format!("<{}>", tid));
+                    let tok_bytes = Some(tok_text.as_bytes().to_vec());
+                    TopLogprobEntry {
+                        token: tok_text,
+                        logprob: tlp,
+                        bytes: tok_bytes,
+                    }
+                })
+                .collect();
+            LogprobEntry {
+                token: lp.token_text.clone(),
+                logprob: lp.logprob,
+                bytes,
+                top_logprobs,
+            }
+        })
+        .collect();
+    ChoiceLogprobs { content }
 }
 
 /// Serialize `value` to a JSON SSE event.  Returns `None` and logs an error on failure.
@@ -1659,6 +1865,7 @@ fn make_sse_stream(
                     reasoning_content: None,
                 },
                 finish_reason: None,
+                logprobs: None,
             }],
         };
         match to_sse_event(&first_chunk, "chat stream role chunk") {
@@ -1673,7 +1880,7 @@ fn make_sse_stream(
             let content = if is_stop || token.text.is_empty() {
                 None
             } else {
-                Some(token.text)
+                Some(token.text.clone())
             };
             let reasoning_content = if token.reasoning_content.is_empty() {
                 None
@@ -1685,6 +1892,43 @@ fn make_sse_stream(
             if content.is_none() && reasoning_content.is_none() && token.finish_reason.is_none() {
                 continue;
             }
+
+            // Build per-token logprob if present.
+            let chunk_logprobs = token.logprob.as_ref().map(|lp| {
+                let token_text = content.clone().unwrap_or_default();
+                let bytes = Some(token_text.as_bytes().to_vec());
+                // Use pre-decoded text from the engine; fall back to the token
+                // ID in angle-bracket notation only if decoding was skipped.
+                let top_logprobs = lp
+                    .top_logprobs
+                    .iter()
+                    .zip(
+                        lp.top_logprob_texts
+                            .iter()
+                            .map(Some)
+                            .chain(std::iter::repeat(None)),
+                    )
+                    .map(|(&(tid, tlp), text)| {
+                        let tok_text = text
+                            .cloned()
+                            .unwrap_or_else(|| format!("<{}>", tid));
+                        let tok_bytes = Some(tok_text.as_bytes().to_vec());
+                        TopLogprobEntry {
+                            token: tok_text,
+                            logprob: tlp,
+                            bytes: tok_bytes,
+                        }
+                    })
+                    .collect();
+                ChoiceLogprobs {
+                    content: vec![LogprobEntry {
+                        token: token_text,
+                        logprob: lp.logprob,
+                        bytes,
+                        top_logprobs,
+                    }],
+                }
+            });
 
             let chunk = ChatCompletionStreamResponse {
                 id: request_id.clone(),
@@ -1699,6 +1943,7 @@ fn make_sse_stream(
                         reasoning_content,
                     },
                     finish_reason: token.finish_reason,
+                    logprobs: chunk_logprobs,
                 }],
             };
             match to_sse_event(&chunk, "chat stream chunk") {
@@ -1728,6 +1973,16 @@ pub struct CompletionRequest {
     pub stream: Option<bool>,
     #[serde(default)]
     pub repetition_penalty: Option<f64>,
+    #[serde(default)]
+    pub frequency_penalty: Option<f64>,
+    #[serde(default)]
+    pub presence_penalty: Option<f64>,
+    #[serde(default)]
+    pub seed: Option<u64>,
+    #[serde(default)]
+    pub logprobs: Option<u8>,
+    #[serde(default)]
+    pub stop: StopSequences,
 }
 
 #[derive(Debug, Serialize)]
@@ -1806,12 +2061,22 @@ async fn completions(
 
     let requested_max_tokens = req.max_tokens.unwrap_or(state.default_params.max_tokens);
     let max_tokens = clamp_max_tokens(requested_max_tokens, prompt_tokens.len(), max_seq_len);
+    let logprobs_n = req.logprobs.unwrap_or(0);
     let params = build_sampling_params(
         req.temperature,
         req.top_p,
         req.top_k,
+        None, // min_p not in CompletionRequest
         req.repetition_penalty,
+        req.frequency_penalty,
+        req.presence_penalty,
+        None, // logit_bias not in CompletionRequest yet
+        req.seed,
+        logprobs_n > 0,
+        logprobs_n,
         max_tokens,
+        req.stop.into_vec(),
+        tokenizer,
         &state.default_params,
     );
 
@@ -1991,8 +2256,17 @@ async fn anthropic_messages(
         req.temperature,
         req.top_p,
         req.top_k,
-        None,
+        None,  // min_p
+        None,  // repetition_penalty
+        None,  // frequency_penalty
+        None,  // presence_penalty
+        None,  // logit_bias
+        None,  // seed
+        false, // logprobs
+        0,     // top_logprobs
         max_tokens,
+        vec![], // stop strings
+        tokenizer,
         &state.default_params,
     );
 
@@ -2205,16 +2479,53 @@ fn make_anthropic_sse_stream(
 
 async fn list_models(State(state): State<Arc<AppState>>) -> Json<ModelListResponse> {
     let created = unix_now();
-    let guard = state.slot.read().await;
-    let data = match &*guard {
-        ModelSlot::Ready(lm) => vec![ModelInfo {
-            id: lm.model_id.clone(),
-            object: "model",
-            created,
-            owned_by: "inferrs".to_string(),
-        }],
-        _ => vec![],
+
+    // Determine which model (if any) is currently loaded.
+    let loaded_id: Option<String> = {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => Some(lm.model_id.clone()),
+            _ => None,
+        }
     };
+
+    // Build the list from all models in the HuggingFace hub cache.
+    // The currently-loaded model is labelled "inferrs (loaded)".
+    let mut data: Vec<ModelInfo> = crate::util::list_cached_models()
+        .into_iter()
+        .map(|m| {
+            let owned_by = if Some(&m.model_id) == loaded_id.as_ref() {
+                "inferrs (loaded)".to_string()
+            } else {
+                "inferrs".to_string()
+            };
+            let model_created = m
+                .modified
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(created);
+            ModelInfo {
+                id: m.model_id,
+                object: "model",
+                created: model_created,
+                owned_by,
+            }
+        })
+        .collect();
+
+    // If the loaded model isn't in the cache (e.g. loaded from a local path),
+    // still expose it in the list.
+    if let Some(ref id) = loaded_id {
+        if !data.iter().any(|m| &m.id == id) {
+            data.push(ModelInfo {
+                id: id.clone(),
+                object: "model",
+                created,
+                owned_by: "inferrs (loaded)".to_string(),
+            });
+        }
+    }
+
     Json(ModelListResponse {
         object: "list",
         data,
@@ -2225,72 +2536,307 @@ async fn health() -> Json<HealthResponse> {
     Json(HealthResponse { status: "ok" })
 }
 
+// ─── Embeddings handlers ──────────────────────────────────────────────────────
+
+/// `POST /v1/embeddings` — OpenAI-compatible text embedding endpoint.
+///
+/// Tokenises each input string, runs a forward pass through the model,
+/// mean-pools the output, L2-normalises, and returns the embedding vectors.
+async fn embeddings(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<EmbeddingRequest>,
+) -> impl IntoResponse {
+    let start = std::time::Instant::now();
+
+    let lm = {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => lm.clone(),
+            ModelSlot::Loading { .. } => {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({"error": "model is loading"})),
+                ));
+            }
+            ModelSlot::Empty => {
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    Json(serde_json::json!({"error": "no model loaded"})),
+                ));
+            }
+        }
+    };
+
+    let (engine_tx, tokenizer, ..) = worker_fields(&lm).map_err(|e| {
+        let msg = e.1.error.message.clone();
+        (e.0, Json(serde_json::json!({"error": msg})))
+    })?;
+
+    let model_id = lm.model_id.clone();
+    let inputs = req.input.into_vec();
+
+    let mut data: Vec<EmbeddingObject> = Vec::with_capacity(inputs.len());
+    let mut total_prompt_tokens = 0usize;
+
+    for (idx, text) in inputs.iter().enumerate() {
+        let tokens = tokenizer.encode(text, true).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("tokenization failed: {e}")})),
+            )
+        })?;
+        total_prompt_tokens += tokens.len();
+
+        let (response_tx, response_rx) = oneshot::channel();
+        let req = crate::engine::EngineRequest::Embed {
+            prompt_tokens: tokens,
+            response_tx,
+        };
+        if engine_tx.send(req).await.is_err() {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "engine unavailable"})),
+            ));
+        }
+        let result = response_rx
+            .await
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "engine dropped request"})),
+                )
+            })?
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": e.to_string()})),
+                )
+            })?;
+        data.push(EmbeddingObject {
+            object: "embedding",
+            index: idx,
+            embedding: result.embedding,
+        });
+    }
+
+    let elapsed_ns = start.elapsed().as_nanos() as u64;
+    tracing::debug!(
+        "Embeddings: {} inputs, {} tokens, {}ms",
+        data.len(),
+        total_prompt_tokens,
+        elapsed_ns / 1_000_000
+    );
+
+    Ok(Json(EmbeddingResponse {
+        object: "list",
+        data,
+        model: model_id,
+        usage: EmbeddingUsage {
+            prompt_tokens: total_prompt_tokens,
+            total_tokens: total_prompt_tokens,
+        },
+    }))
+}
+
+/// `POST /api/embed` — Ollama-compatible batch embedding endpoint.
+async fn ollama_embed(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<OllamaEmbedRequest>,
+) -> impl IntoResponse {
+    let start = std::time::Instant::now();
+
+    let lm = {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => lm.clone(),
+            _ => {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({"error": "no model loaded"})),
+                ));
+            }
+        }
+    };
+
+    let (engine_tx, tokenizer, ..) = worker_fields(&lm).map_err(|e| {
+        let msg = e.1.error.message.clone();
+        (e.0, Json(serde_json::json!({"error": msg})))
+    })?;
+
+    let model_id = lm.model_id.clone();
+    let inputs = req.input.into_vec();
+
+    let mut embeddings: Vec<Vec<f32>> = Vec::with_capacity(inputs.len());
+    let mut total_tokens = 0usize;
+
+    for text in &inputs {
+        let tokens = tokenizer.encode(text, true).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("tokenization failed: {e}")})),
+            )
+        })?;
+        total_tokens += tokens.len();
+
+        let (response_tx, response_rx) = oneshot::channel();
+        if engine_tx
+            .send(crate::engine::EngineRequest::Embed {
+                prompt_tokens: tokens,
+                response_tx,
+            })
+            .await
+            .is_err()
+        {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "engine unavailable"})),
+            ));
+        }
+        let result = response_rx
+            .await
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "engine dropped request"})),
+                )
+            })?
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": e.to_string()})),
+                )
+            })?;
+        embeddings.push(result.embedding);
+    }
+
+    let elapsed_ns = start.elapsed().as_nanos() as u64;
+
+    Ok(Json(OllamaEmbedResponse {
+        model: model_id,
+        embeddings,
+        total_duration: elapsed_ns,
+        load_duration: 0,
+        prompt_eval_count: total_tokens,
+    }))
+}
+
 /// Build [`SamplingParams`] by overlaying per-request values on top of the
 /// server's default params.  Any `None` field falls back to the default.
 ///
-/// `extra_stop_token_ids` is derived from the request's `stop` field: each
-/// stop string is looked up in the tokenizer vocabulary and, when it maps to a
-/// single token, that token ID is added to the per-request stop set.
-/// Multi-token stop strings are logged as a warning and skipped; full
-/// multi-token stop-sequence matching is not yet supported.
+/// Stop strings are split: single-token strings (or exact vocab entries) are
+/// promoted to `extra_stop_token_ids` for zero-latency matching; multi-token
+/// strings go into `stop_strings` for suffix-buffer matching in the engine.
+#[allow(clippy::too_many_arguments)]
 fn build_sampling_params(
     temperature: Option<f64>,
     top_p: Option<f64>,
     top_k: Option<usize>,
+    min_p: Option<f64>,
     repetition_penalty: Option<f64>,
+    frequency_penalty: Option<f64>,
+    presence_penalty: Option<f64>,
+    logit_bias: Option<std::collections::HashMap<u32, f32>>,
+    seed: Option<u64>,
+    logprobs: bool,
+    top_logprobs: u8,
     max_tokens: usize,
+    stop_strings: Vec<String>,
+    tokenizer: &crate::tokenizer::Tokenizer,
     defaults: &SamplingParams,
 ) -> SamplingParams {
+    build_sampling_params_with_grammar(
+        temperature,
+        top_p,
+        top_k,
+        min_p,
+        repetition_penalty,
+        frequency_penalty,
+        presence_penalty,
+        logit_bias,
+        seed,
+        logprobs,
+        top_logprobs,
+        max_tokens,
+        stop_strings,
+        tokenizer,
+        defaults,
+        crate::sampler::GrammarMode::None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_sampling_params_with_grammar(
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<usize>,
+    min_p: Option<f64>,
+    repetition_penalty: Option<f64>,
+    frequency_penalty: Option<f64>,
+    presence_penalty: Option<f64>,
+    logit_bias: Option<std::collections::HashMap<u32, f32>>,
+    seed: Option<u64>,
+    logprobs: bool,
+    top_logprobs: u8,
+    max_tokens: usize,
+    stop_strings: Vec<String>,
+    tokenizer: &crate::tokenizer::Tokenizer,
+    defaults: &SamplingParams,
+    grammar_mode: crate::sampler::GrammarMode,
+) -> SamplingParams {
+    let (extra_stop_token_ids, stop_strings) = resolve_stop_sequences(stop_strings, tokenizer);
     SamplingParams {
         temperature: temperature.unwrap_or(defaults.temperature),
         top_p: top_p.unwrap_or(defaults.top_p),
         top_k: top_k.unwrap_or(defaults.top_k),
+        min_p: min_p.unwrap_or(defaults.min_p),
         repetition_penalty: repetition_penalty.unwrap_or(defaults.repetition_penalty),
+        frequency_penalty: frequency_penalty.unwrap_or(defaults.frequency_penalty),
+        presence_penalty: presence_penalty.unwrap_or(defaults.presence_penalty),
+        logit_bias: logit_bias.unwrap_or_default(),
+        seed,
+        logprobs,
+        top_logprobs,
         max_tokens,
-        extra_stop_token_ids: vec![],
+        extra_stop_token_ids,
+        stop_strings,
+        grammar_mode,
     }
 }
 
-/// Resolve stop strings from an OpenAI-compatible request into per-request
-/// stop token IDs.
+/// Resolve stop strings into token-ID stops and multi-token string stops.
 ///
-/// Each stop string is looked up directly in the tokenizer vocabulary
-/// (single-token strings such as `"</s>"` or `"<|eot_id|>"`).  Multi-token
-/// strings require buffered output matching which is not yet supported; they
-/// are logged as a warning and skipped.
-fn resolve_stop_token_ids(
+/// - Strings that map directly to a single vocab token → `extra_stop_token_ids`
+/// - All other non-empty strings → `stop_strings` (suffix-buffer matching)
+fn resolve_stop_sequences(
     stop_strings: Vec<String>,
     tokenizer: &crate::tokenizer::Tokenizer,
-) -> Vec<u32> {
-    let mut ids = Vec::new();
+) -> (Vec<u32>, Vec<String>) {
+    let mut ids: Vec<u32> = Vec::new();
+    let mut strings: Vec<String> = Vec::new();
     for s in stop_strings {
         if s.is_empty() {
             continue;
         }
+        // Check direct vocab lookup first (fastest path for special tokens).
         if let Some(id) = tokenizer.token_to_id(&s) {
             ids.push(id);
-        } else {
-            // Try tokenizing the string; if it encodes to a single token we
-            // can still use it as a stop token ID.
-            match tokenizer.encode(&s, false) {
-                Ok(tokens) if tokens.len() == 1 => {
-                    ids.push(tokens[0]);
-                }
-                Ok(tokens) => {
-                    tracing::warn!(
-                        "Stop string {:?} encodes to {} tokens — \
-                         multi-token stop sequences are not yet supported and will be ignored",
-                        s,
-                        tokens.len()
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to tokenize stop string {:?}: {}", s, e);
-                }
+            continue;
+        }
+        // Try encoding: single-token result → token ID stop.
+        match tokenizer.encode(&s, false) {
+            Ok(tokens) if tokens.len() == 1 => {
+                ids.push(tokens[0]);
+            }
+            Ok(_) => {
+                // Multi-token stop string — use suffix buffer matching.
+                strings.push(s);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to tokenize stop string {:?}: {}", s, e);
             }
         }
     }
-    ids
+    (ids, strings)
 }
 
 /// Clamp `requested` so that `prompt_len + result <= max_seq_len`.
@@ -2573,19 +3119,58 @@ async fn ollama_version() -> Json<OllamaVersionResponse> {
 
 /// `GET /api/tags` and `HEAD /api/tags` — list locally available models.
 async fn ollama_tags(State(state): State<Arc<AppState>>) -> Json<OllamaListResponse> {
-    let guard = state.slot.read().await;
-    let models = match &*guard {
-        ModelSlot::Ready(lm) => vec![OllamaModelEntry {
-            name: lm.model_id.clone(),
-            model: lm.model_id.clone(),
-            modified_at: "2025-01-01T00:00:00Z".to_string(),
-            size: 0,
-            digest: OLLAMA_PLACEHOLDER_DIGEST.to_string(),
-            details: OllamaModelDetails::default(),
-        }],
-        _ => vec![],
+    let loaded_id: Option<String> = {
+        let guard = state.slot.read().await;
+        match &*guard {
+            ModelSlot::Ready(lm) => Some(lm.model_id.clone()),
+            _ => None,
+        }
     };
+
+    // Enumerate all models in the HF hub cache.
+    let mut models: Vec<OllamaModelEntry> = crate::util::list_cached_models()
+        .into_iter()
+        .map(|m| {
+            let modified_at = m
+                .modified
+                .map(rfc3339_from_system_time)
+                .unwrap_or_else(|| "2025-01-01T00:00:00Z".to_string());
+            OllamaModelEntry {
+                name: m.model_id.clone(),
+                model: m.model_id,
+                modified_at,
+                size: m.size_bytes,
+                digest: OLLAMA_PLACEHOLDER_DIGEST.to_string(),
+                details: OllamaModelDetails::default(),
+            }
+        })
+        .collect();
+
+    // If the loaded model isn't in the cache, still surface it.
+    if let Some(ref id) = loaded_id {
+        if !models.iter().any(|m| &m.name == id) {
+            models.push(OllamaModelEntry {
+                name: id.clone(),
+                model: id.clone(),
+                modified_at: "2025-01-01T00:00:00Z".to_string(),
+                size: 0,
+                digest: OLLAMA_PLACEHOLDER_DIGEST.to_string(),
+                details: OllamaModelDetails::default(),
+            });
+        }
+    }
+
     Json(OllamaListResponse { models })
+}
+
+/// Convert a [`std::time::SystemTime`] to an RFC-3339 timestamp string.
+fn rfc3339_from_system_time(t: std::time::SystemTime) -> String {
+    let secs = t
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let (y, mo, d, h, mi, s) = secs_to_ymd_hms(secs);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z", y, mo, d, h, mi, s)
 }
 
 /// `GET /api/ps` — list running (currently loaded) models.
@@ -2690,51 +3275,64 @@ fn secs_to_ymd_hms(mut secs: u64) -> (u64, u64, u64, u64, u64, u64) {
 
 /// Extract sampling params from optional [`OllamaOptions`].
 #[allow(clippy::type_complexity)]
+/// Parsed Ollama options ready for `build_sampling_params`.
+struct OllamaParamBundle {
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<usize>,
+    min_p: Option<f64>,
+    repetition_penalty: Option<f64>,
+    frequency_penalty: Option<f64>,
+    presence_penalty: Option<f64>,
+    seed: Option<u64>,
+    logit_bias: Option<std::collections::HashMap<u32, f32>>,
+    max_tokens: usize,
+    stop: Vec<String>,
+}
+
 fn ollama_options_to_params(
     opts: Option<&OllamaOptions>,
     defaults: &SamplingParams,
-) -> (
-    Option<f64>,
-    Option<f64>,
-    Option<usize>,
-    Option<f64>,
-    usize,
-    Vec<String>,
-) {
+) -> OllamaParamBundle {
     let temperature = opts.and_then(|o| o.temperature);
     let top_p = opts.and_then(|o| o.top_p);
     let top_k = opts.and_then(|o| o.top_k);
+    let min_p = opts.and_then(|o| o.min_p);
     let repetition_penalty = opts.and_then(|o| o.repeat_penalty);
-    let num_predict = opts
+    let frequency_penalty = opts.and_then(|o| o.frequency_penalty);
+    let presence_penalty = opts.and_then(|o| o.presence_penalty);
+    let seed = opts.and_then(|o| o.seed).map(|s| s as u64);
+    let max_tokens = opts
         .and_then(|o| o.num_predict)
         .unwrap_or(defaults.max_tokens);
     let stop = opts.and_then(|o| o.stop.clone()).unwrap_or_default();
+    let logit_bias = opts
+        .and_then(|o| o.logit_bias.as_ref())
+        .map(parse_logit_bias_map);
 
-    // Warn when the client sends sampling params that the engine doesn't
-    // support yet, so callers know they have no effect.
-    if let Some(o) = opts {
-        if o.seed.is_some() {
-            tracing::warn!("option 'seed' is not yet supported and will be ignored");
-        }
-        if o.min_p.is_some() {
-            tracing::warn!("option 'min_p' is not yet supported and will be ignored");
-        }
-        if o.presence_penalty.is_some() {
-            tracing::warn!("option 'presence_penalty' is not yet supported and will be ignored");
-        }
-        if o.frequency_penalty.is_some() {
-            tracing::warn!("option 'frequency_penalty' is not yet supported and will be ignored");
-        }
-    }
-
-    (
+    OllamaParamBundle {
         temperature,
         top_p,
         top_k,
+        min_p,
         repetition_penalty,
-        num_predict,
+        frequency_penalty,
+        presence_penalty,
+        seed,
+        logit_bias,
+        max_tokens,
         stop,
-    )
+    }
+}
+
+/// Convert a `{"token_id_string": bias_value}` map (OpenAI `logit_bias` format)
+/// to the `HashMap<u32, f32>` format used internally.
+fn parse_logit_bias_map(
+    map: &std::collections::HashMap<String, f64>,
+) -> std::collections::HashMap<u32, f32> {
+    map.iter()
+        .filter_map(|(k, &v)| k.parse::<u32>().ok().map(|id| (id, v as f32)))
+        .collect()
 }
 
 /// Shared Ollama model/tokenizer validation.  Returns the tokenizer when the
@@ -3037,18 +3635,25 @@ async fn ollama_generate(
 
     ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
-    let (temperature, top_p, top_k, repetition_penalty, max_tokens, stop) =
-        ollama_options_to_params(req.options.as_ref(), &state.default_params);
-    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
-    let mut params = build_sampling_params(
-        temperature,
-        top_p,
-        top_k,
-        repetition_penalty,
+    let pb = ollama_options_to_params(req.options.as_ref(), &state.default_params);
+    let max_tokens = clamp_max_tokens(pb.max_tokens, prompt_tokens.len(), max_seq_len);
+    let params = build_sampling_params(
+        pb.temperature,
+        pb.top_p,
+        pb.top_k,
+        pb.min_p,
+        pb.repetition_penalty,
+        pb.frequency_penalty,
+        pb.presence_penalty,
+        pb.logit_bias,
+        pb.seed,
+        false, // logprobs
+        0,
         max_tokens,
+        pb.stop,
+        tokenizer,
         &state.default_params,
     );
-    params.extra_stop_token_ids = resolve_stop_token_ids(stop, tokenizer);
 
     let is_stream = req.stream.unwrap_or(true); // Ollama streams by default
 
@@ -3259,18 +3864,25 @@ async fn ollama_chat(
 
     ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
-    let (temperature, top_p, top_k, repetition_penalty, max_tokens, stop) =
-        ollama_options_to_params(req.options.as_ref(), &state.default_params);
-    let max_tokens = clamp_max_tokens(max_tokens, prompt_tokens.len(), max_seq_len);
-    let mut params = build_sampling_params(
-        temperature,
-        top_p,
-        top_k,
-        repetition_penalty,
+    let pb = ollama_options_to_params(req.options.as_ref(), &state.default_params);
+    let max_tokens = clamp_max_tokens(pb.max_tokens, prompt_tokens.len(), max_seq_len);
+    let params = build_sampling_params(
+        pb.temperature,
+        pb.top_p,
+        pb.top_k,
+        pb.min_p,
+        pb.repetition_penalty,
+        pb.frequency_penalty,
+        pb.presence_penalty,
+        pb.logit_bias,
+        pb.seed,
+        false, // logprobs
+        0,
         max_tokens,
+        pb.stop,
+        tokenizer,
         &state.default_params,
     );
-    params.extra_stop_token_ids = resolve_stop_token_ids(stop, tokenizer);
 
     let think_id = tokenizer
         .token_to_id("<|think|>")

--- a/inferrs/src/util.rs
+++ b/inferrs/src/util.rs
@@ -1,6 +1,10 @@
 //! Shared utility helpers.
+//!
+//! Includes model cache discovery shared by the `inferrs list` CLI command
+//! and the HTTP server's `/v1/models` and `/api/tags` endpoints.
 
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use anyhow::Result;
 
@@ -39,6 +43,83 @@ pub fn home_dir() -> PathBuf {
         .or_else(|_| std::env::var("USERPROFILE"))
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("/"))
+}
+
+// ── Cached model discovery ────────────────────────────────────────────────────
+
+/// Metadata for a single model found in the HuggingFace hub cache.
+#[derive(Debug, Clone)]
+pub struct CachedModel {
+    /// HuggingFace model ID, e.g. `"google/gemma-4-E2B-it"`.
+    pub model_id: String,
+    /// Total size of all files in the model's cache directory (bytes).
+    pub size_bytes: u64,
+    /// Last modification time of the snapshot directory, if available.
+    pub modified: Option<SystemTime>,
+}
+
+/// Scan the HuggingFace hub cache and return all models found there.
+///
+/// The cache layout is:
+/// ```text
+/// $HF_HOME/hub/
+///   models--Org--Name/
+///     snapshots/
+///       <sha>/
+///         config.json   ← presence indicates a usable model snapshot
+/// ```
+///
+/// Each `models--*` subdirectory maps to one model ID.  The returned list is
+/// sorted alphabetically by model ID.
+pub fn list_cached_models() -> Vec<CachedModel> {
+    let cache_dir = cache_root();
+    if !cache_dir.exists() {
+        return vec![];
+    }
+
+    let mut models: Vec<CachedModel> = std::fs::read_dir(&cache_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_type().map(|t| t.is_dir()).unwrap_or(false)
+                && e.file_name().to_string_lossy().starts_with("models--")
+        })
+        .map(|e| {
+            let folder = e.file_name().to_string_lossy().into_owned();
+            let model_id = folder_to_model_id(&folder);
+            let size_bytes = dir_size(&e.path()).unwrap_or(0);
+            // Try to find the most recent snapshot modification time.
+            let modified = snapshot_mtime(&e.path());
+            CachedModel {
+                model_id,
+                size_bytes,
+                modified,
+            }
+        })
+        .collect();
+
+    models.sort_by(|a, b| a.model_id.cmp(&b.model_id));
+    models
+}
+
+/// Convert the HF hub folder name `"models--Org--Name"` → `"Org/Name"`.
+pub fn folder_to_model_id(folder: &str) -> String {
+    folder
+        .strip_prefix("models--")
+        .unwrap_or(folder)
+        .replace("--", "/")
+}
+
+/// Return the most recent mtime among all snapshot directories for a model.
+fn snapshot_mtime(model_dir: &Path) -> Option<SystemTime> {
+    let snapshots_dir = model_dir.join("snapshots");
+    std::fs::read_dir(&snapshots_dir)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        .filter_map(|e| e.metadata().ok()?.modified().ok())
+        .max()
 }
 
 /// Recursively sum the size of all files under `path`.


### PR DESCRIPTION
Add six feature groups inspired by llama.cpp, vLLM, and Ollama:

- Extended sampling: min-p filtering, seeded PRNG (xorshift64*), per-token logit bias, frequency penalty, and presence penalty; all wired through OpenAI and Ollama request schemas

- Multi-token stop sequences: rolling suffix buffer per sequence enables stop strings that span more than one token; single-token stops are still promoted to token-ID set for zero-latency matching

- Logprobs: sample_token now returns TokenLogprob with per-token log probability and top-k alternatives; streamed and non-streamed responses include ChoiceLogprobs matching the OpenAI format

- Model listing from cache: /v1/models and /api/tags now enumerate all models in the HuggingFace hub cache with real sizes and mtimes rather than only the currently loaded model

- Embeddings: POST /v1/embeddings and POST /api/embed run a forward pass, mean-pool the output, and return L2-normalised vectors; handled inline in the engine loop via a new EngineRequest::Embed variant

- JSON grammar: new grammar.rs implements a byte-level FSM that masks invalid token logits at each step; activated via response_format {"type":"json_object"} or {"type":"json_schema"}