### PR TITLE
feat(linear_attn_scan): parallelize K2 linear_attn_state via Blelloch prefix scan

### DIFF
--- a/candle-core/src/cuda_linear_attn_scan.rs
+++ b/candle-core/src/cuda_linear_attn_scan.rs
@@ -1,8 +1,10 @@
-/// CUDA dispatch for the 3-kernel FLA-style GatedDeltaNet chunked scan.
+/// CUDA dispatch for the parallelized GatedDeltaNet chunked scan.
 ///
-/// Three kernels run sequentially on the same CUDA stream:
+/// Kernels run sequentially on the same CUDA stream:
 ///   K1  linear_attn_intra   grid(B*NH*C) — KKT + fwd-subst + WY per chunk
-///   K2  linear_attn_state   grid(B*NH)   — sequential state scan, state in regs
+///   K2a linear_attn_ops     grid(B*NH*C) — compute (A_i, b_i) per chunk
+///   K2b linear_attn_scan    variable     — Blelloch prefix scan over chunks
+///   K2c linear_attn_apply   grid(B*NH*C_padded) — reconstruct state, compute inter/vnew
 ///   K3  linear_attn_output  grid(B*NH*C) — tiled qk + matmul per chunk
 ///
 /// Supports F32 and BF16 inputs for q/k/v.  log_g, beta, state are always F32.
@@ -14,6 +16,17 @@
 ///
 /// Returns `(out [B*NH, C, S, HV], new_state [B*NH, HK, HV])` — both F32.
 use crate::{op::BackpropOp, DType, Result, Storage, Tensor};
+
+fn next_power_of_2(n: usize) -> usize {
+    if n <= 1 {
+        return n;
+    }
+    let mut p = 1;
+    while p < n {
+        p <<= 1;
+    }
+    p
+}
 
 pub fn cuda_linear_attn_scan(
     q: &Tensor,
@@ -31,7 +44,6 @@ pub fn cuda_linear_attn_scan(
         _ => crate::bail!("cuda_linear_attn_scan: requires CUDA device"),
     };
 
-    // q: [b_nh, C, S, HK]
     let (b_nh, c, s, hk) = q.dims4()?;
     let hv = v.dim(3)?;
 
@@ -58,25 +70,28 @@ pub fn cuda_linear_attn_scan(
         ),
     };
 
+    let c_padded = next_power_of_2(c);
+    let c_padded_i = c_padded as i32;
+    let c_real_i = c as i32;
+
     let k1_name = format!("linear_attn_intra_{dtype_tag}_hk{hk_tag}_hv{hv_tag}");
-    let k2_name = format!("linear_attn_state_{dtype_tag}_hk{hk_tag}_hv{hv_tag}");
+    let k2a_name = format!("linear_attn_ops_{dtype_tag}_hk{hk_tag}_hv{hv_tag}");
+    let k2b_up_name = format!("linear_attn_scan_up_hk{hk_tag}_hv{hv_tag}");
+    let k2b_down_name = format!("linear_attn_scan_down_hk{hk_tag}_hv{hv_tag}");
+    let k2b_clear_name = format!("linear_attn_scan_clear_root_hk{hk_tag}_hv{hv_tag}");
+    let k2c_name = format!("linear_attn_apply_{dtype_tag}_hk{hk_tag}_hv{hv_tag}");
     let k3_name = format!("linear_attn_output_{dtype_tag}_hk{hk_tag}_hv{hv_tag}");
 
-    // Shared memory sizes (bytes):
-    //   K1: s_attn[S*S] + s_a_row[S] + s_gcsum[S] + s_tile[S*64] + s_tile2[S*64]
-    //       = (4096 + 64 + 64 + 4096 + 4096) * 4 = 49664 B
-    //   K2: s_row[HK] = HK * 4
-    //   K3: s_attn[S*S] + s_q[S*64] + s_k[S*64] + s_gc[S]
-    //       = (4096 + 4096 + 4096 + 64) * 4 = 49408 B
-    let k1_smem = ((s * s + 2 * s + 2 * s * 64) * std::mem::size_of::<f32>()) as u32; // 64 = BK
-    // K2: s_row[HK] + s_partial[256] + s_vnew_cache[S*HV]
-    // s_partial has 256 elements always (N_GROUPS * HV = 256).
-    // s_vnew_cache caches the full vnew chunk in smem to avoid S global re-reads
-    // and S __syncthreads() in Step B.  Total: (128+256+8192)*4 = 34 KB < 48 KB.
-    let k2_smem = ((hk + 256 + s * hv) * std::mem::size_of::<f32>()) as u32;
-    let k3_smem = ((s * s + 2 * s * 64 + s) * std::mem::size_of::<f32>()) as u32; // 64 = BK=BV
+    let k1_smem = ((s * s + 2 * s + 2 * s * 64) * std::mem::size_of::<f32>()) as u32;
+    let k2a_smem = ((32 * s + s * 32 + s) * std::mem::size_of::<f32>()) as u32;
+    // Up-sweep needs an extra s_pr[BK*HK] buffer (BK=32) to cache P_right row-blocks
+    // and avoid the in-place read-write conflict in the P composition tiling.
+    let k2b_up_smem = ((2 * 32 * 32 + 32 * hk) * std::mem::size_of::<f32>()) as u32;
+    let k2b_down_smem = (2 * 32 * 32 * std::mem::size_of::<f32>()) as u32;
 
-    // Load and configure all three kernels.
+    let k2c_smem = ((hk * 16 + 16 * hv + s + hk + 256) * std::mem::size_of::<f32>()) as u32;
+    let k3_smem = ((s * s + 2 * s * 64 + s) * std::mem::size_of::<f32>()) as u32;
+
     let load_fn = |name: &str, smem: u32| -> Result<_> {
         let func = cuda_dev
             .get_or_load_func(name, &kernels::LINEAR_ATTN_SCAN)
@@ -91,26 +106,43 @@ pub fn cuda_linear_attn_scan(
         Ok((func, smem))
     };
     let (f_k1, smem_k1) = load_fn(&k1_name, k1_smem)?;
-    let (f_k2, smem_k2) = load_fn(&k2_name, k2_smem)?;
+    let (f_k2a, smem_k2a) = load_fn(&k2a_name, k2a_smem)?;
+    let (f_k2b_up, smem_k2b_up) = load_fn(&k2b_up_name, k2b_up_smem)?;
+    let (f_k2b_down, smem_k2b_down) = load_fn(&k2b_down_name, k2b_down_smem)?;
+    let (f_k2b_clear, _smem_k2b_clear) = load_fn(&k2b_clear_name, 0)?;
+    let (f_k2c, smem_k2c) = load_fn(&k2c_name, k2c_smem)?;
     let (f_k3, smem_k3) = load_fn(&k3_name, k3_smem)?;
 
-    // ── One workspace for all 5 intermediate F32 buffers ─────────────────────
-    // The CUDA driver allocator (cuMemAlloc) is not cached; a single allocation
-    // carved with split_at_mut avoids 5 separate round-trips.
+    // ── Workspace for K1 intermediates ─────────────────────────────────────
     let w_n   = b_nh * c * s * hk;
     let u_n   = b_nh * c * s * hv;
     let gc_n  = b_nh * c * s;
-    let ihv_n = b_nh * c * s * hv; // inter and vnew have identical shape
+    let ihv_n = b_nh * c * s * hv;
     let mut workspace = unsafe {
         cuda_dev
             .alloc::<f32>(w_n + u_n + gc_n + ihv_n * 2)
             .map_err(|e| crate::Error::Cuda(Box::new(e)))?
     };
-    // Non-overlapping mutable views — safe because ranges are disjoint.
     let (mut w_v,  mut rest) = workspace.split_at_mut(w_n);
     let (mut u_v,  mut rest) = rest.split_at_mut(u_n);
     let (mut gc_v, mut rest) = rest.split_at_mut(gc_n);
     let (mut inter_v, mut vnew_v) = rest.split_at_mut(ihv_n);
+
+    // ── Prefix scan buffers (padded to power of 2) ─────────────────────────
+    let p_buf_n = b_nh * c_padded * hk * hk;
+    let q_buf_n = b_nh * c_padded * hk * hv;
+    let mut p_buf = unsafe {
+        cuda_dev.alloc::<f32>(p_buf_n).map_err(|e| crate::Error::Cuda(Box::new(e)))?
+    };
+    let mut q_prefix_buf = unsafe {
+        cuda_dev.alloc::<f32>(q_buf_n).map_err(|e| crate::Error::Cuda(Box::new(e)))?
+    };
+    let mut a_buf = unsafe {
+        cuda_dev.alloc::<f32>(p_buf_n).map_err(|e| crate::Error::Cuda(Box::new(e)))?
+    };
+    let mut b_buf = unsafe {
+        cuda_dev.alloc::<f32>(q_buf_n).map_err(|e| crate::Error::Cuda(Box::new(e)))?
+    };
 
     // ── Output + state buffers (F32) ──────────────────────────────────────────
     let out_buf = unsafe {
@@ -118,8 +150,12 @@ pub fn cuda_linear_attn_scan(
             .map_err(|e| crate::Error::Cuda(Box::new(e)))?
     };
 
-    // Copy input state into mutable buffer (K2 reads and writes it).
-    let state_buf = {
+    // state_0_buf: read-only view of the initial state, shared by all K2c blocks.
+    // new_state_buf: written exclusively by the ci==C_real-1 block — keeping these
+    // separate eliminates the concurrent read-write data race that would arise if
+    // all blocks shared a single state buffer (the last-chunk block could overwrite
+    // state_0 before sibling blocks have finished reading it in Step 1).
+    let state_0_buf = {
         let (st_stor, st_lay) = state.storage_and_layout();
         let (st_o1, st_o2) = st_lay
             .contiguous_offsets()
@@ -136,6 +172,10 @@ pub fn cuda_linear_attn_scan(
             .memcpy_dtod(&src, &mut buf)
             .map_err(|e| crate::Error::Cuda(Box::new(e)))?;
         buf
+    };
+    let mut new_state_buf = unsafe {
+        cuda_dev.alloc::<f32>(b_nh * hk * hv)
+            .map_err(|e| crate::Error::Cuda(Box::new(e)))?
     };
 
     // ── Extract log_g and beta slices (always F32) ────────────────────────────
@@ -157,7 +197,6 @@ pub fn cuda_linear_attn_scan(
         _ => crate::bail!("expected Cuda storage for beta"),
     };
 
-    let c_i = c as i32;
 
     // ── Dispatch by dtype ─────────────────────────────────────────────────────
     match q.dtype() {
@@ -184,7 +223,7 @@ pub fn cuda_linear_attn_scan(
             let (v_o1, v_o2) = v_lay
                 .contiguous_offsets()
                 .ok_or_else(|| crate::Error::msg("v not contiguous"))?;
-            let v_sl = match &*v_stor {
+            let _v_sl = match &*v_stor {
                 Storage::Cuda(cs) => cs.as_cuda_slice::<f32>()?.slice(v_o1..v_o2),
                 _ => crate::bail!("expected Cuda storage for v"),
             };
@@ -199,7 +238,7 @@ pub fn cuda_linear_attn_scan(
                 let mut b = f_k1.builder();
                 b.arg(&q_sl);
                 b.arg(&k_sl);
-                b.arg(&v_sl);
+                b.arg(&_v_sl);
                 b.arg(&lg_sl);
                 b.arg(&bt_sl);
                 b.arg(&mut w_v);
@@ -208,23 +247,104 @@ pub fn cuda_linear_attn_scan(
                 unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
             }
 
-            // K2: grid=(b_nh,), produces inter, vnew, state_new
+            // K2a: grid=(b_nh*c,), computes A_i, b_i per chunk
             {
                 let cfg = cudarc::driver::LaunchConfig {
-                    grid_dim: (b_nh as u32, 1, 1),
+                    grid_dim: ((b_nh * c) as u32, 1, 1),
                     block_dim: (256, 1, 1),
-                    shared_mem_bytes: smem_k2,
+                    shared_mem_bytes: smem_k2a,
                 };
-                let mut b = f_k2.builder();
+                let mut b = f_k2a.builder();
                 b.arg(&mut w_v);
                 b.arg(&mut u_v);
                 b.arg(&mut gc_v);
                 b.arg(&k_sl);
+                b.arg(&mut p_buf);
+                b.arg(&mut q_prefix_buf);
+                b.arg(&c_real_i);
+                b.arg(&c_padded_i);
+                unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+            }
+
+            // K2b: Blelloch prefix scan
+            {
+                // Up-sweep
+                let mut stride = 2usize;
+                while stride <= c_padded {
+                    let n_pairs = b_nh * (c_padded / stride);
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (n_pairs as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: smem_k2b_up,
+                    };
+                    let mut b = f_k2b_up.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&mut a_buf);
+                    b.arg(&mut b_buf);
+                    let stride_i = stride as i32; b.arg(&stride_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                    stride <<= 1;
+                }
+
+                // Clear root: P[C_padded-1] = I, q[C_padded-1] = 0
+                {
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (b_nh as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: 0,
+                    };
+                    let mut b = f_k2b_clear.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&c_real_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                }
+
+                // Down-sweep
+                stride = c_padded;
+                while stride >= 2 {
+                    let n_pairs = b_nh * (c_padded / stride);
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (n_pairs as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: smem_k2b_down,
+                    };
+                    let mut b = f_k2b_down.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&a_buf);
+                    b.arg(&b_buf);
+                    let stride_i = stride as i32; b.arg(&stride_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                    stride >>= 1;
+                }
+            }
+
+            // K2c: grid=(b_nh * c_padded,), reconstructs state, computes inter/vnew
+            {
+                let cfg = cudarc::driver::LaunchConfig {
+                    grid_dim: ((b_nh * c_padded) as u32, 1, 1),
+                    block_dim: (256, 1, 1),
+                    shared_mem_bytes: smem_k2c,
+                };
+                let mut b = f_k2c.builder();
+                b.arg(&mut w_v);
+                b.arg(&mut u_v);
+                b.arg(&mut gc_v);
                 b.arg(&q_sl);
-                b.arg(&state_buf);
+                b.arg(&k_sl);
+                b.arg(&state_0_buf);
+                b.arg(&mut new_state_buf);
+                b.arg(&p_buf);
+                b.arg(&q_prefix_buf);
                 b.arg(&mut inter_v);
                 b.arg(&mut vnew_v);
-                b.arg(&c_i);
+                b.arg(&c_real_i);
+                b.arg(&c_padded_i);
                 unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
             }
 
@@ -273,7 +393,7 @@ pub fn cuda_linear_attn_scan(
             let (v_o1, v_o2) = v_lay
                 .contiguous_offsets()
                 .ok_or_else(|| crate::Error::msg("v not contiguous"))?;
-            let v_sl = match &*v_stor {
+            let _v_sl = match &*v_stor {
                 Storage::Cuda(cs) => cs.as_cuda_slice::<half::bf16>()?.slice(v_o1..v_o2),
                 _ => crate::bail!("expected Cuda storage for v"),
             };
@@ -288,7 +408,7 @@ pub fn cuda_linear_attn_scan(
                 let mut b = f_k1.builder();
                 b.arg(&q_sl);
                 b.arg(&k_sl);
-                b.arg(&v_sl);
+                b.arg(&_v_sl);
                 b.arg(&lg_sl);
                 b.arg(&bt_sl);
                 b.arg(&mut w_v);
@@ -297,23 +417,101 @@ pub fn cuda_linear_attn_scan(
                 unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
             }
 
-            // K2
+            // K2a
             {
                 let cfg = cudarc::driver::LaunchConfig {
-                    grid_dim: (b_nh as u32, 1, 1),
+                    grid_dim: ((b_nh * c) as u32, 1, 1),
                     block_dim: (256, 1, 1),
-                    shared_mem_bytes: smem_k2,
+                    shared_mem_bytes: smem_k2a,
                 };
-                let mut b = f_k2.builder();
+                let mut b = f_k2a.builder();
                 b.arg(&mut w_v);
                 b.arg(&mut u_v);
                 b.arg(&mut gc_v);
                 b.arg(&k_sl);
+                b.arg(&mut p_buf);
+                b.arg(&mut q_prefix_buf);
+                b.arg(&c_real_i);
+                b.arg(&c_padded_i);
+                unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+            }
+
+            // K2b: Blelloch prefix scan
+            {
+                let mut stride = 2usize;
+                while stride <= c_padded {
+                    let n_pairs = b_nh * (c_padded / stride);
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (n_pairs as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: smem_k2b_up,
+                    };
+                    let mut b = f_k2b_up.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&mut a_buf);
+                    b.arg(&mut b_buf);
+                    let stride_i = stride as i32; b.arg(&stride_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                    stride <<= 1;
+                }
+
+                {
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (b_nh as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: 0,
+                    };
+                    let mut b = f_k2b_clear.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&c_real_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                }
+
+                stride = c_padded;
+                while stride >= 2 {
+                    let n_pairs = b_nh * (c_padded / stride);
+                    let cfg = cudarc::driver::LaunchConfig {
+                        grid_dim: (n_pairs as u32, 1, 1),
+                        block_dim: (256, 1, 1),
+                        shared_mem_bytes: smem_k2b_down,
+                    };
+                    let mut b = f_k2b_down.builder();
+                    b.arg(&mut p_buf);
+                    b.arg(&mut q_prefix_buf);
+                    b.arg(&a_buf);
+                    b.arg(&b_buf);
+                    let stride_i = stride as i32; b.arg(&stride_i);
+                    b.arg(&c_padded_i);
+                    unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
+                    stride >>= 1;
+                }
+            }
+
+            // K2c
+            {
+                let cfg = cudarc::driver::LaunchConfig {
+                    grid_dim: ((b_nh * c_padded) as u32, 1, 1),
+                    block_dim: (256, 1, 1),
+                    shared_mem_bytes: smem_k2c,
+                };
+                let mut b = f_k2c.builder();
+                b.arg(&mut w_v);
+                b.arg(&mut u_v);
+                b.arg(&mut gc_v);
                 b.arg(&q_sl);
-                b.arg(&state_buf);
+                b.arg(&k_sl);
+                b.arg(&state_0_buf);
+                b.arg(&mut new_state_buf);
+                b.arg(&p_buf);
+                b.arg(&q_prefix_buf);
                 b.arg(&mut inter_v);
                 b.arg(&mut vnew_v);
-                b.arg(&c_i);
+                b.arg(&c_real_i);
+                b.arg(&c_padded_i);
                 unsafe { b.launch(cfg) }.map_err(|e| crate::Error::Cuda(Box::new(e)))?;
             }
 
@@ -345,7 +543,6 @@ pub fn cuda_linear_attn_scan(
     drop(lg_stor);
     drop(bt_stor);
 
-    // ── Wrap raw buffers into candle tensors ──────────────────────────────────
     let out_tensor = {
         let cs = crate::CudaStorage::wrap_cuda_slice(out_buf, cuda_dev.clone());
         let shape = crate::Shape::from_dims(&[b_nh, c, s, hv]);
@@ -353,7 +550,7 @@ pub fn cuda_linear_attn_scan(
     };
 
     let state_tensor = {
-        let cs = crate::CudaStorage::wrap_cuda_slice(state_buf, cuda_dev);
+        let cs = crate::CudaStorage::wrap_cuda_slice(new_state_buf, cuda_dev);
         let shape = crate::Shape::from_dims(&[b_nh, hk, hv]);
         Tensor::from_storage(Storage::Cuda(cs), shape, BackpropOp::none(), false)
     };

--- a/inferrs-kernels/candle-kernels/src/linear_attn_scan.cu
+++ b/inferrs-kernels/candle-kernels/src/linear_attn_scan.cu
@@ -621,3 +621,857 @@ DEF_OUTPUT_KERNEL(f32,  64,  64,  float)
 DEF_OUTPUT_KERNEL(f32,  128, 128, float)
 DEF_OUTPUT_KERNEL(bf16, 64,  64,  __nv_bfloat16)
 DEF_OUTPUT_KERNEL(bf16, 128, 128, __nv_bfloat16)
+
+// ═════════════════════════════════════════════════════════════════════════════
+// K2a — linear_attn_ops
+// Grid : (B*NH*C, 1, 1)   Block : (256, 1, 1)
+//
+// Computes per-chunk linear recurrence operators (A_i, b_i):
+//   K_d[s,j] = k[s,j] * exp(gc_last - gc[s])
+//   A_i = exp(gc_last) * I - K_d^T @ W     [HK, HK]
+//   b_i = K_d^T @ U                         [HK, HV]
+//
+// Outputs:
+//   P_buf : [B*NH*C, HK, HK] row-major  — A_i per chunk
+//   q_buf : [B*NH*C, HK, HV] col-major  — b_i per chunk (same layout as state)
+//
+// Algorithm: Tiled GEMM over the S (timestep) dimension.
+//   BK=32 tiles over HK for the output tiles.
+//   Thread layout: 16x16 block, each thread owns 2x2 sub-tile.
+//
+// Shared memory:
+//   s_kd  [BK, S]   — K_d tile (BK rows of the S-column K_d matrix)
+//   s_x   [S, BK]   — W or U tile
+//   s_gc  [S]       — gc values for the chunk
+//   Total: (BK*S + S*BK + S)*4 = (2048+2048+64)*4 = 16640 B (~16 KB)
+// ═════════════════════════════════════════════════════════════════════════════
+
+template<int HK, int HV, int S = 64, int BK = 32, typename T = float>
+static __device__ void linear_attn_ops_impl(
+    const float* __restrict__ w,
+    const float* __restrict__ u,
+    const float* __restrict__ gc,
+    const T*     __restrict__ k,
+    float*       __restrict__ P_buf,
+    float*       __restrict__ q_buf,
+    int C_real,
+    int C_padded
+) {
+    const int tid = threadIdx.x;
+    const int bh_chunk = blockIdx.x;
+    const int bh = bh_chunk / C_real;
+    const int ci = bh_chunk % C_real;
+
+    const float* w_ci  = w  + (long)bh_chunk * S * HK;
+    const float* u_ci  = u  + (long)bh_chunk * S * HV;
+    const float* gc_ci = gc + (long)bh_chunk * S;
+    const T*     k_ci  = k  + (long)bh_chunk * S * HK;
+
+    float* P_ci = P_buf + ((long)bh * C_padded + ci) * HK * HK;
+    float* q_ci = q_buf + ((long)bh * C_padded + ci) * HK * HV;
+
+    extern __shared__ float smem_k2a[];
+    float* const s_kd = smem_k2a;
+    float* const s_x  = s_kd + BK * S;
+    float* const s_gc_local = s_x + S * BK;
+
+    for (int idx = tid; idx < S; idx += 256)
+        s_gc_local[idx] = gc_ci[idx];
+    __syncthreads();
+
+    float gc_last = s_gc_local[S - 1];
+    float g_end = __expf(gc_last);
+
+    // Thread owns 2x2 sub-tile within a BKxBK tile
+    // 16x16 threads = 256
+    const int tx = tid % 16;
+    const int ty = tid / 16;
+
+    // ── Phase 1: Compute A_i = g_end * I - K_d^T @ W ─────────────────────
+    // Output is [HK, HK] row-major
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HK; ct += BK) {
+            float acc[2][2];
+            acc[0][0] = 0.f; acc[0][1] = 0.f;
+            acc[1][0] = 0.f; acc[1][1] = 0.f;
+
+            for (int s_start = 0; s_start < S; s_start += S) {
+                // Load K_d rows [rt..rt+BK) into s_kd[BK, S]
+                for (int idx = tid; idx < BK * S; idx += 256) {
+                    int br = idx / S;
+                    int sc = idx % S;
+                    int hk = rt + br;
+                    if (hk < HK) {
+                        float kv = load_as_f32(k_ci + sc * HK, hk);
+                        float decay = __expf(gc_last - s_gc_local[sc]);
+                        s_kd[br * S + sc] = kv * decay;
+                    } else {
+                        s_kd[br * S + sc] = 0.f;
+                    }
+                }
+                __syncthreads();
+
+                // Load W rows [0..S) cols [ct..ct+BK) into s_x[S, BK]
+                for (int idx = tid; idx < S * BK; idx += 256) {
+                    int sc = idx / BK;
+                    int bc = idx % BK;
+                    int hk = ct + bc;
+                    s_x[idx] = (hk < HK) ? w_ci[sc * HK + hk] : 0.f;
+                }
+                __syncthreads();
+
+                // Each thread computes 2x2 = 4 elements of the output tile
+                // A[rt+ty*2+dy, ct+tx*2+dx] = -sum_s s_kd[br, s] * s_x[s, bc]
+                for (int s = 0; s < S; s++) {
+                    float kd0 = s_kd[(ty * 2 + 0) * S + s];
+                    float kd1 = s_kd[(ty * 2 + 1) * S + s];
+                    float xs0 = s_x[s * BK + tx * 2 + 0];
+                    float xs1 = s_x[s * BK + tx * 2 + 1];
+                    acc[0][0] -= kd0 * xs0;
+                    acc[0][1] -= kd0 * xs1;
+                    acc[1][0] -= kd1 * xs0;
+                    acc[1][1] -= kd1 * xs1;
+                }
+                __syncthreads();
+            }
+
+            // Add identity * g_end and write
+            int row0 = rt + ty * 2 + 0;
+            int row1 = rt + ty * 2 + 1;
+            int col0 = ct + tx * 2 + 0;
+            int col1 = ct + tx * 2 + 1;
+            if (row0 < HK && col0 < HK) {
+                acc[0][0] += (row0 == col0) ? g_end : 0.f;
+                P_ci[row0 * HK + col0] = acc[0][0];
+            }
+            if (row0 < HK && col1 < HK) {
+                P_ci[row0 * HK + col1] = acc[0][1];
+            }
+            if (row1 < HK && col0 < HK) {
+                P_ci[row1 * HK + col0] = acc[1][0];
+            }
+            if (row1 < HK && col1 < HK) {
+                acc[1][1] += (row1 == col1) ? g_end : 0.f;
+                P_ci[row1 * HK + col1] = acc[1][1];
+            }
+            __syncthreads();
+        }
+    }
+
+    // ── Phase 2: Compute b_i = K_d^T @ U ─────────────────────────────────
+    // Output is [HK, HV] — same col-major layout as state: [hk, hv] -> offset = hk * HV + hv
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HV; ct += BK) {
+            float acc[2][2];
+            acc[0][0] = 0.f; acc[0][1] = 0.f;
+            acc[1][0] = 0.f; acc[1][1] = 0.f;
+
+            for (int s_start = 0; s_start < S; s_start += S) {
+                // Re-load K_d rows [rt..rt+BK) into s_kd
+                for (int idx = tid; idx < BK * S; idx += 256) {
+                    int br = idx / S;
+                    int sc = idx % S;
+                    int hk = rt + br;
+                    if (hk < HK) {
+                        float kv = load_as_f32(k_ci + sc * HK, hk);
+                        float decay = __expf(gc_last - s_gc_local[sc]);
+                        s_kd[br * S + sc] = kv * decay;
+                    } else {
+                        s_kd[br * S + sc] = 0.f;
+                    }
+                }
+                __syncthreads();
+
+                // Load U rows [0..S) cols [ct..ct+BK) into s_x[S, BK]
+                for (int idx = tid; idx < S * BK; idx += 256) {
+                    int sc = idx / BK;
+                    int bc = idx % BK;
+                    int hv = ct + bc;
+                    s_x[idx] = (hv < HV) ? u_ci[sc * HV + hv] : 0.f;
+                }
+                __syncthreads();
+
+                for (int s = 0; s < S; s++) {
+                    float kd0 = s_kd[(ty * 2 + 0) * S + s];
+                    float kd1 = s_kd[(ty * 2 + 1) * S + s];
+                    float xs0 = s_x[s * BK + tx * 2 + 0];
+                    float xs1 = s_x[s * BK + tx * 2 + 1];
+                    acc[0][0] += kd0 * xs0;
+                    acc[0][1] += kd0 * xs1;
+                    acc[1][0] += kd1 * xs0;
+                    acc[1][1] += kd1 * xs1;
+                }
+                __syncthreads();
+            }
+
+            int row0 = rt + ty * 2 + 0;
+            int row1 = rt + ty * 2 + 1;
+            int col0 = ct + tx * 2 + 0;
+            int col1 = ct + tx * 2 + 1;
+            if (row0 < HK && col0 < HV)
+                q_ci[row0 * HV + col0] = acc[0][0];
+            if (row0 < HK && col1 < HV)
+                q_ci[row0 * HV + col1] = acc[0][1];
+            if (row1 < HK && col0 < HV)
+                q_ci[row1 * HV + col0] = acc[1][0];
+            if (row1 < HK && col1 < HV)
+                q_ci[row1 * HV + col1] = acc[1][1];
+            __syncthreads();
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// K2b — linear_attn_prefix_scan (up-sweep)
+// Grid : variable (see Rust dispatch)   Block : (256, 1, 1)
+//
+// One launch per up-sweep level. Each block composes two adjacent chunks:
+//   P[i] = P[i] ∘ P[i-stride]
+//   q[i] = P[i] * q[i-stride] + q[i]
+//   Saved left values: A_buf[i-stride] = old P[i-stride], b_buf[i-stride] = old q[i-stride]
+//
+// BK=16 for smem. Thread layout: 16x16, each thread owns 2x2 sub-tile.
+//
+// Shared memory:
+//   s_a [BK, BK]  — left tile (from P[i-stride])
+//   s_b [BK, BK]  — right tile (from P[i])
+//   Total: 2*BK*BK*4 = 2048 B (~2 KB)
+// ═════════════════════════════════════════════════════════════════════════════
+
+template<int HK, int HV, int BK = 16>
+static __device__ void linear_attn_scan_up_impl(
+    float* __restrict__ P_buf,
+    float* __restrict__ q_buf,
+    float* __restrict__ A_buf,
+    float* __restrict__ b_buf,
+    int stride,
+    int C_padded
+) {
+    const int tid = threadIdx.x;
+    const int pair_id = blockIdx.x;
+    const int pairs_per_bh = C_padded / stride;
+    const int bh = pair_id / pairs_per_bh;
+    const int pair = pair_id % pairs_per_bh;
+    const int i = bh * C_padded + pair * stride + (stride - 1);
+    const int left = i - stride / 2;
+
+    if (pair * stride + (stride - 1) >= C_padded || left < bh * C_padded) return;
+
+    float* P_left  = P_buf + (long)left * HK * HK;
+    float* P_right = P_buf + (long)i    * HK * HK;
+    float* q_left  = q_buf + (long)left * HK * HV;
+    float* q_right = q_buf + (long)i    * HK * HV;
+    float* A_save  = A_buf + (long)left * HK * HK;
+    float* b_save  = b_buf + (long)left * HK * HV;
+
+    const int tx = tid % 16;
+    const int ty = tid / 16;
+
+    // ── Save left values before composition ──────────────────────────────
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HK; ct += BK) {
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HK) A_save[r0 * HK + c0] = P_left[r0 * HK + c0];
+            if (r0 < HK && c1 < HK) A_save[r0 * HK + c1] = P_left[r0 * HK + c1];
+            if (r1 < HK && c0 < HK) A_save[r1 * HK + c0] = P_left[r1 * HK + c0];
+            if (r1 < HK && c1 < HK) A_save[r1 * HK + c1] = P_left[r1 * HK + c1];
+        }
+    }
+
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HV; ct += BK) {
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HV) b_save[r0 * HV + c0] = q_left[r0 * HV + c0];
+            if (r0 < HK && c1 < HV) b_save[r0 * HV + c1] = q_left[r0 * HV + c1];
+            if (r1 < HK && c0 < HV) b_save[r1 * HV + c0] = q_left[r1 * HV + c0];
+            if (r1 < HK && c1 < HV) b_save[r1 * HV + c1] = q_left[r1 * HV + c1];
+        }
+    }
+
+    __syncthreads();
+
+    // ── Compose: q[i] = P_old[i] @ q[left] + q[i], then P[i] = P[i] @ P[left] ─
+    // q composition must happen FIRST because it uses P_right before overwrite.
+    //
+    // Smem layout: s_a[BK*BK] | s_b[BK*BK] | s_pr[BK*HK]
+    //   s_pr caches one row-block of P_right so the P composition can tile over
+    //   output columns (ct) without reading cells that were already overwritten.
+    extern __shared__ float smem_up[];
+    float* const s_a  = smem_up;
+    float* const s_b  = s_a + BK * BK;
+    float* const s_pr = s_b + BK * BK;   // [BK * HK]
+
+    // q composition: q_right = P_right_old @ q_left + q_right
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HV; ct += BK) {
+            float acc[2][2] = {{0.f, 0.f}, {0.f, 0.f}};
+
+            for (int kt = 0; kt < HK; kt += BK) {
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = kt + idx / BK, c = ct + idx % BK;
+                    s_a[idx] = (r < HK && c < HV) ? q_left[r * HV + c] : 0.f;
+                }
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = rt + idx / BK, c = kt + idx % BK;
+                    s_b[idx] = (r < HK && c < HK) ? P_right[r * HK + c] : 0.f;
+                }
+                __syncthreads();
+
+                for (int kk = 0; kk < BK; kk++) {
+                    float b0 = s_b[(ty * 2 + 0) * BK + kk];
+                    float b1 = s_b[(ty * 2 + 1) * BK + kk];
+                    float a0 = s_a[kk * BK + tx * 2 + 0];
+                    float a1 = s_a[kk * BK + tx * 2 + 1];
+                    acc[0][0] += b0 * a0;
+                    acc[0][1] += b0 * a1;
+                    acc[1][0] += b1 * a0;
+                    acc[1][1] += b1 * a1;
+                }
+                __syncthreads();
+            }
+
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HV) q_right[r0 * HV + c0] = acc[0][0] + q_right[r0 * HV + c0];
+            if (r0 < HK && c1 < HV) q_right[r0 * HV + c1] = acc[0][1] + q_right[r0 * HV + c1];
+            if (r1 < HK && c0 < HV) q_right[r1 * HV + c0] = acc[1][0] + q_right[r1 * HV + c0];
+            if (r1 < HK && c1 < HV) q_right[r1 * HV + c1] = acc[1][1] + q_right[r1 * HV + c1];
+            __syncthreads();
+        }
+    }
+
+    // P composition: P_right = P_right @ P_left
+    //
+    // Without care, the tiled in-place write to P_right[rt, ct] would corrupt
+    // subsequent tiles (rt, ct') that still need to read P_right[rt, ct] from
+    // the kt loop.  Fix: for each rt block, cache the full P_right[rt:rt+BK, :]
+    // row into s_pr before computing any output columns for that block.
+    for (int rt = 0; rt < HK; rt += BK) {
+        // Load P_right[rt:rt+BK, 0:HK] into s_pr[BK, HK] before any writes.
+        for (int idx = tid; idx < BK * HK; idx += 256) {
+            int br = idx / HK, bc = idx % HK;
+            int r  = rt + br;
+            s_pr[br * HK + bc] = (r < HK) ? P_right[r * HK + bc] : 0.f;
+        }
+        __syncthreads();
+
+        for (int ct = 0; ct < HK; ct += BK) {
+            float acc[2][2] = {{0.f, 0.f}, {0.f, 0.f}};
+
+            for (int kt = 0; kt < HK; kt += BK) {
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = kt + idx / BK, c = ct + idx % BK;
+                    s_a[idx] = (r < HK && c < HK) ? P_left[r * HK + c] : 0.f;
+                }
+                __syncthreads();
+
+                for (int kk = 0; kk < BK; kk++) {
+                    float pr0 = s_pr[(ty * 2 + 0) * HK + kt + kk];
+                    float pr1 = s_pr[(ty * 2 + 1) * HK + kt + kk];
+                    float pl0 = s_a[kk * BK + tx * 2 + 0];
+                    float pl1 = s_a[kk * BK + tx * 2 + 1];
+                    acc[0][0] += pr0 * pl0;
+                    acc[0][1] += pr0 * pl1;
+                    acc[1][0] += pr1 * pl0;
+                    acc[1][1] += pr1 * pl1;
+                }
+                __syncthreads();
+            }
+
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HK) P_right[r0 * HK + c0] = acc[0][0];
+            if (r0 < HK && c1 < HK) P_right[r0 * HK + c1] = acc[0][1];
+            if (r1 < HK && c0 < HK) P_right[r1 * HK + c0] = acc[1][0];
+            if (r1 < HK && c1 < HK) P_right[r1 * HK + c1] = acc[1][1];
+            __syncthreads();
+        }
+        // s_pr will be overwritten at the top of the next rt iteration,
+        // which is safe because all ct writes for this rt block are done.
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// K2b — linear_attn_prefix_scan (down-sweep)
+// Grid : variable   Block : (256, 1, 1)
+//
+// Non-commutative Blelloch down-sweep. Each block:
+//   old = P[i]
+//   P[i-stride] = old                    (right child gets parent prefix)
+//   P[i] = saved_left[i-stride] @ old    (left child gets left∘parent)
+//
+// Same for q_buf: q[i-stride] = old_q[i], q[i] = saved_b[i-stride] + A[i-stride] @ old_q[i]
+// ═════════════════════════════════════════════════════════════════════════════
+
+template<int HK, int HV, int BK = 16>
+static __device__ void linear_attn_scan_down_impl(
+    float* __restrict__ P_buf,
+    float* __restrict__ q_buf,
+    const float* __restrict__ A_buf,
+    const float* __restrict__ b_buf,
+    int stride,
+    int C_padded
+) {
+    const int tid = threadIdx.x;
+    const int pair_id = blockIdx.x;
+    const int pairs_per_bh = C_padded / stride;
+    const int bh = pair_id / pairs_per_bh;
+    const int pair = pair_id % pairs_per_bh;
+    const int i = bh * C_padded + pair * stride + (stride - 1);
+    const int left = i - stride / 2;
+
+    if (pair * stride + (stride - 1) >= C_padded || left < bh * C_padded) return;
+
+    float* P_left  = P_buf + (long)left * HK * HK;
+    float* P_right = P_buf + (long)i    * HK * HK;
+    float* q_left  = q_buf + (long)left * HK * HV;
+    float* q_right = q_buf + (long)i    * HK * HV;
+    const float* A_saved = A_buf + (long)left * HK * HK;
+    const float* b_saved = b_buf + (long)left * HK * HV;
+
+    const int tx = tid % 16;
+    const int ty = tid / 16;
+
+    extern __shared__ float smem_down[];
+    float* const s_a = smem_down;
+    float* const s_b = s_a + BK * BK;
+
+    // ── Step 1: Save P_right (old) → P_left, q_right (old) → q_left ────
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HK; ct += BK) {
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            float v00 = 0.f, v01 = 0.f, v10 = 0.f, v11 = 0.f;
+            if (r0 < HK && c0 < HK) { v00 = P_right[r0 * HK + c0]; P_left[r0 * HK + c0] = v00; }
+            if (r0 < HK && c1 < HK) { v01 = P_right[r0 * HK + c1]; P_left[r0 * HK + c1] = v01; }
+            if (r1 < HK && c0 < HK) { v10 = P_right[r1 * HK + c0]; P_left[r1 * HK + c0] = v10; }
+            if (r1 < HK && c1 < HK) { v11 = P_right[r1 * HK + c1]; P_left[r1 * HK + c1] = v11; }
+        }
+    }
+
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HV; ct += BK) {
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HV) q_left[r0 * HV + c0] = q_right[r0 * HV + c0];
+            if (r0 < HK && c1 < HV) q_left[r0 * HV + c1] = q_right[r0 * HV + c1];
+            if (r1 < HK && c0 < HV) q_left[r1 * HV + c0] = q_right[r1 * HV + c0];
+            if (r1 < HK && c1 < HV) q_left[r1 * HV + c1] = q_right[r1 * HV + c1];
+        }
+    }
+
+    __syncthreads();
+
+    // ── Step 2: P_right = A_saved @ old_P_right (tiled GEMM) ─────────────
+    // P_right is the old value we just saved to P_left. Now overwrite P_right.
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HK; ct += BK) {
+            float acc[2][2] = {{0.f, 0.f}, {0.f, 0.f}};
+
+            for (int kt = 0; kt < HK; kt += BK) {
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = kt + idx / BK, c = ct + idx % BK;
+                    s_a[idx] = (r < HK && c < HK) ? P_left[r * HK + c] : 0.f;
+                }
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = rt + idx / BK, c = kt + idx % BK;
+                    s_b[idx] = (r < HK && c < HK) ? A_saved[r * HK + c] : 0.f;
+                }
+                __syncthreads();
+
+                for (int kk = 0; kk < BK; kk++) {
+                    float b0 = s_b[(ty * 2 + 0) * BK + kk];
+                    float b1 = s_b[(ty * 2 + 1) * BK + kk];
+                    float a0 = s_a[kk * BK + tx * 2 + 0];
+                    float a1 = s_a[kk * BK + tx * 2 + 1];
+                    acc[0][0] += b0 * a0;
+                    acc[0][1] += b0 * a1;
+                    acc[1][0] += b1 * a0;
+                    acc[1][1] += b1 * a1;
+                }
+                __syncthreads();
+            }
+
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HK) P_right[r0 * HK + c0] = acc[0][0];
+            if (r0 < HK && c1 < HK) P_right[r0 * HK + c1] = acc[0][1];
+            if (r1 < HK && c0 < HK) P_right[r1 * HK + c0] = acc[1][0];
+            if (r1 < HK && c1 < HK) P_right[r1 * HK + c1] = acc[1][1];
+            __syncthreads();
+        }
+    }
+
+    // ── Step 3: q_right = A_saved @ old_q_right + b_saved ────────────────
+    for (int rt = 0; rt < HK; rt += BK) {
+        for (int ct = 0; ct < HV; ct += BK) {
+            float acc[2][2] = {{0.f, 0.f}, {0.f, 0.f}};
+
+            for (int kt = 0; kt < HK; kt += BK) {
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = kt + idx / BK, c = ct + idx % BK;
+                    s_a[idx] = (r < HK && c < HV) ? q_left[r * HV + c] : 0.f;
+                }
+                for (int idx = tid; idx < BK * BK; idx += 256) {
+                    int r = rt + idx / BK, c = kt + idx % BK;
+                    s_b[idx] = (r < HK && c < HK) ? A_saved[r * HK + c] : 0.f;
+                }
+                __syncthreads();
+
+                for (int kk = 0; kk < BK; kk++) {
+                    float b0 = s_b[(ty * 2 + 0) * BK + kk];
+                    float b1 = s_b[(ty * 2 + 1) * BK + kk];
+                    float a0 = s_a[kk * BK + tx * 2 + 0];
+                    float a1 = s_a[kk * BK + tx * 2 + 1];
+                    acc[0][0] += b0 * a0;
+                    acc[0][1] += b0 * a1;
+                    acc[1][0] += b1 * a0;
+                    acc[1][1] += b1 * a1;
+                }
+                __syncthreads();
+            }
+
+            int r0 = rt + ty * 2 + 0, r1 = rt + ty * 2 + 1;
+            int c0 = ct + tx * 2 + 0, c1 = ct + tx * 2 + 1;
+            if (r0 < HK && c0 < HV) q_right[r0 * HV + c0] = acc[0][0] + b_saved[r0 * HV + c0];
+            if (r0 < HK && c1 < HV) q_right[r0 * HV + c1] = acc[0][1] + b_saved[r0 * HV + c1];
+            if (r1 < HK && c0 < HV) q_right[r1 * HV + c0] = acc[1][0] + b_saved[r1 * HV + c0];
+            if (r1 < HK && c1 < HV) q_right[r1 * HV + c1] = acc[1][1] + b_saved[r1 * HV + c1];
+            __syncthreads();
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// K2c — linear_attn_apply
+// Grid : (B*NH*C, 1, 1)   Block : (256, 1, 1)
+//
+// Reconstructs per-chunk state from prefix scan result, then computes
+// inter/vnew (Step A), and optionally new_state for ci==C-1.
+//
+// Inputs per chunk:
+//   P_buf[ci] : [HK, HK] — exclusive prefix A composition
+//   q_buf[ci] : [HK, HV] — exclusive prefix b composition
+//   state_0   : [HK, HV] — initial state (read-only)
+//   w_ci, u_ci, gc_ci, q_ci, k_ci — per-chunk data
+//
+// Thread decomposition: same as K2 (bv_local=tid%HV, hk_group=tid/HV, HPG regs)
+//
+// Shared memory:
+//   s_p_tile  [HK, BK]  — full-HK column tile of P_buf (all groups share one load)
+//   s_st_tile [BK, HV]  — row tile of state_0 (all columns, avoids per-group aliasing)
+//   s_gc      [S]       — gc values
+//   s_row_qw  [HK]      — staging for q/w rows
+//   s_partial [256]     — cross-group reduction
+// ═════════════════════════════════════════════════════════════════════════════
+
+template<int HK, int HV, int S = 64, int HPG = 64, int BK = 16, typename T = float>
+static __device__ void linear_attn_apply_impl(
+    const float* __restrict__ w,
+    const float* __restrict__ u,
+    const float* __restrict__ gc,
+    const T*     __restrict__ q_tensor,
+    const T*     __restrict__ k,
+    const float* __restrict__ state_0,   // initial state — read by ALL blocks concurrently
+    float*       __restrict__ new_state, // updated state — written ONLY by ci==C_real-1 block
+    const float* __restrict__ P_buf,
+    const float* __restrict__ q_buf,
+    float*       __restrict__ inter,
+    float*       __restrict__ vnew,
+    int C_real,
+    int C_padded
+) {
+    const int tid = threadIdx.x;
+    const int bh_chunk = blockIdx.x;
+    const int ci = bh_chunk % C_padded;
+
+    if (ci >= C_real) return;
+
+    const long bh = bh_chunk / C_padded;
+
+    constexpr int N_GROUPS = 256 / HV;
+    const int bv_local      = tid % HV;
+    const int hk_group      = tid / HV;
+    const int hk_local_base = hk_group * HPG;
+
+    float state_reg[HPG];
+
+    extern __shared__ float smem_k2c[];
+    float* const s_p_tile   = smem_k2c;
+    float* const s_st_tile  = s_p_tile  + HK * BK;
+    float* const s_gc_local = s_st_tile + BK * HV;
+    float* const s_row_qw   = s_gc_local + S;
+    float* const s_partial  = s_row_qw  + HK;
+
+    const long real_chunk = (long)bh * C_real + ci;
+
+    const float* w_ci  = w  + real_chunk * S * HK;
+    const float* u_ci  = u  + real_chunk * S * HV;
+    const float* gc_ci = gc + real_chunk * S;
+    const T*     q_ci  = q_tensor + real_chunk * S * HK;
+    float* inter_ci    = inter + real_chunk * S * HV;
+    float* vnew_ci     = vnew  + real_chunk * S * HV;
+
+    const float* P_ci = P_buf + ((long)bh * C_padded + ci) * HK * HK;
+    const float* q_prefix = q_buf + ((long)bh * C_padded + ci) * HK * HV;
+    const float* my_state = state_0 + (long)bh * HK * HV;
+
+    // Load gc
+    for (int idx = tid; idx < S; idx += 256)
+        s_gc_local[idx] = gc_ci[idx];
+    __syncthreads();
+
+    // ── Step 1: state_in = P[ci] @ state_0 + q_prefix ─────────────────────
+    // All thread groups cooperatively load full-HK tiles so every group reads
+    // from its correct row range — the old per-group s_tile caused groups to
+    // overwrite each other's entries (aliased indices) and s_row_st held a
+    // diagonal of the state rather than a single column.
+    for (int j = 0; j < HPG; j++) state_reg[j] = 0.f;
+
+    for (int kt = 0; kt < HK; kt += BK) {
+        // Load P_ci[:, kt:kt+BK] into s_p_tile[HK, BK] — all groups collaborate
+        for (int idx = tid; idx < HK * BK; idx += 256) {
+            int r = idx / BK;
+            int c = kt + idx % BK;
+            s_p_tile[idx] = (c < HK) ? P_ci[r * HK + c] : 0.f;
+        }
+        // Load state_0[kt:kt+BK, :] into s_st_tile[BK, HV] — all groups collaborate
+        for (int idx = tid; idx < BK * HV; idx += 256) {
+            int kk = idx / HV;
+            int bv = idx % HV;
+            int k  = kt + kk;
+            s_st_tile[idx] = (k < HK) ? my_state[k * HV + bv] : 0.f;
+        }
+        __syncthreads();
+
+        for (int j = 0; j < HPG; j++) {
+            for (int kk = 0; kk < BK; kk++) {
+                state_reg[j] += s_p_tile[(hk_local_base + j) * BK + kk]
+                              * s_st_tile[kk * HV + bv_local];
+            }
+        }
+        __syncthreads();
+    }
+
+    // Add q_prefix[hk_local_base..hk_local_base+HPG, bv_local]
+    for (int j = 0; j < HPG; j++) {
+        state_reg[j] += q_prefix[(hk_local_base + j) * HV + bv_local];
+    }
+
+    // ── Step 2: inter and vnew (Step A — same as K2) ──────────────────────
+    for (int s = 0; s < S; s++) {
+        float gc_s = s_gc_local[s];
+
+        // inter
+        for (int idx = tid; idx < HK; idx += 256)
+            s_row_qw[idx] = load_as_f32(q_ci + s * HK, idx);
+        __syncthreads();
+
+        float inter_p = 0.0f;
+        for (int j = 0; j < HPG; j++)
+            inter_p += s_row_qw[hk_local_base + j] * state_reg[j];
+        s_partial[hk_group * HV + bv_local] = inter_p * __expf(gc_s);
+        __syncthreads();
+
+        if (hk_group == 0) {
+            float sum = 0.f;
+            for (int g = 0; g < N_GROUPS; g++)
+                sum += s_partial[g * HV + bv_local];
+            inter_ci[s * HV + bv_local] = sum;
+        }
+        __syncthreads();
+
+        // vnew
+        for (int idx = tid; idx < HK; idx += 256)
+            s_row_qw[idx] = w_ci[s * HK + idx];
+        __syncthreads();
+
+        float w_p = 0.0f;
+        for (int j = 0; j < HPG; j++)
+            w_p += s_row_qw[hk_local_base + j] * state_reg[j];
+        s_partial[hk_group * HV + bv_local] = w_p;
+        __syncthreads();
+
+        if (hk_group == 0) {
+            float sum = 0.f;
+            for (int g = 0; g < N_GROUPS; g++)
+                sum += s_partial[g * HV + bv_local];
+            vnew_ci[s * HV + bv_local] = u_ci[s * HV + bv_local] - sum;
+        }
+        __syncthreads();
+    }
+
+    // ── Step 3: For ci==C_real-1, compute new_state via Step B ─────────────
+    // new_state = A_{C-1} @ state_in + b_{C-1}
+    // But we don't have A_{C-1}/b_{C-1} separately — we have the raw state update:
+    // new_state = exp(gc_last)*state_in + sum_s k_d[s] * decay * vnew[s]
+    if (ci == C_real - 1) {
+        float gc_last = s_gc_local[S - 1];
+        float g_end = __expf(gc_last);
+        for (int j = 0; j < HPG; j++) state_reg[j] *= g_end;
+
+        const T* k_ci = k + real_chunk * S * HK;
+        for (int s2 = 0; s2 < S; s2++) {
+            for (int idx = tid; idx < HK; idx += 256)
+                s_row_qw[idx] = load_as_f32(k_ci + s2 * HK, idx);
+            __syncthreads();
+
+            float decay = __expf(gc_last - s_gc_local[s2]);
+            float vn = vnew_ci[s2 * HV + bv_local];
+            for (int j = 0; j < HPG; j++)
+                state_reg[j] += s_row_qw[hk_local_base + j] * decay * vn;
+            __syncthreads();
+        }
+
+        float* my_new_state = new_state + (long)bh * HK * HV;
+        for (int j = 0; j < HPG; j++) {
+            my_new_state[(hk_local_base + j) * HV + bv_local] = state_reg[j];
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// K2b — Init identity operators for padded chunks + clear root
+// Grid : (B*NH, 1, 1)   Block : (256, 1, 1)
+//
+// For each ci in [C_real, C_padded): sets P[ci] = I, q[ci] = 0.
+// Also sets P[C_padded-1] = I (root of up-sweep tree).
+// When C_real == C_padded, only clears the root.
+// ═════════════════════════════════════════════════════════════════════════════
+
+template<int HK, int HV>
+static __device__ void linear_attn_scan_init_impl(
+    float* __restrict__ P_buf,
+    float* __restrict__ q_buf,
+    int C_real,
+    int C_padded
+) {
+    const int tid = threadIdx.x;
+    const int bh = blockIdx.x;
+
+    for (int ci = C_real; ci < C_padded; ci++) {
+        float* P_ci = P_buf + ((long)bh * C_padded + ci) * HK * HK;
+        float* q_ci = q_buf + ((long)bh * C_padded + ci) * HK * HV;
+
+        for (int idx = tid; idx < HK * HK; idx += 256) {
+            int r = idx / HK, c = idx % HK;
+            P_ci[idx] = (r == c) ? 1.f : 0.f;
+        }
+        for (int idx = tid; idx < HK * HV; idx += 256) {
+            q_ci[idx] = 0.f;
+        }
+    }
+    __syncthreads();
+
+    // Always clear root (C_padded-1) to identity for the up-sweep result
+    {
+        float* P_root = P_buf + ((long)bh * C_padded + C_padded - 1) * HK * HK;
+        float* q_root = q_buf + ((long)bh * C_padded + C_padded - 1) * HK * HV;
+        for (int idx = tid; idx < HK * HK; idx += 256) {
+            int r = idx / HK, c = idx % HK;
+            P_root[idx] = (r == c) ? 1.f : 0.f;
+        }
+        for (int idx = tid; idx < HK * HV; idx += 256) {
+            q_root[idx] = 0.f;
+        }
+    }
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Entry points for K2a, K2b_up, K2b_down, K2b_clear, K2c
+// ═════════════════════════════════════════════════════════════════════════════
+
+// Smem sizes:
+//   K2a: (BK*S + S*BK + S)*4 = (2048+2048+64)*4 = 16640 B  (BK=32)
+//   K2b_up/down: 2*BK*BK*4 = 8192 B (BK=32)
+//   K2c: (HPG*BK + BK + S + HK + 256)*4  — varies by config
+//   K2b_clear: 0
+
+#define K2A_SMEM(BK, S)         (((BK)*(S) + (S)*(BK) + (S))*4)
+// Up-sweep needs s_pr[BK*HK] in addition to s_a+s_b to cache P_right row-blocks
+// before tiling over output columns (avoids in-place read-write conflict).
+#define K2B_UP_SMEM(BK, HK)    ((2*(BK)*(BK) + (BK)*(HK))*4)
+#define K2B_DOWN_SMEM(BK)      (2*(BK)*(BK)*4)
+#define K2C_SMEM(BK, S, HK, HV)  (((HK)*(BK) + (BK)*(HV) + (S) + (HK) + 256)*4)
+
+#define DEF_OPS_KERNEL(DTYPE_NAME, HK_VAL, HV_VAL, T_TYPE)                     \
+extern "C" __global__                                                           \
+__launch_bounds__(256, 2)                                                       \
+void linear_attn_ops_##DTYPE_NAME##_hk##HK_VAL##_hv##HV_VAL(                  \
+    const float* w,  const float* u,  const float* gc,                         \
+    const T_TYPE* k,                                                            \
+    float* P_buf, float* q_buf, int C_real, int C_padded                        \
+) {                                                                             \
+    linear_attn_ops_impl<HK_VAL, HV_VAL, 64, 32, T_TYPE>(                     \
+        w, u, gc, k, P_buf, q_buf, C_real, C_padded);                          \
+}
+
+DEF_OPS_KERNEL(f32,  64,  64,  float)
+DEF_OPS_KERNEL(f32,  128, 128, float)
+DEF_OPS_KERNEL(bf16, 64,  64,  __nv_bfloat16)
+DEF_OPS_KERNEL(bf16, 128, 128, __nv_bfloat16)
+
+#define DEF_SCAN_UP_KERNEL(HK_VAL, HV_VAL)                                     \
+extern "C" __global__                                                           \
+__launch_bounds__(256, 2)                                                       \
+void linear_attn_scan_up_hk##HK_VAL##_hv##HV_VAL(                             \
+    float* P_buf, float* q_buf, float* A_buf, float* b_buf,                    \
+    int stride, int C_padded                                                    \
+) {                                                                             \
+    linear_attn_scan_up_impl<HK_VAL, HV_VAL, 32>(                             \
+        P_buf, q_buf, A_buf, b_buf, stride, C_padded);                        \
+}
+
+DEF_SCAN_UP_KERNEL(64,  64)
+DEF_SCAN_UP_KERNEL(128, 128)
+
+#define DEF_SCAN_DOWN_KERNEL(HK_VAL, HV_VAL)                                   \
+extern "C" __global__                                                           \
+__launch_bounds__(256, 2)                                                       \
+void linear_attn_scan_down_hk##HK_VAL##_hv##HV_VAL(                           \
+    float* P_buf, float* q_buf,                                                \
+    const float* A_buf, const float* b_buf,                                    \
+    int stride, int C_padded                                                    \
+) {                                                                             \
+    linear_attn_scan_down_impl<HK_VAL, HV_VAL, 32>(                           \
+        P_buf, q_buf, A_buf, b_buf, stride, C_padded);                        \
+}
+
+DEF_SCAN_DOWN_KERNEL(64,  64)
+DEF_SCAN_DOWN_KERNEL(128, 128)
+
+#define DEF_CLEAR_ROOT_KERNEL(HK_VAL, HV_VAL)                                  \
+extern "C" __global__                                                           \
+__launch_bounds__(256, 2)                                                       \
+void linear_attn_scan_clear_root_hk##HK_VAL##_hv##HV_VAL(                     \
+    float* P_buf, float* q_buf, int C_real, int C_padded                        \
+) {                                                                             \
+    linear_attn_scan_init_impl<HK_VAL, HV_VAL>(                               \
+        P_buf, q_buf, C_real, C_padded);                                       \
+}
+
+DEF_CLEAR_ROOT_KERNEL(64,  64)
+DEF_CLEAR_ROOT_KERNEL(128, 128)
+
+#define DEF_APPLY_KERNEL(DTYPE_NAME, HK_VAL, HV_VAL, HPG_VAL, T_TYPE)         \
+extern "C" __global__                                                           \
+__launch_bounds__(256, 2)                                                       \
+void linear_attn_apply_##DTYPE_NAME##_hk##HK_VAL##_hv##HV_VAL(                \
+    const float* w,  const float* u,  const float* gc,                         \
+    const T_TYPE* q_tensor, const T_TYPE* k,                                   \
+    const float* state_0, float* new_state,                                    \
+    const float* P_buf, const float* q_buf,                                    \
+    float* inter, float* vnew,                                                 \
+    int C_real, int C_padded                                                    \
+) {                                                                             \
+    linear_attn_apply_impl<HK_VAL, HV_VAL, 64, HPG_VAL, 16, T_TYPE>(          \
+        w, u, gc, q_tensor, k, state_0, new_state, P_buf, q_buf,              \
+        inter, vnew, C_real, C_padded);                                        \
+}
+
+DEF_APPLY_KERNEL(f32,  64,  64,  16, float)
+DEF_APPLY_KERNEL(f32,  128, 128, 64, float)
+DEF_APPLY_KERNEL(bf16, 64,  64,  16, __nv_bfloat16)
+DEF_APPLY_KERNEL(bf16, 128, 128, 64, __nv_bfloat16)

--- a/inferrs-models/src/models/qwen3_5_linear_attn_scan.rs
+++ b/inferrs-models/src/models/qwen3_5_linear_attn_scan.rs
@@ -596,6 +596,54 @@ mod tests {
         run_chunked_large_decay(&device, 42, 16, 128, 128);
     }
 
+    /// Same as `run_chunked_vs_sequential` but starts from a random non-zero
+    /// state, exercising the `P @ state_0` branch inside K2c that was previously
+    /// broken by a per-group smem aliasing bug (s_tile) and a diagonal-read bug
+    /// (s_row_st). With zero state those two terms cancel to 0 and mask the bug.
+    fn run_chunked_vs_sequential_nonzero_state(
+        device: &Device,
+        b: usize,
+        t: usize,
+        n_heads: usize,
+        hk: usize,
+        hv: usize,
+    ) {
+        let q = Tensor::randn(0f32, 0.1f32, (b, t, n_heads, hk), device).unwrap();
+        let k = Tensor::randn(0f32, 0.1f32, (b, t, n_heads, hk), device).unwrap();
+        let v = Tensor::randn(0f32, 1.0f32, (b, t, n_heads, hv), device).unwrap();
+        let g_raw = Tensor::randn(-2.0f32, 1.0f32, (b, t, n_heads), device).unwrap();
+        let g = candle_nn::ops::sigmoid(&g_raw).unwrap();
+        let log_g = g.log().unwrap();
+        let beta_raw = Tensor::randn(0f32, 1.0f32, (b, t, n_heads), device).unwrap();
+        let beta = candle_nn::ops::sigmoid(&beta_raw).unwrap();
+
+        // Build state on CPU then copy to target device twice to get two
+        // independent tensors with identical initial values.
+        let state_cpu = Tensor::randn(0f32, 0.1f32, (b, n_heads, hk, hv), &Device::Cpu).unwrap();
+        let mut state_seq = state_cpu.to_device(device).unwrap();
+        let mut state_chk = state_cpu.to_device(device).unwrap();
+
+        let out_seq = sequential_loop(&q, &k, &v, &g, &beta, &mut state_seq).unwrap();
+        let out_chk = gated_delta_rule_chunked(&q, &k, &v, &log_g, &beta, &mut state_chk).unwrap();
+
+        let out_diff = max_abs_diff(&out_seq, &out_chk);
+        let state_diff = max_abs_diff(&state_seq, &state_chk);
+
+        println!(
+            "nonzero_state b={b} t={t} n_h={n_heads} hk={hk} hv={hv}: \
+             out_diff={out_diff:.6} state_diff={state_diff:.6}"
+        );
+
+        assert!(
+            out_diff < 1e-3,
+            "b={b} t={t}: output mismatch (nonzero state): max diff = {out_diff}"
+        );
+        assert!(
+            state_diff < 1e-3,
+            "b={b} t={t}: state mismatch (nonzero state): max diff = {state_diff}"
+        );
+    }
+
     #[test]
     fn chunked_matches_sequential_cpu() {
         let device = Device::Cpu;
@@ -635,6 +683,37 @@ mod tests {
         // batch > 1: validates identity broadcast and slice_set across batch dim
         run_chunked_vs_sequential(&device, 2, 56, 2, 4, 4);
         run_chunked_vs_sequential(&device, 2, 128, 2, 4, 4);
+    }
+
+    #[test]
+    fn nonzero_state_matches_sequential_cpu() {
+        let device = Device::Cpu;
+        // single chunk — ensures basic P@state correctness on CPU path
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 56, 2, 4, 4);
+        // multi-chunk — exercises composed prefix operators applied to non-zero state
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 128, 2, 4, 4);
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 192, 16, 128, 128);
+        // batch > 1
+        run_chunked_vs_sequential_nonzero_state(&device, 2, 128, 2, 4, 4);
+    }
+
+    #[test]
+    fn nonzero_state_matches_sequential_cuda() {
+        let device = Device::cuda_if_available(0).unwrap_or(Device::Cpu);
+        if matches!(device, Device::Cpu) {
+            eprintln!("CUDA not available, skipping GPU test");
+            return;
+        }
+        // single chunk (ci=0 prefix=I, state_in=state_0 directly)
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 56, 16, 128, 128);
+        // two chunks — ci=1 uses P[1]=A_0, exercises the P@state_0 matvec in K2c
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 128, 16, 128, 128);
+        // four chunks — exercises multi-level Blelloch scan + P@state_0 for ci=2,3
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 200, 16, 128, 128);
+        // hk=hv=64 variant (HPG=16, N_GROUPS=4)
+        run_chunked_vs_sequential_nonzero_state(&device, 1, 128, 16, 64, 64);
+        // batch > 1
+        run_chunked_vs_sequential_nonzero_state(&device, 2, 128, 16, 128, 128);
     }
 
     /// Run a chunked prefill followed by sequential decode steps, comparing


### PR DESCRIPTION
TLDR: prefill + 20%, TTFT -5%

Long answer:

When https://github.com/ericcurtin/inferrs/pull/214 has been developped, it was split into 3 separate kernels

K1: intra-chunk attention (WY)
K2: cross-chunk state scan (which was sequential)
K3:  output projection + correction

Fully inspired by llama cpp with the addition of Woodbury algorithm, so we process in parallel chunks of 64 tokens in K2, which is working sequentially for each chunk. After running profiling on CUDA, K2 was the main bottleneck. So the solution to fix maths is to do more maths by bringing a Blelloch algorithm to to the cross chunk state scan in parallel instead of sequential, with 3 specialized kernels running in parallel (K2a, K2b & K2c). Current implementation should be faster than llama cpp on longer token sequences 


```sh
cargo run --release --features cuda --bin inferrs -- run --device=cuda Qwen/Qwen3.5-2B "Hello, what is 2+2?"
> The answer to **2 + 2** is **4**.
```

Bench :

Inferrs (Qwen/Qwen3.5-2B)
````
  TTFT    : 100.61 ± 1.73 ms
  Prefill : 3133.89 ± 48.89 tok/s
  Decode  : 62.81 ± 0.08 tok/s
````

Llama cpp (lmstudio-community/Qwen3.5-2B-GGUF)
```
  TTFT    : 73.22 ± 4.27 ms
  Prefill : 3979.27 ± 235.33 tok/s
  Decode  : 27.21 ± 0.23 tok/s
```

I think remaining performances is on the infrastructure around kernels and the Linear attention layers