### PR TITLE
Qwen3.5 startup latency (online quantization bottleneck)

### DIFF
--- a/candle-core/src/quantized/k_quants.rs
+++ b/candle-core/src/quantized/k_quants.rs
@@ -1452,63 +1452,65 @@ impl GgmlType for BlockQ4K {
     }
 
     fn from_float(xs: &[f32], ys: &mut [Self]) {
-        for (block, x) in group_for_quantization(xs, ys) {
-            let mut mins: [f32; QK_K / 32] = [0.0; QK_K / 32];
-            let mut scales: [f32; QK_K / 32] = [0.0; QK_K / 32];
+        group_for_quantization(xs, ys)
+            .into_par_iter()
+            .for_each(|(block, x)| {
+                let mut mins: [f32; QK_K / 32] = [0.0; QK_K / 32];
+                let mut scales: [f32; QK_K / 32] = [0.0; QK_K / 32];
 
-            for (j, x_scale_slice) in x.chunks_exact(32).enumerate() {
-                (scales[j], mins[j]) = make_qkx1_quants(15, 5, x_scale_slice);
-            }
-
-            // get max scale and max min and ensure they are >= 0.0
-            let max_scale = scales.iter().fold(0.0, |max, &val| val.max(max));
-            let max_min = mins.iter().fold(0.0, |max, &val| val.max(max));
-
-            let inv_scale = if max_scale > 0.0 {
-                63.0 / max_scale
-            } else {
-                0.0
-            };
-            let inv_min = if max_min > 0.0 { 63.0 / max_min } else { 0.0 };
-
-            for j in 0..QK_K / 32 {
-                let ls = nearest_int(inv_scale * scales[j]).min(63) as u8;
-                let lm = nearest_int(inv_min * mins[j]).min(63) as u8;
-                if j < 4 {
-                    block.scales[j] = ls;
-                    block.scales[j + 4] = lm;
-                } else {
-                    block.scales[j + 4] = (ls & 0xF) | ((lm & 0xF) << 4);
-                    block.scales[j - 4] |= (ls >> 4) << 6;
-                    block.scales[j] |= (lm >> 4) << 6;
+                for (j, x_scale_slice) in x.chunks_exact(32).enumerate() {
+                    (scales[j], mins[j]) = make_qkx1_quants(15, 5, x_scale_slice);
                 }
-            }
 
-            block.d = f16::from_f32(max_scale / 63.0);
-            block.dmin = f16::from_f32(max_min / 63.0);
+                // get max scale and max min and ensure they are >= 0.0
+                let max_scale = scales.iter().fold(0.0, |max, &val| val.max(max));
+                let max_min = mins.iter().fold(0.0, |max, &val| val.max(max));
 
-            let mut l: [u8; QK_K] = [0; QK_K];
+                let inv_scale = if max_scale > 0.0 {
+                    63.0 / max_scale
+                } else {
+                    0.0
+                };
+                let inv_min = if max_min > 0.0 { 63.0 / max_min } else { 0.0 };
 
-            for j in 0..QK_K / 32 {
-                let (sc, m) = get_scale_min_k4(j, &block.scales);
-                let d = block.d.to_f32() * sc as f32;
-                if d != 0.0 {
-                    let dm = block.dmin.to_f32() * m as f32;
-                    for ii in 0..32 {
-                        let l_val = nearest_int((x[32 * j + ii] + dm) / d);
-                        l[32 * j + ii] = l_val.clamp(0, 15) as u8;
+                for j in 0..QK_K / 32 {
+                    let ls = nearest_int(inv_scale * scales[j]).min(63) as u8;
+                    let lm = nearest_int(inv_min * mins[j]).min(63) as u8;
+                    if j < 4 {
+                        block.scales[j] = ls;
+                        block.scales[j + 4] = lm;
+                    } else {
+                        block.scales[j + 4] = (ls & 0xF) | ((lm & 0xF) << 4);
+                        block.scales[j - 4] |= (ls >> 4) << 6;
+                        block.scales[j] |= (lm >> 4) << 6;
                     }
                 }
-            }
 
-            let q = &mut block.qs;
-            for j in (0..QK_K).step_by(64) {
-                for l_val in 0..32 {
-                    let offset_index = (j / 64) * 32 + l_val;
-                    q[offset_index] = l[j + l_val] | (l[j + l_val + 32] << 4);
+                block.d = f16::from_f32(max_scale / 63.0);
+                block.dmin = f16::from_f32(max_min / 63.0);
+
+                let mut l: [u8; QK_K] = [0; QK_K];
+
+                for j in 0..QK_K / 32 {
+                    let (sc, m) = get_scale_min_k4(j, &block.scales);
+                    let d = block.d.to_f32() * sc as f32;
+                    if d != 0.0 {
+                        let dm = block.dmin.to_f32() * m as f32;
+                        for ii in 0..32 {
+                            let l_val = nearest_int((x[32 * j + ii] + dm) / d);
+                            l[32 * j + ii] = l_val.clamp(0, 15) as u8;
+                        }
+                    }
                 }
-            }
-        }
+
+                let q = &mut block.qs;
+                for j in (0..QK_K).step_by(64) {
+                    for l_val in 0..32 {
+                        let offset_index = (j / 64) * 32 + l_val;
+                        q[offset_index] = l[j + l_val] | (l[j + l_val + 32] << 4);
+                    }
+                }
+            });
     }
 
     fn from_float_imatrix(xs: &[f32], ys: &mut [Self], imatrix_weights: &[f32], n_per_row: usize) {

--- a/inferrs/src/models/qwen3_5.rs
+++ b/inferrs/src/models/qwen3_5.rs
@@ -10,6 +10,7 @@
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{embedding, Embedding, Init, RmsNorm, VarBuilder};
+use rayon::prelude::*;
 use std::sync::Arc;
 
 use crate::models::attention_utils::{
@@ -845,76 +846,95 @@ impl Qwen35Model {
             }
         });
 
-        let mut layers = Vec::with_capacity(cfg.num_hidden_layers);
-        for (i, layer_type) in cfg.layer_types.iter().enumerate() {
-            let layer_vb = lm_vb.pp("layers").pp(i.to_string());
-            let layer_qvb = lm_qvb.as_ref().map(|q| q.pp("layers").pp(i.to_string()));
-            let layer = DecoderLayer::new(
-                cfg,
-                layer_vb,
-                layer_qvb.as_ref(),
-                layer_type.is_full_attention,
-                tq_cfg.as_ref(),
-            )
-            .with_context(|| format!("loading layer {i}"))?;
-            layers.push(layer);
-        }
+        // Pre-extract per-layer VarBuilders (sequential, trivial cost) then
+        // construct all layers + lm_head in parallel via rayon::join.
+        // VarBuilder is Send (Arc<TensorData<Box<dyn SimpleBackend>>> where
+        // SimpleBackend: Send + Sync). QGgufVarBuilder is Send (Arc<Mutex<>>).
+        let layer_specs: Vec<_> = cfg
+            .layer_types
+            .iter()
+            .enumerate()
+            .map(|(i, lt)| {
+                let vb = lm_vb.pp("layers").pp(i.to_string());
+                let qvb = lm_qvb.as_ref().map(|q| q.pp("layers").pp(i.to_string()));
+                (vb, qvb, lt.is_full_attention)
+            })
+            .collect();
 
-        let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, lm_vb.pp("norm"), 1.0)?;
+        let norm_vb = lm_vb.pp("norm");
 
-        let lm_head = {
-            let dense = embed_tokens.embeddings().clone();
-            let built = lm_qvb
-                .as_ref()
-                .and_then(|q| q.pp("embed_tokens").try_qlinear_weight());
-            match built {
-                Some(Ok(ql)) => {
-                    tracing::info!("lm_head: using quantized embed_tokens QTensor");
-                    ql
-                }
-                Some(Err(e)) => {
-                    tracing::warn!("lm_head: quantized build failed ({e}), using bf16");
-                    QLinear::from_tensor(dense, None)
-                }
-                None => {
-                    let weight = dense;
-                    let elem_count = weight.elem_count();
-                    let quant_dtype = if elem_count % 256 == 0 {
-                        Some(candle_core::quantized::GgmlDType::Q4K)
-                    } else if elem_count % 32 == 0 {
-                        Some(candle_core::quantized::GgmlDType::Q8_0)
-                    } else {
-                        None
-                    };
-                    let mut quantized = None;
-                    if let Some(dtype) = quant_dtype {
-                        match candle_core::quantized::QTensor::quantize(&weight, dtype) {
-                            Ok(qt) => {
-                                tracing::info!(
-                                    "lm_head: online-quantized embed_tokens to {dtype:?} \
-                                     ({} elements, {:.1} MB BF16)",
-                                    elem_count,
-                                    elem_count as f64 * 2.0 / 1e6,
-                                );
-                                match QLinear::from_qtensor(Arc::new(qt), None) {
-                                    Ok(ql) => quantized = Some(ql),
-                                    Err(e) => tracing::debug!(
-                                        "lm_head: QLinear::from_qtensor failed ({e}), using bf16"
-                                    ),
-                                }
-                            }
-                            Err(e) => tracing::debug!(
-                                "lm_head: online quantization failed ({e}), using bf16"
-                            ),
-                        }
-                    }
-                    quantized.unwrap_or_else(|| {
-                        tracing::debug!("lm_head: using dense bf16");
-                        QLinear::from_tensor(weight, None)
+        // Build layers and lm_head in parallel.
+        // lm_head depends only on embed_tokens (already loaded), not on layers.
+        let (layers_result, lm_head) = rayon::join(
+            || -> Result<Vec<DecoderLayer>> {
+                let layers: Vec<_> = layer_specs
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(i, (vb, qvb, is_full))| {
+                        DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, tq_cfg.as_ref())
+                            .with_context(|| format!("loading layer {i}"))
                     })
-                }
-            }
-        };
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(layers)
+            },
+            || -> QLinear {
+                let dense = embed_tokens.embeddings().clone();
+                let built = lm_qvb
+                    .as_ref()
+                    .and_then(|q| q.pp("embed_tokens").try_qlinear_weight());
+                let ql = match built {
+                    Some(Ok(ql)) => {
+                        tracing::info!("lm_head: using quantized embed_tokens QTensor");
+                        ql
+                    }
+                    Some(Err(e)) => {
+                        tracing::warn!("lm_head: quantized build failed ({e}), using bf16");
+                        QLinear::from_tensor(dense, None)
+                    }
+                    None => {
+                        let weight = dense;
+                        let elem_count = weight.elem_count();
+                        let quant_dtype = if elem_count % 256 == 0 {
+                            Some(candle_core::quantized::GgmlDType::Q4K)
+                        } else if elem_count % 32 == 0 {
+                            Some(candle_core::quantized::GgmlDType::Q8_0)
+                        } else {
+                            None
+                        };
+                        let mut quantized = None;
+                        if let Some(dtype) = quant_dtype {
+                            match candle_core::quantized::QTensor::quantize(&weight, dtype) {
+                                Ok(qt) => {
+                                    tracing::info!(
+                                        "lm_head: online-quantized embed_tokens to {dtype:?} \
+                                         ({} elements, {:.1} MB BF16)",
+                                        elem_count,
+                                        elem_count as f64 * 2.0 / 1e6,
+                                    );
+                                    match QLinear::from_qtensor(Arc::new(qt), None) {
+                                        Ok(ql) => quantized = Some(ql),
+                                        Err(e) => tracing::debug!(
+                                            "lm_head: QLinear::from_qtensor failed ({e}), using bf16"
+                                        ),
+                                    }
+                                }
+                                Err(e) => tracing::debug!(
+                                    "lm_head: online quantization failed ({e}), using bf16"
+                                ),
+                            }
+                        }
+                        quantized.unwrap_or_else(|| {
+                            tracing::debug!("lm_head: using dense bf16");
+                            QLinear::from_tensor(weight, None)
+                        })
+                    }
+                };
+                ql
+            },
+        );
+        let layers = layers_result?;
+
+        let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, norm_vb, 1.0)?;
 
         // Precompute RoPE tables (large enough for typical sequences)
         let max_seq = 32768;


### PR DESCRIPTION
## Problem

Serving a Qwen3.5 model from safetensors triggers an online BF16→Q4K quantization at startup. On the 0.8B model this takes ~19s; on the 2B model ~52s on my hardware. During that time the GPU sits idle and the server is unresponsive.

The bottleneck is 187 sequential CPU quantizations (one per linear projection + lm_head), each doing a GPU→CPU copy, a tight loop over 256-element blocks, then a CPU→GPU copy back.

## Fix

Two targeted changes, no API surface affected:

**Parallelize layer construction** (`qwen3_5.rs`) — the 24 decoder layers are independent of each other, and lm_head depends only on the embedding which is already loaded. A `rayon::join` runs layer construction (`par_iter` over all layers) and lm_head quantization concurrently. `VarBuilder` is `Send`, so no restructuring of constructors was needed.

**Parallelize block quantization** (`candle-core/k_quants.rs`) — `BlockQ4K::from_float` iterated sequentially over 256-element blocks. `group_for_quantization` already returns a `Vec` of disjoint `(&mut block, &[f32])` pairs; replacing the `for` loop with `into_par_iter().for_each` is the entire change. This directly benefits lm_head, which quantizes a single large tensor (254M–509M elements) and can now use the threads freed by the layer pass.

## Result on my hardware

| Model | Before | After |
|---|---|---|
| 0.8B | ~19s | ~3-4s |
| 2B | ~52s | ~6-8s |
