### PR TITLE
fix: lenient vision config parsing, gemma4 PLI dual naming, qwen3.5 SSM head count

### DIFF
--- a/inferrs/src/config.rs
+++ b/inferrs/src/config.rs
@@ -171,9 +171,48 @@ impl<'de> serde::Deserialize<'de> for VisionConfig {
                 Ok(VisionConfig::Qwen(cfg))
             }
             _ => {
+                // Attempt to parse as Gemma4 vision config.  For unsupported encoder
+                // types (e.g. Gemma3's "siglip_vision_model"), parsing will fail
+                // because Gemma4VisionConfig has required fields absent from those
+                // schemas.  Callers should use `deserialize_vision_config_opt` on
+                // RawConfig.vision_config so that failures here surface as `None`
+                // instead of aborting the whole config parse.
                 let cfg: Gemma4VisionConfig =
                     serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
                 Ok(VisionConfig::Gemma4(cfg))
+            }
+        }
+    }
+}
+
+/// Lenient deserializer for `RawConfig.vision_config`: returns `None` for
+/// unknown or unsupported vision encoder types instead of failing the whole
+/// config parse.
+pub fn deserialize_vision_config_opt<'de, D>(
+    de: D,
+) -> std::result::Result<Option<VisionConfig>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw = Option::<serde_json::Value>::deserialize(de)?;
+    let Some(val) = raw else { return Ok(None) };
+
+    let model_type = val.get("model_type").and_then(|v| v.as_str()).unwrap_or("");
+    match model_type {
+        "qwen3_5" | "qwen3_vl" => {
+            let cfg: QwenVisionConfig =
+                serde_json::from_value(val).map_err(serde::de::Error::custom)?;
+            Ok(Some(VisionConfig::Qwen(cfg)))
+        }
+        // Gemma3's vision config uses "siglip_vision_model" which has a different
+        // schema from Gemma4's SigLIP2 config — skip it silently.
+        "siglip_vision_model" => Ok(None),
+        _ => {
+            // Try to parse as Gemma4; on failure fall back to None (e.g. new
+            // unknown encoder types in future model families).
+            match serde_json::from_value::<Gemma4VisionConfig>(val) {
+                Ok(cfg) => Ok(Some(VisionConfig::Gemma4(cfg))),
+                Err(_) => Ok(None),
             }
         }
     }
@@ -276,6 +315,7 @@ pub struct RawConfig {
     // Gemma4 multimodal
     pub audio_config: Option<AudioConfig>,
     pub audio_token_id: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_vision_config_opt")]
     pub vision_config: Option<VisionConfig>,
     pub image_token_id: Option<u32>,
     pub boi_token_id: Option<u32>,

--- a/inferrs/src/models/gemma4.rs
+++ b/inferrs/src/models/gemma4.rs
@@ -109,18 +109,25 @@ impl PliEmbeddingTable {
         let mut file = std::fs::File::open(gguf_path).map_err(candle_core::Error::from)?;
         let content = gguf_file::Content::read(&mut file)?;
 
-        // Find the PLI embedding tensor.  Try both the HF name (inferrs-quantized
-        // GGUFs) and the llama.cpp canonical name (external GGUFs).
-        let tensor_name = "model.language_model.embed_tokens_per_layer.weight";
-        let gguf_tensor_name = "per_layer_token_embd.weight";
-        let info = match content
+        // Find the PLI embedding tensor — check both HF and llama.cpp naming.
+        let tensor_name = if content
+            .tensor_infos
+            .contains_key("model.language_model.embed_tokens_per_layer.weight")
+        {
+            "model.language_model.embed_tokens_per_layer.weight"
+        } else if content
+            .tensor_infos
+            .contains_key("per_layer_token_embd.weight")
+        {
+            "per_layer_token_embd.weight"
+        } else {
+            return Ok(None);
+        };
+        // key was confirmed by contains_key above; unwrap is safe
+        let info = content
             .tensor_infos
             .get(tensor_name)
-            .or_else(|| content.tensor_infos.get(gguf_tensor_name))
-        {
-            Some(t) => t,
-            None => return Ok(None),
-        };
+            .expect("tensor_name key confirmed");
 
         let embed_dim = info.shape.dims()[1];
         let vocab_size = info.shape.dims()[0];
@@ -175,7 +182,7 @@ impl PliEmbeddingTable {
         embed_dim: usize,
         dtype: candle_core::DType,
     ) -> candle_core::Result<candle_core::Tensor> {
-        use candle_core::quantized::{QStorage, QTensor};
+        use candle_core::quantized::{GgmlDType, QStorage, QTensor};
         use std::borrow::Cow;
         use std::io::{Read, Seek, SeekFrom};
 
@@ -197,12 +204,62 @@ impl PliEmbeddingTable {
                     f.read_exact(&mut row_data[i * row_bytes..(i + 1) * row_bytes])
                         .map_err(candle_core::Error::from)?;
                 }
-                let storage =
-                    QStorage::from_data(Cow::Owned(row_data), &candle_core::Device::Cpu, *dtype_q)?;
-                let row_qt = QTensor::new(storage, (n, embed_dim))?;
-                row_qt
-                    .dequantize(&candle_core::Device::Cpu)?
-                    .to_dtype(dtype)
+                // For non-quantized dtypes (BF16, F16, F32), `QStorage::from_data`
+                // reinterprets the `Vec<u8>` as typed values via raw pointer cast.
+                // This is undefined behavior when the buffer's alignment doesn't
+                // satisfy the type's requirement (e.g. BF16 needs 2-byte alignment).
+                // We handle these dtypes directly to avoid the alignment hazard.
+                match dtype_q {
+                    GgmlDType::BF16 => {
+                        let bf16_data: Vec<half::bf16> = row_data
+                            .chunks_exact(2)
+                            .map(|b| half::bf16::from_bits(u16::from_le_bytes([b[0], b[1]])))
+                            .collect();
+                        candle_core::Tensor::from_vec(
+                            bf16_data,
+                            (n, embed_dim),
+                            &candle_core::Device::Cpu,
+                        )?
+                        .to_dtype(dtype)
+                    }
+                    GgmlDType::F16 => {
+                        let f16_data: Vec<half::f16> = row_data
+                            .chunks_exact(2)
+                            .map(|b| half::f16::from_bits(u16::from_le_bytes([b[0], b[1]])))
+                            .collect();
+                        candle_core::Tensor::from_vec(
+                            f16_data,
+                            (n, embed_dim),
+                            &candle_core::Device::Cpu,
+                        )?
+                        .to_dtype(dtype)
+                    }
+                    GgmlDType::F32 => {
+                        let f32_data: Vec<f32> = row_data
+                            .chunks_exact(4)
+                            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                            .collect();
+                        candle_core::Tensor::from_vec(
+                            f32_data,
+                            (n, embed_dim),
+                            &candle_core::Device::Cpu,
+                        )?
+                        .to_dtype(dtype)
+                    }
+                    _ => {
+                        // Quantized dtypes: QStorage::from_data is safe because
+                        // quantized block structs have alignment ≤ 1 byte (packed).
+                        let storage = QStorage::from_data(
+                            Cow::Owned(row_data),
+                            &candle_core::Device::Cpu,
+                            *dtype_q,
+                        )?;
+                        let row_qt = QTensor::new(storage, (n, embed_dim))?;
+                        row_qt
+                            .dequantize(&candle_core::Device::Cpu)?
+                            .to_dtype(dtype)
+                    }
+                }
             }
             PliEmbeddingTable::Quantized {
                 qtensor, row_bytes, ..

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -384,7 +384,7 @@ struct LinearAttn {
 
 impl LinearAttn {
     fn new(cfg: &Qwen35Config, vb: VarBuilder, qvb: Option<&QGgufVarBuilder>) -> Result<Self> {
-        let n_heads = cfg.linear_num_key_heads;
+        let n_heads = cfg.linear_num_value_heads;
         let head_k_dim = cfg.linear_key_head_dim;
         let head_v_dim = cfg.linear_value_head_dim;
         let key_dim = n_heads * head_k_dim;


### PR DESCRIPTION
Three correctness fixes, that came up during my GGUF testing. LMK if you want these as 3 separate PRs.

- config.rs: return Ok(None) for unknown vision encoder types (e.g. Gemma3's `siglip_vision_model`) instead of aborting the parse
- gemma4.rs: PLI embedding lookup tries HF name first, falls back to llama.cpp name; `PliEmbeddingTable` decodes BF16/F16/F32 via chunks_exact safely
- qwen3_5.rs: use linear_num_value_heads (not key heads) for SSM stream count