### PR TITLE
enable --quantize=Q4K by default, disable when --paged-attention is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,6 @@ inferrs run google/gemma-4-E2B-it
 
 ### Serve
 
-#### Serve a specific model (OpenAI/Anthropic/Ollama API on port 8080)
-
-```bash
-inferrs serve google/gemma-4-E2B-it
-```
-
 #### Serve a specific model vLLM-style
 
 ```bash
@@ -66,7 +60,7 @@ inferrs serve --paged-attention google/gemma-4-E2B-it
 #### Serve a specific model llama.cpp-style
 
 ```bash
-inferrs serve --quantize google/gemma-4-E2B-it
+inferrs serve google/gemma-4-E2B-it
 ```
 
 #### Serve models ollama-style
@@ -78,16 +72,4 @@ inferrs serve
 This behaves like `ollama serve` the server starts on `0.0.0.0:17434` and
 exposes the full Ollama API. Any Ollama client — including the `ollama`
 CLI — can point at it directly.
-
-## Architecture
-
-```
-┌─────────┐      HTTP       ┌────────┐  channel  ┌────────┐
-│  Client │ ──────────────▶ │ Server │ ────────▶ │ Engine │
-└─────────┘  (axum + SSE)   └────────┘           └────────┘
-                                                     │
-                               ┌──────────┬──────────┼──────────┐
-                               ▼          ▼          ▼          ▼
-                          Scheduler    Transformer  KV Cache  Sampler
-```
 

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -187,10 +187,12 @@ pub struct ServeArgs {
     /// Accepted formats (case-insensitive): Q4_0, Q4_1, Q5_0, Q5_1, Q8_0,
     /// Q2K, Q3K, Q4K (Q4_K_M), Q5K, Q6K.
     ///
-    /// When used as a plain flag (`--quantize`) the default Q4_K_M (= Q4K) is used.
+    /// Defaults to Q4K when `--paged-attention` is not used.
+    /// Automatically disabled when `--paged-attention` is passed.
+    /// Pass `--quantize=none` (or `--quantize=false`) to run full-precision inference.
     /// Embedding and output (lm_head) tensors are kept at F16 for accuracy.
-    #[arg(long, num_args(0..=1), default_missing_value("Q4K"), require_equals(true),
-          value_name = "FORMAT")]
+    #[arg(long, num_args(0..=1), default_value("Q4K"), default_missing_value("Q4K"),
+          require_equals(true), value_name = "FORMAT")]
     pub quantize: Option<String>,
 }
 
@@ -493,12 +495,29 @@ impl ServeArgs {
         }
     }
 
-    /// Parse the `--quantize` format string (if provided) into a `GgmlDType`.
+    /// Parse the `--quantize` format string into a `GgmlDType`.
+    ///
+    /// Returns `None` in two cases:
+    /// - `--paged-attention` is active (paged attention requires un-quantized
+    ///   safetensors weights; the two options are mutually exclusive at load time).
+    /// - The user explicitly passed `--quantize=none` or `--quantize=false` to
+    ///   request full-precision inference without enabling paged attention.
     pub fn resolve_quant_dtype(&self) -> Result<Option<candle_core::quantized::GgmlDType>> {
-        self.quantize
-            .as_deref()
-            .map(crate::quantize::parse_format)
-            .transpose()
+        if self.paged_attention.is_some() {
+            if let Some(ref q) = self.quantize {
+                if !matches!(q.to_lowercase().as_str(), "none" | "false") {
+                    tracing::warn!(
+                        "--quantize={q} ignored: paged-attention requires un-quantized \
+                         safetensors weights"
+                    );
+                }
+            }
+            return Ok(None);
+        }
+        match self.quantize.as_deref() {
+            Some(s) if matches!(s.to_lowercase().as_str(), "none" | "false") => Ok(None),
+            other => other.map(crate::quantize::parse_format).transpose(),
+        }
     }
 }
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1210,8 +1210,12 @@ async fn spawn_worker(
         if let Some(ref tq) = o.turbo_quant {
             args.push(format!("--turbo-quant={tq}"));
         }
-        if let Some(ref q) = o.quantize {
-            args.push(format!("--quantize={q}"));
+        // Only forward --quantize when paged-attention is not active; the two are
+        // mutually exclusive and paged-attention requires un-quantized weights.
+        if o.paged_attention.is_none() {
+            if let Some(ref q) = o.quantize {
+                args.push(format!("--quantize={q}"));
+            }
         }
         if let Some(ref f) = o.gguf_file {
             args.extend(["--gguf-file".into(), f.clone()]);


### PR DESCRIPTION
Make quantization opt-out rather than opt-in: the flag now defaults to Q4K so users get GGUF caching and reduced memory use without having to pass anything extra.

Pass `--quantize=none` (or `--quantize=false`) to run full-precision inference without enabling paged attention.

When `--paged-attention` is active the two options are mutually exclusive (paged attention requires un-quantized safetensors), so `resolve_quant_dtype` returns `None` and emits a warning if the user also passed an explicit `--quantize` value. The server's worker-spawner skips forwarding `--quantize` in that case.