### PR TITLE
Use candle-nn kernels + enable TurboQuant for Qwen 3.5

### DIFF
--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -519,11 +519,11 @@ pub fn load_model(
     // TurboQuant is on by default; warn if this architecture doesn't support it.
     if turbo_quant_bits.is_some() {
         match arch {
-            ModelArchitecture::Qwen3 | ModelArchitecture::Gemma4 => {} // supported
+            ModelArchitecture::Qwen3 | ModelArchitecture::Qwen35 | ModelArchitecture::Gemma4 => {}
             other => {
                 tracing::warn!(
                     "--turbo-quant is not supported for {:?} and will be ignored. \
-                     TurboQuant KV cache compression is currently only available for Qwen3 and Gemma4. \
+                     TurboQuant KV cache compression is currently only available for Qwen3, Qwen3.5, and Gemma4. \
                      Pass --turbo-quant=false to suppress this warning.",
                     other
                 );

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -470,7 +470,7 @@ impl LinearAttn {
         // ── beta = sigmoid(b_input) ───────────────────────────────────────────
         let b_f32 = b_input.to_dtype(DType::F32)?; // [b, t, n_heads]
                                                    // sigmoid(x) = 1 / (1 + exp(-x))
-        let beta = (b_f32.neg()?.exp()? + 1.0)?.recip()?; // [b, t, n_heads]
+        let beta = candle_nn::ops::sigmoid(&b_f32)?;
 
         // ── Cast q, k, v to F32 for the recurrence ────────────────────────────
         let q_f32 = q.to_dtype(DType::F32)?; // [b, t, n_heads, head_k_dim]
@@ -544,7 +544,7 @@ impl LinearAttn {
             .reshape((b * t * self.n_heads, self.head_v_dim))?; // F32
 
         // RMSNorm over head_v_dim
-        let out_normed = rms_norm_tensor(&out_flat, &self.norm_weight, 1e-6)?; // F32
+        let out_normed = candle_nn::ops::rms_norm(&out_flat, &self.norm_weight, 1e-6)?;
 
         // z gate: [b, t, value_dim] -> [b*t*n_heads, head_v_dim], then silu
         // z is in model dtype; cast to F32 for the gate multiply
@@ -630,26 +630,6 @@ fn softplus(x: &Tensor) -> Result<Tensor> {
     // max(x, 0) = (x + |x|) / 2
     let pos_part = ((x + &abs_x)? / 2.0)?;
     (pos_part + log_term).map_err(Into::into)
-}
-
-/// Manual RMSNorm over the last dimension.
-/// x: [..., head_dim], weight: [head_dim]
-/// Operates in the same dtype as x to avoid round-trip casts on Metal.
-fn rms_norm_tensor(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
-    let dtype = x.dtype();
-    let w = weight.to_dtype(dtype)?;
-
-    let rms = (x.sqr()?.mean_keepdim(candle_core::D::Minus1)? + eps)?.sqrt()?;
-    let normed = x.broadcast_div(&rms)?; // [..., head_dim]
-
-    // Reshape weight to [1, ..., 1, head_dim] to broadcast over all leading dims
-    let w_shape: Vec<usize> = {
-        let mut s = vec![1usize; x.rank() - 1];
-        s.push(w.dim(0)?);
-        s
-    };
-    let w_bc = w.reshape(w_shape)?;
-    normed.broadcast_mul(&w_bc).map_err(Into::into)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace hand-rolled RMS normalization (rms_norm_tensor) and sigmoid in Qwen3.5 linear attention with candle_nn::ops built-in kernels. Removes 20 LOC and leverages optimized Metal/CUDA kernels already available in candle-nn.

Enable TurboQuant KV cache compression for Qwen3.5 — the implementation was already wired in the model, only the architecture guard in models/mod.rs was missing from the match arm.

### Current State of Qwen 3.5 0.8B (inferrs-benchmark)

| Métrique      | inferrs     | llama.cpp   |
|---------------|-------------|-------------|
| TTFT          | 939 ms      | 51 ms       |
| Prefill       | 320 tok/s   | 5783 tok/s  |
| Decode        | 17 tok/s    | 48 tok/s    |
| Peak memory   | 630 MB      | 4079 MB     |

Current implementation is really slow since it's a naive implementation and must be considered as WIP state. There is few issues I'm working on to improve performances compared to llama cpp