### PR TITLE
combine fmt and clippy into a single lint target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,27 +16,14 @@ env:
   CUDA_COMPUTE_CAP: "80"
 
 jobs:
-  fmt:
-    name: Format
+  lint:
+    name: Lint
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
-      # Format-check only the packages that don't require GPU toolchains.
-      # inferrs-backend-musa has no MUSA SDK dependency at compile time (it
-      # probes libmusart.so via dlopen at runtime) so it can be checked here.
-      - run: cargo fmt --check -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - name: Install nvcc (needed by candle-kernels build script)
         run: |
@@ -45,8 +32,9 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends cuda-nvcc-12-6
           echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
-      # inferrs-backend-musa is included here for the same reason as fmt: it has
-      # no compile-time MUSA SDK dependency.
+      # inferrs-backend-musa has no compile-time MUSA SDK dependency (it probes
+      # libmusart.so via dlopen at runtime) so it can be checked here.
+      - run: cargo fmt --check -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
       - run: cargo clippy -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan -- -D warnings
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ HEXAGON_PKG := -p inferrs-backend-hexagon
 # and can be built anywhere (they probe at runtime via dlopen/LoadLibrary).
 NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-kernels -p inferrs-backend-vulkan $(HEXAGON_PKG) -p inferrs-backend-openvino $(CUDA_PKG)
 
-.PHONY: all build release fmt clippy test ui
+.PHONY: all build release lint test ui
 
-all: fmt clippy test build
+all: lint test build
 
 # Convenience target: rebuild just the inferrs binary (which also re-runs
 # build.rs to recompress the web UI if inferrs/ui/index.html changed).
@@ -36,10 +36,8 @@ build:
 release:
 	cargo build --release $(NO_GPU_PKGS)
 
-fmt:
+lint:
 	cargo fmt --check $(NO_GPU_PKGS)
-
-clippy:
 	cargo clippy $(NO_GPU_PKGS) -- -D warnings
 
 test:


### PR DESCRIPTION
Merge the separate fmt and clippy jobs in CI into one lint job, and consolidate the Makefile targets the same way. This reduces CI job overhead and keeps format/lint checks together.