### PR TITLE
add ls alias and GGUF-only repo support

### DIFF
--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -130,8 +130,12 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         .model
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("No model specified; pass a HuggingFace model ID"))?;
-    let model_files =
-        crate::hub::download_and_maybe_quantize(model_id, &args.revision, quant_dtype)?;
+    let model_files = crate::hub::download_and_maybe_quantize(
+        model_id,
+        &args.revision,
+        args.gguf_file.as_deref(),
+        quant_dtype,
+    )?;
 
     let raw_config = RawConfig::from_file(&model_files.config_path)?;
     let arch = raw_config.detect_architecture()?;

--- a/inferrs/src/hub.rs
+++ b/inferrs/src/hub.rs
@@ -5,6 +5,10 @@ use candle_core::quantized::GgmlDType;
 use hf_hub::api::sync::Api;
 use std::path::PathBuf;
 
+/// GGUF metadata key that stores the HuggingFace repo ID of the source model
+/// (e.g. "google/gemma-4-E2B-it").  Set by ggml-org conversion scripts.
+const GGUF_SOURCE_REPO_KEY: &str = "general.source.repo_id";
+
 /// Files needed to load a model.
 pub struct ModelFiles {
     pub config_path: PathBuf,
@@ -74,7 +78,15 @@ pub fn load_local_model(path: &std::path::Path) -> Result<ModelFiles> {
 }
 
 /// Download model files from HuggingFace Hub.
-pub fn download_model(model_id: &str, revision: &str) -> Result<ModelFiles> {
+///
+/// When `gguf_file` is `Some`, the repo is treated as a GGUF-only repo and
+/// that specific file is downloaded.  When `None`, the repo is expected to
+/// contain safetensors weights and the usual config/tokenizer files.
+pub fn download_model(
+    model_id: &str,
+    revision: &str,
+    gguf_file: Option<&str>,
+) -> Result<ModelFiles> {
     // If the model_id looks like a local path, load directly without network.
     let as_path = std::path::Path::new(model_id);
     if as_path.is_absolute()
@@ -94,10 +106,20 @@ pub fn download_model(model_id: &str, revision: &str) -> Result<ModelFiles> {
         revision.to_string(),
     ));
 
-    // Download config.json
-    let config_path = repo
-        .get("config.json")
-        .context("Failed to download config.json")?;
+    // Fast-path: caller explicitly asked for a specific GGUF file.
+    if let Some(fname) = gguf_file {
+        return download_gguf_only_repo(&repo, &api, model_id, fname);
+    }
+
+    // Probe for config.json.  If it is missing the repo is likely GGUF-only
+    // (e.g. ggml-org/gemma-4-E2B-it-GGUF).  Auto-detect and handle it.
+    let config_result = repo.get("config.json");
+    if config_result.is_err() {
+        tracing::info!("config.json not found in {model_id} — checking for GGUF-only repo");
+        let gguf_fname = pick_best_gguf_file(&repo, model_id)?;
+        return download_gguf_only_repo(&repo, &api, model_id, &gguf_fname);
+    }
+    let config_path = config_result.expect("checked above");
     tracing::info!("Downloaded config.json");
 
     // Download tokenizer.json
@@ -124,6 +146,136 @@ pub fn download_model(model_id: &str, revision: &str) -> Result<ModelFiles> {
     })
 }
 
+/// List `.gguf` files in `repo` (excluding vision projectors like `mmproj-*`)
+/// and pick the best one: prefer Q4K, then Q8_0, then the first one found.
+fn pick_best_gguf_file(repo: &hf_hub::api::sync::ApiRepo, model_id: &str) -> Result<String> {
+    let info = repo.info().with_context(|| {
+        format!("Failed to list files in {model_id}: no config.json and repo.info() failed")
+    })?;
+
+    let gguf_files: Vec<String> = info
+        .siblings
+        .iter()
+        .map(|s| s.rfilename.clone())
+        .filter(|name| {
+            name.ends_with(".gguf") && !name.starts_with("mmproj-") && !name.contains("mmproj")
+        })
+        .collect();
+
+    anyhow::ensure!(
+        !gguf_files.is_empty(),
+        "No .gguf files found in {model_id} (and no config.json present)"
+    );
+
+    // Prefer Q4K, then Q8_0, otherwise the first file.
+    let preferred = gguf_files
+        .iter()
+        .find(|f| {
+            let lower = f.to_lowercase();
+            lower.contains("q4_k_m") || lower.contains("q4k") || lower.contains("q4_k-m")
+        })
+        .or_else(|| {
+            gguf_files.iter().find(|f| {
+                let lower = f.to_lowercase();
+                lower.contains("q8_0") || lower.contains("q8-0")
+            })
+        })
+        .unwrap_or(&gguf_files[0]);
+
+    tracing::info!(
+        "GGUF-only repo detected. Available files: {gguf_files:?}. Selected: {preferred}"
+    );
+    Ok(preferred.clone())
+}
+
+/// Download a GGUF file from `repo`, then fetch `config.json` and
+/// `tokenizer.json` from the source model referenced in the GGUF metadata.
+fn download_gguf_only_repo(
+    repo: &hf_hub::api::sync::ApiRepo,
+    api: &Api,
+    model_id: &str,
+    gguf_filename: &str,
+) -> Result<ModelFiles> {
+    tracing::info!("Downloading GGUF file: {gguf_filename}");
+    let gguf_path = repo
+        .get(gguf_filename)
+        .with_context(|| format!("Failed to download {gguf_filename} from {model_id}"))?;
+    tracing::info!("Downloaded {gguf_filename}");
+
+    // Read GGUF metadata to find the source model repo.
+    let source_repo_id = read_gguf_source_repo(&gguf_path)?;
+
+    let (config_path, tokenizer_path, tokenizer_config_path) = match source_repo_id {
+        Some(ref src) => {
+            tracing::info!("Fetching config and tokenizer from source model: {src}");
+            // Always use the default branch for the source model: the
+            // `revision` argument belongs to the GGUF repo and is very
+            // unlikely to exist in the original model repo.
+            let src_repo = api.repo(hf_hub::Repo::new(src.clone(), hf_hub::RepoType::Model));
+            let config_path = src_repo.get("config.json").with_context(|| {
+                format!("Failed to download config.json from source model {src}")
+            })?;
+            tracing::info!("Downloaded config.json from {src}");
+            let tokenizer_path = src_repo.get("tokenizer.json").with_context(|| {
+                format!("Failed to download tokenizer.json from source model {src}")
+            })?;
+            tracing::info!("Downloaded tokenizer.json from {src}");
+            let tokenizer_config_path = src_repo.get("tokenizer_config.json").ok();
+            (config_path, tokenizer_path, tokenizer_config_path)
+        }
+        None => {
+            // No source repo in GGUF metadata — try the GGUF repo itself.
+            tracing::warn!(
+                "GGUF metadata does not contain '{GGUF_SOURCE_REPO_KEY}'. \
+                 Trying config.json and tokenizer.json from the same repo."
+            );
+            let config_path = repo
+                .get("config.json")
+                .context("Failed to download config.json (not in GGUF repo and no source repo found in GGUF metadata)")?;
+            let tokenizer_path = repo
+                .get("tokenizer.json")
+                .context("Failed to download tokenizer.json (not in GGUF repo and no source repo found in GGUF metadata)")?;
+            let tokenizer_config_path = repo.get("tokenizer_config.json").ok();
+            (config_path, tokenizer_path, tokenizer_config_path)
+        }
+    };
+
+    Ok(ModelFiles {
+        config_path,
+        tokenizer_path,
+        tokenizer_config_path,
+        // GGUF-only repos have no safetensors; weight_paths stays empty.
+        weight_paths: vec![],
+        gguf_path: Some(gguf_path),
+    })
+}
+
+/// Open a GGUF file and extract the value of `general.source.repo_id` from
+/// its metadata, returning `None` if the key is absent or the file cannot be
+/// read.
+fn read_gguf_source_repo(gguf_path: &std::path::Path) -> Result<Option<String>> {
+    use candle_core::quantized::gguf_file;
+
+    let file = std::fs::File::open(gguf_path)
+        .with_context(|| format!("Cannot open GGUF {}", gguf_path.display()))?;
+    let mut reader = std::io::BufReader::new(file);
+
+    let content = gguf_file::Content::read(&mut reader)
+        .with_context(|| format!("Failed to parse GGUF header in {}", gguf_path.display()))?;
+
+    let repo_id = content
+        .metadata
+        .get(GGUF_SOURCE_REPO_KEY)
+        .and_then(|v| v.to_string().ok())
+        .cloned();
+
+    if let Some(ref id) = repo_id {
+        tracing::info!("GGUF source repo: {id}");
+    }
+
+    Ok(repo_id)
+}
+
 /// Download the model (same as [`download_model`]) and, when `quant_dtype` is
 /// `Some`, ensure a quantized GGUF is present on disk.
 ///
@@ -131,16 +283,28 @@ pub fn download_model(model_id: &str, revision: &str) -> Result<ModelFiles> {
 /// If the file already exists it is reused without re-running the conversion.
 /// Quantization happens on the CPU and can take up to a few minutes for large
 /// models; progress is logged at INFO level.
+///
+/// `gguf_file` is forwarded to [`download_model`] to support GGUF-only repos.
 pub fn download_and_maybe_quantize(
     model_id: &str,
     revision: &str,
+    gguf_file: Option<&str>,
     quant_dtype: Option<GgmlDType>,
 ) -> Result<ModelFiles> {
-    let mut files = download_model(model_id, revision)?;
+    let mut files = download_model(model_id, revision, gguf_file)?;
 
     let Some(dtype) = quant_dtype else {
         return Ok(files);
     };
+
+    // GGUF-only repos have no safetensors shards to convert.  The GGUF was
+    // already downloaded; skip the quantize step.
+    if files.weight_paths.is_empty() {
+        tracing::warn!(
+            "--quantize is ignored for GGUF-only repos (the downloaded GGUF is used as-is)"
+        );
+        return Ok(files);
+    }
 
     let gguf = crate::quantize::gguf_path(&files.weight_paths, dtype);
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -75,6 +75,9 @@ enum Commands {
     Rm(rm::RmArgs),
     /// List locally cached models
     List(list::ListArgs),
+    /// List locally cached models (alias for list)
+    #[command(name = "ls")]
+    Ls(list::ListArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -161,6 +164,15 @@ pub struct ServeArgs {
     /// Disable entirely with `--turbo-quant=false`.
     #[arg(long, default_value = "8", require_equals(true))]
     pub turbo_quant: TurboQuantArg,
+
+    /// Specific GGUF filename to load from a GGUF-only repo.
+    ///
+    /// Only used when the repo contains GGUF files but no safetensors weights
+    /// (e.g. ggml-org/gemma-4-E2B-it-GGUF).  When omitted, inferrs picks the
+    /// best available quantization automatically (preferring Q4K, then Q8_0,
+    /// then the first .gguf file found).
+    #[arg(long, value_name = "FILENAME")]
+    pub gguf_file: Option<String>,
 
     /// Quantize model weights and cache the result on disk as a GGUF file.
     /// On first use the weights are quantized and saved next to the HuggingFace cache;
@@ -492,7 +504,11 @@ async fn main() -> Result<()> {
     // interactive REPL writes to stdout and log lines would corrupt the prompt display.
     // Users can still get logs by setting RUST_LOG explicitly (e.g. RUST_LOG=debug).
     let default_log_level = match &cli.command {
-        Commands::Run(_) | Commands::Bench(_) | Commands::Rm(_) | Commands::List(_) => "error",
+        Commands::Run(_)
+        | Commands::Bench(_)
+        | Commands::Rm(_)
+        | Commands::List(_)
+        | Commands::Ls(_) => "error",
         _ => "info", // Pull and Serve both benefit from info-level progress log
     };
     tracing_subscriber::fmt()
@@ -530,7 +546,7 @@ async fn main() -> Result<()> {
         Commands::Rm(args) => {
             rm::run(args)?;
         }
-        Commands::List(args) => {
+        Commands::List(args) | Commands::Ls(args) => {
             list::run(args)?;
         }
     }

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -5,12 +5,22 @@ use clap::Parser;
 
 #[derive(Parser, Clone)]
 pub struct PullArgs {
-    /// HuggingFace model ID (e.g. Qwen/Qwen3.5-0.8B)
+    /// HuggingFace model ID (e.g. Qwen/Qwen3.5-0.8B) or a GGUF-only repo
+    /// (e.g. ggml-org/gemma-4-E2B-it-GGUF).
     pub model: String,
 
     /// Git branch or tag on HuggingFace Hub
     #[arg(long, default_value = "main")]
     pub revision: String,
+
+    /// Specific GGUF filename to download from a GGUF-only repo.
+    ///
+    /// Only used when the repo contains GGUF files but no safetensors weights
+    /// (e.g. ggml-org/gemma-4-E2B-it-GGUF).  When omitted, inferrs picks the
+    /// best available quantization automatically (preferring Q4K, then Q8_0,
+    /// then the first .gguf file found).
+    #[arg(long, value_name = "FILENAME")]
+    pub gguf_file: Option<String>,
 
     /// Quantize weights and cache the result as a GGUF file.
     ///
@@ -30,7 +40,12 @@ pub fn run(args: PullArgs) -> Result<()> {
         .map(crate::quantize::parse_format)
         .transpose()?;
 
-    let files = crate::hub::download_and_maybe_quantize(&args.model, &args.revision, quant_dtype)?;
+    let files = crate::hub::download_and_maybe_quantize(
+        &args.model,
+        &args.revision,
+        args.gguf_file.as_deref(),
+        quant_dtype,
+    )?;
 
     println!("Pulled {}", args.model);
     println!("  config:    {}", files.config_path.display());

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -97,6 +97,14 @@ pub struct RunArgs {
     #[arg(long, default_value = "8", require_equals(true))]
     pub turbo_quant: crate::TurboQuantArg,
 
+    /// Specific GGUF filename to load from a GGUF-only repo.
+    ///
+    /// Only used when the repo contains GGUF files but no safetensors weights
+    /// (e.g. ggml-org/gemma-4-E2B-it-GGUF).  When omitted, inferrs picks the
+    /// best available quantization automatically.
+    #[arg(long, value_name = "FILENAME")]
+    pub gguf_file: Option<String>,
+
     /// Quantize model weights on first use and cache as GGUF.
     /// Accepted formats: Q4_0, Q4_1, Q5_0, Q5_1, Q8_0, Q2K, Q3K, Q4K, Q5K, Q6K.
     /// Plain `--quantize` defaults to Q4K.
@@ -499,6 +507,9 @@ async fn warm_up_model(client: &Client, base_url: &str, args: &RunArgs) -> Resul
     }
     if let Some(ref q) = args.quantize {
         options.insert("quantize".into(), q.clone().into());
+    }
+    if let Some(ref f) = args.gguf_file {
+        options.insert("gguf_file".into(), f.clone().into());
     }
 
     let mut body = serde_json::json!({

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -621,6 +621,8 @@ pub struct OllamaOptions {
     pub turbo_quant: Option<String>,
     /// GGUF quantization format, e.g. "Q4K"
     pub quantize: Option<String>,
+    /// Specific GGUF filename to load from a GGUF-only repo
+    pub gguf_file: Option<String>,
 
     // ── Extended sampling fields ──────────────────────────────────────────────
     pub seed: Option<i64>,
@@ -1158,6 +1160,9 @@ async fn spawn_worker(
         }
         if let Some(ref q) = o.quantize {
             args.push(format!("--quantize={q}"));
+        }
+        if let Some(ref f) = o.gguf_file {
+            args.extend(["--gguf-file".into(), f.clone()]);
         }
     }
 


### PR DESCRIPTION
Add 'ls' as an alias for `inferrs list` so users can type the shorter form without changing any existing behavior.

Add support for pulling and serving GGUF-only repos such as ggml-org/gemma-4-E2B-it-GGUF. When config.json is absent, the hub module lists repo files, auto-selects the best GGUF (preferring Q4K then Q8\_0), downloads it, reads the `general.source.repo_id` metadata key to locate the original model, and fetches config.json and tokenizer.json from there. The source model is always fetched from its default branch since the GGUF repo revision is unlikely to exist there. A new `--gguf-file` flag on pull/serve/run lets users override which GGUF file is selected.