### PR TITLE
disable MTP speculative decoding on Metal

### DIFF
--- a/inferrs-models/src/kv_cache.rs
+++ b/inferrs-models/src/kv_cache.rs
@@ -54,11 +54,7 @@ impl PagedCacheConfig {
         // Each block holds block_size tokens × num_kv_heads × head_dim × 2 (K+V) per layer.
         let bytes_per_block =
             block_size * num_kv_heads * head_dim * 2 * num_layers * bytes_per_element;
-        let num_blocks = if bytes_per_block == 0 {
-            0
-        } else {
-            available / bytes_per_block
-        };
+        let num_blocks = available.checked_div(bytes_per_block).unwrap_or(0);
         Self {
             block_size,
             num_blocks,

--- a/inferrs-models/src/models/qwen3_5.rs
+++ b/inferrs-models/src/models/qwen3_5.rs
@@ -1233,6 +1233,15 @@ impl Qwen35Model {
                         "MTP draft module loaded ({} block(s))",
                         cfg.mtp_num_hidden_layers
                     );
+                    #[cfg(target_os = "macos")]
+                    if matches!(
+                        embed_tokens.embeddings().device(),
+                        candle_core::Device::Metal(_)
+                    ) {
+                        tracing::info!(
+                            "MTP speculative decoding disabled on Metal (dispatch overhead)"
+                        );
+                    }
                     Some(m)
                 }
                 Err(e) => {

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1512,11 +1512,16 @@ impl Engine {
                 // Active only for single-sequence batches without grammar
                 // constraints (grammar masking is incompatible with multi-token
                 // verification) and only during the decode phase.
+                #[cfg(target_os = "macos")]
+                let on_metal = matches!(device, candle_core::Device::Metal(_));
+                #[cfg(not(target_os = "macos"))]
+                let on_metal = false;
                 let use_mtp = seq.prefilled
                     && active_count == 1   // single-sequence: no shared-KV conflicts
                     && seq.grammar_fsm.is_none()
                     && !seq.sampling_params.logprobs  // logprobs not supported with MTP
-                    && paged.is_none(); // MTP forward calls use internal concat-KV, not PagedKvStore
+                    && paged.is_none() // MTP forward calls use internal concat-KV, not PagedKvStore
+                    && !on_metal; // Metal dispatch overhead makes MTP slower than baseline
 
                 if use_mtp {
                     let last_token = match seq.output_tokens.last() {

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -1049,47 +1049,37 @@ fn read_line() -> Result<ReadResult> {
                     return Ok(ReadResult::Interrupt);
                 }
 
-                KeyCode::Backspace => {
-                    if cursor_pos > 0 {
-                        cursor_pos -= 1;
-                        buf.remove(cursor_pos);
-                        execute!(stdout, cursor::MoveLeft(1))?;
-                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                    }
+                KeyCode::Backspace if cursor_pos > 0 => {
+                    cursor_pos -= 1;
+                    buf.remove(cursor_pos);
+                    execute!(stdout, cursor::MoveLeft(1))?;
+                    redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
                 }
 
-                KeyCode::Delete => {
-                    if cursor_pos < buf.len() {
-                        buf.remove(cursor_pos);
-                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
-                    }
+                KeyCode::Delete if cursor_pos < buf.len() => {
+                    buf.remove(cursor_pos);
+                    redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
                 }
 
-                KeyCode::Left => {
-                    if cursor_pos > 0 {
-                        cursor_pos -= 1;
-                        execute!(stdout, cursor::MoveLeft(1))?;
-                    }
+                KeyCode::Left if cursor_pos > 0 => {
+                    cursor_pos -= 1;
+                    execute!(stdout, cursor::MoveLeft(1))?;
                 }
 
-                KeyCode::Right => {
-                    if cursor_pos < buf.len() {
-                        cursor_pos += 1;
-                        execute!(stdout, cursor::MoveRight(1))?;
-                    }
+                KeyCode::Right if cursor_pos < buf.len() => {
+                    cursor_pos += 1;
+                    execute!(stdout, cursor::MoveRight(1))?;
                 }
 
-                KeyCode::Home => {
-                    if cursor_pos > 0 {
-                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                        cursor_pos = 0;
-                    }
+                KeyCode::Home if cursor_pos > 0 => {
+                    execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                    cursor_pos = 0;
                 }
-                KeyCode::Char('a') if modifiers.contains(KeyModifiers::CONTROL) => {
-                    if cursor_pos > 0 {
-                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                        cursor_pos = 0;
-                    }
+                KeyCode::Char('a')
+                    if modifiers.contains(KeyModifiers::CONTROL) && cursor_pos > 0 =>
+                {
+                    execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                    cursor_pos = 0;
                 }
 
                 KeyCode::End => {
@@ -1112,30 +1102,30 @@ fn read_line() -> Result<ReadResult> {
                     execute!(stdout, terminal::Clear(ClearType::UntilNewLine))?;
                 }
 
-                KeyCode::Char('u') if modifiers.contains(KeyModifiers::CONTROL) => {
-                    if cursor_pos > 0 {
-                        execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
-                        buf.drain(..cursor_pos);
-                        cursor_pos = 0;
-                        redraw_from_cursor(&mut stdout, &buf, 0)?;
-                    }
+                KeyCode::Char('u')
+                    if modifiers.contains(KeyModifiers::CONTROL) && cursor_pos > 0 =>
+                {
+                    execute!(stdout, cursor::MoveLeft(cursor_pos as u16))?;
+                    buf.drain(..cursor_pos);
+                    cursor_pos = 0;
+                    redraw_from_cursor(&mut stdout, &buf, 0)?;
                 }
 
-                KeyCode::Char('w') if modifiers.contains(KeyModifiers::CONTROL) => {
-                    if cursor_pos > 0 {
-                        let mut end = cursor_pos;
-                        while end > 0 && buf[end - 1] == ' ' {
-                            end -= 1;
-                        }
-                        while end > 0 && buf[end - 1] != ' ' {
-                            end -= 1;
-                        }
-                        let deleted = cursor_pos - end;
-                        execute!(stdout, cursor::MoveLeft(deleted as u16))?;
-                        buf.drain(end..cursor_pos);
-                        cursor_pos = end;
-                        redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
+                KeyCode::Char('w')
+                    if modifiers.contains(KeyModifiers::CONTROL) && cursor_pos > 0 =>
+                {
+                    let mut end = cursor_pos;
+                    while end > 0 && buf[end - 1] == ' ' {
+                        end -= 1;
                     }
+                    while end > 0 && buf[end - 1] != ' ' {
+                        end -= 1;
+                    }
+                    let deleted = cursor_pos - end;
+                    execute!(stdout, cursor::MoveLeft(deleted as u16))?;
+                    buf.drain(end..cursor_pos);
+                    cursor_pos = end;
+                    redraw_from_cursor(&mut stdout, &buf, cursor_pos)?;
                 }
 
                 KeyCode::Char(c) => {


### PR DESCRIPTION
TLDR: MTP makes qwen slower on metal

Long answer: MTP speculative decoding issues ~5 separate command buffer submissions per step (main forward + 2 draft steps + 2 sequential verification passes). On CUDA this is cheap because stream sync has negligible overhead. On Metal, each wait_until_completed is an expensive GPU↔CPU round-trip that flushes the pipeline, making MTP slower than baseline single-token decode.

Disable MTP on Metal until a fused single-command-buffer verification path is implemented.