### PR TITLE
add inferrs stop command to unload a running model

### DIFF
--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -14,6 +14,7 @@ mod rm;
 mod run;
 mod sampler;
 mod server;
+mod stop;
 mod tokenizer;
 mod util;
 
@@ -76,6 +77,8 @@ enum Commands {
     /// List locally cached models (alias for list)
     #[command(name = "ls")]
     Ls(list::ListArgs),
+    /// Stop a running model and unload it from memory
+    Stop(stop::StopArgs),
 }
 
 #[derive(Parser, Clone)]
@@ -511,7 +514,8 @@ async fn main() -> Result<()> {
         | Commands::Bench(_)
         | Commands::Rm(_)
         | Commands::List(_)
-        | Commands::Ls(_) => "error",
+        | Commands::Ls(_)
+        | Commands::Stop(_) => "error",
         _ => "info", // Pull and Serve both benefit from info-level progress log
     };
     tracing_subscriber::fmt()
@@ -551,6 +555,9 @@ async fn main() -> Result<()> {
         }
         Commands::List(args) | Commands::Ls(args) => {
             list::run(args)?;
+        }
+        Commands::Stop(args) => {
+            stop::run(args).await?;
         }
     }
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -566,6 +566,11 @@ pub struct OllamaGenerateRequest {
     /// chain-of-thought will be returned in the `thinking` field.
     #[serde(default)]
     pub think: Option<bool>,
+    /// How long (in seconds) to keep the model loaded after the last request.
+    /// A value of `0` unloads the model immediately — this is what
+    /// `inferrs stop` / `ollama stop` sends.
+    #[serde(default)]
+    pub keep_alive: Option<i64>,
 }
 
 /// Ollama `POST /api/chat` request.
@@ -1360,7 +1365,23 @@ async fn load_model_on_demand(
             let lm = Arc::new(lm);
             {
                 let mut guard = state.slot.write().await;
-                *guard = ModelSlot::Ready(Arc::clone(&lm));
+                // Only transition to Ready when the slot is still in the
+                // Loading state for this model.  A concurrent `stop` request
+                // may have already reset the slot to Empty while we were
+                // loading; in that case we discard the freshly-loaded model
+                // rather than silently overwriting the stop.
+                let still_loading = matches!(&*guard,
+                    ModelSlot::Loading { model_id: loading_id, .. }
+                        if model_matches_id(loading_id, model_id));
+                if still_loading {
+                    *guard = ModelSlot::Ready(Arc::clone(&lm));
+                } else {
+                    tracing::info!(
+                        "Load of '{}' completed but slot was cleared (stop request \
+                         raced with load) — discarding loaded model",
+                        model_id
+                    );
+                }
             }
             let _ = tx.send(Some(Ok(Arc::clone(&lm))));
             Ok(lm)
@@ -3774,6 +3795,45 @@ async fn ollama_generate(
     let request_id = format!("gen-{}", uuid::Uuid::new_v4());
     let created_at = rfc3339_now();
 
+    // Unload request: empty prompt + keep_alive=0 (the protocol used by both
+    // `ollama stop` and `inferrs stop`).  We handle this before calling
+    // `load_model_on_demand` so we never trigger a load just to unload.
+    let prompt = req.prompt.as_deref().unwrap_or("");
+    if prompt.is_empty() && req.keep_alive == Some(0) {
+        {
+            let mut slot = state.slot.write().await;
+            // Only evict the slot when the requested model is the one that is
+            // currently loaded or loading.  Without this check, stopping model
+            // "B" while model "A" is loaded would silently unload "A".
+            // We also match on Loading so that a stop issued while the model is
+            // still being fetched/initialised correctly cancels it (the loader
+            // will find the slot is no longer in the Loading state it set up and
+            // will discard its result rather than overwriting Empty → Ready).
+            let matches = match &*slot {
+                ModelSlot::Ready(lm) => model_matches_id(&lm.model_id, &req.model),
+                ModelSlot::Loading { model_id, .. } => model_matches_id(model_id, &req.model),
+                _ => false,
+            };
+            if matches {
+                *slot = ModelSlot::Empty;
+                tracing::info!("Model '{}' unloaded via stop request", req.model);
+            } else {
+                tracing::info!(
+                    "Stop request for '{}' but that model is not loaded — ignoring",
+                    req.model
+                );
+            }
+        }
+        return Ok(Json(serde_json::json!({
+            "model": req.model,
+            "created_at": created_at,
+            "response": "",
+            "done": true,
+            "done_reason": "unload",
+        }))
+        .into_response());
+    }
+
     let lm = load_model_on_demand(&state, &req.model, req.options.as_ref()).await?;
 
     // Proxy mode: forward the request to the worker.
@@ -3781,7 +3841,6 @@ async fn ollama_generate(
         return proxy_to_worker(&state.http_client, worker_url, "/api/generate", &req).await;
     }
 
-    let prompt = req.prompt.as_deref().unwrap_or("");
     if prompt.is_empty() {
         // Ollama uses an empty prompt to "warm up" (load) the model.
         return Ok(Json(serde_json::json!({

--- a/inferrs/src/stop.rs
+++ b/inferrs/src/stop.rs
@@ -1,0 +1,83 @@
+//! `inferrs stop` — unload a running model from the server.
+//!
+//! Sends `POST /api/generate` with an empty prompt and `keep_alive=0`,
+//! which is the same wire protocol used by `ollama stop`.
+//!
+//! The server URL is resolved from (in priority order):
+//!   1. `--host` / `--port` CLI flags
+//!   2. `INFERRS_HOST` environment variable  (e.g. `http://10.0.0.5:17434`)
+//!   3. Default: `http://127.0.0.1:17434`
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use reqwest::Client;
+
+const DEFAULT_PORT: u16 = 17434;
+
+#[derive(Parser, Clone)]
+pub struct StopArgs {
+    /// Model to unload (e.g. Qwen/Qwen3-0.6B)
+    pub model: String,
+
+    /// Address of the `inferrs serve` daemon.
+    /// Overrides `INFERRS_HOST`.  Defaults to `127.0.0.1`.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// Port of the `inferrs serve` daemon.
+    /// Overrides the port part of `INFERRS_HOST`.  Defaults to 17434.
+    #[arg(long, default_value_t = DEFAULT_PORT)]
+    pub port: u16,
+}
+
+impl StopArgs {
+    fn server_url(&self) -> String {
+        let from_flags = self.host != "127.0.0.1" || self.port != DEFAULT_PORT;
+        if from_flags {
+            return format!("http://{}:{}", self.host, self.port);
+        }
+
+        if let Ok(env) = std::env::var("INFERRS_HOST") {
+            let env = env.trim().to_string();
+            if !env.is_empty() {
+                return if env.starts_with("http://") || env.starts_with("https://") {
+                    env
+                } else {
+                    format!("http://{env}")
+                };
+            }
+        }
+
+        format!("http://{}:{}", self.host, self.port)
+    }
+}
+
+pub async fn run(args: StopArgs) -> Result<()> {
+    let base_url = args.server_url();
+    let client = Client::new();
+
+    let url = format!("{base_url}/api/generate");
+    let body = serde_json::json!({
+        "model": args.model,
+        "prompt": "",
+        "keep_alive": 0,
+        "stream": false,
+    });
+
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .context("failed to connect to inferrs server")?;
+
+    if resp.status().is_success() {
+        println!("Stopped {}", args.model);
+    } else {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {text}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Implements `inferrs stop <MODEL>` modeled after `ollama stop`.

The CLI sends POST /api/generate with an empty prompt and keep_alive=0, the same wire protocol ollama uses. The server now recognises this signal and unloads the model slot before any load is triggered, returning done_reason="unload" in the response.