### PR TITLE
add inferrs-backend-metal plugin for Apple Metal GPU detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferrs-backend-metal"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "candle-core",
+]
+
+[[package]]
 name = "inferrs-backend-musa"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "inferrs-kernels",
     "backends/inferrs-backend-cann",
     "backends/inferrs-backend-cuda",
+    "backends/inferrs-backend-metal",
     "backends/inferrs-backend-musa",
     "backends/inferrs-backend-rocm",
     "backends/inferrs-backend-vulkan",
@@ -20,6 +21,8 @@ members = [
 #   cargo build -p inferrs-backend-rocm     (requires hipcc / ROCm)
 #   cargo build -p inferrs-backend-cann     (Linux/Android only; requires
 #                                            libascendcl.so from CANN SDK)
+# The Metal backend links against the system Metal framework (always present on
+# macOS) and has no external SDK dependency; it is included in default-members.
 # The MUSA backend has no compile-time SDK dependency (it probes libmusart.so
 # via dlopen at runtime) so it is included in default-members.
 # The Hexagon backend likewise has no exotic toolchain requirement and compiles
@@ -30,6 +33,7 @@ default-members = [
     "inferrs-models",
     "inferrs-multimodal",
     "inferrs-kernels",
+    "backends/inferrs-backend-metal",
     "backends/inferrs-backend-musa",
     "backends/inferrs-backend-vulkan",
     "backends/inferrs-backend-hexagon",

--- a/backends/inferrs-backend-metal/Cargo.toml
+++ b/backends/inferrs-backend-metal/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "inferrs-backend-metal"
+version = "0.1.0"
+edition = "2021"
+description = "Apple Metal backend plugin for inferrs"
+license = "Apache-2.0"
+
+[lib]
+name = "inferrs_backend_metal"
+crate-type = ["cdylib"]
+
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { workspace = true, features = ["metal"] }

--- a/backends/inferrs-backend-metal/src/lib.rs
+++ b/backends/inferrs-backend-metal/src/lib.rs
@@ -1,0 +1,26 @@
+/// Probe whether an Apple Metal device is available and functional.
+///
+/// This is implemented by attempting to create a `candle_core::Device::Metal`
+/// using `Device::new_metal(0)`.  The Metal framework is part of macOS and
+/// is always present on supported hardware; the probe will only fail on
+/// headless CI environments or very old hardware that pre-dates Metal support
+/// (pre-2012 Macs).
+///
+/// The backend shared library links against the Metal framework at compile
+/// time (`candle-core` with the `metal` feature), so this plugin can only
+/// be built on macOS.  On all other platforms the probe immediately returns
+/// non-zero.
+///
+/// Returns 0 if `Device::new_metal(0)` succeeds, 1 otherwise.
+#[no_mangle]
+pub extern "C" fn inferrs_backend_probe() -> i32 {
+    #[cfg(target_os = "macos")]
+    {
+        match candle_core::Device::new_metal(0) {
+            Ok(_) => return 0,
+            Err(_) => return 1,
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    1
+}

--- a/inferrs/src/backend.rs
+++ b/inferrs/src/backend.rs
@@ -20,14 +20,14 @@
 //!
 //! ## Platform support matrix
 //!
-//! | Platform                  | CUDA | MUSA | ROCm | CANN | Hexagon | Vulkan |
-//! |---------------------------|------|------|------|------|---------|--------|
-//! | Linux x86_64              | ✓    | ✓    | ✓    | ✓    | —       | ✓      |
-//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓    | ✓       | ✓      |
-//! | Windows x86_64            | ✓    | ✓    | ✓    | —    | —       | ✓      |
-//! | Windows aarch64           | —    | —    | —    | —    | ✓       | ✓      |
-//! | macOS x86_64 / aarch64    | —    | —    | —    | —    | —       | ✓      |
-//! | Android aarch64           | —    | —    | —    | ✓    | ✓       | ✓      |
+//! | Platform                  | CUDA | MUSA | ROCm | CANN | Hexagon | Vulkan | Metal |
+//! |---------------------------|------|------|------|------|---------|--------|-------|
+//! | Linux x86_64              | ✓    | ✓    | ✓    | ✓    | —       | ✓      | —     |
+//! | Linux aarch64             | ✓    | ✓    | ✓    | ✓    | ✓       | ✓      | —     |
+//! | Windows x86_64            | ✓    | ✓    | ✓    | —    | —       | ✓      | —     |
+//! | Windows aarch64           | —    | —    | —    | —    | ✓       | ✓      | —     |
+//! | macOS x86_64 / aarch64    | —    | —    | —    | —    | —       | ✓      | ✓     |
+//! | Android aarch64           | —    | —    | —    | ✓    | ✓       | ✓      | —     |
 //!
 //! ROCm on Windows is supported from ROCm 5.5+ (HIP SDK for Windows).
 //! ROCm on Linux aarch64 is supported on hardware such as AMD MI300A APUs
@@ -61,11 +61,6 @@
 //!   3. OpenVINO (`.dll`) → CPU fallback with info log
 //!   4. CPU     (always available)
 //!
-//! **macOS x86_64 / aarch64:**
-//!   Metal is tried first (linked directly).  If Metal fails:
-//!   1. Vulkan (`.dylib`, via MoltenVK) → CPU fallback with info log
-//!   2. CPU    (always available)
-//!
 //! **Android aarch64:**
 //!   1. CANN    (`.so`)   → CPU fallback with info log (pending candle CANN Device)
 //!   2. Hexagon (`.so`)   → CPU fallback with info log (pending candle Hexagon Device)
@@ -74,10 +69,10 @@
 //!   5. CPU     (always available)
 //!
 //! **macOS x86_64 / aarch64:**
-//!   Metal is tried first (linked directly).  If Metal fails:
-//!   1. Vulkan  (`.dylib`, via MoltenVK) → CPU fallback with info log
-//!   2. OpenVINO (`.dylib`)              → CPU fallback with info log
-//!   3. CPU     (always available)
+//!   1. Metal   (`.dylib`) → `Device::new_metal(0)` (via plugin)
+//!   2. OpenVINO (`.dylib`) → CPU fallback with info log
+//!   3. Vulkan  (`.dylib`, via MoltenVK) → CPU fallback with info log
+//!   4. CPU     (always available)
 
 // ── Shared helpers ────────────────────────────────────────────────────────────
 //
@@ -304,9 +299,10 @@ pub use android::{detect_backend, BackendKind};
 
 // ── macOS ─────────────────────────────────────────────────────────────────────
 //
-// Metal is linked directly and is always preferred.  Vulkan is also available
-// via MoltenVK.  OpenVINO is probed for future CPU acceleration (Intel provides
-// macOS builds for both x86_64 and aarch64).
+// Metal is probed first via the plugin system; if Metal is unavailable (e.g.
+// headless CI VM without a GPU), Vulkan is available via MoltenVK and
+// OpenVINO is probed for future CPU acceleration (Intel provides macOS builds
+// for both x86_64 and aarch64).
 //
 // Architectures: x86_64-apple-darwin, aarch64-apple-darwin.
 
@@ -314,10 +310,11 @@ pub use android::{detect_backend, BackendKind};
 mod macos {
     use std::path::PathBuf;
 
-    /// The detected backend on macOS (Metal is handled directly in
-    /// `auto_device` before the plugin system is invoked).
+    /// The detected backend on macOS.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum BackendKind {
+        /// Apple Metal GPU — probed via the `inferrs-backend-metal` plugin.
+        Metal,
         /// Vulkan via MoltenVK is detected; candle 0.8 has no Vulkan Device yet.
         Vulkan,
         /// OpenVINO runtime found; the main binary uses Metal for GPU inference
@@ -329,7 +326,9 @@ mod macos {
     pub fn detect_backend() -> BackendKind {
         let search_dirs = plugin_search_dirs();
 
+        // Priority: Metal → OpenVINO → Vulkan → CPU.
         let candidates: &[(&str, BackendKind)] = &[
+            ("libinferrs_backend_metal.dylib", BackendKind::Metal),
             ("libinferrs_backend_openvino.dylib", BackendKind::OpenVino),
             ("libinferrs_backend_vulkan.dylib", BackendKind::Vulkan),
         ];

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -240,28 +240,17 @@ impl ServeArgs {
     }
 
     fn auto_device() -> Result<candle_core::Device> {
-        // macOS: always prefer Metal (linked directly, no plugin needed).
-        // After that, probe for Vulkan/MoltenVK and OpenVINO plugins.
+        // macOS: probe backends via the plugin system.
+        // Priority: Metal → OpenVINO → Vulkan → CPU.
         #[cfg(target_os = "macos")]
         {
             use crate::backend::BackendKind;
-            if let Ok(device) = candle_core::Device::new_metal(0) {
-                tracing::info!("Using Metal device");
-                // Still probe for OpenVINO so users know it is (or isn't)
-                // available for a future CPU-only OpenVINO path.
-                if matches!(crate::backend::detect_backend(), BackendKind::OpenVino) {
-                    tracing::info!(
-                        "OpenVINO runtime detected alongside Metal — OpenVINO CPU \
-                         acceleration will be available once candle gains an \
-                         OpenVINO backend."
-                    );
-                }
-                return Ok(device);
-            }
-
-            // Metal unavailable (e.g. CI VM without GPU): probe for
-            // Vulkan/MoltenVK and OpenVINO and log their availability.
             match crate::backend::detect_backend() {
+                BackendKind::Metal => {
+                    let device = candle_core::Device::new_metal(0)?;
+                    tracing::info!("Using Metal device (via plugin)");
+                    return Ok(device);
+                }
                 BackendKind::Vulkan => {
                     tracing::info!(
                         "Vulkan/MoltenVK driver detected but candle 0.8 has no \
@@ -288,7 +277,7 @@ impl ServeArgs {
         // Platform notes:
         //   Linux x86_64 / aarch64 : CUDA → ROCm → Hexagon → OpenVINO → MUSA → CANN → Vulkan → CPU
         //   Android aarch64         : Hexagon → OpenVINO → CANN → Vulkan → CPU
-        //   macOS                   : Metal → OpenVINO → Vulkan → CPU
+        //   macOS                   : Metal → OpenVINO → Vulkan → CPU  (handled above)
         //   Windows x86_64          : CUDA → ROCm → OpenVINO → MUSA → Vulkan → CPU
         //   Windows aarch64         : Hexagon → OpenVINO → Vulkan → CPU
         #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]


### PR DESCRIPTION
Introduce a new cdylib backend plugin that probes Apple Metal GPU
availability via candle_core::Device::new_metal(0), following the same
pattern as inferrs-backend-cuda.

Metal detection is moved from a hardcoded Device::new_metal(0) call in
auto_device() into the plugin system so macOS backend discovery is
consistent with all other platforms. BackendKind::Metal is added to the
macOS module in backend.rs with the highest priority (Metal → OpenVINO →
Vulkan → CPU). The plugin is included in default-members since the Metal
framework is always present on macOS and requires no external SDK.