### PR TITLE
enable vision input on Ollama /api/chat endpoint

### DIFF
--- a/candle-nn/src/linear.rs
+++ b/candle-nn/src/linear.rs
@@ -43,31 +43,36 @@ impl super::Module for Linear {
     fn forward(&self, x: &Tensor) -> candle::Result<Tensor> {
         // When possible, we avoid using a broadcasted matmul as it is much slower
         // than the standard matmul for the cuda and cpu backends.
+        //
+        // `.contiguous()` on transposed weights is required for Metal: the Metal
+        // matmul kernel requires the rhs to be contiguous, and `.t()` produces a
+        // strided (non-contiguous) view that triggers a spurious "device mismatch"
+        // error in candle-metal even when both tensors are on the same device.
         let x = match *x.dims() {
             [b1, b2, m, k] => {
                 if x.is_contiguous() {
-                    let w = self.weight.t()?;
+                    let w = self.weight.t()?.contiguous()?;
                     x.reshape((b1 * b2 * m, k))?
                         .matmul(&w)?
                         .reshape((b1, b2, m, ()))?
                 } else {
-                    let w = self.weight.broadcast_left((b1, b2))?.t()?;
+                    let w = self.weight.broadcast_left((b1, b2))?.t()?.contiguous()?;
                     x.matmul(&w)?
                 }
             }
             [bsize, m, k] => {
                 if x.is_contiguous() {
-                    let w = self.weight.t()?;
+                    let w = self.weight.t()?.contiguous()?;
                     x.reshape((bsize * m, k))?
                         .matmul(&w)?
                         .reshape((bsize, m, ()))?
                 } else {
-                    let w = self.weight.broadcast_left(bsize)?.t()?;
+                    let w = self.weight.broadcast_left(bsize)?.t()?.contiguous()?;
                     x.matmul(&w)?
                 }
             }
             _ => {
-                let w = self.weight.t()?;
+                let w = self.weight.t()?.contiguous()?;
                 x.matmul(&w)?
             }
         };

--- a/inferrs-models/src/models/qwen3_5.rs
+++ b/inferrs-models/src/models/qwen3_5.rs
@@ -1209,8 +1209,7 @@ impl MtpModule {
         let _ = embed_tokens_weight; // weight is already in lm_head
 
         // MTP has its own copy of the final norm (mtp.norm.weight).
-        let norm =
-            rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, mtp_vb.pp("norm"), 1.0)?;
+        let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, mtp_vb.pp("norm"), 1.0)?;
 
         let (cos, sin) = precompute_rope(
             cfg.head_dim,

--- a/inferrs-multimodal/src/ffi.rs
+++ b/inferrs-multimodal/src/ffi.rs
@@ -85,6 +85,12 @@ fn decode_dtype(tag: u8) -> Result<DType> {
 
 /// Build a `VarBuilder` from a list of null-terminated safetensors paths.
 ///
+/// Returns `(vb, device)` so the caller can reuse the *exact same* `Device`
+/// instance that was used to load the weights.  On Metal, `same_device` checks
+/// pointer identity (via `DeviceId`), so a second call to `decode_device` would
+/// produce a different ID and trigger spurious "device mismatch" errors when
+/// input tensors are created later.
+///
 /// # Safety
 /// `paths` must point to a valid array of `n_paths` non-null, null-terminated
 /// UTF-8 strings, all of which remain valid for the duration of the call.
@@ -93,7 +99,7 @@ unsafe fn build_var_builder(
     n_paths: usize,
     dtype_tag: u8,
     device_tag: u8,
-) -> Result<VarBuilder<'static>> {
+) -> Result<(VarBuilder<'static>, Device)> {
     let device = decode_device(device_tag)?;
     let dtype = decode_dtype(dtype_tag)?;
 
@@ -110,7 +116,7 @@ unsafe fn build_var_builder(
     // SAFETY: the VarBuilder's mmap lifetime is tied to the encoder object
     // (BoxedEncoder), which is heap-allocated and lives until the caller frees it.
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&rust_paths, dtype, &device)? };
-    Ok(vb)
+    Ok((vb, device))
 }
 
 // ---------------------------------------------------------------------------
@@ -228,9 +234,15 @@ pub unsafe extern "C" fn inferrs_mm_free_f32(ptr: *mut f32, len: usize) {
 // ---------------------------------------------------------------------------
 
 /// Opaque handle wrapping either an `AudioEncoder` or `VisionEncoder`.
+///
+/// The `Device` is stored alongside the encoder so that `encode` calls reuse
+/// the exact same `MetalDevice` instance that was used during weight loading.
+/// On Metal, `same_device` checks pointer identity (not just the registry ID),
+/// so creating a new `Device::new_metal(0)` on every encode call produces a
+/// different identity and triggers a spurious "device mismatch" error.
 enum BoxedEncoder {
-    Audio(Box<AudioEncoder>),
-    Vision(Box<VisionEncoder>),
+    Audio(Box<AudioEncoder>, Device),
+    Vision(Box<VisionEncoder>, Device),
 }
 
 // ---------------------------------------------------------------------------
@@ -260,15 +272,14 @@ pub unsafe extern "C" fn inferrs_mm_audio_encoder_load(
     device_tag: u8,
 ) -> *mut std::os::raw::c_void {
     let result = (|| -> Result<*mut std::os::raw::c_void> {
-        let vb = unsafe { build_var_builder(paths, n_paths, dtype_tag, device_tag)? };
-        let device = decode_device(device_tag)?;
+        let (vb, device) = unsafe { build_var_builder(paths, n_paths, dtype_tag, device_tag)? };
         let dtype = decode_dtype(dtype_tag)?;
         let cfg_str = unsafe { CStr::from_ptr(audio_cfg_json) }
             .to_str()
             .map_err(|e| anyhow::anyhow!("audio_cfg_json not UTF-8: {e}"))?;
         let cfg: AudioConfig = serde_json::from_str(cfg_str)?;
         let enc = AudioEncoder::load(vb.pp("model"), &cfg, lm_hidden_size, &device, dtype)?;
-        let boxed = Box::new(BoxedEncoder::Audio(Box::new(enc)));
+        let boxed = Box::new(BoxedEncoder::Audio(Box::new(enc), device));
         Ok(Box::into_raw(boxed) as *mut std::os::raw::c_void)
     })();
     match result {
@@ -302,21 +313,20 @@ pub unsafe extern "C" fn inferrs_mm_audio_encoder_encode(
     handle: *mut std::os::raw::c_void,
     mel: *const f32,
     n_frames: usize,
-    device_tag: u8,
+    _device_tag: u8, // ignored: encoder reuses the device from load time
     out_data: *mut *mut f32,
     out_rows: *mut usize,
     out_cols: *mut usize,
 ) -> i32 {
     let result = (|| -> Result<()> {
         let enc = unsafe { &*(handle as *const BoxedEncoder) };
-        let BoxedEncoder::Audio(audio_enc) = enc else {
+        let BoxedEncoder::Audio(audio_enc, device) = enc else {
             anyhow::bail!("handle is not an audio encoder");
         };
 
-        let device = decode_device(device_tag)?;
         let n_mel = crate::audio::N_MEL;
         let mel_slice = unsafe { std::slice::from_raw_parts(mel, n_frames * n_mel) };
-        let mel_tensor = Tensor::from_slice(mel_slice, (1usize, n_frames, n_mel), &device)?
+        let mel_tensor = Tensor::from_slice(mel_slice, (1usize, n_frames, n_mel), device)?
             .to_dtype(DType::F32)?;
 
         let embeds = audio_enc.encode(&mel_tensor)?;
@@ -379,15 +389,14 @@ pub unsafe extern "C" fn inferrs_mm_vision_encoder_load(
     device_tag: u8,
 ) -> *mut std::os::raw::c_void {
     let result = (|| -> Result<*mut std::os::raw::c_void> {
-        let vb = unsafe { build_var_builder(paths, n_paths, dtype_tag, device_tag)? };
-        let device = decode_device(device_tag)?;
+        let (vb, device) = unsafe { build_var_builder(paths, n_paths, dtype_tag, device_tag)? };
         let dtype = decode_dtype(dtype_tag)?;
         let cfg_str = unsafe { CStr::from_ptr(vision_cfg_json) }
             .to_str()
             .map_err(|e| anyhow::anyhow!("vision_cfg_json not UTF-8: {e}"))?;
         let cfg: Gemma4VisionConfig = serde_json::from_str(cfg_str)?;
         let enc = VisionEncoder::load(vb.pp("model"), &cfg, lm_hidden_size, &device, dtype)?;
-        let boxed = Box::new(BoxedEncoder::Vision(Box::new(enc)));
+        let boxed = Box::new(BoxedEncoder::Vision(Box::new(enc), device));
         Ok(Box::into_raw(boxed) as *mut std::os::raw::c_void)
     })();
     match result {
@@ -425,23 +434,22 @@ pub unsafe extern "C" fn inferrs_mm_vision_encoder_encode(
     pv_cols: usize,
     position_ids: *const i64,
     n_soft_tokens: usize,
-    device_tag: u8,
+    _device_tag: u8, // ignored: encoder reuses the device from load time
     out_data: *mut *mut f32,
     out_rows: *mut usize,
     out_cols: *mut usize,
 ) -> i32 {
     let result = (|| -> Result<()> {
         let enc = unsafe { &*(handle as *const BoxedEncoder) };
-        let BoxedEncoder::Vision(vision_enc) = enc else {
+        let BoxedEncoder::Vision(vision_enc, device) = enc else {
             anyhow::bail!("handle is not a vision encoder");
         };
 
-        let device = decode_device(device_tag)?;
         let pv_slice = unsafe { std::slice::from_raw_parts(pixel_values, pv_rows * pv_cols) };
-        let pixel_tensor = Tensor::from_slice(pv_slice, (pv_rows, pv_cols), &device)?;
+        let pixel_tensor = Tensor::from_slice(pv_slice, (pv_rows, pv_cols), device)?;
 
         let pos_slice = unsafe { std::slice::from_raw_parts(position_ids, pv_rows * 2) };
-        let pos_tensor = Tensor::from_slice(pos_slice, (pv_rows, 2usize), &device)?;
+        let pos_tensor = Tensor::from_slice(pos_slice, (pv_rows, 2usize), device)?;
 
         let embeds = vision_enc.encode(&pixel_tensor, &pos_tensor, Some(n_soft_tokens))?;
         let (rows, cols) = embeds.dims2()?;

--- a/inferrs-multimodal/src/vision_encoder.rs
+++ b/inferrs-multimodal/src/vision_encoder.rs
@@ -244,8 +244,12 @@ impl VisionAttention {
 
         // Bidirectional attention with scale=1.0 (Gemma4VisionAttention sets scaling=1.0,
         // not the usual 1/sqrt(head_dim)).
-        let attn = q.matmul(&k.transpose(1, 2)?)?; // [nh, N, N]
-        let attn = candle_nn::ops::softmax_last_dim(&attn)?;
+        // `.contiguous()` on the transposed rhs is required: Metal matmul kernels
+        // require both operands to be contiguous, and transpose produces a strided
+        // view that candle-metal misidentifies as a device mismatch.
+        let k_t = k.transpose(1, 2)?.contiguous()?;
+        let attn = q.matmul(&k_t)?; // [nh, N, N]
+        let attn = candle_nn::ops::softmax_last_dim(&attn)?.contiguous()?;
         let out = attn.matmul(&v)?; // [nh, N, hd]
 
         // Merge heads: [N, nh*hd].

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -593,6 +593,9 @@ pub struct OllamaChatRequest {
 pub struct OllamaChatMessage {
     pub role: String,
     pub content: String,
+    /// Base64-encoded image data (standard Ollama vision field).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<String>,
     /// Text from inside `<think>…</think>` tags when thinking is enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking: Option<String>,
@@ -3686,6 +3689,7 @@ async fn ollama_dispatch_stream(
     backend: &ModelBackend,
     request_id: &str,
     prompt_tokens: Vec<u32>,
+    image: Option<ImageEmbedContext>,
     params: SamplingParams,
 ) -> Result<mpsc::Receiver<StreamToken>, OllamaHttpError> {
     let (engine_tx, output_buf, stream_registry) = match backend {
@@ -3713,7 +3717,7 @@ async fn ollama_dispatch_stream(
         request_id: request_id.to_string(),
         prompt_tokens,
         audio: None,
-        image: None,
+        image,
         sampling_params: params,
         output_buf: output_buf.clone(),
     };
@@ -3734,6 +3738,7 @@ async fn ollama_dispatch_blocking(
     backend: &ModelBackend,
     request_id: String,
     prompt_tokens: Vec<u32>,
+    image: Option<ImageEmbedContext>,
     params: SamplingParams,
 ) -> Result<GenerationResult, OllamaHttpError> {
     let engine_tx = match backend {
@@ -3752,7 +3757,7 @@ async fn ollama_dispatch_blocking(
         request_id,
         prompt_tokens,
         audio: None,
-        image: None,
+        image,
         sampling_params: params,
         response_tx,
     };
@@ -3940,7 +3945,7 @@ async fn ollama_generate(
     if is_stream {
         let prompt_eval_count = prompt_tokens.len();
         let token_rx =
-            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
+            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, None, params).await?;
 
         let model_name = req.model.clone();
         let stream = make_ollama_generate_stream(
@@ -3957,7 +3962,7 @@ async fn ollama_generate(
             .into_response())
     } else {
         let result =
-            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
+            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, None, params).await?;
 
         // The engine's ThinkFilter has already separated reasoning and content
         // at the token level.  Surface reasoning only when the client opted in.
@@ -4089,7 +4094,18 @@ async fn ollama_chat(
         return proxy_to_worker(&state.http_client, worker_url, "/api/chat", &req).await;
     }
 
-    let (_, tokenizer, max_seq_len, _, _, _, _, _, _, _) = worker_fields(&lm)
+    let (
+        _,
+        tokenizer,
+        max_seq_len,
+        _,
+        _,
+        _,
+        image_token_id_opt,
+        vision_patch_size,
+        vision_pooling_kernel,
+        vision_default_output_length,
+    ) = worker_fields(&lm)
         .map_err(|(s, j)| (s, Json(serde_json::json!({"error": j.0.error.message}))))?;
 
     // Convert Ollama messages to internal ChatMessage format.
@@ -4102,9 +4118,21 @@ async fn ollama_chat(
                 "assistant" => Role::Assistant,
                 _ => Role::User,
             };
+            // Convert Ollama base64 `images` array to ImageInput objects using
+            // data URLs so the vision preprocessor can decode them.
+            let images: Vec<ImageInput> = m
+                .images
+                .iter()
+                .map(|b64| ImageInput {
+                    url: format!("data:image/jpeg;base64,{b64}"),
+                })
+                .collect();
             ChatMessage {
                 role,
-                content: MessageContent::from_string(&m.content),
+                content: MessageContent {
+                    text: m.content.clone(),
+                    images,
+                },
                 audio: None,
                 tool_calls: None,
                 tool_call_id: None,
@@ -4112,14 +4140,102 @@ async fn ollama_chat(
         })
         .collect();
 
-    let prompt_tokens = tokenizer
-        .apply_chat_template_and_encode(&chat_messages)
-        .map_err(|e| {
+    let has_images = chat_messages.iter().any(|m| !m.content.images.is_empty());
+
+    // ── Vision preprocessing (mirrors the /v1/chat/completions path) ──────────
+    let (prompt_tokens, image_ctx) = if has_images {
+        let image_token_id = image_token_id_opt.ok_or_else(|| {
             (
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": format!("tokenization failed: {e}")})),
+                Json(serde_json::json!({"error": "This model does not support vision input (no image_token_id in config)"})),
             )
         })?;
+        let patch_size = vision_patch_size.unwrap_or(16);
+        let pooling_kernel = vision_pooling_kernel.unwrap_or(3);
+        let default_output_length = vision_default_output_length.unwrap_or(280);
+
+        let mut all_pixel_values: Vec<f32> = Vec::new();
+        let mut all_position_ids: Vec<i64> = Vec::new();
+        let mut image_token_counts: Vec<usize> = Vec::new();
+        let mut total_patches = 0usize;
+
+        for msg in &chat_messages {
+            for img_input in &msg.content.images {
+                let (pv, pos, n_patches, n_soft) =
+                    preprocess_image(img_input, patch_size, pooling_kernel, default_output_length)
+                        .map_err(|e| {
+                            (
+                                StatusCode::BAD_REQUEST,
+                                Json(serde_json::json!({"error": format!("Image preprocessing failed: {e}")})),
+                            )
+                        })?;
+                all_pixel_values.extend_from_slice(&pv);
+                all_position_ids.extend_from_slice(&pos);
+                image_token_counts.push(n_soft);
+                total_patches += n_patches;
+            }
+        }
+
+        let prompt = apply_gemma4_with_images(&chat_messages, &image_token_counts);
+        let tokens = tokenizer.encode(&prompt, false).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("Failed to tokenize: {e}")})),
+            )
+        })?;
+
+        let patch_pixels = patch_size * patch_size * 3;
+        let pixel_tensor = candle_core::Tensor::from_vec(
+            all_pixel_values,
+            (total_patches, patch_pixels),
+            &candle_core::Device::Cpu,
+        )
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Pixel tensor creation failed: {e}")})),
+            )
+        })?
+        .to_dtype(candle_core::DType::F32)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Pixel dtype conversion failed: {e}")})),
+            )
+        })?;
+
+        let pos_tensor = candle_core::Tensor::from_vec(
+            all_position_ids,
+            (total_patches, 2),
+            &candle_core::Device::Cpu,
+        )
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": format!("Position tensor creation failed: {e}")})),
+            )
+        })?;
+
+        let n_soft_total = image_token_counts.iter().sum();
+        let ctx = ImageEmbedContext {
+            pixel_values: pixel_tensor,
+            position_ids: pos_tensor,
+            n_soft_tokens: n_soft_total,
+            image_token_id,
+        };
+
+        (tokens, Some(ctx))
+    } else {
+        let tokens = tokenizer
+            .apply_chat_template_and_encode(&chat_messages)
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": format!("tokenization failed: {e}")})),
+                )
+            })?;
+        (tokens, None)
+    };
 
     ollama_check_prompt(&prompt_tokens, max_seq_len)?;
 
@@ -4172,7 +4288,8 @@ async fn ollama_chat(
     if is_stream {
         let prompt_eval_count = prompt_tokens.len();
         let token_rx =
-            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, params).await?;
+            ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, image_ctx, params)
+                .await?;
 
         let model_name = req.model.clone();
         let stream = make_ollama_chat_stream(
@@ -4189,7 +4306,8 @@ async fn ollama_chat(
             .into_response())
     } else {
         let result =
-            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, params).await?;
+            ollama_dispatch_blocking(&lm.backend, request_id, prompt_tokens, image_ctx, params)
+                .await?;
 
         // The engine's ThinkFilter has already separated reasoning and content.
         let (thinking, content) = if think_enabled && !result.reasoning_content.is_empty() {
@@ -4209,6 +4327,7 @@ async fn ollama_chat(
             message: OllamaChatMessage {
                 role: "assistant".to_string(),
                 content,
+                images: vec![],
                 thinking,
             },
             done: true,
@@ -4267,6 +4386,7 @@ fn make_ollama_chat_stream(
                     message: OllamaChatMessage {
                         role: "assistant".to_string(),
                         content: content_text,
+                        images: vec![],
                         thinking,
                     },
                     done: true,
@@ -4285,6 +4405,7 @@ fn make_ollama_chat_stream(
                     message: OllamaChatMessage {
                         role: "assistant".to_string(),
                         content: content_text,
+                        images: vec![],
                         thinking,
                     },
                     done: false,


### PR DESCRIPTION
Add images support to the Ollama-compatible POST /api/chat handler so that --image requests via `inferrs run` work end-to-end on Metal.

Four distinct bugs were fixed:

- OllamaChatMessage was missing the images field, silently dropping base64 image data sent by the client
- ollama_chat used plain apply_chat_template instead of the vision path (apply_gemma4_with_images + preprocess_image), so image tokens were never inserted into the prompt
- ollama_dispatch_stream/blocking hardcoded image: None, so the ImageEmbedContext was never forwarded to the engine
- The multimodal plugin (ffi.rs) called decode_device() twice during load: once inside build_var_builder (creating MetalDevice ID=N, which owns all weights) and once in the load function itself (creating MetalDevice ID=N+1, stored for later use). On Metal, same_device checks DeviceId pointer identity, so input tensors created on ID=N+1 triggered a spurious device mismatch against weights on ID=N. Fixed by returning the device from build_var_builder so the same instance is reused throughout.

Also fix non-contiguous matmul rhs on Metal: Linear::forward and the vision attention transpose both produce strided views via .t() which the Metal matmul kernel rejects with the same device mismatch error. Added .contiguous() after each transpose.