### PR TITLE
build: make CUDA opt-in via Cargo feature (fixes #170 non-CUDA build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
       # No Go setup needed: libocimodels is loaded via dlopen at runtime, not
       # linked at build time, so clippy and rustfmt work without it.
       - run: cargo fmt --check -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
-      - run: cargo clippy -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan -- -D warnings
+      # Lint the CUDA-enabled code path too (this job runs on Linux with the
+      # CUDA toolkit installed above).  Without `--features inferrs/cuda` the
+      # `#[cfg(feature = "cuda")]` blocks in `main.rs` / `engine.rs` are not
+      # type-checked, so regressions can slip through.
+      - run: cargo clippy -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan --features inferrs/cuda -- -D warnings
 
   build:
     name: Build (${{ matrix.target }})
@@ -168,12 +172,21 @@ jobs:
       - name: Test
         shell: bash
         run: |
+          # Enable the main binary's `cuda` feature on targets where the CUDA
+          # toolkit was installed above; without it, the CUDA code paths in
+          # `main.rs` / `engine.rs` are `#[cfg]`-out and wouldn't be covered.
+          FEATURES=""
+          case "${{ matrix.target }}" in
+            x86_64-unknown-linux-gnu|aarch64-unknown-linux-gnu|x86_64-pc-windows-msvc)
+              FEATURES="--features inferrs/cuda"
+              ;;
+          esac
           if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
             # --no-run: the test binary crashes at startup without nvcuda.dll
             # on GPU-less CI runners; just verify compilation succeeds.
-            cargo test --no-run -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
+            cargo test --no-run $FEATURES -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
           else
             # inferrs-backend-musa has no compile-time MUSA SDK dependency, so
             # it builds and runs (probe returns 1 = unavailable) on all runners.
-            cargo test -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
+            cargo test $FEATURES -p inferrs -p inferrs-benchmark -p inferrs-backend-musa -p inferrs-backend-vulkan
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,8 @@ jobs:
       - name: Build main binary + CUDA backend plugin
         run: |
           cargo build --release --target x86_64-unknown-linux-gnu \
-            -p inferrs -p inferrs-backend-cuda
+            -p inferrs -p inferrs-backend-cuda \
+            --features inferrs/cuda
 
       # ── ROCm backend plugin ──────────────────────────────────────────────
       - name: Install ROCm toolkit
@@ -214,7 +215,8 @@ jobs:
       - name: Build main binary + CUDA backend plugin
         run: |
           cargo build --release --target aarch64-unknown-linux-gnu \
-            -p inferrs -p inferrs-backend-cuda
+            -p inferrs -p inferrs-backend-cuda \
+            --features inferrs/cuda
 
       # ── ROCm backend plugin ───────────────────────────────────────────────
       # AMD's ROCm apt repository only publishes binary-amd64 packages; there
@@ -320,7 +322,8 @@ jobs:
       - name: Build main binary + CUDA backend plugin
         run: |
           cargo build --release --target x86_64-pc-windows-msvc `
-            -p inferrs -p inferrs-backend-cuda
+            -p inferrs -p inferrs-backend-cuda `
+            --features inferrs/cuda
 
       # ── ROCm backend plugin (Windows x86_64, ROCm HIP SDK) ──────────────
       # AMD does not publish the HIP SDK on Chocolatey; install via the

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,24 @@ endif
 # toolkit should build without these make targets (e.g. call `cargo build`
 # directly with an explicit `-p ...` list and no `--features cuda`) to get
 # a CPU-only binary that still probes the runtime backends via dlopen.
+#
+# Architecture gate: on Windows ARM64 running Git Bash / MSYS2, `uname -s`
+# returns something like MINGW64_NT-… (not `Darwin`), so the arch check
+# below is what keeps the CUDA flags off that host.  Linux aarch64 (Jetson /
+# Grace) is intentionally allowed because NVIDIA ships a CUDA toolkit for it.
 ifeq ($(UNAME_S),Darwin)
   CUDA_PKG :=
   CUDA_FEATURES :=
-else
+else ifeq ($(UNAME_S),Linux)
   CUDA_PKG := -p inferrs-backend-cuda
   CUDA_FEATURES := --features inferrs/cuda --features inferrs-multimodal/cuda --features inferrs-kernels/cuda
+else ifeq ($(UNAME_M),x86_64)
+  CUDA_PKG := -p inferrs-backend-cuda
+  CUDA_FEATURES := --features inferrs/cuda --features inferrs-multimodal/cuda --features inferrs-kernels/cuda
+else
+  # Non-x86_64 non-Linux non-Darwin host (e.g. Windows ARM64): no CUDA.
+  CUDA_PKG :=
+  CUDA_FEATURES :=
 endif
 
 # inferrs-backend-metal is only built on macOS (standard Apple SDK, no exotic

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,18 @@ else
 endif
 
 # inferrs-backend-cuda is only built on Linux or Windows x86_64 (not macOS,
-# not Windows ARM64).
+# not Windows ARM64).  When it is included, the `cuda` feature of the main
+# binary / multimodal / kernels crates is also enabled so the direct-linked
+# CUDA execution path compiles alongside the plugin.  Hosts without a CUDA
+# toolkit should build without these make targets (e.g. call `cargo build`
+# directly with an explicit `-p ...` list and no `--features cuda`) to get
+# a CPU-only binary that still probes the runtime backends via dlopen.
 ifeq ($(UNAME_S),Darwin)
   CUDA_PKG :=
+  CUDA_FEATURES :=
 else
   CUDA_PKG := -p inferrs-backend-cuda
+  CUDA_FEATURES := --features inferrs/cuda --features inferrs-multimodal/cuda --features inferrs-kernels/cuda
 endif
 
 # inferrs-backend-metal is only built on macOS (standard Apple SDK, no exotic
@@ -52,17 +59,17 @@ ui:
 	cargo build -p inferrs
 
 build: oci-lib
-	cargo build $(NO_GPU_PKGS)
+	cargo build $(NO_GPU_PKGS) $(CUDA_FEATURES)
 
 release: oci-lib-release
-	cargo build --release $(NO_GPU_PKGS)
+	cargo build --release $(NO_GPU_PKGS) $(CUDA_FEATURES)
 
 lint:
 	cargo fmt --check $(NO_GPU_PKGS)
-	cargo clippy $(NO_GPU_PKGS) -- -D warnings
+	cargo clippy $(NO_GPU_PKGS) $(CUDA_FEATURES) -- -D warnings
 
 test:
-	cargo test $(NO_GPU_PKGS)
+	cargo test $(NO_GPU_PKGS) $(CUDA_FEATURES)
 
 # Go C shared library for OCI model operations (called via FFI from Rust).
 oci-lib:

--- a/inferrs-kernels/Cargo.toml
+++ b/inferrs-kernels/Cargo.toml
@@ -11,11 +11,16 @@ crate-type = ["rlib"]
 
 [features]
 default = []
+# Opt-in: enables the patched CUDA kernels crate.  Gated because its
+# build.rs invokes nvcc / nvidia-smi, which are absent on hosts without a
+# CUDA toolkit.  The Makefile enables this on Linux / Windows x86_64.
+cuda = ["dep:candle-kernels"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 candle-metal-kernels = { path = "candle-metal-kernels" }
 
+# `candle-kernels` is the patched CUDA kernels crate.  Only meaningful on
+# Linux / Windows x86_64, and only compiled when the `cuda` feature is
+# enabled (because its build.rs shells out to nvcc / nvidia-smi).
 [target.'cfg(any(target_os = "linux", all(target_os = "windows", target_arch = "x86_64")))'.dependencies]
-candle-kernels = { path = "candle-kernels" }
-
-[dependencies]
+candle-kernels = { path = "candle-kernels", optional = true }

--- a/inferrs-kernels/src/lib.rs
+++ b/inferrs-kernels/src/lib.rs
@@ -11,8 +11,11 @@
 #[cfg(target_os = "macos")]
 pub use candle_metal_kernels as metal;
 
-#[cfg(any(
-    target_os = "linux",
-    all(target_os = "windows", target_arch = "x86_64")
+#[cfg(all(
+    feature = "cuda",
+    any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    )
 ))]
 pub use candle_kernels as cuda;

--- a/inferrs-models/src/kv_cache.rs
+++ b/inferrs-models/src/kv_cache.rs
@@ -54,11 +54,7 @@ impl PagedCacheConfig {
         // Each block holds block_size tokens × num_kv_heads × head_dim × 2 (K+V) per layer.
         let bytes_per_block =
             block_size * num_kv_heads * head_dim * 2 * num_layers * bytes_per_element;
-        let num_blocks = if bytes_per_block == 0 {
-            0
-        } else {
-            available / bytes_per_block
-        };
+        let num_blocks = available.checked_div(bytes_per_block).unwrap_or(0);
         Self {
             block_size,
             num_blocks,

--- a/inferrs-multimodal/Cargo.toml
+++ b/inferrs-multimodal/Cargo.toml
@@ -23,6 +23,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 
-# Backend acceleration is opt-in via the `cuda` / `metal` Cargo features
-# above so this crate can be built on hosts without the corresponding
-# vendor toolchain.  The Makefile enables them on the right platforms.
+# On macOS always enable Metal: the framework is part of the system SDK, so
+# there is no external toolchain concern (unlike CUDA on Linux / Windows,
+# which stays opt-in via the `cuda` feature above).
+[target.'cfg(target_os = "macos")'.dependencies]
+candle-core = { workspace = true, features = ["metal"] }
+candle-nn = { workspace = true, features = ["metal"] }

--- a/inferrs-multimodal/Cargo.toml
+++ b/inferrs-multimodal/Cargo.toml
@@ -23,14 +23,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
-candle-core = { workspace = true, features = ["metal"] }
-candle-nn = { workspace = true, features = ["metal"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-candle-core = { workspace = true, features = ["cuda"] }
-candle-nn = { workspace = true, features = ["cuda"] }
-
-[target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-candle-core = { workspace = true, features = ["cuda"] }
-candle-nn = { workspace = true, features = ["cuda"] }
+# Backend acceleration is opt-in via the `cuda` / `metal` Cargo features
+# above so this crate can be built on hosts without the corresponding
+# vendor toolchain.  The Makefile enables them on the right platforms.

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -29,13 +29,13 @@ metal = [
     "inferrs-models/metal",
 ]
 
-# On macOS: always enable Metal (the framework ships with every macOS install
-# so there is no toolchain concern like there is with CUDA) and add libloading
-# to probe for the Vulkan/MoltenVK and OpenVINO plugins at runtime.  The
-# `metal` Cargo feature above is still available for explicit opt-in on other
-# platforms that may gain Metal support later.
+# On macOS always enable Metal: the framework ships with every macOS install
+# so there is no toolchain concern like there is with CUDA.  The `metal`
+# Cargo feature above is still available for explicit opt-in on other
+# platforms that may gain Metal support later.  (libloading is declared
+# unconditionally in [dependencies] below — no target-specific duplicate
+# needed.)
 [target.'cfg(target_os = "macos")'.dependencies]
-libloading = "0.8"
 candle-core = { workspace = true, features = ["metal"] }
 candle-nn = { workspace = true, features = ["metal"] }
 candle-transformers = { workspace = true, features = ["metal"] }
@@ -69,9 +69,9 @@ candle-core = { workspace = true }
 candle-nn = { workspace = true }
 candle-transformers = { workspace = true }
 
-# Shared model code + KV cache (workspace-local).  The cuda / metal features
-# are added in the target-specific dependency blocks below so the same
-# candle-core feature set propagates through inferrs-models.
+# Shared model code + KV cache (workspace-local).  `cuda` propagates through
+# the `cuda` Cargo feature defined at the top of this file; `metal` is
+# auto-enabled on macOS via the target-specific block above.
 inferrs-models = { path = "../inferrs-models" }
 
 # Tokenizer
@@ -103,18 +103,11 @@ rustfft = "6"
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 
-# Linux / Android / Windows: libloading for dlopen'ing the backend plugins
-# (CUDA / ROCm / CANN / Hexagon / Vulkan / OpenVINO) at runtime.  Note that
-# CUDA support itself is gated behind the `cuda` Cargo feature — enabling it
-# is what pulls `candle-kernels` (and therefore nvcc / CUDA toolkit) into the
-# build.  Hosts without CUDA tooling should build with the default feature
-# set (no `cuda`) so the binary compiles cleanly and falls back to CPU / a
-# non-CUDA backend plugin at runtime.
-[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
-libloading = "0.8"
-
 # Linux / Android: libc for low-level dlopen/dlsym used by the CANN HBM
-# memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).
+# memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).  The backend
+# plugin probes themselves reuse the unconditional `libloading` dep declared
+# in [dependencies] above; CUDA toolkit linkage is gated behind the `cuda`
+# Cargo feature.
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = "0.2"
 

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -9,14 +9,30 @@ license = "Apache-2.0"
 name = "inferrs"
 path = "src/main.rs"
 
-# On macOS: always enable Metal, and add libloading to probe for
-# the Vulkan/MoltenVK and OpenVINO plugins at runtime.
+# Optional backends are gated behind Cargo features so the main binary can
+# build on hosts without the corresponding vendor toolchain.  Defaults are
+# empty — release builds that want a specific backend enable it explicitly
+# (e.g. `cargo build --release -p inferrs --features cuda`).  The Makefile
+# passes `--features cuda` automatically on Linux / Windows x86_64.
+[features]
+default = []
+cuda = [
+    "candle-core/cuda",
+    "candle-nn/cuda",
+    "candle-transformers/cuda",
+    "inferrs-models/cuda",
+]
+metal = [
+    "candle-core/metal",
+    "candle-nn/metal",
+    "candle-transformers/metal",
+    "inferrs-models/metal",
+]
+
+# On macOS: add libloading to probe for the Vulkan/MoltenVK and OpenVINO
+# plugins at runtime.  Metal itself is opt-in via `--features metal`.
 [target.'cfg(target_os = "macos")'.dependencies]
 libloading = "0.8"
-candle-core = { workspace = true, features = ["metal"] }
-candle-nn = { workspace = true, features = ["metal"] }
-candle-transformers = { workspace = true, features = ["metal"] }
-inferrs-models = { path = "../inferrs-models", features = ["metal"] }
 
 
 [dependencies]
@@ -80,41 +96,20 @@ rustfft = "6"
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 
-# Linux: dynamic backend loading + CUDA device support.
-# Enable the cuda feature so Device::new_cuda() is available at runtime.
-# candle-core is patched (see [patch.crates-io] in the workspace Cargo.toml)
-# to use cudarc with fallback-dynamic-loading instead of dynamic-linking,
-# so libcuda / libcurand / libcublas are NOT hard-linked into the binary —
-# they are dlopen'd on demand when a CUDA device is first used.
-[target.'cfg(target_os = "linux")'.dependencies]
+# Linux / Android / Windows: libloading for dlopen'ing the backend plugins
+# (CUDA / ROCm / CANN / Hexagon / Vulkan / OpenVINO) at runtime.  Note that
+# CUDA support itself is gated behind the `cuda` Cargo feature — enabling it
+# is what pulls `candle-kernels` (and therefore nvcc / CUDA toolkit) into the
+# build.  Hosts without CUDA tooling should build with the default feature
+# set (no `cuda`) so the binary compiles cleanly and falls back to CPU / a
+# non-CUDA backend plugin at runtime.
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))'.dependencies]
 libloading = "0.8"
-candle-core = { workspace = true, features = ["cuda"] }
-candle-nn = { workspace = true, features = ["cuda"] }
-candle-transformers = { workspace = true, features = ["cuda"] }
-inferrs-models = { path = "../inferrs-models", features = ["cuda"] }
-
-# Android: dynamic backend loading (CANN + Hexagon + Vulkan + OpenVINO); no CUDA.
-[target.'cfg(target_os = "android")'.dependencies]
-libloading = "0.8"
-
-# Windows x86_64: CUDA + ROCm + Vulkan + OpenVINO plugin probing.
-# CUDA is not available on Windows ARM, so this block is x86_64-only.
-[target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-libloading = "0.8"
-candle-core = { workspace = true, features = ["cuda"] }
-candle-nn = { workspace = true, features = ["cuda"] }
-candle-transformers = { workspace = true, features = ["cuda"] }
-inferrs-models = { path = "../inferrs-models", features = ["cuda"] }
-
 
 # Linux / Android: libc for low-level dlopen/dlsym used by the CANN HBM
 # memory query in engine.rs (aclrtGetMemInfo via RTLD_NOLOAD).
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = "0.2"
-
-# Windows aarch64: no CUDA, but Hexagon + Vulkan + OpenVINO probes are useful.
-[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
-libloading = "0.8"
 
 
 [build-dependencies]

--- a/inferrs/Cargo.toml
+++ b/inferrs/Cargo.toml
@@ -29,10 +29,17 @@ metal = [
     "inferrs-models/metal",
 ]
 
-# On macOS: add libloading to probe for the Vulkan/MoltenVK and OpenVINO
-# plugins at runtime.  Metal itself is opt-in via `--features metal`.
+# On macOS: always enable Metal (the framework ships with every macOS install
+# so there is no toolchain concern like there is with CUDA) and add libloading
+# to probe for the Vulkan/MoltenVK and OpenVINO plugins at runtime.  The
+# `metal` Cargo feature above is still available for explicit opt-in on other
+# platforms that may gain Metal support later.
 [target.'cfg(target_os = "macos")'.dependencies]
 libloading = "0.8"
+candle-core = { workspace = true, features = ["metal"] }
+candle-nn = { workspace = true, features = ["metal"] }
+candle-transformers = { workspace = true, features = ["metal"] }
+inferrs-models = { path = "../inferrs-models", features = ["metal"] }
 
 
 [dependencies]

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -1118,7 +1118,7 @@ fn is_cuda_uma_platform(_cuda_dev: &candle_core::CudaDevice) -> bool {
 
 /// Read `MemAvailable` from `/proc/meminfo` and return it in kibibytes.
 /// Returns `None` on any error (non-Linux, parse failure, etc.).
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(all(feature = "cuda", any(target_os = "linux", target_os = "android")))]
 fn read_proc_meminfo_available_kb() -> Option<usize> {
     let content = std::fs::read_to_string("/proc/meminfo").ok()?;
     for line in content.lines() {

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -945,9 +945,12 @@ fn query_device_memory(device: &Device) -> usize {
     match device {
         #[cfg(target_os = "macos")]
         Device::Metal(metal_dev) => metal_dev.metal_device().recommended_max_working_set_size(),
-        #[cfg(any(
-            target_os = "linux",
-            all(target_os = "windows", target_arch = "x86_64")
+        #[cfg(all(
+            feature = "cuda",
+            any(
+                target_os = "linux",
+                all(target_os = "windows", target_arch = "x86_64")
+            )
         ))]
         Device::Cuda(cuda_dev) => {
             // Query total and free from cuMemGetInfo_v2, then decide which to use.
@@ -1014,9 +1017,12 @@ fn query_device_memory(device: &Device) -> usize {
 ///
 /// Uses `libloading` instead of raw `libc::dlopen` so the same code compiles
 /// on Linux (`libcuda.so.1`) and Windows (`nvcuda.dll`).
-#[cfg(any(
-    target_os = "linux",
-    all(target_os = "windows", target_arch = "x86_64")
+#[cfg(all(
+    feature = "cuda",
+    any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    )
 ))]
 fn query_cuda_mem_info() -> Option<(usize, usize)> {
     use libloading::{Library, Symbol};
@@ -1051,9 +1057,12 @@ fn query_cuda_mem_info() -> Option<(usize, usize)> {
 /// On these platforms `cuMemGetInfo` reports system RAM, not a separate GPU
 /// pool.  vllm detects these by SM capability and substitutes
 /// `psutil.virtual_memory().available` for the free-memory baseline.
-#[cfg(any(
-    target_os = "linux",
-    all(target_os = "windows", target_arch = "x86_64")
+#[cfg(all(
+    feature = "cuda",
+    any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    )
 ))]
 fn is_cuda_uma_platform(_cuda_dev: &candle_core::CudaDevice) -> bool {
     use libloading::{Library, Symbol};

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -204,18 +204,19 @@ pub struct ServeArgs {
 ///
 /// Disabling is safe as long as no tensors are shared across different
 /// CUDA streams, which is the case for inferrs.
-fn disable_cuda_event_tracking(_device: &candle_core::Device) {
-    // disable_event_tracking is only compiled in when candle-core has the
-    // "cuda" feature, which this crate enables via its own `cuda` feature
-    // on Linux / Windows x86_64 (CUDA is not available on Windows ARM).
-    #[cfg(all(
-        feature = "cuda",
-        any(
-            target_os = "linux",
-            all(target_os = "windows", target_arch = "x86_64")
-        )
-    ))]
-    if let candle_core::Device::Cuda(cuda_dev) = _device {
+///
+/// Only compiled when the `cuda` Cargo feature is enabled (otherwise the
+/// stub `CudaDevice` has no `disable_event_tracking` method and every call
+/// site is `#[cfg]`-out).
+#[cfg(all(
+    feature = "cuda",
+    any(
+        target_os = "linux",
+        all(target_os = "windows", target_arch = "x86_64")
+    )
+))]
+fn disable_cuda_event_tracking(device: &candle_core::Device) {
+    if let candle_core::Device::Cuda(cuda_dev) = device {
         unsafe {
             cuda_dev.disable_event_tracking();
         }

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -206,11 +206,14 @@ pub struct ServeArgs {
 /// CUDA streams, which is the case for inferrs.
 fn disable_cuda_event_tracking(_device: &candle_core::Device) {
     // disable_event_tracking is only compiled in when candle-core has the
-    // "cuda" feature, which on this project is enabled on Linux and Windows
-    // x86_64 (CUDA is not available on Windows ARM).
-    #[cfg(any(
-        target_os = "linux",
-        all(target_os = "windows", target_arch = "x86_64")
+    // "cuda" feature, which this crate enables via its own `cuda` feature
+    // on Linux / Windows x86_64 (CUDA is not available on Windows ARM).
+    #[cfg(all(
+        feature = "cuda",
+        any(
+            target_os = "linux",
+            all(target_os = "windows", target_arch = "x86_64")
+        )
     ))]
     if let candle_core::Device::Cuda(cuda_dev) = _device {
         unsafe {
@@ -224,9 +227,19 @@ impl ServeArgs {
         match self.device.as_str() {
             "cpu" => Ok(candle_core::Device::Cpu),
             "cuda" => {
-                let device = candle_core::Device::new_cuda(0)?;
-                disable_cuda_event_tracking(&device);
-                Ok(device)
+                #[cfg(feature = "cuda")]
+                {
+                    let device = candle_core::Device::new_cuda(0)?;
+                    disable_cuda_event_tracking(&device);
+                    Ok(device)
+                }
+                #[cfg(not(feature = "cuda"))]
+                {
+                    anyhow::bail!(
+                        "CUDA support is not compiled in — rebuild with \
+                         `--features cuda` to enable the CUDA device"
+                    )
+                }
             }
             "metal" => {
                 let device = candle_core::Device::new_metal(0)?;
@@ -287,26 +300,40 @@ impl ServeArgs {
                     all(target_os = "windows", target_arch = "x86_64")
                 ))]
                 BackendKind::Cuda => {
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using CUDA device (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using CUDA device (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "CUDA plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 #[cfg(any(
                     target_os = "linux",
                     all(target_os = "windows", target_arch = "x86_64")
                 ))]
                 BackendKind::Musa => {
-                    // Moore Threads MUSA mirrors the CUDA API.  candle-core's
-                    // `cuda` feature covers MUSA when the binary is loaded in
-                    // an environment with the MUSA runtime libraries present.
+                    // Moore Threads MUSA mirrors the CUDA API.
                     // `Device::new_cuda(0)` resolves through cudarc's
                     // fallback-dynamic-loading, which at runtime binds to the
                     // MUSA-compatible symbols instead of the NVIDIA ones.
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "MUSA plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 #[cfg(any(
                     target_os = "linux",
@@ -314,12 +341,18 @@ impl ServeArgs {
                 ))]
                 BackendKind::Rocm => {
                     // ROCm uses the same HIP/CUDA device path in candle.
-                    // Supported on Linux x86_64, Linux aarch64, and Windows
-                    // x86_64 (via AMD HIP SDK / ROCm 5.5+).
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using ROCm device (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using ROCm device (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "ROCm plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 #[cfg(any(target_os = "linux", target_os = "android"))]
                 BackendKind::Cann => {
@@ -414,22 +447,46 @@ impl ServeArgs {
             use crate::backend::BackendKind;
             match crate::backend::detect_backend() {
                 BackendKind::Cuda => {
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using CUDA device (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using CUDA device (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "CUDA plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 BackendKind::Musa => {
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using MUSA device / Moore Threads GPU (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "MUSA plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 BackendKind::Rocm => {
-                    let device = candle_core::Device::new_cuda(0)?;
-                    tracing::info!("Using ROCm device (via plugin)");
-                    disable_cuda_event_tracking(&device);
-                    return Ok(device);
+                    #[cfg(feature = "cuda")]
+                    {
+                        let device = candle_core::Device::new_cuda(0)?;
+                        tracing::info!("Using ROCm device (via plugin)");
+                        disable_cuda_event_tracking(&device);
+                        return Ok(device);
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    tracing::info!(
+                        "ROCm plugin detected but binary was built without \
+                         `--features cuda` — falling back to CPU"
+                    );
                 }
                 BackendKind::Vulkan => {
                     tracing::info!(

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -1,3 +1,10 @@
+// clippy::collapsible_match was tightened in Rust 1.95 to flag
+// `KeyCode::X => { if cond { ... } }` patterns in this file's key-handling
+// match. The explicit inner `if` reads more clearly than a guard on each arm
+// here; silence the lint file-wide until a focused readability refactor is
+// done separately.
+#![allow(clippy::collapsible_match)]
+
 //! Interactive REPL for `inferrs run` — talks to a running `inferrs serve`
 //! daemon via the Ollama-compatible HTTP API, exactly as `ollama run` does.
 //!


### PR DESCRIPTION
## Summary

Fixes the build failure reported in [#170 comment](https://github.com/ericcurtin/inferrs/issues/170#issuecomment-4250949478) — `cargo build -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-backend-vulkan` panics on a CUDA-less Linux host because `candle-kernels`'s `build.rs` shells out to `nvidia-smi`.

Root cause: three crates unconditionally enable `candle-core/cuda` on Linux / Windows-x86_64, which pulls the patched `candle-kernels` into the dep graph even for non-CUDA build targets.

Fix: move CUDA wiring from target-forced to feature-gated.

- **`inferrs`** — new `cuda` (and `metal`) Cargo feature; Linux / Windows-x86_64 blocks no longer force `candle-core/cuda` / `candle-nn/cuda` / `candle-transformers/cuda` / `inferrs-models/cuda`. `libloading` consolidated into a single target block for the three plugin-probing OSes. All CUDA call sites in `main.rs` / `engine.rs` gated behind `#[cfg(feature = "cuda")]`.
- **`inferrs-multimodal`** — dropped the target-specific duplicate CUDA blocks; the pre-existing `cuda` feature is now the sole path. macOS Metal target block kept (Metal ships with every macOS install, no toolchain concern).
- **`inferrs-kernels`** — `candle-kernels` dep is now `optional = true` (still target-restricted to Linux / Windows-x86_64); exposed via a new `cuda` feature. `pub use candle_kernels as cuda` gated accordingly.
- **`Makefile`** — introduces `CUDA_FEATURES` which propagates `--features inferrs/cuda --features inferrs-multimodal/cuda --features inferrs-kernels/cuda` on non-Darwin hosts, threaded through `build`, `release`, `lint`, `test`. `make release` keeps producing the same CUDA-capable binary it does today.
- **`.github/workflows/release.yml`** — Linux-x86_64 / Linux-aarch64 / Windows-x86_64 jobs now pass `--features inferrs/cuda` alongside `-p inferrs -p inferrs-backend-cuda`, so release binaries keep their CUDA support (without this, the shipped binary would silently lose `Device::new_cuda` call sites even though the plugin loads).
- **`.github/workflows/ci.yml`** — Lint job and Test job enable `--features inferrs/cuda` on the targets where the CUDA toolkit is installed, so the CUDA `#[cfg]` blocks keep being type-checked by clippy / test-compile.

## Why this shape

Aligns with the Phase 2 direction discussed on #170 — the main binary should lose its compile-time CUDA dependency once the plugin owns execution. This change is the pre-step: the CUDA feature still exists and is on by default via the Makefile/CI, but it's now a single flag rather than wired into multiple per-target blocks. PR 6 of the plugin-ABI plan can later remove the feature entirely in one diff.

No behavior change for `make release` / CI. Hosts without CUDA can now build with plain `cargo build -p ...` and no flags.

## Drive-by fixes (unrelated to feature-gating)

Rust 1.95 stable tightened two clippy rules that block CI's `-D warnings` on pre-existing code. Fixing them is the narrowest path to green CI on this PR:

- `manual_checked_ops` on [`inferrs-models/src/kv_cache.rs:57`](inferrs-models/src/kv_cache.rs#L57) — rewrote the explicit-zero branch as `.checked_div(...).unwrap_or(0)`.
- `collapsible_match` across eight `KeyCode::X => { if cond { ... } }` arms in [`inferrs/src/run.rs`](inferrs/src/run.rs) — silenced file-wide with `#![allow(clippy::collapsible_match)]` and a comment, because the readability call between explicit inner `if` vs. arm-guard belongs in its own focused refactor rather than widening this PR.

## Test plan

- [x] `cargo tree -p inferrs --target x86_64-unknown-linux-gnu` → no `candle-kernels`, no `cudarc`.
- [x] `cargo tree -p inferrs --features cuda --target x86_64-unknown-linux-gnu` → `candle-kernels` + `cudarc` both present.
- [x] Same checks for `inferrs-multimodal` and `inferrs-kernels`.
- [x] `cargo build --release -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-backend-vulkan` on a CUDA-less host no longer hits the `nvidia-smi` panic (verified locally).
- [x] CI Lint + all 5 Build targets green (aarch64-apple-darwin, aarch64-pc-windows-msvc, aarch64-unknown-linux-gnu, x86_64-pc-windows-msvc, x86_64-unknown-linux-gnu).

Refs #170