### PR TITLE
feat(qwen3.5): native tool-calling on OpenAI and Ollama endpoints + enable thinking

### DIFF
--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -14,6 +14,7 @@ mod sampler;
 mod server;
 mod stop;
 mod tokenizer;
+mod tool_call_parser;
 mod util;
 
 use anyhow::Result;

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -170,9 +170,11 @@ pub struct ChatCompletionRequest {
     #[serde(default)]
     #[allow(dead_code)]
     pub store: Option<serde_json::Value>,
-    /// OpenAI reasoning effort hint.  Accepted and silently ignored.
+    /// OpenAI reasoning effort hint.  On Qwen3.5 any non-null value enables
+    /// chain-of-thought (the chat template stops pre-filling an empty
+    /// `<think>…</think>` block, letting the model emit its own).  Ignored
+    /// on templates that don't support thinking.
     #[serde(default)]
-    #[allow(dead_code)]
     pub reasoning_effort: Option<serde_json::Value>,
 }
 
@@ -233,6 +235,24 @@ pub struct ChatCompletionChoice {
 pub struct ChatCompletionMessage {
     pub role: String,
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub function: FunctionCall,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct FunctionCall {
+    pub name: String,
+    /// OpenAI wire format requires a JSON-encoded *string* here (clients
+    /// re-parse).  `OllamaFunctionCall.arguments` uses an object instead.
+    pub arguments: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -264,6 +284,29 @@ pub struct DeltaMessage {
     /// and llama-server's default `reasoning_content_delta` behaviour.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<StreamingToolCall>>,
+}
+
+/// Streaming counterpart of [`ToolCall`]: `id`/`kind`/`function.name` ride
+/// only on the first chunk of a call, subsequent chunks carry
+/// `function.arguments` fragments.
+#[derive(Debug, Serialize, Clone)]
+pub struct StreamingToolCall {
+    pub index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    pub kind: Option<&'static str>,
+    pub function: StreamingFunctionCall,
+}
+
+#[derive(Debug, Serialize, Clone, Default)]
+pub struct StreamingFunctionCall {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -590,9 +633,14 @@ pub struct OllamaChatRequest {
     /// chain-of-thought will be returned in the `thinking` field.
     #[serde(default)]
     pub think: Option<bool>,
+    /// OpenAI-style tool definitions (`[{type:"function", function:{...}}]`).
+    /// Consumed by templates that render tool-calling natively (Qwen3.5);
+    /// ignored otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<serde_json::Value>,
 }
 
-/// A single message in an Ollama chat request.
+/// A single message in an Ollama chat request or response.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct OllamaChatMessage {
     pub role: String,
@@ -603,6 +651,30 @@ pub struct OllamaChatMessage {
     /// Text from inside `<think>…</think>` tags when thinking is enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thinking: Option<String>,
+    /// Inbound and outbound shapes differ (history: `[{function:{…}}]`,
+    /// response: `[{type:"function", function:{index,name,arguments}}]`), so
+    /// this stays opaque and conversion lives in the handler.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<serde_json::Value>,
+    /// Ollama name for OpenAI's `tool_call_id` on `role:"tool"` messages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct OllamaToolCall {
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    pub function: OllamaFunctionCall,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct OllamaFunctionCall {
+    pub index: u32,
+    pub name: String,
+    /// JSON object (the Ollama wire format diverges from OpenAI, which uses
+    /// a JSON-encoded string — see `FunctionCall.arguments`).
+    pub arguments: serde_json::Value,
 }
 
 /// Sampling options passed inside an Ollama request.
@@ -1718,28 +1790,39 @@ async fn chat_completions(
     // ── Audio preprocessing ──────────────────────────────────────────────────
     let has_audio = req.messages.iter().any(|m| m.audio.is_some());
 
-    // When the caller provides tool definitions (e.g. from an OpenClaw agent
-    // runtime), prepend a synthetic system message that describes the available
-    // tools in plain text.  This gives models that do not natively process
-    // OpenAI tool schemas (e.g. Gemma) the information they need to reason
-    // about tool calls, without triggering schema-validation failures inside
-    // the model or the chat template renderer.
+    // When the caller provides tool definitions, two paths exist:
     //
-    // If the message list already begins with a system message the tool
-    // summary is appended to it so the context stays in a single system turn
-    // (avoiding two consecutive system messages which some templates reject).
+    // - Templates that render tools natively (Qwen3.5): pass `req.tools`
+    //   straight through to `apply_chat_template` — the template emits the
+    //   `<tools>…</tools>` block and the instruction to return
+    //   `<tool_call>{…}</tool_call>`.  Prose injection would duplicate.
+    //
+    // - Other templates (Gemma, ChatML, Phi, …): fold the tool definitions
+    //   into a synthetic system message in plain text, merging into any
+    //   existing system turn so the model sees a single system block.
+    //
     // Done before the audio/non-audio split so both paths share one injection.
+    let tools_native =
+        crate::tokenizer::chat_template_handles_tools_natively(&tokenizer.chat_template);
     let messages_with_tools: Vec<ChatMessage>;
-    let messages = if let Some(ref tools) = req.tools {
-        tracing::info!(
-            "Request {}: tools provided — injecting as system context",
-            request_id
-        );
-        let tool_summary = format_tools_as_system_context(tools);
-        messages_with_tools = inject_tools_into_messages(&req.messages, &tool_summary);
-        &messages_with_tools[..]
-    } else {
-        &req.messages[..]
+    let messages: &[ChatMessage] = match (req.tools.as_ref(), tools_native) {
+        (Some(_), true) => {
+            tracing::info!(
+                "Request {}: tools provided — rendered natively via chat template",
+                request_id
+            );
+            &req.messages[..]
+        }
+        (Some(tools), false) => {
+            tracing::info!(
+                "Request {}: tools provided — injecting as system context",
+                request_id
+            );
+            let tool_summary = format_tools_as_system_context(tools);
+            messages_with_tools = inject_tools_into_messages(&req.messages, &tool_summary);
+            &messages_with_tools[..]
+        }
+        (None, _) => &req.messages[..],
     };
 
     let has_images = req.messages.iter().any(|m| !m.content.images.is_empty());
@@ -1873,7 +1956,16 @@ async fn chat_completions(
 
         (tokens, None, Some(image_ctx))
     } else {
-        let tokens = match tokenizer.apply_chat_template_and_encode(messages) {
+        // Pass `req.tools` through: templates that handle tools natively
+        // (Qwen3.5) render them into the prompt; others ignore the arg.
+        // Thinking: OpenAI `reasoning_effort` — presence of any non-null
+        // value toggles the Qwen3.5 `<think>` pre-fill off.
+        let enable_thinking = req.reasoning_effort.as_ref().is_some_and(|v| !v.is_null());
+        let tokens = match tokenizer.apply_chat_template_and_encode(
+            messages,
+            req.tools.as_ref(),
+            enable_thinking,
+        ) {
             Ok(t) => t,
             Err(e) => return Err(tokenization_error(e)),
         };
@@ -1956,7 +2048,21 @@ async fn chat_completions(
             return Err(server_error("Engine unavailable"));
         }
 
-        let stream = make_sse_stream(token_rx, request_id, model_id, created);
+        // When the active template handles tools natively and the caller
+        // supplied tools, install a per-request `ToolCallStreamState` that
+        // routes `<tool_call>…</tool_call>` tokens out of `delta.content`
+        // and into `delta.tool_calls`.
+        let tool_state = if tools_native && req.tools.is_some() {
+            let filter = crate::tool_call_parser::ToolCallFilter::from_tokenizer(tokenizer);
+            if filter.is_enabled() {
+                Some(crate::tool_call_parser::ToolCallStreamState::new(filter))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        let stream = make_sse_stream(token_rx, request_id, model_id, created, tool_state);
         Ok(Sse::new(stream).into_response())
     } else {
         // Non-streaming response
@@ -1982,6 +2088,42 @@ async fn chat_completions(
                 } else {
                     Some(token_logprobs_to_choice(&result.token_logprobs))
                 };
+
+                // Parse `<tool_call>…</tool_call>` blocks out of the output
+                // when the active template renders tool calls natively and
+                // tools were provided in the request.
+                let (content, tool_calls, finish_reason) = if tools_native && req.tools.is_some() {
+                    let (clean, parsed) =
+                        crate::tool_call_parser::extract_tool_calls(&result.output_text);
+                    if parsed.is_empty() {
+                        (result.output_text, None, result.finish_reason)
+                    } else {
+                        let calls: Vec<ToolCall> = parsed
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, c)| ToolCall {
+                                id: format!("call_{i}"),
+                                kind: "function",
+                                function: FunctionCall {
+                                    name: c.name,
+                                    arguments: c.arguments,
+                                },
+                            })
+                            .collect();
+                        // OpenAI convention: when the model returned tool
+                        // calls, `finish_reason` is `"tool_calls"` even if
+                        // the sampler reported `"stop"`.
+                        let fr = if result.finish_reason == "stop" {
+                            "tool_calls".to_string()
+                        } else {
+                            result.finish_reason
+                        };
+                        (clean, Some(calls), fr)
+                    }
+                } else {
+                    (result.output_text, None, result.finish_reason)
+                };
+
                 let response = ChatCompletionResponse {
                     id: request_id,
                     object: "chat.completion",
@@ -1991,9 +2133,10 @@ async fn chat_completions(
                         index: 0,
                         message: ChatCompletionMessage {
                             role: "assistant".to_string(),
-                            content: result.output_text,
+                            content,
+                            tool_calls,
                         },
-                        finish_reason: Some(result.finish_reason),
+                        finish_reason: Some(finish_reason),
                         logprobs: choice_logprobs,
                     }],
                     usage: UsageInfo {
@@ -2062,8 +2205,14 @@ fn make_sse_stream(
     request_id: String,
     model_id: String,
     created: u64,
+    tool_state: Option<crate::tool_call_parser::ToolCallStreamState>,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
+    use crate::tool_call_parser::ToolCallStreamEvent;
+
     async_stream::stream! {
+        let mut tool_state = tool_state;
+        let mut emitted_tool_call = false;
+
         // First chunk: role
         let first_chunk = ChatCompletionStreamResponse {
             id: request_id.clone(),
@@ -2076,6 +2225,7 @@ fn make_sse_stream(
                     role: Some("assistant".to_string()),
                     content: None,
                     reasoning_content: None,
+                    tool_calls: None,
                 },
                 finish_reason: None,
                 logprobs: None,
@@ -2090,58 +2240,125 @@ fn make_sse_stream(
         while let Some(token) = token_rx.recv().await {
             // Don't send EOS token text as content.
             let is_stop = token.finish_reason.as_deref() == Some("stop");
-            let content = if is_stop || token.text.is_empty() {
-                None
+
+            // Route this token through the tool-call filter when active.
+            // The filter classifies each token as content, tool-call start,
+            // tool-call arguments delta, or tool-call end.
+            let (content, tool_calls_delta) = if let Some(state) = tool_state.as_mut() {
+                let events = state.push_token(token.token_id, &token.text);
+                let mut content_acc = String::new();
+                let mut tc_deltas: Vec<StreamingToolCall> = Vec::new();
+                for ev in events {
+                    match ev {
+                        ToolCallStreamEvent::Content(s) => content_acc.push_str(&s),
+                        ToolCallStreamEvent::ToolCallStart { index, id, name } => {
+                            emitted_tool_call = true;
+                            tc_deltas.push(StreamingToolCall {
+                                index,
+                                id: Some(id),
+                                kind: Some("function"),
+                                function: StreamingFunctionCall {
+                                    name: Some(name),
+                                    arguments: Some(String::new()),
+                                },
+                            });
+                        }
+                        ToolCallStreamEvent::ToolCallArgsDelta { index, delta } => {
+                            tc_deltas.push(StreamingToolCall {
+                                index,
+                                id: None,
+                                kind: None,
+                                function: StreamingFunctionCall {
+                                    name: None,
+                                    arguments: Some(delta),
+                                },
+                            });
+                        }
+                        ToolCallStreamEvent::ToolCallEnd { .. } => {}
+                    }
+                }
+                let c = if is_stop || content_acc.is_empty() {
+                    None
+                } else {
+                    Some(content_acc)
+                };
+                let tc = if tc_deltas.is_empty() {
+                    None
+                } else {
+                    Some(tc_deltas)
+                };
+                (c, tc)
             } else {
-                Some(token.text.clone())
+                let c = if is_stop || token.text.is_empty() {
+                    None
+                } else {
+                    Some(token.text.clone())
+                };
+                (c, None)
             };
+
             let reasoning_content = if token.reasoning_content.is_empty() {
                 None
             } else {
                 Some(token.reasoning_content)
             };
 
-            // Skip chunks that carry no text and no finish signal.
-            if content.is_none() && reasoning_content.is_none() && token.finish_reason.is_none() {
+            // Skip chunks that carry no text, no tool_calls, and no finish signal.
+            if content.is_none()
+                && reasoning_content.is_none()
+                && tool_calls_delta.is_none()
+                && token.finish_reason.is_none()
+            {
                 continue;
             }
 
-            // Build per-token logprob if present.
-            let chunk_logprobs = token.logprob.as_ref().map(|lp| {
-                let token_text = content.clone().unwrap_or_default();
-                let bytes = Some(token_text.as_bytes().to_vec());
-                // Use pre-decoded text from the engine; fall back to the token
-                // ID in angle-bracket notation only if decoding was skipped.
-                let top_logprobs = lp
-                    .top_logprobs
-                    .iter()
-                    .zip(
-                        lp.top_logprob_texts
-                            .iter()
-                            .map(Some)
-                            .chain(std::iter::repeat(None)),
-                    )
-                    .map(|(&(tid, tlp), text)| {
-                        let tok_text = text
-                            .cloned()
-                            .unwrap_or_else(|| format!("<{}>", tid));
-                        let tok_bytes = Some(tok_text.as_bytes().to_vec());
-                        TopLogprobEntry {
-                            token: tok_text,
-                            logprob: tlp,
-                            bytes: tok_bytes,
-                        }
-                    })
-                    .collect();
-                ChoiceLogprobs {
-                    content: vec![LogprobEntry {
-                        token: token_text,
-                        logprob: lp.logprob,
-                        bytes,
-                        top_logprobs,
-                    }],
-                }
-            });
+            // Per-token logprob only when the token's text actually landed in
+            // `content` — delimiter and tool-call-body tokens don't carry a
+            // meaningful per-character logprob for the client.
+            let chunk_logprobs = if content.is_some() {
+                token.logprob.as_ref().map(|lp| {
+                    let token_text = content.clone().unwrap_or_default();
+                    let bytes = Some(token_text.as_bytes().to_vec());
+                    let top_logprobs = lp
+                        .top_logprobs
+                        .iter()
+                        .zip(
+                            lp.top_logprob_texts
+                                .iter()
+                                .map(Some)
+                                .chain(std::iter::repeat(None)),
+                        )
+                        .map(|(&(tid, tlp), text)| {
+                            let tok_text = text
+                                .cloned()
+                                .unwrap_or_else(|| format!("<{}>", tid));
+                            let tok_bytes = Some(tok_text.as_bytes().to_vec());
+                            TopLogprobEntry {
+                                token: tok_text,
+                                logprob: tlp,
+                                bytes: tok_bytes,
+                            }
+                        })
+                        .collect();
+                    ChoiceLogprobs {
+                        content: vec![LogprobEntry {
+                            token: token_text,
+                            logprob: lp.logprob,
+                            bytes,
+                            top_logprobs,
+                        }],
+                    }
+                })
+            } else {
+                None
+            };
+
+            // Override sampler's "stop" to "tool_calls" when the model
+            // emitted at least one tool call (OpenAI convention).
+            let finish_reason = match token.finish_reason.as_deref() {
+                Some("stop") if emitted_tool_call => Some("tool_calls".to_string()),
+                _ => token.finish_reason,
+            };
 
             let chunk = ChatCompletionStreamResponse {
                 id: request_id.clone(),
@@ -2154,14 +2371,46 @@ fn make_sse_stream(
                         role: None,
                         content,
                         reasoning_content,
+                        tool_calls: tool_calls_delta,
                     },
-                    finish_reason: token.finish_reason,
+                    finish_reason,
                     logprobs: chunk_logprobs,
                 }],
             };
             match to_sse_event(&chunk, "chat stream chunk") {
                 Some(event) => yield Ok(event),
                 None => break,
+            }
+        }
+
+        // Flush any residual unclosed call buffer as plain content (fail-safe).
+        if let Some(state) = tool_state.as_mut() {
+            for ev in state.flush() {
+                if let ToolCallStreamEvent::Content(text) = ev {
+                    if text.is_empty() {
+                        continue;
+                    }
+                    let chunk = ChatCompletionStreamResponse {
+                        id: request_id.clone(),
+                        object: "chat.completion.chunk",
+                        created,
+                        model: model_id.clone(),
+                        choices: vec![ChatCompletionStreamChoice {
+                            index: 0,
+                            delta: DeltaMessage {
+                                role: None,
+                                content: Some(text),
+                                reasoning_content: None,
+                                tool_calls: None,
+                            },
+                            finish_reason: None,
+                            logprobs: None,
+                        }],
+                    };
+                    if let Some(event) = to_sse_event(&chunk, "chat stream flush") {
+                        yield Ok(event);
+                    }
+                }
             }
         }
 
@@ -2437,7 +2686,8 @@ async fn anthropic_messages(
     // Convert Anthropic messages (with optional top-level system) to ChatMessage list.
     let chat_messages = anthropic_messages_to_chat(req.system.as_deref(), &req.messages);
 
-    let prompt_tokens = match tokenizer.apply_chat_template_and_encode(&chat_messages) {
+    let prompt_tokens = match tokenizer.apply_chat_template_and_encode(&chat_messages, None, false)
+    {
         Ok(tokens) => tokens,
         Err(e) => {
             return Err(anthropic_error(
@@ -3905,7 +4155,7 @@ async fn ollama_generate(
             tool_calls: None,
             tool_call_id: None,
         });
-        tokenizer.apply_chat_template_and_encode(&msgs)
+        tokenizer.apply_chat_template_and_encode(&msgs, None, false)
     }
     .map_err(|e| {
         (
@@ -4127,13 +4377,17 @@ async fn ollama_chat(
         .map_err(|(s, j)| (s, Json(serde_json::json!({"error": j.0.error.message}))))?;
 
     // Convert Ollama messages to internal ChatMessage format.
-    let chat_messages: Vec<ChatMessage> = req
+    let chat_messages_raw: Vec<ChatMessage> = req
         .messages
         .iter()
         .map(|m| {
+            // Ollama uses `role:"tool"` for tool-response turns (vs OpenAI's
+            // own "tool" role).  Map it to Role::Tool so the chat template
+            // can wrap it in `<tool_response>…</tool_response>`.
             let role = match m.role.as_str() {
                 "system" => Role::System,
                 "assistant" => Role::Assistant,
+                "tool" => Role::Tool,
                 _ => Role::User,
             };
             // Convert Ollama base64 `images` array to ImageInput objects using
@@ -4152,11 +4406,27 @@ async fn ollama_chat(
                     images,
                 },
                 audio: None,
-                tool_calls: None,
-                tool_call_id: None,
+                tool_calls: m.tool_calls.clone(),
+                // Ollama sends `tool_name` where OpenAI sends `tool_call_id`;
+                // internally we use the OpenAI naming.
+                tool_call_id: m.tool_name.clone(),
             }
         })
         .collect();
+
+    // Tools injection: for templates that render tool-calls natively (Qwen3.5)
+    // we pass `req.tools` straight through to the template; for others we
+    // fall back to prose-injected system context (so e.g. Gemma still gets
+    // the tool signatures in readable form).
+    let tools_native =
+        crate::tokenizer::chat_template_handles_tools_natively(&tokenizer.chat_template);
+    let chat_messages: Vec<ChatMessage> = match (req.tools.as_ref(), tools_native) {
+        (Some(tools), false) => {
+            let tool_summary = format_tools_as_system_context(tools);
+            inject_tools_into_messages(&chat_messages_raw, &tool_summary)
+        }
+        _ => chat_messages_raw,
+    };
 
     let has_images = chat_messages.iter().any(|m| !m.content.images.is_empty());
 
@@ -4244,8 +4514,19 @@ async fn ollama_chat(
 
         (tokens, Some(ctx))
     } else {
+        // Pass `req.tools` through: native-handling templates render them into
+        // the prompt; others ignore the arg (prose injection happened above).
+        let template_tools = if tools_native {
+            req.tools.as_ref()
+        } else {
+            None
+        };
+        // Thinking: Ollama `think: true` stops the Qwen3.5 template from
+        // pre-filling an empty `<think>…</think>` block, letting the model
+        // emit its own reasoning.
+        let enable_thinking = req.think.unwrap_or(false);
         let tokens = tokenizer
-            .apply_chat_template_and_encode(&chat_messages)
+            .apply_chat_template_and_encode(&chat_messages, template_tools, enable_thinking)
             .map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
@@ -4310,6 +4591,17 @@ async fn ollama_chat(
             ollama_dispatch_stream(&lm.backend, &request_id, prompt_tokens, image_ctx, params)
                 .await?;
 
+        let tool_state = if tools_native && req.tools.is_some() {
+            let filter = crate::tool_call_parser::ToolCallFilter::from_tokenizer(tokenizer);
+            if filter.is_enabled() {
+                Some(crate::tool_call_parser::ToolCallStreamState::new(filter))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let model_name = req.model.clone();
         let stream = make_ollama_chat_stream(
             token_rx,
@@ -4317,6 +4609,7 @@ async fn ollama_chat(
             created_at,
             think_enabled,
             prompt_eval_count,
+            tool_state,
         );
         Ok((
             [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
@@ -4340,6 +4633,48 @@ async fn ollama_chat(
             (None, result.output_text)
         };
 
+        // When the active template renders tool calls natively and the
+        // caller supplied tools, split `<tool_call>…</tool_call>` blocks out
+        // of `content` into a structured `tool_calls` field.  Ollama wire
+        // format uses an `arguments` object (not a JSON-encoded string).
+        let (content, tool_calls_value, done_reason) = if tools_native && req.tools.is_some() {
+            let (clean, parsed) = crate::tool_call_parser::extract_tool_calls(&content);
+            if parsed.is_empty() {
+                (
+                    content,
+                    None,
+                    Some(ollama_done_reason(&result.finish_reason)),
+                )
+            } else {
+                let calls: Vec<OllamaToolCall> = parsed
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, c)| OllamaToolCall {
+                        kind: "function",
+                        function: OllamaFunctionCall {
+                            index: i as u32,
+                            name: c.name,
+                            arguments: serde_json::from_str(&c.arguments)
+                                .unwrap_or(serde_json::Value::Object(Default::default())),
+                        },
+                    })
+                    .collect();
+                let val = serde_json::to_value(&calls).ok();
+                let dr = if result.finish_reason == "stop" {
+                    Some("tool_calls".to_string())
+                } else {
+                    Some(ollama_done_reason(&result.finish_reason))
+                };
+                (clean, val, dr)
+            }
+        } else {
+            (
+                content,
+                None,
+                Some(ollama_done_reason(&result.finish_reason)),
+            )
+        };
+
         Ok(Json(OllamaChatResponse {
             model: req.model,
             created_at,
@@ -4348,9 +4683,11 @@ async fn ollama_chat(
                 content,
                 images: vec![],
                 thinking,
+                tool_calls: tool_calls_value,
+                tool_name: None,
             },
             done: true,
-            done_reason: Some(ollama_done_reason(&result.finish_reason)),
+            done_reason,
             prompt_eval_count: result.prompt_tokens,
             eval_count: result.completion_tokens,
             total_duration: result.total_duration_ns,
@@ -4368,17 +4705,72 @@ fn make_ollama_chat_stream(
     created_at: String,
     think_enabled: bool,
     prompt_eval_count: usize,
+    tool_state: Option<crate::tool_call_parser::ToolCallStreamState>,
 ) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
+    use crate::tool_call_parser::ToolCallStreamEvent;
+
     async_stream::stream! {
         let mut eval_count: usize = 0;
+        let mut tool_state = tool_state;
+        let mut emitted_any_tool_call = false;
+        // Per-in-progress-call args accumulator: (index, name, args_json_string).
+        let mut in_progress: Vec<(u32, String, String)> = Vec::new();
 
         while let Some(token) = token_rx.recv().await {
             let is_final = token.finish_reason.is_some();
-            let content_text = if token.finish_reason.as_deref() == Some("stop") {
+            let raw_content = if token.finish_reason.as_deref() == Some("stop") {
                 String::new()
             } else {
                 eval_count += 1;
-                token.text
+                token.text.clone()
+            };
+
+            // Route this token through the tool-call filter, if active.
+            // Ollama wire format expects complete `OllamaToolCall` objects per
+            // chunk (not OpenAI-style deltas), so we accumulate args across
+            // tokens and only emit the finished call on `ToolCallEnd`.
+            let (content_text, tool_calls_this_chunk) = if let Some(state) = tool_state.as_mut() {
+                let events = state.push_token(token.token_id, &token.text);
+                let mut content_acc = String::new();
+                let mut finished: Vec<OllamaToolCall> = Vec::new();
+                for ev in events {
+                    match ev {
+                        ToolCallStreamEvent::Content(s) => content_acc.push_str(&s),
+                        ToolCallStreamEvent::ToolCallStart { index, name, .. } => {
+                            emitted_any_tool_call = true;
+                            in_progress.push((index, name, String::new()));
+                        }
+                        ToolCallStreamEvent::ToolCallArgsDelta { index, delta } => {
+                            if let Some(entry) =
+                                in_progress.iter_mut().find(|(i, _, _)| *i == index)
+                            {
+                                entry.2.push_str(&delta);
+                            }
+                        }
+                        ToolCallStreamEvent::ToolCallEnd { index } => {
+                            if let Some(pos) =
+                                in_progress.iter().position(|(i, _, _)| *i == index)
+                            {
+                                let (idx, name, args_str) = in_progress.remove(pos);
+                                let arguments: serde_json::Value =
+                                    serde_json::from_str(&args_str).unwrap_or(
+                                        serde_json::Value::Object(Default::default()),
+                                    );
+                                finished.push(OllamaToolCall {
+                                    kind: "function",
+                                    function: OllamaFunctionCall {
+                                        index: idx,
+                                        name,
+                                        arguments,
+                                    },
+                                });
+                            }
+                        }
+                    }
+                }
+                (content_acc, finished)
+            } else {
+                (raw_content, Vec::new())
             };
 
             // The engine's ThinkFilter has already split content and reasoning
@@ -4398,7 +4790,18 @@ fn make_ollama_chat_stream(
                 (None, content_text)
             };
 
+            let tool_calls_value = if tool_calls_this_chunk.is_empty() {
+                None
+            } else {
+                serde_json::to_value(&tool_calls_this_chunk).ok()
+            };
+
             let chunk = if is_final {
+                let done_reason = match token.finish_reason.as_deref() {
+                    Some("stop") if emitted_any_tool_call => Some("tool_calls".to_string()),
+                    Some(fr) => Some(ollama_done_reason(fr)),
+                    None => None,
+                };
                 OllamaChatChunk {
                     model: model_name.clone(),
                     created_at: created_at.clone(),
@@ -4407,9 +4810,11 @@ fn make_ollama_chat_stream(
                         content: content_text,
                         images: vec![],
                         thinking,
+                        tool_calls: tool_calls_value,
+                        tool_name: None,
                     },
                     done: true,
-                    done_reason: token.finish_reason.as_deref().map(ollama_done_reason),
+                    done_reason,
                     prompt_eval_count: Some(prompt_eval_count),
                     eval_count: Some(eval_count),
                     total_duration: token.total_duration_ns,
@@ -4426,6 +4831,8 @@ fn make_ollama_chat_stream(
                         content: content_text,
                         images: vec![],
                         thinking,
+                        tool_calls: tool_calls_value,
+                        tool_name: None,
                     },
                     done: false,
                     done_reason: None,

--- a/inferrs/src/tokenizer.rs
+++ b/inferrs/src/tokenizer.rs
@@ -406,10 +406,24 @@ impl Tokenizer {
     }
 
     /// Apply chat template to messages and return the prompt string.
-    pub fn apply_chat_template(&self, messages: &[ChatMessage]) -> Result<String> {
+    ///
+    /// - `tools` is only consumed by templates that render function-calling
+    ///   natively (currently Qwen3.5).  For others it's ignored — the caller
+    ///   remains responsible for injecting tools as prose via
+    ///   `format_tools_as_system_context` if desired.
+    /// - `enable_thinking` is only consumed by Qwen3.5: when `false` the
+    ///   assistant turn is primed with `<think>\n\n</think>\n\n` so the model
+    ///   skips chain-of-thought; when `true` the suffix is omitted and the
+    ///   model may emit its own `<think>…</think>` block.
+    pub fn apply_chat_template(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&serde_json::Value>,
+        enable_thinking: bool,
+    ) -> Result<String> {
         let prompt = match &self.chat_template {
             ChatTemplate::ChatML => apply_chatml(messages, &self.bos_token),
-            ChatTemplate::Qwen35 => apply_qwen35(messages),
+            ChatTemplate::Qwen35 => apply_qwen35(messages, tools, enable_thinking),
             ChatTemplate::Gemma => apply_gemma(messages, &self.bos_token),
             ChatTemplate::Gemma3 => apply_gemma3(messages),
             ChatTemplate::Gemma4 => apply_gemma4(messages),
@@ -420,8 +434,13 @@ impl Tokenizer {
     }
 
     /// Apply chat template, encode, and return token IDs ready for inference.
-    pub fn apply_chat_template_and_encode(&self, messages: &[ChatMessage]) -> Result<Vec<u32>> {
-        let prompt = self.apply_chat_template(messages)?;
+    pub fn apply_chat_template_and_encode(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&serde_json::Value>,
+        enable_thinking: bool,
+    ) -> Result<Vec<u32>> {
+        let prompt = self.apply_chat_template(messages, tools, enable_thinking)?;
         // For chat templates, don't add special tokens - the template handles them
         self.encode(&prompt, false)
     }
@@ -542,16 +561,163 @@ fn apply_chatml(messages: &[ChatMessage], _bos_token: &Option<String>) -> String
     apply_chatml_inner(messages, "")
 }
 
-/// Qwen3.5 ChatML template with thinking disabled.
+/// Return `true` when the template renders tools/tool_calls/tool_responses
+/// natively from the `ChatMessage` struct.  When this returns true the HTTP
+/// handler must pass the incoming `tools` payload through to
+/// `apply_chat_template` and skip prose injection via
+/// `format_tools_as_system_context`; otherwise the model would see the tools
+/// block twice.
+pub fn chat_template_handles_tools_natively(kind: &ChatTemplate) -> bool {
+    matches!(kind, ChatTemplate::Qwen35)
+}
+
+/// Qwen3.5 chat template, 1:1 with `Qwen/Qwen3-Next-*-Instruct` jinja.
 ///
-/// Identical to ChatML but appends `<think>\n\n</think>\n\n` after the
-/// `<|im_start|>assistant\n` prefix.  This matches the model's chat template
-/// when `enable_thinking=false`, which instructs the model to emit an empty
-/// thinking block and proceed directly to the answer.  Without this prefix
-/// the model enters thinking mode and prepends a long chain-of-thought before
-/// the actual reply.
-fn apply_qwen35(messages: &[ChatMessage]) -> String {
-    apply_chatml_inner(messages, "<think>\n\n</think>\n\n")
+/// Unlike `apply_chatml` this function:
+///
+/// - Emits the native `<tools>…</tools>` + `<tool_call>…</tool_call>`
+///   instruction block when `tools` is present (so the model emits structured
+///   calls instead of falling back to Hermes-style XML).
+/// - Renders assistant-turn `tool_calls` as `<tool_call>{"name": …}…</tool_call>`
+///   (the jinja version keeps history turns that carry only tool_calls — they
+///   are NOT dropped here, unlike `normalize_messages`).
+/// - Wraps `role:"tool"` messages in `<tool_response>…</tool_response>`,
+///   grouping consecutive tool messages under a single user turn.
+///
+/// `enable_thinking = false` (the inferrs default) appends
+/// `<think>\n\n</think>\n\n` after `<|im_start|>assistant\n`, priming the
+/// model to skip its chain-of-thought block.  `enable_thinking = true`
+/// omits the suffix so the model can emit its own `<think>…</think>` —
+/// this is what the Ollama `think: true` flag and the OpenAI
+/// `reasoning_effort` field (when present and non-null) map to.
+fn apply_qwen35(
+    messages: &[ChatMessage],
+    tools: Option<&serde_json::Value>,
+    enable_thinking: bool,
+) -> String {
+    let mut prompt = String::new();
+
+    // Only treat tools as "present" when it's a non-empty JSON array.
+    let tool_array: Option<&Vec<serde_json::Value>> =
+        tools.and_then(|v| v.as_array()).filter(|a| !a.is_empty());
+
+    let first_is_system = matches!(messages.first().map(|m| &m.role), Some(Role::System));
+
+    // ── Prelude: system + optional tools block ──
+    if let Some(tools_arr) = tool_array {
+        prompt.push_str("<|im_start|>system\n");
+        if first_is_system {
+            prompt.push_str(&messages[0].content.text);
+            prompt.push_str("\n\n");
+        }
+        prompt.push_str(
+            "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>",
+        );
+        for tool in tools_arr {
+            prompt.push('\n');
+            prompt.push_str(&serde_json::to_string(tool).unwrap_or_else(|_| "null".to_string()));
+        }
+        prompt.push_str(
+            "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n",
+        );
+    } else if first_is_system {
+        prompt.push_str("<|im_start|>system\n");
+        prompt.push_str(&messages[0].content.text);
+        prompt.push_str("<|im_end|>\n");
+    }
+
+    // If the first message was consumed above, skip it in the main loop.
+    let start_idx = if first_is_system { 1 } else { 0 };
+
+    // Track whether a `<|im_start|>user` tool-response group is currently open.
+    let mut tool_group_open = false;
+
+    for idx in start_idx..messages.len() {
+        let msg = &messages[idx];
+        let content = msg.content.text.as_str();
+
+        match msg.role {
+            Role::User => {
+                if tool_group_open {
+                    prompt.push_str("<|im_end|>\n");
+                    tool_group_open = false;
+                }
+                prompt.push_str("<|im_start|>user\n");
+                prompt.push_str(content);
+                prompt.push_str("<|im_end|>\n");
+            }
+            Role::System => {
+                if tool_group_open {
+                    prompt.push_str("<|im_end|>\n");
+                    tool_group_open = false;
+                }
+                prompt.push_str("<|im_start|>system\n");
+                prompt.push_str(content);
+                prompt.push_str("<|im_end|>\n");
+            }
+            Role::Assistant => {
+                if tool_group_open {
+                    prompt.push_str("<|im_end|>\n");
+                    tool_group_open = false;
+                }
+                prompt.push_str("<|im_start|>assistant\n");
+                prompt.push_str(content);
+                if let Some(calls) = msg.tool_calls.as_ref().and_then(|v| v.as_array()) {
+                    let content_nonempty = !content.is_empty();
+                    for (i, call) in calls.iter().enumerate() {
+                        // Unwrap `{ function: {...} }` (OpenAI nested) to match
+                        // the jinja `{%- set tool_call = tool_call.function %}`.
+                        let inner = call.get("function").unwrap_or(call);
+                        // Jinja: `(loop.first and content) or (not loop.first)` → '\n'
+                        if (i == 0 && content_nonempty) || i > 0 {
+                            prompt.push('\n');
+                        }
+                        let name = inner.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                        prompt.push_str("<tool_call>\n{\"name\": \"");
+                        prompt.push_str(name);
+                        prompt.push_str("\", \"arguments\": ");
+                        match inner.get("arguments") {
+                            // Pre-stringified JSON (OpenAI wire format): emit raw.
+                            Some(serde_json::Value::String(s)) => prompt.push_str(s),
+                            Some(other) => prompt.push_str(
+                                &serde_json::to_string(other).unwrap_or_else(|_| "{}".to_string()),
+                            ),
+                            None => prompt.push_str("{}"),
+                        }
+                        prompt.push_str("}\n</tool_call>");
+                    }
+                }
+                prompt.push_str("<|im_end|>\n");
+            }
+            Role::Tool | Role::Function => {
+                if !tool_group_open {
+                    prompt.push_str("<|im_start|>user");
+                    tool_group_open = true;
+                }
+                prompt.push_str("\n<tool_response>\n");
+                prompt.push_str(content);
+                prompt.push_str("\n</tool_response>");
+                let next_is_tool = messages
+                    .get(idx + 1)
+                    .is_some_and(|n| matches!(n.role, Role::Tool | Role::Function));
+                if !next_is_tool {
+                    prompt.push_str("<|im_end|>\n");
+                    tool_group_open = false;
+                }
+            }
+        }
+    }
+
+    // (No post-loop `tool_group_open` close — the inline branch always
+    // closes the group on the last tool message, since `messages.get(idx+1)`
+    // returns None and `next_is_tool` is false.)
+
+    prompt.push_str("<|im_start|>assistant\n");
+    if !enable_thinking {
+        // Pre-fill an empty thinking block so the model skips chain-of-thought.
+        prompt.push_str("<think>\n\n</think>\n\n");
+    }
+    prompt
 }
 
 fn apply_gemma(messages: &[ChatMessage], bos_token: &Option<String>) -> String {
@@ -884,9 +1050,202 @@ mod tests {
     #[test]
     fn qwen35_template_has_no_think_prefix() {
         let msgs = vec![user_msg("Hello!")];
-        let prompt = apply_qwen35(&msgs);
+        let prompt = apply_qwen35(&msgs, None, false);
         assert!(prompt.contains("<|im_start|>user\nHello!<|im_end|>"));
         assert!(prompt.ends_with("<|im_start|>assistant\n<think>\n\n</think>\n\n"));
+    }
+
+    #[test]
+    fn qwen35_enable_thinking_omits_empty_think_block() {
+        let msgs = vec![user_msg("Hello!")];
+        let prompt = apply_qwen35(&msgs, None, true);
+        // No prefilled `<think>…</think>` — model is free to emit its own.
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+        assert!(!prompt.contains("<think>"));
+    }
+
+    fn assistant_tool_call_msg(content: &str, tool_calls: serde_json::Value) -> ChatMessage {
+        ChatMessage {
+            role: Role::Assistant,
+            audio: None,
+            content: MessageContent::from_string(content),
+            tool_calls: Some(tool_calls),
+            tool_call_id: None,
+        }
+    }
+
+    fn tool_result_msg(content: &str) -> ChatMessage {
+        ChatMessage {
+            role: Role::Tool,
+            audio: None,
+            content: MessageContent::from_string(content),
+            tool_calls: None,
+            tool_call_id: Some("c1".to_string()),
+        }
+    }
+
+    #[test]
+    fn qwen35_tools_with_system_renders_tools_block() {
+        let msgs = vec![system_msg("You are helpful."), user_msg("What time is it?")];
+        let tools = serde_json::json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_time",
+                    "description": "Return the current time.",
+                    "parameters": {"type": "object", "properties": {}}
+                }
+            }
+        ]);
+        let prompt = apply_qwen35(&msgs, Some(&tools), false);
+        assert!(
+            prompt.starts_with("<|im_start|>system\nYou are helpful.\n\n# Tools\n\n"),
+            "prompt: {prompt}"
+        );
+        assert!(prompt.contains(
+            "You are provided with function signatures within <tools></tools> XML tags:\n<tools>"
+        ));
+        assert!(prompt.contains("\"name\":\"get_time\""));
+        assert!(prompt.contains(
+            "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n"
+        ));
+        assert!(prompt.contains("<|im_start|>user\nWhat time is it?<|im_end|>"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n<think>\n\n</think>\n\n"));
+    }
+
+    #[test]
+    fn qwen35_tools_without_system_still_emits_tools_block() {
+        let msgs = vec![user_msg("Hi")];
+        let tools = serde_json::json!([
+            {"type":"function","function":{"name":"f","parameters":{"type":"object"}}}
+        ]);
+        let prompt = apply_qwen35(&msgs, Some(&tools), false);
+        // `<|im_start|>system\n` immediately followed by `# Tools` (no intervening
+        // system content) when no system message is present.
+        assert!(prompt.starts_with("<|im_start|>system\n# Tools\n\n"));
+        assert!(prompt.contains("<|im_start|>user\nHi<|im_end|>"));
+    }
+
+    #[test]
+    fn qwen35_empty_tools_array_skips_tools_block() {
+        let msgs = vec![user_msg("Hi")];
+        let tools = serde_json::json!([]);
+        let prompt = apply_qwen35(&msgs, Some(&tools), false);
+        assert!(!prompt.contains("# Tools"));
+        assert!(!prompt.contains("<tools>"));
+    }
+
+    #[test]
+    fn qwen35_assistant_toolcall_empty_content_no_leading_newline() {
+        // Nested OpenAI format: {id, type, function:{name, arguments}}
+        let calls = serde_json::json!([
+            {"id":"c1","type":"function","function":{"name":"f","arguments":{"x":1}}}
+        ]);
+        let msgs = vec![
+            user_msg("go"),
+            assistant_tool_call_msg("", calls),
+            tool_result_msg("42"),
+        ];
+        let prompt = apply_qwen35(&msgs, None, false);
+        // No '\n' between `<|im_start|>assistant\n` and `<tool_call>` when content is empty.
+        assert!(prompt.contains("<|im_start|>assistant\n<tool_call>\n"));
+        assert!(prompt.contains("\"name\": \"f\""));
+        assert!(prompt.contains("\"arguments\": {\"x\":1}"));
+        assert!(prompt.contains("</tool_call><|im_end|>\n"));
+    }
+
+    #[test]
+    fn qwen35_assistant_toolcall_with_content_prepends_newline() {
+        let calls = serde_json::json!([
+            {"function":{"name":"f","arguments":{}}}
+        ]);
+        let msgs = vec![
+            user_msg("go"),
+            assistant_tool_call_msg("Thinking...", calls),
+        ];
+        let prompt = apply_qwen35(&msgs, None, false);
+        // '\n' between content and `<tool_call>` when content is non-empty.
+        assert!(prompt.contains("<|im_start|>assistant\nThinking...\n<tool_call>\n"));
+    }
+
+    #[test]
+    fn qwen35_multiple_toolcalls_separated_by_newline() {
+        let calls = serde_json::json!([
+            {"function":{"name":"a","arguments":{}}},
+            {"function":{"name":"b","arguments":{"k":"v"}}}
+        ]);
+        let msgs = vec![user_msg("go"), assistant_tool_call_msg("", calls)];
+        let prompt = apply_qwen35(&msgs, None, false);
+        // Second call is preceded by '\n' even when assistant content is empty.
+        let a_pos = prompt.find("\"name\": \"a\"").expect("call a present");
+        let b_pos = prompt.find("\"name\": \"b\"").expect("call b present");
+        assert!(a_pos < b_pos);
+        assert!(prompt.contains("</tool_call>\n<tool_call>"));
+    }
+
+    #[test]
+    fn qwen35_flat_toolcall_also_renders() {
+        // Flat format (no `function` wrapper): {name, arguments}.
+        let calls = serde_json::json!([{"name":"f","arguments":{"x":1}}]);
+        let msgs = vec![user_msg("go"), assistant_tool_call_msg("", calls)];
+        let prompt = apply_qwen35(&msgs, None, false);
+        assert!(prompt.contains("\"name\": \"f\""));
+        assert!(prompt.contains("\"arguments\": {\"x\":1}"));
+    }
+
+    #[test]
+    fn qwen35_string_arguments_passed_raw() {
+        // When arguments is already a JSON-encoded string, emit it as-is
+        // (matching the jinja `{%- if tool_call.arguments is string %}` branch).
+        let calls = serde_json::json!([
+            {"function":{"name":"f","arguments":"{\"x\":1}"}}
+        ]);
+        let msgs = vec![user_msg("go"), assistant_tool_call_msg("", calls)];
+        let prompt = apply_qwen35(&msgs, None, false);
+        assert!(prompt.contains("\"arguments\": {\"x\":1}"));
+        // No double-quoting: should NOT contain `"arguments": "{`.
+        assert!(!prompt.contains("\"arguments\": \"{"));
+    }
+
+    #[test]
+    fn qwen35_two_consecutive_tool_responses_share_user_turn() {
+        let calls = serde_json::json!([
+            {"function":{"name":"a","arguments":{}}},
+            {"function":{"name":"b","arguments":{}}}
+        ]);
+        let msgs = vec![
+            user_msg("go"),
+            assistant_tool_call_msg("", calls),
+            tool_result_msg("res_a"),
+            tool_result_msg("res_b"),
+            user_msg("next"),
+        ];
+        let prompt = apply_qwen35(&msgs, None, false);
+        // Two `<tool_response>` blocks inside a single `<|im_start|>user` turn.
+        let user_starts: Vec<_> = prompt.match_indices("<|im_start|>user").collect();
+        // Expect 3: initial "go", tool-response group, final "next".
+        assert_eq!(user_starts.len(), 3, "prompt: {prompt}");
+        assert!(prompt.contains(
+            "<|im_start|>user\n<tool_response>\nres_a\n</tool_response>\n<tool_response>\nres_b\n</tool_response><|im_end|>\n"
+        ));
+    }
+
+    #[test]
+    fn qwen35_tool_call_in_history_is_not_dropped() {
+        // Regression guard: the ChatML path drops assistant turns with empty
+        // content + tool_calls; the Qwen35 path must render them.
+        let calls = serde_json::json!([
+            {"function":{"name":"f","arguments":{}}}
+        ]);
+        let msgs = vec![
+            user_msg("go"),
+            assistant_tool_call_msg("", calls),
+            tool_result_msg("done"),
+            user_msg("thanks"),
+        ];
+        let prompt = apply_qwen35(&msgs, None, false);
+        assert!(prompt.contains("<tool_call>"));
+        assert!(prompt.contains("\"name\": \"f\""));
     }
 
     #[test]

--- a/inferrs/src/tool_call_parser.rs
+++ b/inferrs/src/tool_call_parser.rs
@@ -1,0 +1,959 @@
+//! Parse Qwen-style `<tool_call>{JSON}</tool_call>` blocks out of model output.
+//!
+//! Qwen 3.5 tool-calling: the chat template instructs the model to emit each
+//! function call as `<tool_call>\n{"name": "...", "arguments": {...}}\n</tool_call>`.
+//! This module extracts those blocks into a structured form for the
+//! OpenAI / Ollama response `tool_calls` field.
+//!
+//! Two entry points:
+//!
+//! - [`extract_tool_calls`] — non-streaming: scans a finished output string.
+//! - [`ToolCallStreamState`] — streaming: consumes tokens one at a time via
+//!   atomic `<tool_call>` / `</tool_call>` token IDs resolved through
+//!   [`ToolCallFilter::from_tokenizer`] (mirrors the `ThinkFilter` pattern in
+//!   `engine.rs`).
+//!
+//! If the tokenizer does not expose the sentinel tokens, the filter is
+//! disabled and all tokens pass through as content — no crash, no regression
+//! for models that don't use this format.
+
+use crate::tokenizer::Tokenizer;
+
+const TOOL_CALL_OPEN: &str = "<tool_call>";
+const TOOL_CALL_CLOSE: &str = "</tool_call>";
+
+/// A parsed tool call.  `arguments` is already a JSON string (as required by
+/// the OpenAI API).  Callers that need a JSON object (Ollama) re-parse it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedToolCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+/// Scan `output` for `<tool_call>…</tool_call>` blocks.  Returns the content
+/// with those blocks stripped (trimmed) and the extracted calls in order.
+///
+/// Blocks whose body is not valid JSON are left in the content untouched
+/// (so the caller still sees the raw text and can debug).
+pub fn extract_tool_calls(output: &str) -> (String, Vec<ParsedToolCall>) {
+    let mut clean = String::new();
+    let mut calls = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(open_rel) = output[cursor..].find(TOOL_CALL_OPEN) {
+        let open_abs = cursor + open_rel;
+        let body_start = open_abs + TOOL_CALL_OPEN.len();
+        let Some(close_rel) = output[body_start..].find(TOOL_CALL_CLOSE) else {
+            break;
+        };
+        let close_abs = body_start + close_rel;
+        let body = output[body_start..close_abs].trim();
+
+        match serde_json::from_str::<serde_json::Value>(body) {
+            Ok(v) => {
+                if let Some(name) = v.get("name").and_then(|n| n.as_str()) {
+                    let arguments = v
+                        .get("arguments")
+                        .map(openai_arguments_wire_format)
+                        .unwrap_or_else(|| "{}".to_string());
+                    clean.push_str(&output[cursor..open_abs]);
+                    calls.push(ParsedToolCall {
+                        name: name.to_string(),
+                        arguments,
+                    });
+                    cursor = close_abs + TOOL_CALL_CLOSE.len();
+                    continue;
+                }
+                clean.push_str(&output[cursor..close_abs + TOOL_CALL_CLOSE.len()]);
+                cursor = close_abs + TOOL_CALL_CLOSE.len();
+            }
+            Err(_) => {
+                clean.push_str(&output[cursor..close_abs + TOOL_CALL_CLOSE.len()]);
+                cursor = close_abs + TOOL_CALL_CLOSE.len();
+            }
+        }
+    }
+
+    clean.push_str(&output[cursor..]);
+    (clean.trim().to_string(), calls)
+}
+
+/// Render a JSON value as the string that belongs on the OpenAI wire as
+/// `function.arguments`.  Objects/arrays/scalars get standard JSON encoding;
+/// an existing `Value::String` is forwarded **unquoted** because OpenAI
+/// clients expect `arguments` to already be a JSON-encoded string and
+/// double-encoding would produce `"\"{\\\"x\\\": 1}\""`.  This is *not* a
+/// generic serializer — don't reuse it for other fields.
+fn openai_arguments_wire_format(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        _ => v.to_string(),
+    }
+}
+
+// ── Streaming ────────────────────────────────────────────────────────────────
+
+/// Resolves the atomic token IDs for `<tool_call>` / `</tool_call>` from a
+/// tokenizer's vocabulary.  Mirrors the `ThinkFilter` pattern in `engine.rs`.
+///
+/// If either sentinel is absent from the vocab, `enabled` is false and the
+/// downstream state machine passes every token through as content.
+#[derive(Debug, Default, Clone)]
+pub struct ToolCallFilter {
+    open_ids: Vec<u32>,
+    close_ids: Vec<u32>,
+    enabled: bool,
+}
+
+impl ToolCallFilter {
+    pub fn from_tokenizer(tok: &Tokenizer) -> Self {
+        let open_candidates = [TOOL_CALL_OPEN];
+        let close_candidates = [TOOL_CALL_CLOSE];
+        let mut open_ids = Vec::new();
+        let mut close_ids = Vec::new();
+        for name in &open_candidates {
+            if let Some(id) = tok.token_to_id(name) {
+                open_ids.push(id);
+            }
+        }
+        for name in &close_candidates {
+            if let Some(id) = tok.token_to_id(name) {
+                close_ids.push(id);
+            }
+        }
+        open_ids.dedup();
+        close_ids.dedup();
+        let enabled = !open_ids.is_empty() && !close_ids.is_empty();
+        if enabled {
+            tracing::debug!(
+                "ToolCallFilter enabled: open_ids={:?} close_ids={:?}",
+                open_ids,
+                close_ids
+            );
+        } else {
+            tracing::debug!("ToolCallFilter disabled: no <tool_call>/</tool_call> tokens in vocab");
+        }
+        Self {
+            open_ids,
+            close_ids,
+            enabled,
+        }
+    }
+
+    /// Build a filter from explicit token IDs — for tests.
+    #[cfg(test)]
+    pub fn from_ids(open_ids: Vec<u32>, close_ids: Vec<u32>) -> Self {
+        let enabled = !open_ids.is_empty() && !close_ids.is_empty();
+        Self {
+            open_ids,
+            close_ids,
+            enabled,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+    pub fn is_open(&self, token_id: u32) -> bool {
+        self.open_ids.contains(&token_id)
+    }
+    pub fn is_close(&self, token_id: u32) -> bool {
+        self.close_ids.contains(&token_id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Phase {
+    OutsideCall,
+    InsideCall,
+}
+
+/// Token-by-token stream classifier.
+///
+/// On each generated token, call [`push_token`](Self::push_token) with the
+/// token's ID and its decoded text; the returned events describe how to route
+/// that token (passthrough content vs. start/args/end of a tool call).
+///
+/// At end-of-stream call [`flush`](Self::flush) to drain any unterminated
+/// call buffer as content (fail-safe).
+///
+/// Incremental argument streaming is supported when `arguments` is a JSON
+/// object or array (the common case and what the Qwen template instructs
+/// the model to emit): bytes flow out via `ToolCallArgsDelta` as they
+/// arrive, using brace-depth tracking to stop before the outer closer.
+/// For scalar `arguments` (string/number/bool/null) the parser falls back
+/// to emitting the full value at close via canonical re-serialization.
+pub struct ToolCallStreamState {
+    filter: ToolCallFilter,
+    phase: Phase,
+    json_buffer: String,
+    call_index: u32,
+    name_emitted: bool,
+
+    // ── Incremental arguments streaming state ────────────────────────────
+    // Byte offset in `json_buffer` where the `arguments` *value* starts
+    // (i.e. the first non-whitespace char after `"arguments":`).
+    args_value_start: Option<usize>,
+    // Number of bytes of the value already emitted via `ToolCallArgsDelta`.
+    args_emitted_len: usize,
+    // Next byte to scan in `json_buffer` for depth/string tracking.
+    args_scan_pos: usize,
+    // JSON brace/bracket depth inside the value.  Only valid once
+    // `args_compound` is true.
+    args_depth: i32,
+    // Inside a JSON string literal inside the value.
+    args_in_string: bool,
+    // Previous char was an unescaped backslash inside a string.
+    args_in_escape: bool,
+    // True once depth has returned to 0 after entering a compound value.
+    args_complete: bool,
+    // True if the value opens with `{` or `[` — we can stream incrementally.
+    // When false (scalar or unknown), we defer emission to close-time.
+    args_compound: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolCallStreamEvent {
+    Content(String),
+    ToolCallStart {
+        index: u32,
+        id: String,
+        name: String,
+    },
+    ToolCallArgsDelta {
+        index: u32,
+        delta: String,
+    },
+    ToolCallEnd {
+        index: u32,
+    },
+}
+
+impl ToolCallStreamState {
+    pub fn new(filter: ToolCallFilter) -> Self {
+        Self {
+            filter,
+            phase: Phase::OutsideCall,
+            json_buffer: String::new(),
+            call_index: 0,
+            name_emitted: false,
+            args_value_start: None,
+            args_emitted_len: 0,
+            args_scan_pos: 0,
+            args_depth: 0,
+            args_in_string: false,
+            args_in_escape: false,
+            args_complete: false,
+            args_compound: false,
+        }
+    }
+
+    fn reset_call_state(&mut self) {
+        self.json_buffer.clear();
+        self.name_emitted = false;
+        self.args_value_start = None;
+        self.args_emitted_len = 0;
+        self.args_scan_pos = 0;
+        self.args_depth = 0;
+        self.args_in_string = false;
+        self.args_in_escape = false;
+        self.args_complete = false;
+        self.args_compound = false;
+    }
+
+    pub fn push_token(&mut self, token_id: u32, text: &str) -> Vec<ToolCallStreamEvent> {
+        let mut events = Vec::new();
+        if !self.filter.is_enabled() {
+            if !text.is_empty() {
+                events.push(ToolCallStreamEvent::Content(text.to_string()));
+            }
+            return events;
+        }
+        match self.phase {
+            Phase::OutsideCall if self.filter.is_open(token_id) => {
+                self.phase = Phase::InsideCall;
+                self.reset_call_state();
+            }
+            Phase::OutsideCall => {
+                if !text.is_empty() {
+                    events.push(ToolCallStreamEvent::Content(text.to_string()));
+                }
+            }
+            Phase::InsideCall if self.filter.is_close(token_id) => {
+                // Parse the full body once to catch anything we missed during
+                // incremental streaming (e.g. scalar args, or the unstreamable
+                // trailing bytes of a compound value).
+                let body = self.json_buffer.trim();
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+                    if !self.name_emitted {
+                        if let Some(name) = v.get("name").and_then(|n| n.as_str()) {
+                            events.push(ToolCallStreamEvent::ToolCallStart {
+                                index: self.call_index,
+                                id: format!("call_{}", self.call_index),
+                                name: name.to_string(),
+                            });
+                            self.name_emitted = true;
+                        }
+                    }
+                    if self.name_emitted {
+                        let canonical = v
+                            .get("arguments")
+                            .map(openai_arguments_wire_format)
+                            .unwrap_or_else(|| "{}".to_string());
+                        if canonical.len() > self.args_emitted_len {
+                            events.push(ToolCallStreamEvent::ToolCallArgsDelta {
+                                index: self.call_index,
+                                delta: canonical[self.args_emitted_len..].to_string(),
+                            });
+                        }
+                    }
+                }
+                if self.name_emitted {
+                    events.push(ToolCallStreamEvent::ToolCallEnd {
+                        index: self.call_index,
+                    });
+                    self.call_index += 1;
+                }
+                self.phase = Phase::OutsideCall;
+                self.reset_call_state();
+            }
+            Phase::InsideCall => {
+                self.json_buffer.push_str(text);
+                if !self.name_emitted {
+                    // Assumes the JSON key `"name"` appears at the root level
+                    // before any nested object with a `"name"` field.  The
+                    // Qwen3.5 template always emits `{"name": ..., "arguments":
+                    // ...}` in that order — if a future template reverses it,
+                    // the wrong string could be extracted.
+                    if let Some(name) = scan_for_name(&self.json_buffer) {
+                        events.push(ToolCallStreamEvent::ToolCallStart {
+                            index: self.call_index,
+                            id: format!("call_{}", self.call_index),
+                            name,
+                        });
+                        self.name_emitted = true;
+                    }
+                }
+                if self.name_emitted {
+                    if let Some(delta) = self.advance_args_streaming() {
+                        events.push(ToolCallStreamEvent::ToolCallArgsDelta {
+                            index: self.call_index,
+                            delta,
+                        });
+                    }
+                }
+            }
+        }
+        events
+    }
+
+    /// Scan new bytes in `json_buffer`, tracking JSON depth/string state
+    /// inside the `arguments` value, and return any prefix that's safe to
+    /// emit as a delta (stopping before the outer closer).
+    ///
+    /// Only emits for compound values (object/array) — scalar values are
+    /// deferred to close-time full re-serialization.
+    fn advance_args_streaming(&mut self) -> Option<String> {
+        // Locate the value start on first use.
+        if self.args_value_start.is_none() {
+            let start = find_args_value_start(&self.json_buffer)?;
+            self.args_value_start = Some(start);
+            self.args_scan_pos = start;
+            // Inspect the opening byte to decide whether we can stream.
+            let bytes = self.json_buffer.as_bytes();
+            if start < bytes.len() {
+                self.args_compound = matches!(bytes[start], b'{' | b'[');
+            }
+        }
+        let start = self.args_value_start?;
+        if !self.args_compound || self.args_complete {
+            return None;
+        }
+
+        let bytes = self.json_buffer.as_bytes();
+        let mut emit_end = start + self.args_emitted_len;
+        while self.args_scan_pos < bytes.len() {
+            let b = bytes[self.args_scan_pos];
+            if self.args_in_escape {
+                self.args_in_escape = false;
+            } else if self.args_in_string {
+                match b {
+                    b'\\' => self.args_in_escape = true,
+                    b'"' => self.args_in_string = false,
+                    _ => {}
+                }
+            } else {
+                match b {
+                    b'"' => self.args_in_string = true,
+                    b'{' | b'[' => self.args_depth += 1,
+                    b'}' | b']' => {
+                        if self.args_depth > 0 {
+                            self.args_depth -= 1;
+                            if self.args_depth == 0 {
+                                self.args_complete = true;
+                                self.args_scan_pos += 1;
+                                emit_end = self.args_scan_pos;
+                                break;
+                            }
+                        } else {
+                            // Underflow — treat as end-of-value (defensive).
+                            self.args_complete = true;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            self.args_scan_pos += 1;
+            emit_end = self.args_scan_pos;
+        }
+
+        let already_at = start + self.args_emitted_len;
+        if emit_end > already_at {
+            let delta = self.json_buffer[already_at..emit_end].to_string();
+            self.args_emitted_len = emit_end - start;
+            Some(delta)
+        } else {
+            None
+        }
+    }
+
+    pub fn flush(&mut self) -> Vec<ToolCallStreamEvent> {
+        let mut events = Vec::new();
+        if matches!(self.phase, Phase::InsideCall) && !self.json_buffer.is_empty() {
+            events.push(ToolCallStreamEvent::Content(self.json_buffer.clone()));
+            self.phase = Phase::OutsideCall;
+            self.reset_call_state();
+        }
+        events
+    }
+}
+
+/// Walk a partial JSON object in `buf` and return the byte offset of the
+/// first non-whitespace character of the value associated with `key` when
+/// `key` appears at the **root level** of the object.
+///
+/// Unlike a naive `buf.find("\"key\"")`, this skips:
+/// - contents of string literals (so `"name"` appearing inside another
+///   field's value doesn't match),
+/// - nested objects and arrays (so inner keys don't leak to the root).
+///
+/// Returns `None` when the buffer doesn't start an object, the key isn't
+/// visible at root level yet, or the structure is malformed.  The caller
+/// may retry as more tokens arrive.
+fn find_root_key_value_start(buf: &str, key: &str) -> Option<usize> {
+    let bytes = buf.as_bytes();
+    let key_bytes = key.as_bytes();
+    let n = bytes.len();
+    let mut i = 0;
+
+    // Skip leading whitespace and the root `{`.
+    while i < n && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if i >= n || bytes[i] != b'{' {
+        return None;
+    }
+    i += 1;
+
+    loop {
+        while i < n && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= n {
+            return None;
+        }
+        if bytes[i] == b'}' {
+            return None;
+        }
+        if bytes[i] == b',' {
+            i += 1;
+            continue;
+        }
+        if bytes[i] != b'"' {
+            return None; // malformed
+        }
+
+        // Read the key string with escapes.
+        let key_start = i + 1;
+        i = key_start;
+        let mut escape = false;
+        while i < n {
+            if escape {
+                escape = false;
+                i += 1;
+                continue;
+            }
+            if bytes[i] == b'\\' {
+                escape = true;
+                i += 1;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                break;
+            }
+            i += 1;
+        }
+        if i >= n {
+            return None; // unclosed key
+        }
+        let key_end = i; // closing `"`
+        i += 1;
+
+        while i < n && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= n || bytes[i] != b':' {
+            return None;
+        }
+        i += 1;
+        while i < n && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= n {
+            return None;
+        }
+
+        if bytes.get(key_start..key_end) == Some(key_bytes) {
+            return Some(i);
+        }
+
+        // Not our key — skip the value to get to the next key.
+        i = skip_json_value(bytes, i)?;
+    }
+}
+
+/// Skip past a single JSON value starting at `start`, returning the byte
+/// offset immediately after it.  Handles strings (with escapes), nested
+/// objects/arrays (via depth tracking), and scalars.  Returns `None` when
+/// the value isn't fully visible in `bytes`.
+fn skip_json_value(bytes: &[u8], start: usize) -> Option<usize> {
+    let n = bytes.len();
+    let mut i = start;
+    if i >= n {
+        return None;
+    }
+    match bytes[i] {
+        b'"' => {
+            i += 1;
+            let mut escape = false;
+            while i < n {
+                if escape {
+                    escape = false;
+                    i += 1;
+                    continue;
+                }
+                if bytes[i] == b'\\' {
+                    escape = true;
+                    i += 1;
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    return Some(i + 1);
+                }
+                i += 1;
+            }
+            None
+        }
+        b'{' | b'[' => {
+            let mut depth = 1i32;
+            let mut in_string = false;
+            let mut escape = false;
+            i += 1;
+            while i < n {
+                let b = bytes[i];
+                if escape {
+                    escape = false;
+                } else if in_string {
+                    match b {
+                        b'\\' => escape = true,
+                        b'"' => in_string = false,
+                        _ => {}
+                    }
+                } else {
+                    match b {
+                        b'"' => in_string = true,
+                        b'{' | b'[' => depth += 1,
+                        b'}' | b']' => {
+                            depth -= 1;
+                            if depth == 0 {
+                                return Some(i + 1);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                i += 1;
+            }
+            None
+        }
+        _ => {
+            // Scalar (number, true, false, null): terminates at `,`, `}`,
+            // `]`, or whitespace.
+            while i < n
+                && !matches!(bytes[i], b',' | b'}' | b']')
+                && !bytes[i].is_ascii_whitespace()
+            {
+                i += 1;
+            }
+            Some(i)
+        }
+    }
+}
+
+fn find_args_value_start(buf: &str) -> Option<usize> {
+    find_root_key_value_start(buf, "arguments")
+}
+
+/// Extract the root-level `"name"` string value from a partially-accumulated
+/// JSON buffer.  Returns `None` until both quotes of the value are visible
+/// (so a streaming caller can retry on the next token).
+///
+/// Walks the JSON structure rather than `find`ing the substring so that
+/// `"name"` appearing inside an earlier field's value (e.g.
+/// `{"id":"name",…}`) does not produce a false positive.
+fn scan_for_name(buf: &str) -> Option<String> {
+    let value_start = find_root_key_value_start(buf, "name")?;
+    let bytes = buf.as_bytes();
+    if value_start >= bytes.len() || bytes[value_start] != b'"' {
+        return None;
+    }
+    let rest = &buf[value_start + 1..];
+    let mut out = String::new();
+    let mut chars = rest.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next()? {
+                '"' => out.push('"'),
+                '\\' => out.push('\\'),
+                '/' => out.push('/'),
+                'n' => out.push('\n'),
+                't' => out.push('\t'),
+                'r' => out.push('\r'),
+                'b' => out.push('\u{0008}'),
+                'f' => out.push('\u{000c}'),
+                other => out.push(other),
+            }
+        } else if c == '"' {
+            return Some(out);
+        } else {
+            out.push(c);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── extract_tool_calls ───────────────────────────────────────────────────
+
+    #[test]
+    fn extract_no_blocks_is_passthrough() {
+        let (content, calls) = extract_tool_calls("Hello, world!");
+        assert_eq!(content, "Hello, world!");
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn extract_single_block() {
+        let input = "Reasoning...\n<tool_call>\n{\"name\": \"web_search\", \"arguments\": {\"query\": \"hi\"}}\n</tool_call>";
+        let (content, calls) = extract_tool_calls(input);
+        assert_eq!(content, "Reasoning...");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(calls[0].arguments, r#"{"query":"hi"}"#);
+    }
+
+    #[test]
+    fn extract_multiple_blocks_preserves_order() {
+        let input = "<tool_call>\n{\"name\":\"a\",\"arguments\":{}}\n</tool_call>middle<tool_call>\n{\"name\":\"b\",\"arguments\":{\"x\":1}}\n</tool_call>";
+        let (content, calls) = extract_tool_calls(input);
+        assert_eq!(content, "middle");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].name, "a");
+        assert_eq!(calls[1].name, "b");
+        assert_eq!(calls[1].arguments, r#"{"x":1}"#);
+    }
+
+    #[test]
+    fn extract_arguments_as_string_is_passed_through_raw() {
+        // Some models emit `"arguments": "{...}"` (args pre-stringified).
+        let input = "<tool_call>\n{\"name\":\"f\",\"arguments\":\"{\\\"k\\\":1}\"}\n</tool_call>";
+        let (_, calls) = extract_tool_calls(input);
+        assert_eq!(calls[0].arguments, r#"{"k":1}"#);
+    }
+
+    #[test]
+    fn extract_arguments_missing_defaults_to_empty_object() {
+        let input = "<tool_call>\n{\"name\":\"f\"}\n</tool_call>";
+        let (_, calls) = extract_tool_calls(input);
+        assert_eq!(calls[0].arguments, "{}");
+    }
+
+    #[test]
+    fn extract_invalid_json_is_kept_in_content() {
+        let input = "before<tool_call>\nnot valid json\n</tool_call>after";
+        let (content, calls) = extract_tool_calls(input);
+        assert!(calls.is_empty());
+        assert!(content.contains("<tool_call>"));
+        assert!(content.contains("not valid json"));
+    }
+
+    #[test]
+    fn extract_unclosed_block_is_kept() {
+        let input = "before<tool_call>\n{\"name\":\"f\"";
+        let (content, calls) = extract_tool_calls(input);
+        assert!(calls.is_empty());
+        assert!(content.contains("<tool_call>"));
+    }
+
+    // ── ToolCallFilter ───────────────────────────────────────────────────────
+
+    #[test]
+    fn filter_without_sentinels_is_disabled() {
+        let f = ToolCallFilter::from_ids(vec![], vec![]);
+        assert!(!f.is_enabled());
+    }
+
+    #[test]
+    fn filter_with_sentinels_is_enabled() {
+        let f = ToolCallFilter::from_ids(vec![100], vec![101]);
+        assert!(f.is_enabled());
+        assert!(f.is_open(100));
+        assert!(f.is_close(101));
+        assert!(!f.is_open(101));
+    }
+
+    // ── ToolCallStreamState ──────────────────────────────────────────────────
+
+    fn mk_state() -> ToolCallStreamState {
+        ToolCallStreamState::new(ToolCallFilter::from_ids(vec![100], vec![101]))
+    }
+
+    #[test]
+    fn stream_passthrough_when_filter_disabled() {
+        let mut s = ToolCallStreamState::new(ToolCallFilter::from_ids(vec![], vec![]));
+        let events = s.push_token(42, "hello");
+        assert_eq!(
+            events,
+            vec![ToolCallStreamEvent::Content("hello".to_string())]
+        );
+    }
+
+    #[test]
+    fn stream_content_outside_calls_passes_through() {
+        let mut s = mk_state();
+        let ev = s.push_token(7, "Hello ");
+        assert_eq!(ev, vec![ToolCallStreamEvent::Content("Hello ".to_string())]);
+        let ev = s.push_token(8, "world");
+        assert_eq!(ev, vec![ToolCallStreamEvent::Content("world".to_string())]);
+    }
+
+    /// Concatenate all `ToolCallArgsDelta.delta` bytes for a given call index
+    /// across the stream.  The reassembled string is what an OpenAI streaming
+    /// client would build; it must parse as the expected JSON value.
+    fn collect_args(events: &[ToolCallStreamEvent], index: u32) -> String {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                ToolCallStreamEvent::ToolCallArgsDelta { index: i, delta } if *i == index => {
+                    Some(delta.as_str())
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn stream_single_call_emits_start_args_end() {
+        let mut s = mk_state();
+        let mut all = Vec::new();
+        // Open token (text body of delimiter is suppressed, not emitted as content).
+        assert!(s.push_token(100, "<tool_call>").is_empty());
+        // Body split arbitrarily across several tokens.
+        all.extend(s.push_token(1, "\n{\"name\": \"web_"));
+        let events = s.push_token(2, "search\", \"argu");
+        // Name should be emitted as soon as visible.
+        assert!(events.iter().any(
+            |e| matches!(e, ToolCallStreamEvent::ToolCallStart { name, .. } if name == "web_search")
+        ));
+        all.extend(events);
+        all.extend(s.push_token(3, "ments\": {\"q\": 1}}\n"));
+        all.extend(s.push_token(101, "</tool_call>"));
+
+        // Concatenated args deltas must parse to {"q": 1}.  The streamed form
+        // preserves model whitespace; the close-time diff adds any canonical
+        // suffix that wasn't already emitted.
+        let reassembled = collect_args(&all, 0);
+        let parsed: serde_json::Value = serde_json::from_str(&reassembled).unwrap();
+        assert_eq!(parsed, serde_json::json!({"q": 1}));
+        assert!(all
+            .iter()
+            .any(|e| matches!(e, ToolCallStreamEvent::ToolCallEnd { index: 0 })));
+    }
+
+    #[test]
+    fn stream_args_delta_emitted_incrementally() {
+        // Args object bytes arrive across multiple tokens — each should
+        // produce a delta before the closing token, not hold everything
+        // until close.
+        let mut s = mk_state();
+        let mut deltas_per_token: Vec<usize> = Vec::new();
+        let _ = s.push_token(100, "<tool_call>");
+        deltas_per_token.push(count_args_deltas(
+            &s.push_token(1, "{\"name\":\"f\",\"arguments\":{\"qu"),
+        ));
+        deltas_per_token.push(count_args_deltas(&s.push_token(2, "ery\":\"hel")));
+        deltas_per_token.push(count_args_deltas(&s.push_token(3, "lo\"}")));
+        let close_events = s.push_token(101, "</tool_call>");
+        // At least one delta must have arrived before the close token.
+        let before_close: usize = deltas_per_token.iter().sum();
+        assert!(
+            before_close >= 1,
+            "expected incremental args deltas before close, got {deltas_per_token:?}"
+        );
+        // The close must not be the *only* source of args.
+        let close_delta_count = count_args_deltas(&close_events);
+        assert!(
+            before_close >= close_delta_count,
+            "expected the bulk of args to stream pre-close; got {before_close} pre-close vs {close_delta_count} at close"
+        );
+    }
+
+    fn count_args_deltas(events: &[ToolCallStreamEvent]) -> usize {
+        events
+            .iter()
+            .filter(|e| matches!(e, ToolCallStreamEvent::ToolCallArgsDelta { .. }))
+            .count()
+    }
+
+    #[test]
+    fn stream_two_consecutive_calls_increment_index() {
+        let mut s = mk_state();
+
+        // `ToolCallStart` is emitted the moment the name is visible (i.e. on
+        // the body token), not at close — so we must collect events across
+        // every push to see the full lifecycle of each call.
+        let mut first = Vec::new();
+        first.extend(s.push_token(100, "<tool_call>"));
+        first.extend(s.push_token(1, "{\"name\":\"a\",\"arguments\":{}}"));
+        first.extend(s.push_token(101, "</tool_call>"));
+        assert!(first
+            .iter()
+            .any(|e| matches!(e, ToolCallStreamEvent::ToolCallStart { index: 0, .. })));
+        assert!(first
+            .iter()
+            .any(|e| matches!(e, ToolCallStreamEvent::ToolCallEnd { index: 0 })));
+
+        let mut second = Vec::new();
+        second.extend(s.push_token(100, "<tool_call>"));
+        second.extend(s.push_token(2, "{\"name\":\"b\",\"arguments\":{\"x\":1}}"));
+        second.extend(s.push_token(101, "</tool_call>"));
+        assert!(second.iter().any(|e| matches!(
+            e,
+            ToolCallStreamEvent::ToolCallStart { index: 1, name, .. } if name == "b"
+        )));
+        assert!(second
+            .iter()
+            .any(|e| matches!(e, ToolCallStreamEvent::ToolCallEnd { index: 1 })));
+    }
+
+    #[test]
+    fn stream_flush_drains_unclosed_buffer_as_content() {
+        let mut s = mk_state();
+        let _ = s.push_token(100, "<tool_call>");
+        let _ = s.push_token(1, "{\"name\":\"f\"");
+        let events = s.flush();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ToolCallStreamEvent::Content(text) => assert!(text.contains("name")),
+            _ => panic!("expected Content fallback"),
+        }
+    }
+
+    #[test]
+    fn stream_invalid_json_in_call_emits_end_only_if_name_extracted() {
+        let mut s = mk_state();
+        let _ = s.push_token(100, "<tool_call>");
+        let _ = s.push_token(1, "garbage, not json");
+        let events = s.push_token(101, "</tool_call>");
+        // No name was extracted, no valid JSON: no Start/Args/End emitted.
+        assert!(events.is_empty());
+    }
+
+    // ── scan_for_name ────────────────────────────────────────────────────────
+
+    #[test]
+    fn scan_for_name_requires_closing_quote() {
+        assert_eq!(scan_for_name("{\"name\": \"foo"), None);
+        assert_eq!(scan_for_name("{\"name\": \"foo\""), Some("foo".to_string()));
+    }
+
+    #[test]
+    fn scan_for_name_handles_escapes() {
+        assert_eq!(
+            scan_for_name(r#"{"name":"a\"b"}"#),
+            Some("a\"b".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_for_name_ignores_name_inside_preceding_value() {
+        // `"name"` appears first as a STRING VALUE of `id`, then as the real
+        // root-level key.  A naive substring match would pick up the value.
+        assert_eq!(
+            scan_for_name(r#"{"id":"name","name":"get_weather"}"#),
+            Some("get_weather".to_string())
+        );
+    }
+
+    #[test]
+    fn scan_for_name_ignores_name_key_inside_nested_object() {
+        // `"name"` appears inside an earlier field's nested object.
+        assert_eq!(
+            scan_for_name(r#"{"meta":{"name":"inner"},"name":"outer"}"#),
+            Some("outer".to_string())
+        );
+    }
+
+    #[test]
+    fn find_args_ignores_arguments_substring_in_preceding_value() {
+        // `"arguments"` appears first as a VALUE, not a key.  Must be
+        // skipped; the real value start is the `{` of `{"q":1}`.
+        let buf = r#"{"name":"list_arguments","arguments":{"q":1}}"#;
+        let pos = find_args_value_start(buf).expect("args found");
+        assert_eq!(&buf[pos..pos + 1], "{");
+    }
+
+    #[test]
+    fn find_args_not_yet_visible_returns_none() {
+        // `"arguments"` key not emitted yet.
+        assert_eq!(find_args_value_start(r#"{"name":"f","argum"#), None);
+    }
+
+    // ── Pre-stringified args in the streaming path ───────────────────────────
+
+    #[test]
+    fn stream_string_valued_arguments_pass_through_unquoted() {
+        // Some models emit `"arguments": "{\"k\":1}"` — already a JSON
+        // string.  Incremental streaming must skip these (first non-ws char
+        // of the value is `"`, not `{` / `[`) and emit the full unquoted
+        // inner string at close.  Regression guard for the `args_compound`
+        // gate interacting with `openai_arguments_wire_format`.
+        let mut s = mk_state();
+        let mut all = Vec::new();
+        assert!(s.push_token(100, "<tool_call>").is_empty());
+        all.extend(s.push_token(1, "{\"name\":\"f\",\"arguments\":\"{\\\"k\\\":1}\"}"));
+        all.extend(s.push_token(101, "</tool_call>"));
+
+        let reassembled = collect_args(&all, 0);
+        // Client-side concat must parse as the inner object.
+        let parsed: serde_json::Value = serde_json::from_str(&reassembled).unwrap();
+        assert_eq!(parsed, serde_json::json!({"k": 1}));
+        // And it must not carry the JSON-string surrounding quotes.
+        assert!(!reassembled.starts_with('"'));
+        assert!(!reassembled.ends_with('"'));
+    }
+}


### PR DESCRIPTION
TLDR: see tests below

Long answer: Render the Qwen3.5 chat template 1:1 with the official jinja (tools block, conditional `\n` before `<tool_call>`, nested `function` unwrap, grouped `<tool_response>`) so the model emits canonical JSON-in- `<tool_call>` instead of Hermes-style XML (issue #217).  Parse those blocks back into OpenAI `tool_calls: [{id, type, function:{name, arguments}}]` (arguments as JSON string) and Ollama `tool_calls: [{type, function: {index, name, arguments}}]` (arguments as object), with `finish_reason` / `done_reason` overridden to `"tool_calls"`.

Streaming uses a token-ID ToolCallFilter mirroring ThinkFilter: bytes flow out incrementally via ToolCallArgsDelta events as the args value accumulates, using brace-depth tracking to stop before the outer closer; a close-time canonical diff covers scalar args or trailing bytes.

`enable_thinking` threaded through apply_chat_template: wired to Ollama `think:` and OpenAI `reasoning_effort` (removes the #[allow(dead_code)] there).  Ollama handler also gains `tools` on the request and `tool_calls`/`tool_name` on messages, with `role:"tool"` now mapped to Role::Tool and `tool_name` ↔ `tool_call_id` conversion.

Non-Qwen3.5 templates (Gemma, Phi, ChatML) are strictly unchanged — the new `apply_qwen35` path bypasses `normalize_messages` entirely, and the `chat_template_handles_tools_natively` guard keeps prose tool injection as the fallback for everyone else.

### tests

> `cargo run --release --features cuda --bin inferrs -- serve --device=cuda Qwen/Qwen3.5-2B`

#### OpenAI
```bash
curl -s http://127.0.0.1:8080/v1/chat/completions   -H 'Content-Type: application/json'   -d '{
    "model": "Qwen/Qwen3.5-2B",
    "messages": [{"role": "user", "content": "Weather in Paris?"}],
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get weather for a city.",
        "parameters": {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
      }
    }]
  }' | jq .
```

````json
{
  "id": "chatcmpl-3e2821c9-4b89-42ab-a9dc-a79bc2780dfe",
  "object": "chat.completion",
  "created": 1776720024,
  "model": "Qwen/Qwen3.5-2B",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "",
        "tool_calls": [
          {
            "id": "call_0",
            "type": "function",
            "function": {
              "name": "get_weather",
              "arguments": "{\"city\":\"paris\"}"
            }
          }
        ]
      },
      "finish_reason": "tool_calls"
    }
  ],
  "usage": {
    "prompt_tokens": 145,
    "completion_tokens": 22,
    "total_tokens": 167
  }
}
````

#### Ollama

```bash
curl -s http://127.0.0.1:8080/api/chat \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen/Qwen3.5-2B",
    "stream": false,
    "messages": [{"role": "user", "content": "Weather in Paris?"}],
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get weather for a city.",
        "parameters": {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}
      }
    }]
  }' | jq .
```

```json
{
  "model": "Qwen/Qwen3.5-2B",
  "created_at": "2026-04-20T21:21:11Z",
  "message": {
    "role": "assistant",
    "content": "",
    "tool_calls": [
      {
        "function": {
          "arguments": {
            "city": "Paris"
          },
          "index": 0,
          "name": "get_weather"
        },
        "type": "function"
      }
    ]
  },
  "done": true,
  "done_reason": "tool_calls",
  "prompt_eval_count": 145,
  "eval_count": 21,
  "total_duration": 446046064,
  "load_duration": 0,
  "prompt_eval_duration": 81287621,
  "eval_duration": 364758443
}
```

