### PR TITLE
perf: pre-compute conv1d_weight (F32) and lm_head transposition at model load

### DIFF
--- a/inferrs/src/models/attention_utils.rs
+++ b/inferrs/src/models/attention_utils.rs
@@ -376,14 +376,21 @@ pub fn paged_write_gather_sdpa(
 /// Extract the last-token hidden state and project it through the LM head.
 ///
 /// `x`              : `[b, t, hidden]` — hidden states after the final norm
-/// `lm_head_weight` : `[vocab, hidden]` — the unembedding weight matrix
+/// `lm_head_weight_t` : `[hidden, vocab]` — the unembedding weight matrix, pre-transposed & contiguous
 ///
 /// Returns `[b, 1, vocab]`.
-pub fn compute_logits(x: &Tensor, lm_head_weight: &Tensor) -> Result<Tensor> {
+pub fn compute_logits(x: &Tensor, lm_head_weight_t: &Tensor) -> Result<Tensor> {
+    debug_assert!(
+        lm_head_weight_t.dims().len() == 2
+            && lm_head_weight_t.dim(0)? == x.dim(2)?
+            && lm_head_weight_t.is_contiguous(),
+        "compute_logits: lm_head_weight_t must be [hidden, vocab] contiguous, got {:?}",
+        lm_head_weight_t.shape()
+    );
     let (_b, t, _h) = x.dims3()?;
     let last = x.narrow(1, t - 1, 1)?; // [b, 1, hidden]
     let last_2d = last.squeeze(1)?.contiguous()?; // [b, hidden]
-    let logits = last_2d.matmul(&lm_head_weight.t()?.contiguous()?)?; // [b, vocab]
+    let logits = last_2d.matmul(lm_head_weight_t)?; // [b, vocab]
     logits.unsqueeze(1).map_err(Into::into) // [b, 1, vocab]
 }
 

--- a/inferrs/src/models/qwen3.rs
+++ b/inferrs/src/models/qwen3.rs
@@ -332,7 +332,7 @@ pub struct Qwen3Model {
     embed_tokens: Embedding,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
-    lm_head_weight: Tensor,
+    lm_head_weight_t: Tensor,
     cos: Tensor,
     sin: Tensor,
 }
@@ -370,6 +370,7 @@ impl Qwen3Model {
             .pp("lm_head")
             .get((cfg.vocab_size, cfg.hidden_size), "weight")
             .unwrap_or_else(|_| embed_tokens.embeddings().clone());
+        let lm_head_weight_t = lm_head_weight.t()?.contiguous()?;
 
         // Precompute RoPE tables (large enough for typical sequences).
         // Qwen3 uses full-head-dim rotation (partial_factor = 1.0).
@@ -387,7 +388,7 @@ impl Qwen3Model {
             embed_tokens,
             layers,
             norm,
-            lm_head_weight,
+            lm_head_weight_t,
             cos,
             sin,
         })
@@ -402,7 +403,7 @@ impl Qwen3Model {
         }
 
         x = self.norm.forward(&x)?;
-        compute_logits(&x, &self.lm_head_weight)
+        compute_logits(&x, &self.lm_head_weight_t)
     }
 
     /// Paged-attention forward pass.
@@ -435,7 +436,7 @@ impl Qwen3Model {
         }
 
         x = self.norm.forward(&x)?;
-        compute_logits(&x, &self.lm_head_weight)
+        compute_logits(&x, &self.lm_head_weight_t)
     }
 
     pub fn clear_kv_cache(&mut self) {

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -372,7 +372,9 @@ impl LinearAttn {
         let in_proj_b = linear_no_bias(hidden, n_heads, vb.pp("in_proj_b"))?;
 
         // conv1d weight: [conv_dim, 1, kernel] -- depthwise
-        let conv1d_weight = vb.get((conv_dim, 1, kernel), "conv1d.weight")?;
+        let conv1d_weight = vb
+            .get((conv_dim, 1, kernel), "conv1d.weight")?
+            .to_dtype(DType::F32)?;
 
         // A_log, dt_bias, and norm.weight must be kept in F32 for the SSM recurrence.
         let a_log = vb
@@ -594,19 +596,9 @@ impl LinearAttn {
         self.conv_state = Some(padded.narrow(1, total - pad_len, pad_len)?.contiguous()?);
 
         // Use candle's native conv1d (Metal-accelerated depthwise: groups = c).
-        // Metal conv1d only supports F32; cast if needed and cast back after.
-        let conv_dtype = if dtype == DType::BF16 || dtype == DType::F16 {
-            DType::F32
-        } else {
-            dtype
-        };
-        let w = self.conv1d_weight.to_dtype(conv_dtype)?;
-
-        // Transpose padded: [b, pad_len+t, c] -> [b, c, pad_len+t]
-        let inp = padded.to_dtype(conv_dtype)?.transpose(1, 2)?.contiguous()?;
-
-        // Depthwise conv1d: groups = c, no padding (we already padded manually), stride=1
-        let out = inp.conv1d(&w, 0, 1, 1, c)?; // [b, c, t]
+        // conv1d_weight is pre-computed in F32 at construction time.
+        let inp = padded.to_dtype(DType::F32)?.transpose(1, 2)?.contiguous()?;
+        let out = inp.conv1d(&self.conv1d_weight, 0, 1, 1, c)?; // [b, c, t]
 
         // Transpose back: [b, c, t] -> [b, t, c], restore original dtype, then SiLU
         out.transpose(1, 2)?
@@ -752,7 +744,7 @@ pub struct Qwen35Model {
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
     // Shared weights with embed_tokens (tied)
-    lm_head_weight: Tensor,
+    lm_head_weight_t: Tensor,
     cos: Tensor,
     sin: Tensor,
 }
@@ -783,8 +775,11 @@ impl Qwen35Model {
 
         let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"), 1.0)?;
 
-        // Tied weights: lm_head = embed_tokens.weight transposed
-        let lm_head_weight = embed_tokens.embeddings().clone();
+        // Tied weights: lm_head = embed_tokens.weight transposed.
+        // This duplicates the embedding table (~vocab×hidden, e.g. ~467 MB for 0.8B)
+        // alongside embed_tokens — acceptable because it eliminates a per-forward
+        // transpose+copy of the same size.
+        let lm_head_weight_t = embed_tokens.embeddings().t()?.contiguous()?;
 
         // Precompute RoPE tables (large enough for typical sequences)
         let max_seq = 32768;
@@ -801,7 +796,7 @@ impl Qwen35Model {
             embed_tokens,
             layers,
             norm,
-            lm_head_weight,
+            lm_head_weight_t,
             cos,
             sin,
         })
@@ -818,7 +813,7 @@ impl Qwen35Model {
         }
 
         x = self.norm.forward(&x)?;
-        compute_logits(&x, &self.lm_head_weight)
+        compute_logits(&x, &self.lm_head_weight_t)
     }
 
     /// Paged-attention forward pass.
@@ -866,7 +861,7 @@ impl Qwen35Model {
         }
 
         x = self.norm.forward(&x)?;
-        compute_logits(&x, &self.lm_head_weight)
+        compute_logits(&x, &self.lm_head_weight_t)
     }
 
     pub fn clear_kv_cache(&mut self) {


### PR DESCRIPTION
## Perf: pre-compute conv1d F32 cast & lm_head transpose at model load

Two redundant operations moved from the forward path to model construction:
- BF16→F32 dtype cast of conv1d weight in linear attention layers (18 layers × per forward on Qwen3.5)
- Transpose + contiguous materialization of lm_head (~300MB per forward on Qwen3.5-0.8B)

Affects Qwen3 and Qwen3.5. Gemma4 unaffected (QLinear for lm_head, no conv1d).

**Expected gains:** Eliminates per-layer GPU dispatch overhead on every prefill + a full vocab-sized allocation on every decode step.