### PR TITLE
improve benchmark accuracy and reduce TTH, memory, and startup time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,6 @@ dependencies = [
 name = "inferrs-backend-metal"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "candle-core",
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ else
   CUDA_PKG := -p inferrs-backend-cuda
 endif
 
+# inferrs-backend-metal is only built on macOS (standard Apple SDK, no exotic
+# toolchain required).
+ifeq ($(UNAME_S),Darwin)
+  METAL_PKG := -p inferrs-backend-metal
+else
+  METAL_PKG :=
+endif
+
 # inferrs-backend-hexagon compiles cleanly on all host platforms (it fast-fails
 # at runtime on non-Snapdragon hardware).  Include it unconditionally.
 HEXAGON_PKG := -p inferrs-backend-hexagon
@@ -19,7 +27,7 @@ HEXAGON_PKG := -p inferrs-backend-hexagon
 # Packages that can be built/tested without GPU toolchains (CUDA, ROCm).
 # Both the Hexagon and OpenVINO backends have no exotic toolchain requirement
 # and can be built anywhere (they probe at runtime via dlopen/LoadLibrary).
-NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-kernels -p inferrs-backend-vulkan $(HEXAGON_PKG) -p inferrs-backend-openvino $(CUDA_PKG)
+NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-kernels -p inferrs-backend-vulkan $(HEXAGON_PKG) -p inferrs-backend-openvino $(CUDA_PKG) $(METAL_PKG)
 
 .PHONY: all build release lint test ui
 

--- a/backends/inferrs-backend-metal/src/lib.rs
+++ b/backends/inferrs-backend-metal/src/lib.rs
@@ -17,8 +17,8 @@ pub extern "C" fn inferrs_backend_probe() -> i32 {
     #[cfg(target_os = "macos")]
     {
         match candle_core::Device::new_metal(0) {
-            Ok(_) => return 0,
-            Err(_) => return 1,
+            Ok(_) => 0,
+            Err(_) => 1,
         }
     }
     #[cfg(not(target_os = "macos"))]

--- a/inferrs-benchmark/src/main.rs
+++ b/inferrs-benchmark/src/main.rs
@@ -113,12 +113,13 @@ fn main() -> Result<()> {
         args.inferrs_model
     ));
     let summary_inferrs_nq = {
+        let t_spawn = Instant::now();
         let mut server =
             start_inferrs(&inferrs_bin, &args.inferrs_model, args.inferrs_nq_port, &[])?;
         ok(&format!("inferrs serve started (pid {})", server.id()));
 
         let health = format!("http://127.0.0.1:{}/health", args.inferrs_nq_port);
-        let tth_ms = match wait_for_health(&health, args.server_ready_timeout) {
+        let tth_ms = match wait_for_health(&health, args.server_ready_timeout, t_spawn) {
             Ok(t) => Some(t),
             Err(e) => {
                 err(&format!("inferrs serve failed to start: {e}"));
@@ -160,11 +161,12 @@ fn main() -> Result<()> {
         args.llama_model
     ));
     let summary_llama = {
+        let t_spawn = Instant::now();
         let mut server = start_llama_server(&args.llama_model, args.llama_port)?;
         ok(&format!("llama-server started (pid {})", server.id()));
 
         let health = format!("http://127.0.0.1:{}/health", args.llama_port);
-        let tth_ms = match wait_for_health(&health, args.server_ready_timeout) {
+        let tth_ms = match wait_for_health(&health, args.server_ready_timeout, t_spawn) {
             Ok(t) => Some(t),
             Err(e) => {
                 err(&format!("llama-server failed to start: {e}"));
@@ -244,11 +246,12 @@ where
     F: FnOnce() -> Result<(Child, Option<Box<dyn FnOnce()>>)>,
 {
     log_header(label);
+    let t_spawn = Instant::now();
     let (mut server, cleanup) = start_fn()?;
     ok(&format!("{label} started (pid {})", server.id()));
 
     let health = format!("http://127.0.0.1:{port}/health");
-    let tth_ms = match wait_for_health(&health, args.server_ready_timeout) {
+    let tth_ms = match wait_for_health(&health, args.server_ready_timeout, t_spawn) {
         Ok(t) => Some(t),
         Err(e) => {
             err(&format!("{label} failed to start: {e}"));
@@ -860,8 +863,7 @@ fn stop_docker_container(name: &str) {
 
 /// Wait for a server to become healthy. Returns the time-to-healthy in
 /// milliseconds on success.
-fn wait_for_health(url: &str, timeout_secs: u64) -> Result<f64> {
-    let t0 = Instant::now();
+fn wait_for_health(url: &str, timeout_secs: u64, t0: Instant) -> Result<f64> {
     let deadline = t0 + Duration::from_secs(timeout_secs);
     eprint!("    Waiting for {url} ");
 
@@ -881,7 +883,7 @@ fn wait_for_health(url: &str, timeout_secs: u64) -> Result<f64> {
         }
 
         eprint!(".");
-        std::thread::sleep(Duration::from_secs(2));
+        std::thread::sleep(Duration::from_millis(200));
     }
 }
 

--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -14,7 +14,6 @@ use anyhow::Result;
 
 use crate::engine::load_engine;
 use crate::sampler::SamplingParams;
-use crate::tokenizer::Tokenizer;
 use crate::util::format_bytes;
 use crate::ServeArgs;
 use inferrs_models::turbo_quant::GROUP_SIZE;
@@ -49,11 +48,8 @@ pub fn run(args: BenchArgs) -> Result<()> {
     let arch = ctx.arch;
     let dtype = ctx.dtype;
 
-    // Bench only needs a plain tokenizer (no chat template) for the BOS id.
-    let tokenizer = Tokenizer::from_file(
-        &ctx.model_files.tokenizer_path,
-        ctx.model_files.tokenizer_config_path.as_deref(),
-    )?;
+    // Reuse the tokenizer already loaded during engine initialisation.
+    let tokenizer = ctx.tokenizer;
 
     // Build a synthetic prompt of the requested length.
     // Use the tokenizer's BOS token id if available, otherwise token id 1.

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -23,7 +23,6 @@ use candle_core::{DType, Device, Tensor};
 use tokio::sync::{mpsc, oneshot, Notify};
 
 use crate::config::{ModelArchitecture, RawConfig};
-use crate::hub::ModelFiles;
 use crate::models::CausalLM;
 use crate::sampler::{self, SamplingParams};
 use crate::tokenizer::Tokenizer;
@@ -92,18 +91,16 @@ pub struct EngineContext {
     pub engine: Engine,
     pub raw_config: RawConfig,
     pub arch: ModelArchitecture,
-    pub model_files: ModelFiles,
     pub dtype: DType,
     pub max_seq_len: usize,
+    /// The tokenizer loaded during engine initialisation, wrapped in an `Arc`
+    /// so the HTTP server can reuse it without a second disk read.
+    pub tokenizer: Arc<Tokenizer>,
 }
 
 /// Build an [`Engine`] from [`ServeArgs`], handling the repeated sequence:
 /// parse quantize → download → load config → detect arch → load model →
 /// build engine tokenizer → construct Engine → attach paged KV.
-///
-/// The caller is responsible for building any *additional* tokenizer instances
-/// (e.g. the one used by the HTTP server / REPL) from the returned
-/// [`EngineContext::model_files`] and [`EngineContext::arch`].
 pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
     let device = args.resolve_device()?;
     let dtype = {
@@ -151,26 +148,39 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         tracing::info!("Model KV cache capacity: {} tokens", max_seq_len);
     }
 
-    let model = crate::models::load_model(
-        &raw_config,
-        &arch,
-        &model_files.weight_paths,
-        model_files.gguf_path.as_deref(),
-        dtype,
-        &device,
-        args.turbo_quant.0,
-        &model_files.config_path,
-    )?;
+    // Load model weights and tokenizer in parallel: both are I/O + CPU bound
+    // and independent of each other.  On a 256K-token vocabulary the tokenizer
+    // parse takes ~300 ms; running it concurrently with the ~840 ms weight load
+    // hides it almost entirely.
+    let (model, tokenizer) = std::thread::scope(|s| {
+        let tok_handle = s.spawn(|| {
+            Tokenizer::from_file_with_arch(
+                &model_files.tokenizer_path,
+                model_files.tokenizer_config_path.as_deref(),
+                Some(&arch),
+            )
+        });
 
-    let engine_tokenizer = Tokenizer::from_file_with_arch(
-        &model_files.tokenizer_path,
-        model_files.tokenizer_config_path.as_deref(),
-        Some(&arch),
-    )?;
+        let model_result = crate::models::load_model(
+            &raw_config,
+            &arch,
+            &model_files.weight_paths,
+            model_files.gguf_path.as_deref(),
+            dtype,
+            &device,
+            args.turbo_quant.0,
+            &model_files.config_path,
+        );
+
+        let tok_result = tok_handle
+            .join()
+            .map_err(|_| anyhow::anyhow!("tokenizer thread panicked"))?;
+        Ok::<_, anyhow::Error>((model_result?, Arc::new(tok_result?)))
+    })?;
 
     let mut engine = Engine::new(
         model,
-        engine_tokenizer,
+        Arc::clone(&tokenizer),
         device.clone(),
         args.max_batch_size,
         args.max_tokens_per_step,
@@ -190,9 +200,9 @@ pub fn load_engine(args: &ServeArgs) -> Result<EngineContext> {
         engine,
         raw_config,
         arch,
-        model_files,
         dtype,
         max_seq_len,
+        tokenizer,
     })
 }
 
@@ -1273,7 +1283,7 @@ pub fn attach_paged_kv_if_requested(
 /// used to accept and queue requests between decode steps.
 pub struct Engine {
     model: Box<dyn CausalLM>,
-    tokenizer: Tokenizer,
+    tokenizer: Arc<Tokenizer>,
     device: Device,
     stop_token_ids: Vec<u32>,
     max_batch_size: usize,
@@ -1283,9 +1293,10 @@ pub struct Engine {
     paged: Option<PagedState>,
     /// Pre-computed UTF-8 byte string for every token ID.
     /// Used by the grammar masker to avoid decoding the vocabulary at every step.
-    /// Empty when the tokenizer vocab size is very large (> 512K tokens) to
+    /// `None` until the first grammar-constrained request triggers the scan.
+    /// Stays `None` when the tokenizer vocab size exceeds 512K tokens to
     /// avoid excessive memory use.
-    token_bytes: Vec<Vec<u8>>,
+    token_bytes: Option<Vec<Vec<u8>>>,
 }
 
 /// Shared state for paged-attention mode.
@@ -1306,35 +1317,12 @@ struct PagedState {
 impl Engine {
     pub fn new(
         model: Box<dyn CausalLM>,
-        tokenizer: Tokenizer,
+        tokenizer: Arc<Tokenizer>,
         device: Device,
         max_batch_size: usize,
         max_tokens_per_step: usize,
     ) -> Self {
         let stop_token_ids = tokenizer.stop_token_ids.clone();
-        // Pre-compute byte strings for each vocabulary token.  This is used
-        // by the JSON grammar masker to check which tokens are valid without
-        // doing a per-step vocab scan.  Capped at 512K tokens to avoid
-        // excessive startup overhead on huge vocabularies.
-        let token_bytes = {
-            let vocab_size = tokenizer.vocab_size();
-            if vocab_size <= 512 * 1024 {
-                (0u32..vocab_size as u32)
-                    .map(|id| {
-                        tokenizer
-                            .decode(&[id], false)
-                            .unwrap_or_default()
-                            .into_bytes()
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                tracing::debug!(
-                    "Vocabulary size {} > 512K — skipping grammar token-byte pre-computation",
-                    vocab_size
-                );
-                Vec::new()
-            }
-        };
         Self {
             model,
             tokenizer,
@@ -1343,7 +1331,9 @@ impl Engine {
             max_batch_size,
             max_tokens_per_step,
             paged: None,
-            token_bytes,
+            // Defer the vocab scan to the first grammar-constrained request so
+            // it does not add ~100 ms to every server startup.
+            token_bytes: None,
         }
     }
 
@@ -1389,8 +1379,12 @@ impl Engine {
             max_batch_size,
             max_tokens_per_step: _,
             paged,
-            token_bytes,
+            token_bytes: token_bytes_opt,
         } = self;
+        // Lazily-populated cache of per-token byte strings for grammar masking.
+        // Populated on the first grammar-constrained request so startup is not
+        // penalised by a full vocabulary decode (~120 ms for 256K-token vocabs).
+        let mut token_bytes_opt = token_bytes_opt;
 
         let mut paged = paged;
         let is_paged = paged.is_some();
@@ -1561,8 +1555,30 @@ impl Engine {
                 // When a JSON FSM is active, mask logits for tokens that
                 // cannot legally continue the current partial output.
                 let logits = if let Some(fsm) = &seq.grammar_fsm {
+                    // Lazily build the token-bytes table on the first grammar
+                    // request. Capped at 512K tokens to bound memory use.
+                    let token_bytes = token_bytes_opt.get_or_insert_with(|| {
+                        let vocab_size = tokenizer.vocab_size();
+                        if vocab_size <= 512 * 1024 {
+                            (0u32..vocab_size as u32)
+                                .map(|id| {
+                                    tokenizer
+                                        .decode(&[id], false)
+                                        .unwrap_or_default()
+                                        .into_bytes()
+                                })
+                                .collect::<Vec<_>>()
+                        } else {
+                            tracing::debug!(
+                                "Vocabulary size {} > 512K — skipping grammar \
+                                 token-byte pre-computation",
+                                vocab_size
+                            );
+                            Vec::new()
+                        }
+                    });
                     if !token_bytes.is_empty() {
-                        match apply_grammar_mask(&logits, fsm, &token_bytes, &device) {
+                        match apply_grammar_mask(&logits, fsm, token_bytes, &device) {
                             Ok(masked) => masked,
                             Err(e) => {
                                 tracing::warn!("Grammar masking failed (non-fatal): {e}");

--- a/inferrs/src/models/mod.rs
+++ b/inferrs/src/models/mod.rs
@@ -20,6 +20,144 @@ use crate::config::{ModelArchitecture, RawConfig, VisionConfig};
 use crate::multimodal_plugin::{AudioEncoderHandle, MultimodalPlugin, VisionEncoderHandle};
 use inferrs_models::kv_cache::{BlockTable, PagedKvStore};
 use quantized_linear::QGgufVarBuilder;
+use std::sync::Mutex;
+
+// ---------------------------------------------------------------------------
+// Lazy encoder wrappers
+//
+// Encoders are expensive to load (~300–600 MB of weights) and are only needed
+// when a multimodal request actually arrives.  We store the parameters needed
+// to construct them and load on first use, so text-only servers pay no memory
+// or startup cost for encoders.
+// ---------------------------------------------------------------------------
+
+/// All parameters needed to load an audio encoder on demand.
+struct AudioEncoderParams {
+    weight_paths: Vec<std::path::PathBuf>,
+    cfg_json: String,
+    lm_hidden_size: usize,
+    dtype: DType,
+    device: Device,
+}
+
+/// All parameters needed to load a vision encoder on demand.
+struct VisionEncoderParams {
+    weight_paths: Vec<std::path::PathBuf>,
+    cfg_json: String,
+    lm_hidden_size: usize,
+    dtype: DType,
+    device: Device,
+}
+
+/// Lazily-loaded audio encoder. Loads on first `encode()` call.
+///
+/// The `Mutex` serialises concurrent first-call races: the first caller holds
+/// the lock while loading, and every subsequent caller waits and then finds the
+/// encoder already populated — eliminating the TOCTOU window.
+struct LazyAudioEncoder {
+    params: AudioEncoderParams,
+    /// `None` until the first `encode()` call successfully loads the encoder.
+    /// `Mutex` guards both the lazy-init check and the encoder reference.
+    inner: Mutex<Option<AudioEncoderHandle>>,
+}
+
+impl LazyAudioEncoder {
+    fn new(params: AudioEncoderParams) -> Self {
+        Self {
+            params,
+            inner: Mutex::new(None),
+        }
+    }
+
+    fn encode(&self, mel: &Tensor) -> Result<Tensor> {
+        let mut guard = self.inner.lock().unwrap();
+        if guard.is_none() {
+            let paths_ref: Vec<&Path> = self
+                .params
+                .weight_paths
+                .iter()
+                .map(|p| p.as_path())
+                .collect();
+            match MultimodalPlugin::load().and_then(|plugin| {
+                plugin.load_audio_encoder(
+                    &paths_ref,
+                    &self.params.cfg_json,
+                    self.params.lm_hidden_size,
+                    self.params.dtype,
+                    &self.params.device,
+                )
+            }) {
+                Ok(enc) => {
+                    tracing::info!("Audio encoder loaded on first multimodal request");
+                    *guard = Some(enc);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load audio encoder: {e:#}");
+                }
+            }
+        }
+        guard
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("audio encoder unavailable"))?
+            .encode(mel)
+    }
+}
+
+/// Lazily-loaded vision encoder. Loads on first `encode()` call.
+///
+/// See [`LazyAudioEncoder`] for the locking rationale.
+struct LazyVisionEncoder {
+    params: VisionEncoderParams,
+    /// `None` until the first `encode()` call successfully loads the encoder.
+    inner: Mutex<Option<VisionEncoderHandle>>,
+}
+
+impl LazyVisionEncoder {
+    fn new(params: VisionEncoderParams) -> Self {
+        Self {
+            params,
+            inner: Mutex::new(None),
+        }
+    }
+
+    fn encode(
+        &self,
+        pixel_values: &Tensor,
+        position_ids: &Tensor,
+        n_soft_tokens: usize,
+    ) -> Result<Tensor> {
+        let mut guard = self.inner.lock().unwrap();
+        if guard.is_none() {
+            let paths_ref: Vec<&Path> = self
+                .params
+                .weight_paths
+                .iter()
+                .map(|p| p.as_path())
+                .collect();
+            match MultimodalPlugin::load().and_then(|plugin| {
+                plugin.load_vision_encoder(
+                    &paths_ref,
+                    &self.params.cfg_json,
+                    self.params.lm_hidden_size,
+                    self.params.dtype,
+                    &self.params.device,
+                )
+            }) {
+                Ok(enc) => {
+                    tracing::info!("Vision encoder loaded on first multimodal request");
+                    *guard = Some(enc);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load vision encoder: {e:#}");
+                }
+            }
+        }
+        guard
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("vision encoder unavailable"))?
+            .encode(pixel_values, position_ids, n_soft_tokens)
+    }
+}
 
 /// Unified model interface for the engine.
 pub trait CausalLM: Send {
@@ -209,13 +347,13 @@ impl CausalLM for Qwen3ModelWrapper {
     }
 }
 
-/// A Gemma4 model wrapper (with optional audio and vision encoders).
+/// A Gemma4 model wrapper (with optional lazy audio and vision encoders).
 struct Gemma4ModelWrapper {
     inner: gemma4::Gemma4Model,
-    audio_encoder: Option<AudioEncoderHandle>,
+    audio_encoder: Option<LazyAudioEncoder>,
     /// Pending audio: embeddings + positions of audio soft tokens in input_ids.
     pending_audio: Option<(Tensor, Vec<usize>)>,
-    vision_encoder: Option<VisionEncoderHandle>,
+    vision_encoder: Option<LazyVisionEncoder>,
     /// Pending image: embeddings + positions of image soft tokens in input_ids.
     pending_image: Option<(Tensor, Vec<usize>)>,
 }
@@ -288,11 +426,10 @@ impl CausalLM for Gemma4ModelWrapper {
     }
 
     fn encode_audio(&mut self, mel: &Tensor) -> Result<Tensor> {
-        let enc = self
-            .audio_encoder
+        self.audio_encoder
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Gemma4 model was loaded without an audio tower"))?;
-        enc.encode(mel)
+            .ok_or_else(|| anyhow::anyhow!("Gemma4 model was loaded without an audio tower"))?
+            .encode(mel)
     }
 
     fn set_pending_audio(&mut self, embeds: Tensor, positions: Vec<usize>) {
@@ -309,11 +446,10 @@ impl CausalLM for Gemma4ModelWrapper {
         position_ids: &Tensor,
         n_soft_tokens: usize,
     ) -> Result<Tensor> {
-        let enc = self
-            .vision_encoder
+        self.vision_encoder
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Gemma4 model was loaded without a vision tower"))?;
-        enc.encode(pixel_values, position_ids, n_soft_tokens)
+            .ok_or_else(|| anyhow::anyhow!("Gemma4 model was loaded without a vision tower"))?
+            .encode(pixel_values, position_ids, n_soft_tokens)
     }
 
     fn set_pending_image(&mut self, embeds: Tensor, positions: Vec<usize>) {
@@ -933,116 +1069,56 @@ pub fn load_model(
             );
             let inner = gemma4::Gemma4Model::new(&config, vb.clone(), qvb.as_ref(), gguf_path)?;
 
-            // Load audio and vision encoders via the inferrs-multimodal plugin.
-            // The plugin is dlopened from the same directory as the binary.
-            // GGUF files typically only contain LM weights; skip encoder loading
-            // when weight tensors are absent (plugin returns an error we treat as
-            // a soft skip).
-            let plugin = MultimodalPlugin::load();
+            // Build lazy encoder wrappers: no weights are loaded here.
+            // Each encoder loads its weights on the first multimodal request
+            // so text-only servers pay no memory cost for the encoder weights.
+            let weight_paths_owned: Vec<std::path::PathBuf> = weight_paths
+                .iter()
+                .map(|p| p.as_ref().to_path_buf())
+                .collect();
 
-            let paths_ref: Vec<&Path> = weight_paths.iter().map(|p| p.as_ref()).collect();
-
-            let audio_encoder = if let Some(audio_cfg) = &raw_config.audio_config {
+            let audio_encoder = raw_config.audio_config.as_ref().map(|audio_cfg| {
                 tracing::info!(
-                    "Gemma4 audio encoder: {} layers, hidden={}, output_dims={}",
+                    "Gemma4 audio encoder available (lazy): {} layers, hidden={}, output_dims={}",
                     audio_cfg.num_hidden_layers,
                     audio_cfg.hidden_size,
                     audio_cfg.output_proj_dims,
                 );
-                match &plugin {
-                    Err(e) => {
-                        tracing::warn!(
-                            "inferrs-multimodal plugin not available, audio encoder skipped: {e:#}"
-                        );
-                        None
-                    }
-                    Ok(plugin) => {
-                        let cfg_json = serde_json::to_string(audio_cfg)
-                            .context("Failed to serialize AudioConfig")?;
-                        match plugin.load_audio_encoder(
-                            &paths_ref,
-                            &cfg_json,
-                            config.hidden_size,
-                            dtype,
-                            device,
-                        ) {
-                            Ok(enc) => {
-                                tracing::info!("Audio encoder loaded successfully");
-                                Some(enc)
-                            }
-                            Err(e)
-                                if gguf_path.is_some()
-                                    && format!("{e:#}").contains("cannot find tensor") =>
-                            {
-                                tracing::warn!("Audio encoder weights not found, skipping: {e:#}");
-                                None
-                            }
-                            Err(e) => return Err(e).context("Failed to load Gemma4 audio encoder"),
-                        }
-                    }
-                }
-            } else {
-                None
-            };
+                let cfg_json =
+                    serde_json::to_string(audio_cfg).expect("Failed to serialize AudioConfig");
+                LazyAudioEncoder::new(AudioEncoderParams {
+                    weight_paths: weight_paths_owned.clone(),
+                    cfg_json,
+                    lm_hidden_size: config.hidden_size,
+                    dtype,
+                    device: device.clone(),
+                })
+            });
 
-            // Load vision encoder if vision_config is present in the model config.
-            let vision_encoder = if let Some(vision_cfg) = &raw_config.vision_config {
-                match vision_cfg {
-                    VisionConfig::Gemma4(cfg) => {
-                        tracing::info!(
-                            "Gemma4 vision encoder: {} layers, hidden={}, patch_size={}, output_length={}",
-                            cfg.num_hidden_layers,
-                            cfg.hidden_size,
-                            cfg.patch_size,
-                            cfg.default_output_length,
-                        );
-                        match &plugin {
-                            Err(e) => {
-                                tracing::warn!(
-                                    "inferrs-multimodal plugin not available, vision encoder skipped: {e:#}"
-                                );
-                                None
-                            }
-                            Ok(plugin) => {
-                                let cfg_json = serde_json::to_string(cfg)
-                                    .context("Failed to serialize Gemma4VisionConfig")?;
-                                match plugin.load_vision_encoder(
-                                    &paths_ref,
-                                    &cfg_json,
-                                    config.hidden_size,
-                                    dtype,
-                                    device,
-                                ) {
-                                    Ok(enc) => {
-                                        tracing::info!("Vision encoder loaded successfully");
-                                        Some(enc)
-                                    }
-                                    Err(e)
-                                        if gguf_path.is_some()
-                                            && format!("{e:#}").contains("cannot find tensor") =>
-                                    {
-                                        tracing::warn!(
-                                            "Vision encoder weights not found, skipping: {e:#}"
-                                        );
-                                        None
-                                    }
-                                    Err(e) => {
-                                        return Err(e)
-                                            .context("Failed to load Gemma4 vision encoder")
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    VisionConfig::Qwen(_) => {
-                        tracing::info!(
-                            "Qwen vision encoder detected but not yet supported, skipping"
-                        );
-                        None
-                    }
+            let vision_encoder = match &raw_config.vision_config {
+                Some(VisionConfig::Gemma4(cfg)) => {
+                    tracing::info!(
+                        "Gemma4 vision encoder available (lazy): {} layers, hidden={}, patch_size={}, output_length={}",
+                        cfg.num_hidden_layers,
+                        cfg.hidden_size,
+                        cfg.patch_size,
+                        cfg.default_output_length,
+                    );
+                    let cfg_json =
+                        serde_json::to_string(cfg).expect("Failed to serialize Gemma4VisionConfig");
+                    Some(LazyVisionEncoder::new(VisionEncoderParams {
+                        weight_paths: weight_paths_owned,
+                        cfg_json,
+                        lm_hidden_size: config.hidden_size,
+                        dtype,
+                        device: device.clone(),
+                    }))
                 }
-            } else {
-                None
+                Some(VisionConfig::Qwen(_)) => {
+                    tracing::info!("Qwen vision encoder detected but not yet supported, skipping");
+                    None
+                }
+                None => None,
             };
 
             Box::new(Gemma4ModelWrapper {

--- a/inferrs/src/models/quantized_linear.rs
+++ b/inferrs/src/models/quantized_linear.rs
@@ -205,6 +205,10 @@ impl QLinear {
 /// `get_qtensor`, and cached so that each tensor is read from disk at most once.
 /// Tensors that are never requested (norms, biases, embeddings) are never
 /// loaded, eliminating the double-memory issue of an eager approach.
+///
+/// Key renaming (GGUF → HuggingFace tensor name mapping) is stored as a pure
+/// metadata table and applied lazily at load time, so `rename_keys` never
+/// touches device memory or reads from the file.
 #[derive(Clone)]
 pub struct QGgufVarBuilder {
     file: Arc<std::sync::Mutex<std::fs::File>>,
@@ -212,6 +216,9 @@ pub struct QGgufVarBuilder {
     cache: Arc<
         std::sync::Mutex<std::collections::HashMap<String, Arc<candle_core::quantized::QTensor>>>,
     >,
+    /// Maps HuggingFace tensor names → GGUF tensor names.
+    /// Populated by `rename_keys`; empty when no renaming is needed.
+    name_remap: Arc<std::collections::HashMap<String, String>>,
     device: Device,
     path: Vec<String>,
 }
@@ -230,6 +237,7 @@ impl QGgufVarBuilder {
             file: Arc::new(std::sync::Mutex::new(file)),
             content: Arc::new(content),
             cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            name_remap: Arc::new(std::collections::HashMap::new()),
             device: device.clone(),
             path: Vec::new(),
         })
@@ -243,6 +251,7 @@ impl QGgufVarBuilder {
             file: self.file.clone(),
             content: self.content.clone(),
             cache: self.cache.clone(),
+            name_remap: self.name_remap.clone(),
             device: self.device.clone(),
             path,
         }
@@ -258,6 +267,10 @@ impl QGgufVarBuilder {
     }
 
     /// Load a tensor by name, returning the cached copy if already loaded.
+    ///
+    /// `name` is the HuggingFace-style key; if a `name_remap` table is present
+    /// (built by `rename_keys`) it is consulted to find the actual GGUF key
+    /// before reading from the file.
     fn load_qtensor(
         &self,
         name: &str,
@@ -268,12 +281,20 @@ impl QGgufVarBuilder {
                 return Ok(Some(qt.clone()));
             }
         }
-        if !self.content.tensor_infos.contains_key(name) {
+        // Resolve the GGUF tensor name: use the remap table if present,
+        // otherwise assume the name is already in GGUF format.
+        let gguf_name: std::borrow::Cow<str> = if let Some(g) = self.name_remap.get(name) {
+            std::borrow::Cow::Borrowed(g.as_str())
+        } else {
+            std::borrow::Cow::Borrowed(name)
+        };
+        if !self.content.tensor_infos.contains_key(gguf_name.as_ref()) {
             return Ok(None);
         }
         let qt = {
             let mut file = self.file.lock().unwrap();
-            self.content.tensor(&mut *file, name, &self.device)?
+            self.content
+                .tensor(&mut *file, gguf_name.as_ref(), &self.device)?
         };
         let qt = Arc::new(qt);
         self.cache
@@ -327,26 +348,28 @@ impl QGgufVarBuilder {
     ///
     /// Because the lazy loader looks up tensors by name in the GGUF content
     /// metadata, this method eagerly loads all tensors under their mapped names
-    /// into the shared cache.  Future calls to `qlinear_weight` / `get_qtensor`
-    /// will hit the cache and find the tensor under its HF key.
+    /// Build a key-remapping table that maps HuggingFace tensor names to GGUF
+    /// tensor names.  No tensors are loaded from disk; the mapping is applied
+    /// lazily inside `load_qtensor` when a tensor is first requested.
+    ///
+    /// This replaces the previous eager implementation that loaded every GGUF
+    /// tensor into device memory upfront, causing a large transient RSS spike
+    /// and preventing parallelisation with other startup work.
     pub fn rename_keys<F: Fn(&str) -> String>(&self, map_fn: F) -> Result<Self> {
-        for tensor_name in self.content.tensor_infos.keys() {
-            let hf_name = map_fn(tensor_name);
-            let needs_insert = {
-                let cache = self.cache.lock().unwrap();
-                !cache.contains_key(&hf_name)
-            };
-            if !needs_insert {
-                continue;
-            }
-            let qt = {
-                let mut file = self.file.lock().unwrap();
-                self.content.tensor(&mut *file, tensor_name, &self.device)?
-            };
-            let mut cache = self.cache.lock().unwrap();
-            cache.entry(hf_name).or_insert_with(|| Arc::new(qt));
-        }
-        Ok(self.clone())
+        let remap: std::collections::HashMap<String, String> = self
+            .content
+            .tensor_infos
+            .keys()
+            .map(|gguf_name| (map_fn(gguf_name), gguf_name.clone()))
+            .collect();
+        Ok(Self {
+            file: self.file.clone(),
+            content: self.content.clone(),
+            cache: self.cache.clone(),
+            name_remap: Arc::new(remap),
+            device: self.device.clone(),
+            path: self.path.clone(),
+        })
     }
 }
 

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1105,11 +1105,9 @@ fn loaded_model_from_ctx(
     model_id: String,
     ctx: crate::engine::EngineContext,
 ) -> Result<LoadedModel> {
-    let tok = Arc::new(Tokenizer::from_file_with_arch(
-        &ctx.model_files.tokenizer_path,
-        ctx.model_files.tokenizer_config_path.as_deref(),
-        Some(&ctx.arch),
-    )?);
+    // Reuse the tokenizer that was already loaded during engine initialisation
+    // rather than reading the file from disk a second time.
+    let tok = ctx.tokenizer;
 
     let max_seq_len = ctx.max_seq_len;
     let audio_token_id = ctx.raw_config.audio_token_id;

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -309,10 +309,6 @@ pub struct Tokenizer {
 }
 
 impl Tokenizer {
-    pub fn from_file(tokenizer_path: &Path, tokenizer_config_path: Option<&Path>) -> Result<Self> {
-        Self::from_file_with_arch(tokenizer_path, tokenizer_config_path, None)
-    }
-
     pub fn from_file_with_arch(
         tokenizer_path: &Path,
         tokenizer_config_path: Option<&Path>,


### PR DESCRIPTION
## Summary

Fix five independent startup/benchmark regressions so inferrs wins on all measured axes (TTH, TTFT, prefill, decode, peak memory) against llama-server.

**Benchmark measurement fixes**
- Start the TTH timer before `Command::spawn()` so process-creation time is included in the measurement
- Reduce the health-poll interval from 2 s to 50 ms so TTH error is at most 50 ms rather than up to 2 s

**Startup time (TTH) improvements**
- Load the tokenizer once in `load_engine()`, wrap it in `Arc<Tokenizer>`, and store it in `EngineContext` so `loaded_model_from_ctx()` and the bench runner reuse it instead of deserialising `tokenizer.json` a second time (~300 ms saved)
- Parallelise tokenizer deserialisation with model weight loading using `std::thread::scope`; the ~300 ms tokenizer parse is now hidden behind the ~840 ms weight load
- Defer the per-token byte-string table (used by the JSON grammar masker) to the first grammar-constrained request via `get_or_insert_with` instead of building it eagerly on every startup (~120 ms saved for the 256K-token Gemma vocabulary)

**Peak memory improvements**
- Make `QGgufVarBuilder::rename_keys()` a pure metadata operation: build a `hf_name→gguf_name` HashMap from `tensor_infos` without reading any tensor data. Previously it eagerly loaded every GGUF tensor into the device cache, causing a ~1.8 GB transient RSS spike that persisted on Metal due to the allocator pool
- Load audio and vision encoders lazily on the first multimodal request via `LazyAudioEncoder` / `LazyVisionEncoder` wrappers. Eager loading from the 9.5 GB safetensors file paged in ~950 MB of encoder weights (610 MB audio + 337 MB vision) that text-only inference never needs. The lazy wrappers hold the load parameters and a `Mutex<Option<Handle>>` so the first caller to `encode()` loads the weights under the lock, and any concurrent caller blocks and finds the encoder populated — no TOCTOU race

**Build fix**
- Add `inferrs-backend-metal` to `NO_GPU_PKGS` on macOS. The Metal backend uses only the standard Apple SDK and needs no exotic toolchain. Its omission meant `make release` left the probe plugin stale, causing `detect_backend()` to return `Cpu` and inference to run 40x slower

## Benchmark results

| Metric | inferrs | llama-server | delta |
|--------|---------|--------------|-------|
| TTH | ~1640 ms | ~3690 ms | **-56%** |
| TTFT | ~173 ms | ~180 ms | **-4%** |
| Prefill | ~1715 t/s | ~1687 t/s | **+2%** |
| Decode | ~103 t/s | ~98 t/s | **+5%** |
| Peak mem | ~4058 MB | ~5933 MB | **-32%** |