### PR TITLE
Graceful CUDA shutdown on Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +737,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -1704,6 +1717,7 @@ dependencies = [
  "candle-transformers",
  "clap",
  "crossterm",
+ "ctrlc",
  "flate2",
  "futures",
  "half",
@@ -2086,6 +2100,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -2560,7 +2586,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -69,6 +69,7 @@ indicatif = "0.17"
 rustfft = "6"
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+ctrlc = "3"
 
 # Linux: dynamic backend loading + CUDA device support.
 # Enable the cuda feature so Device::new_cuda() is available at runtime.

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -520,7 +520,11 @@ async fn main() -> Result<()> {
     // A second Ctrl+C forces an immediate exit — useful when the server is
     // stuck in a long prefill or CUDA kernel.
     let _ = ctrlc::set_handler(|| {
-        let prev = SHUTDOWN_REQUESTED.fetch_add(1, Ordering::SeqCst);
+        let prev = SHUTDOWN_REQUESTED
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                Some(v.saturating_add(1))
+            })
+            .unwrap_or(u8::MAX);
         if prev >= 1 {
             std::process::exit(1);
         }

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -21,7 +21,16 @@ mod util;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use std::sync::atomic::{AtomicU8, Ordering};
 use tracing_subscriber::EnvFilter;
+
+/// Ctrl+C counter used for graceful shutdown.
+///
+/// - `0` → normal operation
+/// - `1` → first Ctrl+C: the inference loop should exit cleanly (dropping
+///   in-flight HTTP connections, freeing CUDA tensors on the server side).
+/// - `2` → second Ctrl+C: the handler calls `std::process::exit(1)` directly.
+pub static SHUTDOWN_REQUESTED: AtomicU8 = AtomicU8::new(0);
 
 /// CLI argument for `--turbo-quant`.
 ///
@@ -504,6 +513,18 @@ impl ServeArgs {
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Install a Ctrl+C handler for graceful shutdown.  The first Ctrl+C sets
+    // SHUTDOWN_REQUESTED so the inference loop can exit cleanly (dropping
+    // in-flight HTTP connections, freeing CUDA tensors on the server side).
+    // A second Ctrl+C forces an immediate exit — useful when the server is
+    // stuck in a long prefill or CUDA kernel.
+    let _ = ctrlc::set_handler(|| {
+        let prev = SHUTDOWN_REQUESTED.fetch_add(1, Ordering::SeqCst);
+        if prev >= 1 {
+            std::process::exit(1);
+        }
+    });
 
     // For `run`, `bench`, `rm`, and `list`, suppress info-level logging by default — the
     // interactive REPL writes to stdout and log lines would corrupt the prompt display.

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -417,7 +417,9 @@ async fn drain_ndjson_stream(response: reqwest::Response) -> Result<String> {
                 stdout.flush()?;
             }
 
-            if parsed.done || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1 {
+            if parsed.done
+                || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1
+            {
                 return Ok(full_text);
             }
         }
@@ -449,7 +451,9 @@ async fn drain_openai_sse_stream(response: reqwest::Response) -> Result<String> 
             let Some(json) = line.strip_prefix("data: ") else {
                 continue;
             };
-            if json == "[DONE]" || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1 {
+            if json == "[DONE]"
+                || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1
+            {
                 return Ok(full_text);
             }
 

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -417,7 +417,7 @@ async fn drain_ndjson_stream(response: reqwest::Response) -> Result<String> {
                 stdout.flush()?;
             }
 
-            if parsed.done {
+            if parsed.done || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1 {
                 return Ok(full_text);
             }
         }
@@ -449,7 +449,7 @@ async fn drain_openai_sse_stream(response: reqwest::Response) -> Result<String> 
             let Some(json) = line.strip_prefix("data: ") else {
                 continue;
             };
-            if json == "[DONE]" {
+            if json == "[DONE]" || crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1 {
                 return Ok(full_text);
             }
 
@@ -704,6 +704,10 @@ async fn repl(
             ReadResult::Line(l) => l,
             ReadResult::Interrupt => {
                 println!();
+                // Ctrl+C at the prompt triggers the global signal handler, which
+                // increments SHUTDOWN_REQUESTED.  Reset it here so the *next*
+                // generation isn't immediately cancelled.
+                crate::SHUTDOWN_REQUESTED.store(0, std::sync::atomic::Ordering::Release);
                 buf.clear();
                 multiline = MultilineState::None;
                 continue;
@@ -743,14 +747,16 @@ async fn repl(
 
                 let trimmed = buf.trim().to_string();
                 if trimmed.starts_with('/') {
-                    handle_command(
+                    if handle_command(
                         &trimmed,
                         &mut messages,
                         &mut temperature,
                         &mut top_p,
                         &mut top_k,
                         &mut max_tokens,
-                    );
+                    ) {
+                        break;
+                    }
                     buf.clear();
                     continue;
                 }
@@ -802,6 +808,16 @@ async fn repl(
             }
         };
 
+        // If the user pressed Ctrl+C during generation, discard the partial
+        // turn and go back to the prompt.
+        if crate::SHUTDOWN_REQUESTED.load(std::sync::atomic::Ordering::Acquire) >= 1 {
+            crate::SHUTDOWN_REQUESTED.store(0, std::sync::atomic::Ordering::Release);
+            println!("\n[interrupted]");
+            messages.pop();
+            flush_pending_input();
+            continue;
+        }
+
         println!();
 
         // Discard any keystrokes the user typed during the streaming response.
@@ -829,11 +845,11 @@ fn handle_command(
     top_p: &mut f64,
     top_k: &mut usize,
     max_tokens: &mut usize,
-) {
+) -> bool {
     let parts: Vec<&str> = cmd.splitn(3, ' ').collect();
     match parts[0] {
         "/bye" | "/exit" | "/quit" => {
-            std::process::exit(0);
+            return true;
         }
         "/clear" => {
             let sys: Vec<ApiMessage> = messages.drain(..).filter(|m| m.role == "system").collect();
@@ -923,6 +939,7 @@ fn handle_command(
         }
         other => println!("Unknown command: {other}"),
     }
+    false
 }
 
 // ─── Input helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problems solved

**CUDA crash on relaunch after Ctrl+C**
Interrupting an inference with Ctrl+C during `inferrs run` consistently caused a CUDA error (`initialization error` or `unknown error`) on the next launch. Reproducible on WSL2 with `--device cuda`.

**GPU resource leak on normal exit**
Even without interruption, CUDA tensors (model weights, KV cache) were not guaranteed to be freed before the process exited.
