### PR TITLE
Feat/repetition penalty flags Fixes #183

### DIFF
--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -62,9 +62,14 @@ pub struct RunArgs {
 
     /// Repetition penalty (llama.cpp style): divides positive logits and
     /// multiplies negative logits of previously-seen tokens.
-    /// 1.0 = disabled (default).  Values around 1.1–1.3 reduce looping.
-    #[arg(long, default_value_t = 1.0)]
+    /// 1.0 = disabled.  Default 1.1 (llama.cpp default).
+    #[arg(long, default_value_t = 1.1)]
     pub repetition_penalty: f64,
+
+    /// Number of most-recent tokens to consider for repetition/frequency
+    /// penalties.  0 = disabled.  Default 64 (llama.cpp default).
+    #[arg(long, default_value_t = 64)]
+    pub repeat_last_n: usize,
 
     /// Frequency penalty (OpenAI style): subtracts `frequency_penalty × count`
     /// from each token's logit, penalising tokens proportional to how often
@@ -178,6 +183,7 @@ struct SamplingParams {
     top_k: usize,
     max_tokens: usize,
     repetition_penalty: f64,
+    repeat_last_n: usize,
     frequency_penalty: f64,
 }
 
@@ -189,6 +195,7 @@ impl SamplingParams {
             top_k: args.top_k,
             max_tokens: args.max_tokens,
             repetition_penalty: args.repetition_penalty,
+            repeat_last_n: args.repeat_last_n,
             frequency_penalty: args.frequency_penalty,
         }
     }
@@ -227,6 +234,8 @@ struct ChatOptions {
     num_predict: usize,
     #[serde(skip_serializing_if = "is_one")]
     repeat_penalty: f64,
+    #[serde(skip_serializing_if = "is_default_repeat_last_n")]
+    repeat_last_n: usize,
     #[serde(skip_serializing_if = "is_zero")]
     frequency_penalty: f64,
 }
@@ -236,6 +245,9 @@ fn is_one(v: &f64) -> bool {
 }
 fn is_zero(v: &f64) -> bool {
     v.abs() < 1e-9
+}
+fn is_default_repeat_last_n(v: &usize) -> bool {
+    *v == 64
 }
 
 /// One NDJSON line from a streaming `/api/chat` response.
@@ -333,6 +345,7 @@ async fn chat_stream(
             top_k: params.top_k,
             num_predict: params.max_tokens,
             repeat_penalty: params.repetition_penalty,
+            repeat_last_n: params.repeat_last_n,
             frequency_penalty: params.frequency_penalty,
         }),
     };
@@ -393,6 +406,9 @@ async fn audio_stream(
     });
     if !is_one(&params.repetition_penalty) {
         body["repetition_penalty"] = serde_json::json!(params.repetition_penalty);
+    }
+    if !is_default_repeat_last_n(&params.repeat_last_n) {
+        body["repeat_last_n"] = serde_json::json!(params.repeat_last_n);
     }
     if !is_zero(&params.frequency_penalty) {
         body["frequency_penalty"] = serde_json::json!(params.frequency_penalty);
@@ -723,6 +739,7 @@ async fn repl(
     let mut top_k = args.top_k;
     let mut max_tokens = args.max_tokens;
     let repetition_penalty = args.repetition_penalty;
+    let repeat_last_n = args.repeat_last_n;
     let frequency_penalty = args.frequency_penalty;
 
     let mut multiline = MultilineState::None;
@@ -828,6 +845,7 @@ async fn repl(
                 top_k,
                 max_tokens,
                 repetition_penalty,
+                repeat_last_n,
                 frequency_penalty,
             },
         )

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -232,7 +232,7 @@ struct ChatOptions {
     top_p: f64,
     top_k: usize,
     num_predict: usize,
-    #[serde(skip_serializing_if = "is_one")]
+    #[serde(skip_serializing_if = "is_default_repeat_penalty")]
     repeat_penalty: f64,
     #[serde(skip_serializing_if = "is_default_repeat_last_n")]
     repeat_last_n: usize,
@@ -240,8 +240,8 @@ struct ChatOptions {
     frequency_penalty: f64,
 }
 
-fn is_one(v: &f64) -> bool {
-    (*v - 1.0).abs() < 1e-9
+fn is_default_repeat_penalty(v: &f64) -> bool {
+    (*v - 1.1).abs() < 1e-9
 }
 fn is_zero(v: &f64) -> bool {
     v.abs() < 1e-9
@@ -404,7 +404,7 @@ async fn audio_stream(
         "top_p": params.top_p,
         "top_k": params.top_k,
     });
-    if !is_one(&params.repetition_penalty) {
+    if !is_default_repeat_penalty(&params.repetition_penalty) {
         body["repetition_penalty"] = serde_json::json!(params.repetition_penalty);
     }
     if !is_default_repeat_last_n(&params.repeat_last_n) {

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -60,6 +60,18 @@ pub struct RunArgs {
     #[arg(long, default_value_t = 2048)]
     pub max_tokens: usize,
 
+    /// Repetition penalty (llama.cpp style): divides positive logits and
+    /// multiplies negative logits of previously-seen tokens.
+    /// 1.0 = disabled (default).  Values around 1.1–1.3 reduce looping.
+    #[arg(long, default_value_t = 1.0)]
+    pub repetition_penalty: f64,
+
+    /// Frequency penalty (OpenAI style): subtracts `frequency_penalty × count`
+    /// from each token's logit, penalising tokens proportional to how often
+    /// they have appeared in the context.  0.0 = disabled (default).
+    #[arg(long, default_value_t = 0.0)]
+    pub frequency_penalty: f64,
+
     // ── Server connection ─────────────────────────────────────────────────────
     /// Address of the `inferrs serve` daemon.
     /// Overrides `INFERRS_HOST`.  Defaults to `127.0.0.1`.
@@ -165,6 +177,8 @@ struct SamplingParams {
     top_p: f64,
     top_k: usize,
     max_tokens: usize,
+    repetition_penalty: f64,
+    frequency_penalty: f64,
 }
 
 impl SamplingParams {
@@ -174,6 +188,8 @@ impl SamplingParams {
             top_p: args.top_p,
             top_k: args.top_k,
             max_tokens: args.max_tokens,
+            repetition_penalty: args.repetition_penalty,
+            frequency_penalty: args.frequency_penalty,
         }
     }
 }
@@ -209,6 +225,17 @@ struct ChatOptions {
     top_p: f64,
     top_k: usize,
     num_predict: usize,
+    #[serde(skip_serializing_if = "is_one")]
+    repeat_penalty: f64,
+    #[serde(skip_serializing_if = "is_zero")]
+    frequency_penalty: f64,
+}
+
+fn is_one(v: &f64) -> bool {
+    (*v - 1.0).abs() < 1e-9
+}
+fn is_zero(v: &f64) -> bool {
+    v.abs() < 1e-9
 }
 
 /// One NDJSON line from a streaming `/api/chat` response.
@@ -305,6 +332,8 @@ async fn chat_stream(
             top_p: params.top_p,
             top_k: params.top_k,
             num_predict: params.max_tokens,
+            repeat_penalty: params.repetition_penalty,
+            frequency_penalty: params.frequency_penalty,
         }),
     };
 
@@ -353,7 +382,7 @@ async fn audio_stream(
         ]
     }));
 
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "model": model,
         "messages": messages,
         "stream": true,
@@ -362,6 +391,12 @@ async fn audio_stream(
         "top_p": params.top_p,
         "top_k": params.top_k,
     });
+    if !is_one(&params.repetition_penalty) {
+        body["repetition_penalty"] = serde_json::json!(params.repetition_penalty);
+    }
+    if !is_zero(&params.frequency_penalty) {
+        body["frequency_penalty"] = serde_json::json!(params.frequency_penalty);
+    }
 
     let response = client
         .post(&url)
@@ -687,6 +722,8 @@ async fn repl(
     let mut top_p = args.top_p;
     let mut top_k = args.top_k;
     let mut max_tokens = args.max_tokens;
+    let repetition_penalty = args.repetition_penalty;
+    let frequency_penalty = args.frequency_penalty;
 
     let mut multiline = MultilineState::None;
     let mut buf = String::new();
@@ -790,6 +827,8 @@ async fn repl(
                 top_p,
                 top_k,
                 max_tokens,
+                repetition_penalty,
+                frequency_penalty,
             },
         )
         .await

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -30,7 +30,12 @@ pub struct SamplingParams {
     pub top_k: usize,
     /// llama.cpp / Ollama `repeat_penalty`: divides positive logits and
     /// multiplies negative logits of previously-seen tokens.  1.0 = disabled.
+    /// Default 1.1 (llama.cpp default) — mild suppression of repeated tokens.
     pub repetition_penalty: f64,
+    /// Number of most-recent tokens to consider for `repetition_penalty` and
+    /// `frequency_penalty`.  Mirrors llama.cpp `repeat_last_n`.
+    /// 0 = disabled (penalty not applied).  Default: 64.
+    pub repeat_last_n: usize,
     /// OpenAI `frequency_penalty`: subtracts `frequency_penalty * count` from
     /// each token's logit, penalising tokens proportional to how often they
     /// have already appeared.  0.0 = disabled.  Typical range: [0.0, 2.0].
@@ -84,7 +89,8 @@ impl Default for SamplingParams {
             temperature: 0.7,
             top_p: 0.9,
             top_k: 50,
-            repetition_penalty: 1.0,
+            repetition_penalty: 1.1,
+            repeat_last_n: 64,
             frequency_penalty: 0.0,
             presence_penalty: 0.0,
             min_p: 0.0,
@@ -148,10 +154,19 @@ pub fn sample_token(
     // ── Greedy fast-path ─────────────────────────────────────────────────────
     // Argmax in native dtype (bf16/f32) avoids a full-vocab dtype conversion.
     // Only safe when nothing modifies relative ordering (no penalties/biases).
+    //
+    // Window previous_tokens to the last `repeat_last_n` tokens (llama.cpp
+    // semantics: 0 = disabled, any other value = use last N tokens).
+    let penalty_tokens: &[u32] = if params.repeat_last_n == 0 {
+        &[]
+    } else {
+        let start = previous_tokens.len().saturating_sub(params.repeat_last_n);
+        &previous_tokens[start..]
+    };
     let has_penalty = (params.repetition_penalty != 1.0
         || params.frequency_penalty != 0.0
         || params.presence_penalty != 0.0)
-        && !previous_tokens.is_empty();
+        && !penalty_tokens.is_empty();
     let has_bias = !params.logit_bias.is_empty();
     if params.temperature < SAMPLING_EPS && !has_penalty && !has_bias && !params.logprobs {
         let token_id = logits.argmax(0)?.to_scalar::<u32>()?;
@@ -171,10 +186,11 @@ pub fn sample_token(
 
     // ── 2. Repetition penalty (llama.cpp / Ollama) ────────────────────────────
     // Formula: logit / penalty if logit ≥ 0, logit * penalty if logit < 0.
-    if params.repetition_penalty != 1.0 && !previous_tokens.is_empty() {
+    // Applied only to tokens within the `repeat_last_n` window.
+    if params.repetition_penalty != 1.0 && !penalty_tokens.is_empty() {
         let p = params.repetition_penalty as f32;
         let mut seen = std::collections::HashSet::new();
-        for &id in previous_tokens {
+        for &id in penalty_tokens {
             if id as usize >= vocab || !seen.insert(id) {
                 continue;
             }
@@ -184,13 +200,14 @@ pub fn sample_token(
     }
 
     // ── 3. Frequency + presence penalties (OpenAI) ────────────────────────────
+    // Applied only to tokens within the `repeat_last_n` window.
     if (params.frequency_penalty != 0.0 || params.presence_penalty != 0.0)
-        && !previous_tokens.is_empty()
+        && !penalty_tokens.is_empty()
     {
         let fp = params.frequency_penalty as f32;
         let pp = params.presence_penalty as f32;
         let mut counts: HashMap<u32, u32> = HashMap::new();
-        for &id in previous_tokens {
+        for &id in penalty_tokens {
             if (id as usize) < vocab {
                 *counts.entry(id).or_insert(0) += 1;
             }
@@ -550,4 +567,113 @@ fn rand_state_thread_local() -> u64 {
         s.set(x);
         x
     })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    /// Default params have llama.cpp-matching values.
+    #[test]
+    fn defaults_match_llama_cpp() {
+        let p = SamplingParams::default();
+        assert!(
+            (p.repetition_penalty - 1.1).abs() < 1e-9,
+            "repetition_penalty default should be 1.1, got {}",
+            p.repetition_penalty
+        );
+        assert_eq!(p.repeat_last_n, 64, "repeat_last_n default should be 64");
+        assert!(
+            p.frequency_penalty.abs() < 1e-9,
+            "frequency_penalty default should be 0.0"
+        );
+    }
+
+    /// Tokens OUTSIDE the repeat_last_n window must NOT be penalised.
+    ///
+    /// Setup: vocab size 4, logits all 1.0.
+    /// previous_tokens = [0, 1, 2, 3] (4 tokens).
+    /// repeat_last_n = 2  →  only tokens [2, 3] are in the window.
+    /// After penalty (1.5), tokens 0 and 1 should be unchanged (still 1.0),
+    /// tokens 2 and 3 should be divided: 1.0 / 1.5 ≈ 0.6667.
+    #[test]
+    fn repeat_last_n_windows_correctly() {
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 1.5,
+            repeat_last_n: 2,
+            ..SamplingParams::default()
+        };
+        let previous = vec![0u32, 1, 2, 3];
+        // Build a (vocab=4,) logits tensor via sample_token's internal path.
+        // We extract the post-penalty logits by using greedy (temp=0) and
+        // checking which token is selected, but for a direct check we call
+        // the internal logic by constructing a discriminating logit vector:
+        // Give token 0 a much higher logit than token 2 — if token 0 is
+        // penalised we'd select token 2 instead.
+        // Token 1 is the runner-up at 8.0.  Token 0 outside window → 10.0 / 1.0
+        // = 10.0 still wins.  Token 0 inside window → 10.0 / 1.5 ≈ 6.67 < 8.0
+        // → token 1 wins.
+        let base: Vec<f32> = vec![10.0, 8.0, 0.0, 0.0];
+        let t = Tensor::from_vec(base, 4usize, &Device::Cpu).unwrap();
+        let (tok, _) = sample_token(&t, &params, &previous).unwrap();
+        // Token 0 is OUTSIDE the window → not penalised → still highest logit.
+        assert_eq!(tok, 0, "token 0 (outside window) should win; got {tok}");
+
+        // Now put token 0 INSIDE the window — 10.0/1.5 ≈ 6.67 < 8.0 → token 1 wins.
+        let previous_with_0_in_window = vec![1u32, 2, 3, 0]; // 0 is in last 2
+        let (tok2, _) = sample_token(&t, &params, &previous_with_0_in_window).unwrap();
+        assert_eq!(
+            tok2, 1,
+            "token 0 (inside window) should be penalised below token 1 (8.0); got {tok2}"
+        );
+    }
+
+    /// repeat_last_n = 0 disables the penalty entirely — even tokens in the
+    /// immediate history are not suppressed.
+    #[test]
+    fn repeat_last_n_zero_disables_penalty() {
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 2.0, // strong penalty if applied
+            repeat_last_n: 0,        // disabled
+            ..SamplingParams::default()
+        };
+        let previous = vec![0u32]; // token 0 was just emitted
+        let base: Vec<f32> = vec![10.0, 0.0, 0.0, 0.0];
+        let t = Tensor::from_vec(base, 4usize, &Device::Cpu).unwrap();
+        let (tok, _) = sample_token(&t, &params, &previous).unwrap();
+        assert_eq!(tok, 0, "penalty disabled; token 0 should still win");
+    }
+
+    /// When history is shorter than repeat_last_n the entire history is used
+    /// (no out-of-bounds / saturation issues).
+    #[test]
+    fn repeat_last_n_longer_than_history_uses_full_history() {
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 1.5,
+            repeat_last_n: 64, // window >> history length
+            ..SamplingParams::default()
+        };
+        let previous = vec![0u32]; // only 1 token in history
+        let base: Vec<f32> = vec![10.0, 5.0];
+        let t = Tensor::from_vec(base, 2usize, &Device::Cpu).unwrap();
+        let (tok, _) = sample_token(&t, &params, &previous).unwrap();
+        // 10.0 / 1.5 ≈ 6.67, still > 5.0, so token 0 still wins but is penalised
+        assert_eq!(tok, 0, "token 0 still highest even after penalty");
+
+        // Now use a penalty strong enough to flip the winner.
+        let strong = SamplingParams {
+            repetition_penalty: 10.0,
+            ..params
+        };
+        let (tok2, _) = sample_token(&t, &strong, &previous).unwrap();
+        assert_eq!(tok2, 1, "strong penalty should suppress token 0");
+    }
 }

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -187,7 +187,11 @@ pub fn sample_token(
     // ── 2. Repetition penalty (llama.cpp / Ollama) ────────────────────────────
     // Formula: logit / penalty if logit ≥ 0, logit * penalty if logit < 0.
     // Applied only to tokens within the `repeat_last_n` window.
-    if params.repetition_penalty != 1.0 && !penalty_tokens.is_empty() {
+    // Guard against 1.0 (no-op) and 0.0 (would divide by zero).
+    if params.repetition_penalty != 1.0
+        && params.repetition_penalty != 0.0
+        && !penalty_tokens.is_empty()
+    {
         let p = params.repetition_penalty as f32;
         let mut seen = std::collections::HashSet::new();
         for &id in penalty_tokens {
@@ -675,5 +679,22 @@ mod tests {
         };
         let (tok2, _) = sample_token(&t, &strong, &previous).unwrap();
         assert_eq!(tok2, 1, "strong penalty should suppress token 0");
+    }
+
+    /// repetition_penalty=0.0 must not divide by zero; behaves as disabled.
+    #[test]
+    fn repetition_penalty_zero_does_not_divide_by_zero() {
+        let params = SamplingParams {
+            temperature: 0.0,
+            repetition_penalty: 0.0,
+            repeat_last_n: 64,
+            ..SamplingParams::default()
+        };
+        let previous = vec![0u32];
+        let base: Vec<f32> = vec![10.0, 5.0];
+        let t = Tensor::from_vec(base, 2usize, &Device::Cpu).unwrap();
+        // Should not panic; token 0 wins since no penalty is applied.
+        let (tok, _) = sample_token(&t, &params, &previous).unwrap();
+        assert_eq!(tok, 0, "zero penalty acts as disabled; token 0 still wins");
     }
 }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -112,6 +112,10 @@ pub struct ChatCompletionRequest {
     pub stream: Option<bool>,
     #[serde(default)]
     pub repetition_penalty: Option<f64>,
+    /// Number of most-recent tokens to consider for penalties (llama.cpp
+    /// `repeat_last_n`).  0 = disabled.
+    #[serde(default)]
+    pub repeat_last_n: Option<usize>,
     /// OpenAI `frequency_penalty`: penalises tokens proportional to how often
     /// they have appeared in the output so far.  Range [0, 2].
     #[serde(default)]
@@ -615,6 +619,7 @@ pub struct OllamaOptions {
     pub top_k: Option<usize>,
     pub num_predict: Option<usize>,
     pub repeat_penalty: Option<f64>,
+    pub repeat_last_n: Option<usize>,
 
     // ── inferrs model-loading extensions ─────────────────────────────────────
     /// Weight data type: f32, f16, bf16
@@ -1913,6 +1918,7 @@ async fn chat_completions(
         req.top_k,
         req.min_p,
         req.repetition_penalty,
+        req.repeat_last_n,
         req.frequency_penalty,
         req.presence_penalty,
         logit_bias,
@@ -2181,6 +2187,8 @@ pub struct CompletionRequest {
     #[serde(default)]
     pub repetition_penalty: Option<f64>,
     #[serde(default)]
+    pub repeat_last_n: Option<usize>,
+    #[serde(default)]
     pub frequency_penalty: Option<f64>,
     #[serde(default)]
     pub presence_penalty: Option<f64>,
@@ -2275,6 +2283,7 @@ async fn completions(
         req.top_k,
         None, // min_p not in CompletionRequest
         req.repetition_penalty,
+        req.repeat_last_n,
         req.frequency_penalty,
         req.presence_penalty,
         None, // logit_bias not in CompletionRequest yet
@@ -2465,6 +2474,7 @@ async fn anthropic_messages(
         req.top_k,
         None,  // min_p
         None,  // repetition_penalty
+        None,  // repeat_last_n
         None,  // frequency_penalty
         None,  // presence_penalty
         None,  // logit_bias
@@ -2957,6 +2967,7 @@ fn build_sampling_params(
     top_k: Option<usize>,
     min_p: Option<f64>,
     repetition_penalty: Option<f64>,
+    repeat_last_n: Option<usize>,
     frequency_penalty: Option<f64>,
     presence_penalty: Option<f64>,
     logit_bias: Option<std::collections::HashMap<u32, f32>>,
@@ -2974,6 +2985,7 @@ fn build_sampling_params(
         top_k,
         min_p,
         repetition_penalty,
+        repeat_last_n,
         frequency_penalty,
         presence_penalty,
         logit_bias,
@@ -2995,6 +3007,7 @@ fn build_sampling_params_with_grammar(
     top_k: Option<usize>,
     min_p: Option<f64>,
     repetition_penalty: Option<f64>,
+    repeat_last_n: Option<usize>,
     frequency_penalty: Option<f64>,
     presence_penalty: Option<f64>,
     logit_bias: Option<std::collections::HashMap<u32, f32>>,
@@ -3014,6 +3027,7 @@ fn build_sampling_params_with_grammar(
         top_k: top_k.unwrap_or(defaults.top_k),
         min_p: min_p.unwrap_or(defaults.min_p),
         repetition_penalty: repetition_penalty.unwrap_or(defaults.repetition_penalty),
+        repeat_last_n: repeat_last_n.unwrap_or(defaults.repeat_last_n),
         frequency_penalty: frequency_penalty.unwrap_or(defaults.frequency_penalty),
         presence_penalty: presence_penalty.unwrap_or(defaults.presence_penalty),
         logit_bias: logit_bias.unwrap_or_default(),
@@ -3506,6 +3520,7 @@ struct OllamaParamBundle {
     top_k: Option<usize>,
     min_p: Option<f64>,
     repetition_penalty: Option<f64>,
+    repeat_last_n: Option<usize>,
     frequency_penalty: Option<f64>,
     presence_penalty: Option<f64>,
     seed: Option<u64>,
@@ -3523,6 +3538,7 @@ fn ollama_options_to_params(
     let top_k = opts.and_then(|o| o.top_k);
     let min_p = opts.and_then(|o| o.min_p);
     let repetition_penalty = opts.and_then(|o| o.repeat_penalty);
+    let repeat_last_n = opts.and_then(|o| o.repeat_last_n);
     let frequency_penalty = opts.and_then(|o| o.frequency_penalty);
     let presence_penalty = opts.and_then(|o| o.presence_penalty);
     let seed = opts.and_then(|o| o.seed).map(|s| s as u64);
@@ -3540,6 +3556,7 @@ fn ollama_options_to_params(
         top_k,
         min_p,
         repetition_penalty,
+        repeat_last_n,
         frequency_penalty,
         presence_penalty,
         seed,
@@ -3907,6 +3924,7 @@ async fn ollama_generate(
         pb.top_k,
         pb.min_p,
         pb.repetition_penalty,
+        pb.repeat_last_n,
         pb.frequency_penalty,
         pb.presence_penalty,
         pb.logit_bias,
@@ -4247,6 +4265,7 @@ async fn ollama_chat(
         pb.top_k,
         pb.min_p,
         pb.repetition_penalty,
+        pb.repeat_last_n,
         pb.frequency_penalty,
         pb.presence_penalty,
         pb.logit_bias,


### PR DESCRIPTION
feat(sampler): add repeat_last_n window and match llama.cpp defaults

- Default repetition_penalty changed from 1.0 to 1.1 (llama.cpp default)
- Add repeat_last_n parameter (default 64) to limit penalty window to
  the last N tokens, preventing suppression of common vocabulary over
  long generations
- Wire repeat_last_n through CLI (--repeat-last-n), server (OpenAI,
  Anthropic, Ollama APIs), and run.rs REPL
- Add 4 unit tests covering defaults, windowing, zero-disables, and
  window-larger-than-history edge case

feat(run): add --repetition-penalty and --frequency-penalty CLI flags

Exposes the sampler's existing repetition_penalty and frequency_penalty
parameters as CLI flags on `inferrs run`. 

Wired through:
- RunArgs (clap CLI flags)
- Local SamplingParams bundle in run.rs
- ChatOptions for the Ollama /api/chat path (repeat_penalty, frequency_penalty)
- audio_stream OpenAI path (conditionally added to JSON body via is_one/is_zero)

Fixes: ericcurtin/inferrs#183