### PR TITLE
OCI model pull with streaming progress via `/api/pull`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,16 @@ else
   GO_INSTALL_NAME_RELEASE = -ldflags='-s -w'
 endif
 
+# The standalone OCI helper uses the platform executable suffix on Windows.
+ifeq ($(OS),Windows_NT)
+  HELPER_BIN_EXT := .exe
+else
+  HELPER_BIN_EXT :=
+endif
+
+# Keep the helper filename in one place so build targets match Rust probing.
+HELPER_BIN := inferrs-oci-models$(HELPER_BIN_EXT)
+
 # inferrs-backend-cuda is only built on Linux or Windows x86_64 (not macOS,
 # not Windows ARM64).
 ifeq ($(UNAME_S),Darwin)
@@ -51,10 +61,10 @@ all: lint test build
 ui:
 	cargo build -p inferrs
 
-build: oci-lib
+build: oci-lib oci-models
 	cargo build $(NO_GPU_PKGS)
 
-release: oci-lib-release
+release: oci-lib-release oci-models-release
 	cargo build --release $(NO_GPU_PKGS)
 
 lint:
@@ -77,11 +87,11 @@ oci-lib-release:
 		-trimpath $(GO_INSTALL_NAME_RELEASE) \
 		-o ../target/release/libocimodels.$(LIB_EXT) .
 
-# Standalone CLI binary (optional, useful for debugging).
+# Standalone CLI binary used by the HTTP server for OCI pull streaming.
 oci-models:
 	mkdir -p target/debug
-	cd oci-models && go build -o ../target/debug/inferrs-oci-models .
+	cd oci-models && go build -o ../target/debug/$(HELPER_BIN) .
 
 oci-models-release:
 	mkdir -p target/release
-	cd oci-models && go build -trimpath -ldflags='-s -w' -o ../target/release/inferrs-oci-models .
+	cd oci-models && go build -trimpath -ldflags='-s -w' -o ../target/release/$(HELPER_BIN) .

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ HEXAGON_PKG := -p inferrs-backend-hexagon
 # and can be built anywhere (they probe at runtime via dlopen/LoadLibrary).
 NO_GPU_PKGS := -p inferrs -p inferrs-benchmark -p inferrs-multimodal -p inferrs-kernels -p inferrs-backend-vulkan $(HEXAGON_PKG) -p inferrs-backend-openvino $(CUDA_PKG) $(METAL_PKG)
 
-.PHONY: all build release lint test ui oci-lib oci-lib-release oci-models oci-models-release
+.PHONY: all build release lint test ui oci-lib oci-lib-release
 
 all: lint test build
 
@@ -80,10 +80,10 @@ all: lint test build
 ui:
 	cargo build -p inferrs
 
-build: oci-lib oci-models
+build: oci-lib
 	cargo build $(NO_GPU_PKGS) $(CUDA_FEATURES)
 
-release: oci-lib-release oci-models-release
+release: oci-lib-release
 	cargo build --release $(NO_GPU_PKGS) $(CUDA_FEATURES)
 
 lint:

--- a/inferrs/src/main.rs
+++ b/inferrs/src/main.rs
@@ -554,7 +554,7 @@ async fn main() -> Result<()> {
             bench::run(args)?;
         }
         Commands::Pull(args) => {
-            pull::run(args)?;
+            pull::run(args).await?;
         }
         Commands::Rm(args) => {
             rm::run(args)?;

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -58,6 +58,12 @@ const LIB_NAME: &str = "ocimodels.dll";
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 const LIB_NAME: &str = "libocimodels.so";
 
+/// Platform-specific helper binary name used by the HTTP server.
+#[cfg(target_os = "windows")]
+const HELPER_BIN_NAME: &str = "inferrs-oci-models.exe";
+#[cfg(not(target_os = "windows"))]
+const HELPER_BIN_NAME: &str = "inferrs-oci-models";
+
 /// Try to load the OCI shared library, returning a reference to the resolved
 /// function pointers.  The library is loaded at most once; subsequent calls
 /// return the cached result.
@@ -128,6 +134,89 @@ fn get_last_oci_error(lib: &OciLib) -> String {
         (lib.free_string)(err_ptr);
         msg
     }
+}
+
+/// Normalize an OCI reference the same way Docker Model Runner does.
+///
+/// This is used only for `/api/pull` bookkeeping so concurrent pull requests
+/// such as `gemma3` and `ai/gemma3:latest` share the same in-flight job.
+pub fn normalize_oci_reference(reference: &str) -> String {
+    const DEFAULT_ORG: &str = "ai";
+    const DEFAULT_TAG: &str = "latest";
+
+    let mut reference = reference.trim().to_string();
+    if reference.is_empty() {
+        return reference;
+    }
+
+    if let Some(rest) = reference.strip_prefix("hf.co/") {
+        reference = format!("huggingface.co/{rest}");
+    }
+
+    let last_slash = reference.rfind('/').unwrap_or(0);
+    let last_colon = reference.rfind(':');
+    let has_tag = matches!(last_colon, Some(idx) if idx > last_slash);
+
+    let (mut name, tag) = if has_tag {
+        let colon = last_colon.expect("checked above");
+        let name = reference[..colon].to_string();
+        let tag = reference[colon + 1..].trim();
+        let tag = if tag.is_empty() { DEFAULT_TAG } else { tag };
+        (name, tag.to_string())
+    } else {
+        (reference, DEFAULT_TAG.to_string())
+    };
+
+    let first_slash = name.find('/');
+    let has_registry = matches!(first_slash, Some(idx) if name[..idx].contains('.'));
+
+    if !has_registry && !name.contains('/') {
+        name = format!("{DEFAULT_ORG}/{name}");
+    }
+
+    format!("{}:{tag}", name.to_lowercase())
+}
+
+/// Resolve the standalone OCI helper binary used by the HTTP server.
+pub fn oci_helper_binary() -> Result<PathBuf> {
+    for env_name in ["INFERRS_OCI_MODELS_BIN", "INFERRS_OCI_PULL_BIN"] {
+        if let Some(path) = std::env::var_os(env_name) {
+            let path = PathBuf::from(path);
+            anyhow::ensure!(
+                path.exists(),
+                "{env_name} points to a missing helper: {}",
+                path.display()
+            );
+            return Ok(path);
+        }
+    }
+
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(parent) = exe.parent() {
+            let sibling = parent.join(HELPER_BIN_NAME);
+            if sibling.exists() {
+                return Ok(sibling);
+            }
+        }
+    }
+
+    if let Some(path) = find_in_path(HELPER_BIN_NAME) {
+        return Ok(path);
+    }
+
+    anyhow::bail!(
+        "OCI pull streaming requires {}. Build it with `make oci-models` and \
+         place it next to the inferrs binary, or set INFERRS_OCI_MODELS_BIN.",
+        HELPER_BIN_NAME
+    );
+}
+
+/// Search for a binary in the current PATH.
+fn find_in_path(file_name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(file_name))
+        .find(|candidate| candidate.is_file())
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +451,7 @@ mod tests {
         // Single word → OCI (docker.io/ai)
         assert_eq!(classify_reference("gemma3"), RefKind::Oci);
         assert_eq!(classify_reference("llama"), RefKind::Oci);
+        assert_eq!(classify_reference("gemma3:latest"), RefKind::Oci);
 
         // org/model → HuggingFace
         assert_eq!(
@@ -391,5 +481,15 @@ mod tests {
 
         // localhost without a port → OCI (local registry)
         assert_eq!(classify_reference("localhost/model"), RefKind::Oci);
+    }
+
+    #[test]
+    fn test_normalize_oci_reference_matches_dmr_defaults() {
+        assert_eq!(normalize_oci_reference("gemma3"), "ai/gemma3:latest");
+        assert_eq!(normalize_oci_reference("AI/Gemma3"), "ai/gemma3:latest");
+        assert_eq!(
+            normalize_oci_reference("registry.example.com/MyOrg/Model:Q4_K_M"),
+            "registry.example.com/myorg/model:Q4_K_M"
+        );
     }
 }

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -70,7 +70,6 @@ const LIB_NAME: &str = "ocimodels.dll";
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 const LIB_NAME: &str = "libocimodels.so";
 
-
 /// Try to load the OCI shared library, returning a reference to the resolved
 /// function pointers.  The library is loaded at most once; subsequent calls
 /// return the cached result.

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -1,16 +1,21 @@
 //! `inferrs pull` — pre-download a model to the local cache.
 //!
 //! Reference resolution:
-//!   - `oneword`                → OCI pull from docker.io/ai (via Go helper)
+//!   - `oneword`                → OCI pull via `POST /api/pull` on the server
 //!   - `wordone/wordtwo`        → HuggingFace pull (default for org/model)
 //!   - `hf.co/org/model`        → HuggingFace pull
 //!   - `huggingface.co/org/model` → HuggingFace pull
-//!   - `docker.io/org/model`    → OCI pull (via Go helper)
-//!   - `registry.io/org/model`  → OCI pull (via Go helper)
+//!   - `docker.io/org/model`    → OCI pull via `POST /api/pull` on the server
+//!   - `registry.io/org/model`  → OCI pull via `POST /api/pull` on the server
+//!
+//! OCI pulls are delegated to the `inferrs serve` daemon through its
+//! Ollama-compatible `/api/pull` endpoint.  If the server is not running,
+//! it is auto-started (same pattern as `inferrs run`).
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use std::ffi::{CStr, CString};
+use std::io::Write;
 use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -223,6 +228,9 @@ fn find_in_path(file_name: &str) -> Option<PathBuf> {
 // CLI args
 // ---------------------------------------------------------------------------
 
+/// Default port for the Ollama-compatible API.
+const DEFAULT_PORT: u16 = 17434;
+
 #[derive(Parser, Clone)]
 pub struct PullArgs {
     /// Model reference.
@@ -262,6 +270,41 @@ pub struct PullArgs {
     #[arg(long, num_args(0..=1), default_missing_value("Q4K"), require_equals(true),
           value_name = "FORMAT")]
     pub quantize: Option<String>,
+
+    // ── Server connection (OCI pulls only) ────────────────────────────────────
+    /// Address of the `inferrs serve` daemon.
+    /// Overrides `INFERRS_HOST`.  Defaults to `127.0.0.1`.
+    #[arg(long, default_value = "127.0.0.1")]
+    pub host: String,
+
+    /// Port of the `inferrs serve` daemon.
+    /// Overrides the port part of `INFERRS_HOST`.  Defaults to 17434.
+    #[arg(long, default_value_t = DEFAULT_PORT)]
+    pub port: u16,
+}
+
+impl PullArgs {
+    /// Resolve the base URL for the server, matching the pattern used by
+    /// `inferrs run` and `inferrs stop`.
+    fn server_url(&self) -> String {
+        let from_flags = self.host != "127.0.0.1" || self.port != DEFAULT_PORT;
+        if from_flags {
+            return format!("http://{}:{}", self.host, self.port);
+        }
+
+        if let Ok(env) = std::env::var("INFERRS_HOST") {
+            let env = env.trim().to_string();
+            if !env.is_empty() {
+                return if env.starts_with("http://") || env.starts_with("https://") {
+                    env
+                } else {
+                    format!("http://{env}")
+                };
+            }
+        }
+
+        format!("http://{}:{}", self.host, self.port)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -384,13 +427,154 @@ pub fn oci_bundle_path(reference: &str) -> Option<PathBuf> {
 }
 
 // ---------------------------------------------------------------------------
+// OCI pull via HTTP — NDJSON progress rendering
+// ---------------------------------------------------------------------------
+
+/// One NDJSON status object from `POST /api/pull` (Ollama-compatible).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[allow(dead_code)]
+struct PullStatus {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    digest: Option<String>,
+    #[serde(default)]
+    total: Option<u64>,
+    #[serde(default)]
+    completed: Option<u64>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Format a byte count as a human-readable string (e.g. "1.2 GB").
+fn human_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+
+    let b = bytes as f64;
+    if b >= GB {
+        format!("{:.1} GB", b / GB)
+    } else if b >= MB {
+        format!("{:.0} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.0} KB", b / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Pull an OCI model via the server's `/api/pull` endpoint with streaming
+/// progress, rendering Ollama-style output to the terminal.
+async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
+    use futures::StreamExt;
+
+    let client = reqwest::Client::new();
+
+    // Ensure the daemon is up, auto-starting it when needed.
+    crate::run::ensure_server_running(&client, base_url).await?;
+
+    let url = format!("{base_url}/api/pull");
+    let response = client
+        .post(&url)
+        .json(&serde_json::json!({
+            "model": model,
+            "stream": true,
+        }))
+        .send()
+        .await
+        .with_context(|| format!("POST {url} failed"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        anyhow::bail!("Server returned {status}: {text}");
+    }
+
+    // Drain the NDJSON stream and render progress.
+    let mut stdout = std::io::stderr();
+    let mut byte_stream = response.bytes_stream();
+    let mut line_buf = String::new();
+    let mut last_was_progress = false;
+
+    while let Some(chunk) = byte_stream.next().await {
+        let chunk = chunk.context("Error reading pull response stream")?;
+        let text = std::str::from_utf8(&chunk).context("Non-UTF-8 bytes in pull response")?;
+        line_buf.push_str(text);
+
+        while let Some(newline_pos) = line_buf.find('\n') {
+            let line = line_buf[..newline_pos].trim().to_string();
+            line_buf.drain(..=newline_pos);
+
+            if line.is_empty() {
+                continue;
+            }
+
+            let status: PullStatus = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("Warning: failed to parse pull progress: {e}");
+                    continue;
+                }
+            };
+
+            // Check for errors
+            if let Some(ref err) = status.error {
+                if last_was_progress {
+                    eprintln!(); // newline after progress bar
+                }
+                anyhow::bail!("Pull failed: {err}");
+            }
+
+            // Render progress
+            if let (Some(ref msg), Some(total), Some(completed)) =
+                (&status.status, status.total, status.completed)
+            {
+                if total > 0 {
+                    let pct = (completed as f64 / total as f64 * 100.0).min(100.0);
+                    let bar_width = 30;
+                    let filled = (pct / 100.0 * bar_width as f64) as usize;
+                    let empty = bar_width - filled;
+                    write!(
+                        stdout,
+                        "\r{msg}  {pct:5.1}% [{}>{}] {}/{}  ",
+                        "█".repeat(filled),
+                        "░".repeat(empty),
+                        human_bytes(completed),
+                        human_bytes(total),
+                    )?;
+                    stdout.flush()?;
+                    last_was_progress = true;
+                    continue;
+                }
+            }
+
+            // Status-only line (no progress bar)
+            if let Some(ref msg) = status.status {
+                if last_was_progress {
+                    eprintln!(); // newline after progress bar
+                    last_was_progress = false;
+                }
+                eprintln!("{msg}");
+            }
+        }
+    }
+
+    if last_was_progress {
+        eprintln!(); // final newline after progress bar
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // `inferrs pull` entry point
 // ---------------------------------------------------------------------------
 
-pub fn run(args: PullArgs) -> Result<()> {
+pub async fn run(args: PullArgs) -> Result<()> {
     match classify_reference(&args.model) {
         RefKind::Oci => {
-            // [7] --revision is only meaningful for HuggingFace references.
+            // --revision is only meaningful for HuggingFace references.
             if args.revision != "main" {
                 anyhow::bail!(
                     "--revision is not supported for OCI references \
@@ -401,9 +585,8 @@ pub fn run(args: PullArgs) -> Result<()> {
                 );
             }
 
-            let bundle_path = oci_pull_model(&args.model)?;
-            println!("Pulled {} (OCI)", args.model);
-            println!("  bundle: {}", bundle_path.display());
+            let base_url = args.server_url();
+            oci_pull_via_server(&args.model, &base_url).await?;
         }
         RefKind::HuggingFace => {
             // Strip explicit HF prefixes for the HF Hub API

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -438,7 +438,6 @@ struct PullStatus {
     status: Option<String>,
     #[serde(default)]
     digest: Option<String>,
-    #[serde(default)]
     total: Option<u64>,
     #[serde(default)]
     completed: Option<u64>,
@@ -464,8 +463,64 @@ fn human_bytes(bytes: u64) -> String {
     }
 }
 
+/// State for multi-line progress rendering (one line per layer digest).
+struct PullProgress {
+    /// Ordered list of digest strings we've seen so far.
+    digests: Vec<String>,
+    /// Current total number of output lines (status + progress lines).
+    total_lines: usize,
+}
+
+impl PullProgress {
+    fn new() -> Self {
+        Self {
+            digests: Vec::new(),
+            total_lines: 0,
+        }
+    }
+
+    /// Return the line index (0-based from top) for a digest, adding a new
+    /// line if this digest hasn't been seen before.
+    fn line_for_digest(&mut self, digest: &str, out: &mut impl Write) -> std::io::Result<usize> {
+        if let Some(pos) = self.digests.iter().position(|d| d == digest) {
+            return Ok(pos);
+        }
+        // New digest — allocate a new line at the bottom.
+        let idx = self.digests.len();
+        self.digests.push(digest.to_string());
+        // Print a blank line for this new entry.
+        writeln!(out)?;
+        self.total_lines += 1;
+        Ok(idx)
+    }
+
+    /// Move the cursor to a specific progress line, update it, then move back
+    /// to the bottom.
+    fn update_line(
+        &self,
+        line_idx: usize,
+        content: &str,
+        out: &mut impl Write,
+    ) -> std::io::Result<()> {
+        let bottom = self.total_lines - 1;
+        let lines_up = bottom - line_idx;
+
+        if lines_up > 0 {
+            // Move cursor up N lines.
+            write!(out, "\x1b[{lines_up}A")?;
+        }
+        // Overwrite the line.
+        write!(out, "\r\x1b[2K{content}")?;
+        if lines_up > 0 {
+            // Move cursor back down.
+            write!(out, "\x1b[{lines_up}B")?;
+        }
+        out.flush()
+    }
+}
+
 /// Pull an OCI model via the server's `/api/pull` endpoint with streaming
-/// progress, rendering Ollama-style output to the terminal.
+/// progress, rendering Ollama-style multi-line output to the terminal.
 async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
     use futures::StreamExt;
 
@@ -491,11 +546,11 @@ async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
         anyhow::bail!("Server returned {status}: {text}");
     }
 
-    // Drain the NDJSON stream and render progress.
-    let mut stdout = std::io::stderr();
+    // Drain the NDJSON stream and render multi-line progress.
+    let mut out = std::io::stderr();
     let mut byte_stream = response.bytes_stream();
     let mut line_buf = String::new();
-    let mut last_was_progress = false;
+    let mut progress = PullProgress::new();
 
     while let Some(chunk) = byte_stream.next().await {
         let chunk = chunk.context("Error reading pull response stream")?;
@@ -518,53 +573,60 @@ async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
                 }
             };
 
-            // Check for errors
+            // Check for errors.
             if let Some(ref err) = status.error {
-                if last_was_progress {
-                    eprintln!(); // newline after progress bar
-                }
+                writeln!(out)?;
                 anyhow::bail!("Pull failed: {err}");
             }
 
-            // Render progress
-            if let (Some(ref msg), Some(total), Some(completed)) =
-                (&status.status, status.total, status.completed)
+            // Progress update for a specific layer (has digest + total > 0).
+            if let (Some(ref digest), Some(total), Some(completed)) =
+                (&status.digest, status.total, status.completed)
             {
-                if total > 0 {
+                if total > 0 && !digest.is_empty() {
+                    let line_idx = progress.line_for_digest(digest, &mut out)?;
+
                     let pct = (completed as f64 / total as f64 * 100.0).min(100.0);
-                    let bar_width = 30;
+                    let bar_width = 20;
                     let filled = (pct / 100.0 * bar_width as f64) as usize;
                     let empty = bar_width - filled;
-                    write!(
-                        stdout,
-                        "\r{msg}  {pct:5.1}% [{}>{}] {}/{}  ",
+
+                    let short = short_digest(digest);
+                    let bar = format!(
+                        "pulling {short}  {pct:5.1}% ▕{}{}▏ {}/{}",
                         "█".repeat(filled),
                         "░".repeat(empty),
                         human_bytes(completed),
                         human_bytes(total),
-                    )?;
-                    stdout.flush()?;
-                    last_was_progress = true;
+                    );
+                    progress.update_line(line_idx, &bar, &mut out)?;
                     continue;
                 }
             }
 
-            // Status-only line (no progress bar)
+            // Status-only line (no progress bar) — print at the bottom.
             if let Some(ref msg) = status.status {
-                if last_was_progress {
-                    eprintln!(); // newline after progress bar
-                    last_was_progress = false;
-                }
-                eprintln!("{msg}");
+                writeln!(out, "\r\x1b[2K{msg}")?;
+                progress.total_lines += 1;
+                out.flush()?;
             }
         }
     }
 
-    if last_was_progress {
-        eprintln!(); // final newline after progress bar
-    }
-
     Ok(())
+}
+
+/// Shorten a digest for display (e.g. "sha256:abcdef123456..." → "abcdef123456").
+fn short_digest(digest: &str) -> &str {
+    const PREFIX: &str = "sha256:";
+    const SHORT_LEN: usize = 12;
+
+    let s = digest.strip_prefix(PREFIX).unwrap_or(digest);
+    if s.len() > SHORT_LEN {
+        &s[..SHORT_LEN]
+    } else {
+        s
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -275,9 +275,7 @@ pub fn oci_list_models() -> Result<Vec<(String, String)>> {
     let entries = raw
         .lines()
         .filter_map(|line| {
-            let mut parts = line.splitn(2, '\t');
-            let tag = parts.next()?;
-            let id = parts.next()?;
+            let (tag, id) = line.split_once('\t')?;
             Some((tag.to_string(), id.to_string()))
         })
         .collect();
@@ -608,6 +606,10 @@ async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
     }
 
     // Drain the NDJSON stream and render multi-line progress.
+    // Only use ANSI escape codes when stderr is an interactive terminal;
+    // fall back to plain line-based output otherwise (e.g. log files).
+    use std::io::IsTerminal;
+    let is_tty = std::io::stderr().is_terminal();
     let mut out = std::io::stderr();
     let mut byte_stream = response.bytes_stream();
     let mut line_buf = String::new();
@@ -645,30 +647,38 @@ async fn oci_pull_via_server(model: &str, base_url: &str) -> Result<()> {
                 (&status.digest, status.total, status.completed)
             {
                 if total > 0 && !digest.is_empty() {
-                    let line_idx = progress.line_for_digest(digest, &mut out)?;
+                    if is_tty {
+                        let line_idx = progress.line_for_digest(digest, &mut out)?;
 
-                    let pct = (completed as f64 / total as f64 * 100.0).min(100.0);
-                    let bar_width = 20;
-                    let filled = (pct / 100.0 * bar_width as f64) as usize;
-                    let empty = bar_width - filled;
+                        let pct = (completed as f64 / total as f64 * 100.0).min(100.0);
+                        let bar_width = 20;
+                        let filled = (pct / 100.0 * bar_width as f64) as usize;
+                        let empty = bar_width - filled;
 
-                    let short = short_digest(digest);
-                    let bar = format!(
-                        "pulling {short}  {pct:5.1}% ▕{}{}▏ {}/{}",
-                        "█".repeat(filled),
-                        "░".repeat(empty),
-                        human_bytes(completed),
-                        human_bytes(total),
-                    );
-                    progress.update_line(line_idx, &bar, &mut out)?;
+                        let short = short_digest(digest);
+                        let bar = format!(
+                            "pulling {short}  {pct:5.1}% ▕{}{}▏ {}/{}",
+                            "█".repeat(filled),
+                            "░".repeat(empty),
+                            human_bytes(completed),
+                            human_bytes(total),
+                        );
+                        progress.update_line(line_idx, &bar, &mut out)?;
+                    }
+                    // Non-TTY: skip per-chunk progress to avoid flooding logs;
+                    // status-only lines below still print completion milestones.
                     continue;
                 }
             }
 
             // Status-only line (no progress bar) — print at the bottom.
             if let Some(ref msg) = status.status {
-                writeln!(out, "\r\x1b[2K{msg}")?;
-                progress.total_lines += 1;
+                if is_tty {
+                    writeln!(out, "\r\x1b[2K{msg}")?;
+                    progress.total_lines += 1;
+                } else {
+                    writeln!(out, "{msg}")?;
+                }
                 out.flush()?;
             }
         }

--- a/inferrs/src/pull.rs
+++ b/inferrs/src/pull.rs
@@ -14,9 +14,8 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::io::Write;
-use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
@@ -32,6 +31,12 @@ use std::sync::OnceLock;
 /// Function-pointer signatures matching the Go C exports in lib.go.
 type FnOciPull = unsafe extern "C" fn(*const c_char) -> *mut c_char;
 type FnOciBundle = unsafe extern "C" fn(*const c_char) -> *mut c_char;
+type FnOciPullStream = unsafe extern "C" fn(
+    *const c_char,
+    Option<unsafe extern "C" fn(*const c_char, *mut c_void)>,
+    *mut c_void,
+) -> c_int;
+type FnOciList = unsafe extern "C" fn() -> *mut c_char;
 type FnOciLastError = unsafe extern "C" fn() -> *mut c_char;
 type FnOciFreeString = unsafe extern "C" fn(*mut c_char);
 
@@ -42,6 +47,8 @@ struct OciLib {
     _lib: libloading::Library,
     pull: FnOciPull,
     bundle: FnOciBundle,
+    pull_stream: FnOciPullStream,
+    list: FnOciList,
     last_error: FnOciLastError,
     free_string: FnOciFreeString,
 }
@@ -63,11 +70,6 @@ const LIB_NAME: &str = "ocimodels.dll";
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 const LIB_NAME: &str = "libocimodels.so";
 
-/// Platform-specific helper binary name used by the HTTP server.
-#[cfg(target_os = "windows")]
-const HELPER_BIN_NAME: &str = "inferrs-oci-models.exe";
-#[cfg(not(target_os = "windows"))]
-const HELPER_BIN_NAME: &str = "inferrs-oci-models";
 
 /// Try to load the OCI shared library, returning a reference to the resolved
 /// function pointers.  The library is loaded at most once; subsequent calls
@@ -103,7 +105,7 @@ fn try_load_oci_lib() -> Result<OciLib, String> {
         )
     })?;
 
-    // Resolve the four exported symbols.
+    // Resolve the exported symbols.
     unsafe {
         let pull: FnOciPull = *lib
             .get::<FnOciPull>(b"oci_pull\0")
@@ -111,6 +113,12 @@ fn try_load_oci_lib() -> Result<OciLib, String> {
         let bundle: FnOciBundle = *lib
             .get::<FnOciBundle>(b"oci_bundle\0")
             .map_err(|e| format!("failed to resolve oci_bundle: {e}"))?;
+        let pull_stream: FnOciPullStream = *lib
+            .get::<FnOciPullStream>(b"oci_pull_stream\0")
+            .map_err(|e| format!("failed to resolve oci_pull_stream: {e}"))?;
+        let list: FnOciList = *lib
+            .get::<FnOciList>(b"oci_list\0")
+            .map_err(|e| format!("failed to resolve oci_list: {e}"))?;
         let last_error: FnOciLastError = *lib
             .get::<FnOciLastError>(b"oci_last_error\0")
             .map_err(|e| format!("failed to resolve oci_last_error: {e}"))?;
@@ -122,6 +130,8 @@ fn try_load_oci_lib() -> Result<OciLib, String> {
             _lib: lib,
             pull,
             bundle,
+            pull_stream,
+            list,
             last_error,
             free_string,
         })
@@ -182,46 +192,97 @@ pub fn normalize_oci_reference(reference: &str) -> String {
     format!("{}:{tag}", name.to_lowercase())
 }
 
-/// Resolve the standalone OCI helper binary used by the HTTP server.
-pub fn oci_helper_binary() -> Result<PathBuf> {
-    for env_name in ["INFERRS_OCI_MODELS_BIN", "INFERRS_OCI_PULL_BIN"] {
-        if let Some(path) = std::env::var_os(env_name) {
-            let path = PathBuf::from(path);
-            anyhow::ensure!(
-                path.exists(),
-                "{env_name} points to a missing helper: {}",
-                path.display()
-            );
-            return Ok(path);
-        }
-    }
+// ---------------------------------------------------------------------------
+// OCI pull streaming (via FFI callback) — used by the HTTP server's
+// `POST /api/pull` endpoint to stream Ollama-compatible NDJSON progress
+// without spawning a separate helper process.
+// ---------------------------------------------------------------------------
 
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(parent) = exe.parent() {
-            let sibling = parent.join(HELPER_BIN_NAME);
-            if sibling.exists() {
-                return Ok(sibling);
-            }
-        }
-    }
-
-    if let Some(path) = find_in_path(HELPER_BIN_NAME) {
-        return Ok(path);
-    }
-
-    anyhow::bail!(
-        "OCI pull streaming requires {}. Build it with `make oci-models` and \
-         place it next to the inferrs binary, or set INFERRS_OCI_MODELS_BIN.",
-        HELPER_BIN_NAME
-    );
+/// Handle returned by [`oci_pull_stream_start`].  The receiver yields one
+/// NDJSON line per message; when the channel closes the pull is complete.
+pub struct OciStreamHandle {
+    /// Receiver for NDJSON progress lines from the Go shared library.
+    pub lines: tokio::sync::mpsc::UnboundedReceiver<String>,
 }
 
-/// Search for a binary in the current PATH.
-fn find_in_path(file_name: &str) -> Option<PathBuf> {
-    let path_var = std::env::var_os("PATH")?;
-    std::env::split_paths(&path_var)
-        .map(|dir| dir.join(file_name))
-        .find(|candidate| candidate.is_file())
+/// C callback trampoline invoked by the Go shared library for each NDJSON
+/// progress line.  `ctx` points to a boxed `UnboundedSender<String>`.
+///
+/// # Safety
+/// Called from Go goroutines via the C trampoline.  The pointer must remain
+/// valid until `oci_pull_stream` returns (guaranteed by the caller).
+unsafe extern "C" fn pull_stream_trampoline(line: *const c_char, ctx: *mut c_void) {
+    if line.is_null() || ctx.is_null() {
+        return;
+    }
+    let tx = unsafe { &*(ctx as *const tokio::sync::mpsc::UnboundedSender<String>) };
+    if let Ok(s) = unsafe { CStr::from_ptr(line) }.to_str() {
+        let _ = tx.send(s.to_string());
+    }
+}
+
+/// Start an OCI pull with streaming Ollama-compatible NDJSON progress.
+///
+/// The pull runs on a dedicated OS thread (the Go shared library blocks).
+/// Each NDJSON line is delivered through the returned channel.  When the
+/// channel closes, the pull is complete.  Errors are communicated as NDJSON
+/// objects with an `"error"` field, matching the Ollama wire format.
+pub fn oci_pull_stream_start(reference: &str) -> Result<OciStreamHandle> {
+    let lib = load_oci_lib().map_err(|e| anyhow::anyhow!("{e}"))?;
+    let c_ref = CString::new(reference).context("OCI reference contains interior NUL byte")?;
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+    std::thread::spawn(move || {
+        // Box the sender and convert to a raw pointer inside the thread so
+        // the raw pointer never crosses a thread boundary from Rust's
+        // perspective.  The Go callback may invoke it from any goroutine
+        // thread, which is safe because UnboundedSender::send is threadsafe.
+        let tx_ptr = Box::into_raw(Box::new(tx));
+        unsafe {
+            (lib.pull_stream)(
+                c_ref.as_ptr(),
+                Some(pull_stream_trampoline),
+                tx_ptr as *mut c_void,
+            );
+            // Reclaim and drop the sender, closing the channel.
+            drop(Box::from_raw(tx_ptr));
+        }
+    });
+
+    Ok(OciStreamHandle { lines: rx })
+}
+
+/// List all OCI models in the local store.
+///
+/// Returns a list of `(tag, digest)` pairs.
+#[allow(dead_code)]
+pub fn oci_list_models() -> Result<Vec<(String, String)>> {
+    let lib = load_oci_lib().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let result = unsafe { (lib.list)() };
+    if result.is_null() {
+        let err = get_last_oci_error(lib);
+        anyhow::bail!("OCI list failed: {err}");
+    }
+
+    let raw = unsafe {
+        let s = CStr::from_ptr(result).to_string_lossy().into_owned();
+        (lib.free_string)(result);
+        s
+    };
+
+    let entries = raw
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let tag = parts.next()?;
+            let id = parts.next()?;
+            Some((tag.to_string(), id.to_string()))
+        })
+        .collect();
+
+    Ok(entries)
 }
 
 // ---------------------------------------------------------------------------

--- a/inferrs/src/run.rs
+++ b/inferrs/src/run.rs
@@ -280,7 +280,7 @@ struct OaiChunk {
 
 /// Probe the server with `HEAD /` (Ollama heartbeat endpoint).
 /// Returns `true` if the server responded, `false` if connection was refused.
-async fn heartbeat(client: &Client, base_url: &str) -> bool {
+pub async fn heartbeat(client: &Client, base_url: &str) -> bool {
     let url = format!("{base_url}/");
     client.head(&url).send().await.is_ok()
 }
@@ -291,7 +291,7 @@ async fn heartbeat(client: &Client, base_url: &str) -> bool {
 /// the server is not up, spawn `inferrs serve` (no arguments — the bare daemon,
 /// just like `ollama serve`) using the same executable that is currently
 /// running, then poll every 200 ms until it responds (up to 60 s).
-async fn ensure_server_running(client: &Client, base_url: &str) -> Result<()> {
+pub async fn ensure_server_running(client: &Client, base_url: &str) -> Result<()> {
     if heartbeat(client, base_url).await {
         return Ok(());
     }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -1262,8 +1262,8 @@ fn spawn_active_pull(
     key: String,
     reference: String,
 ) -> Result<Arc<ActivePull>, String> {
-    let mut stream_handle = crate::pull::oci_pull_stream_start(&reference)
-        .map_err(|e| e.to_string())?;
+    let mut stream_handle =
+        crate::pull::oci_pull_stream_start(&reference).map_err(|e| e.to_string())?;
 
     let (tx, _) = broadcast::channel(256);
     let (done_tx, done_rx) = watch::channel(None);

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -16,10 +16,8 @@ use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::process::Stdio;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{broadcast, mpsc, oneshot, watch, Mutex};
 use tower_http::cors::CorsLayer;
 
@@ -1258,25 +1256,14 @@ impl PullManager {
     }
 }
 
-/// Spawn the standalone OCI helper and return the shared pull state.
+/// Start an OCI pull via the shared library and return the shared pull state.
 fn spawn_active_pull(
     registry: PullRegistry,
     key: String,
     reference: String,
 ) -> Result<Arc<ActivePull>, String> {
-    let helper = crate::pull::oci_helper_binary().map_err(|e| e.to_string())?;
-    let mut child = tokio::process::Command::new(&helper)
-        .arg("stream")
-        .arg(&reference)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .map_err(|e| format!("failed to spawn {}: {e}", helper.display()))?;
-
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "OCI helper did not expose stdout".to_string())?;
+    let mut stream_handle = crate::pull::oci_pull_stream_start(&reference)
+        .map_err(|e| e.to_string())?;
 
     let (tx, _) = broadcast::channel(256);
     let (done_tx, done_rx) = watch::channel(None);
@@ -1291,33 +1278,39 @@ fn spawn_active_pull(
     });
 
     tokio::spawn(async move {
-        run_active_pull(registry, key, child, stdout, tx, history, done_tx, waiters).await;
+        run_active_pull(
+            registry,
+            key,
+            &mut stream_handle.lines,
+            tx,
+            history,
+            done_tx,
+            waiters,
+        )
+        .await;
     });
 
     Ok(active)
 }
 
-/// Drain helper stdout, fan out progress lines, and publish the final result.
+/// Drain FFI progress lines, fan out to subscribers, and publish the final result.
 async fn run_active_pull(
     registry: PullRegistry,
     key: String,
-    mut child: tokio::process::Child,
-    stdout: tokio::process::ChildStdout,
+    line_rx: &mut tokio::sync::mpsc::UnboundedReceiver<String>,
     tx: broadcast::Sender<axum::body::Bytes>,
     history: Arc<Mutex<Vec<axum::body::Bytes>>>,
     done_tx: watch::Sender<Option<Result<(), String>>>,
     waiters: Arc<AtomicUsize>,
 ) {
-    let mut lines = BufReader::new(stdout).lines();
     let mut last_error: Option<String> = None;
     let mut emitted_error_line = false;
-    let mut cancelled = false;
 
     loop {
         tokio::select! {
-            line = lines.next_line() => {
+            line = line_rx.recv() => {
                 match line {
-                    Ok(Some(raw_line)) => {
+                    Some(raw_line) => {
                         let trimmed = raw_line.trim();
                         if trimmed.is_empty() {
                             continue;
@@ -1342,36 +1335,24 @@ async fn run_active_pull(
                             }
                         }
                     }
-                    Ok(None) => break,
-                    Err(err) => {
-                        last_error = Some(format!(
-                            "failed to read OCI pull progress: {err}"
-                        ));
-                        break;
-                    }
+                    None => break, // Channel closed — pull complete.
                 }
             }
             _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {
+                // If no subscribers remain, stop broadcasting.  The Go pull
+                // continues to completion in the background but we no longer
+                // buffer its output.
                 if tx.receiver_count() == 0 && waiters.load(Ordering::Relaxed) == 0 {
-                    cancelled = true;
-                    let _ = child.start_kill();
+                    line_rx.close();
+                    break;
                 }
             }
         }
     }
 
-    let final_result = match child.wait().await {
-        Ok(_status) if cancelled => {
-            Err("OCI pull cancelled because all clients disconnected".to_string())
-        }
-        Ok(status) if status.success() => match last_error {
-            Some(error) => Err(error),
-            None => Ok(()),
-        },
-        Ok(status) => {
-            Err(last_error.unwrap_or_else(|| format!("OCI helper exited with status {status}")))
-        }
-        Err(err) => Err(format!("failed to wait for OCI pull helper: {err}")),
+    let final_result = match last_error {
+        Some(error) => Err(error),
+        None => Ok(()),
     };
 
     if let Err(ref message) = final_result {

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -16,8 +16,11 @@ use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::{broadcast, mpsc, oneshot, watch, Mutex};
 use tower_http::cors::CorsLayer;
 
 use crate::engine::{
@@ -815,6 +818,78 @@ pub struct OllamaShowResponse {
     pub model_info: serde_json::Value,
 }
 
+/// `POST /api/pull` request.
+#[derive(Debug, Deserialize)]
+pub struct OllamaPullRequest {
+    /// Canonical Ollama field for the target model.
+    #[serde(default)]
+    pub model: String,
+    /// Legacy alias still accepted by Ollama-compatible clients.
+    #[serde(default)]
+    pub name: String,
+    /// Accepted for compatibility. The current helper decides transport.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub insecure: bool,
+    /// When `false`, wait for completion and return a single JSON object.
+    #[serde(default)]
+    pub stream: Option<bool>,
+}
+
+impl OllamaPullRequest {
+    /// Return the client-requested model, preferring `name` over `model`.
+    fn requested_model(&self) -> Option<&str> {
+        let preferred = if self.name.trim().is_empty() {
+            self.model.trim()
+        } else {
+            self.name.trim()
+        };
+        if preferred.is_empty() {
+            None
+        } else {
+            Some(preferred)
+        }
+    }
+}
+
+/// One NDJSON status object emitted by `POST /api/pull`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct OllamaPullStatus {
+    /// Human-readable pull phase such as `pulling manifest`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Layer digest currently being downloaded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub digest: Option<String>,
+    /// Total bytes in the current layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u64>,
+    /// Bytes already downloaded for the current layer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed: Option<u64>,
+    /// Error text emitted after streaming has already started.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl OllamaPullStatus {
+    /// Build a terminal success object.
+    fn success() -> Self {
+        Self {
+            status: Some("success".to_string()),
+            ..Self::default()
+        }
+    }
+
+    /// Build a terminal error object.
+    fn error(message: impl Into<String>) -> Self {
+        Self {
+            error: Some(message.into()),
+            ..Self::default()
+        }
+    }
+}
+
 /// `GET /api/version` response.
 #[derive(Debug, Serialize)]
 pub struct OllamaVersionResponse {
@@ -1023,6 +1098,31 @@ enum ModelSlot {
     Failed(String),
 }
 
+/// Maps normalized OCI references to their active pull job.
+type PullRegistry = Arc<Mutex<HashMap<String, Arc<ActivePull>>>>;
+
+/// Shared pull manager for `POST /api/pull`.
+#[derive(Clone, Default)]
+struct PullManager {
+    /// In-flight OCI pulls keyed by normalized model reference.
+    active: PullRegistry,
+}
+
+/// One active OCI pull plus the channels used by HTTP subscribers.
+struct ActivePull {
+    /// Fan-out channel for NDJSON progress lines.
+    tx: broadcast::Sender<axum::body::Bytes>,
+    /// Already-emitted NDJSON lines kept for late subscribers.
+    ///
+    /// The mutex also serialises history snapshots with new broadcasts so
+    /// late subscribers never see the same NDJSON line twice.
+    history: Arc<Mutex<Vec<axum::body::Bytes>>>,
+    /// Final pull result once the helper process exits.
+    done_rx: watch::Receiver<Option<Result<(), String>>>,
+    /// Count of blocking `stream=false` waiters that still need the job alive.
+    waiters: Arc<AtomicUsize>,
+}
+
 struct AppState {
     /// The current model slot — empty, loading, or ready.
     slot: tokio::sync::RwLock<ModelSlot>,
@@ -1032,6 +1132,255 @@ struct AppState {
     serve_args: crate::ServeArgs,
     /// HTTP client used by the daemon to proxy requests to workers.
     http_client: reqwest::Client,
+    /// Shared OCI pull coordination for Ollama-compatible clients.
+    pull_manager: PullManager,
+}
+
+/// Keeps a blocking `stream=false` waiter counted while it is alive.
+struct PullWaitGuard {
+    /// Shared waiter counter for the underlying pull job.
+    waiters: Arc<AtomicUsize>,
+}
+
+impl PullWaitGuard {
+    /// Increment the waiter count until the guard is dropped.
+    fn new(waiters: Arc<AtomicUsize>) -> Self {
+        waiters.fetch_add(1, Ordering::Relaxed);
+        Self { waiters }
+    }
+}
+
+impl Drop for PullWaitGuard {
+    fn drop(&mut self) {
+        self.waiters.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl ActivePull {
+    /// Snapshot pull history and subscribe to future progress atomically.
+    async fn snapshot_stream(
+        &self,
+    ) -> (
+        Vec<axum::body::Bytes>,
+        broadcast::Receiver<axum::body::Bytes>,
+    ) {
+        let history = self.history.lock().await;
+        let snapshot = history.clone();
+        let rx = self.tx.subscribe();
+        (snapshot, rx)
+    }
+}
+
+impl PullManager {
+    /// Return the existing pull job for `reference`, or start a new one.
+    async fn get_or_start(&self, reference: &str) -> Result<Arc<ActivePull>, String> {
+        let key = crate::pull::normalize_oci_reference(reference);
+        let mut guard = self.active.lock().await;
+        if let Some(active) = guard.get(&key) {
+            return Ok(Arc::clone(active));
+        }
+
+        let active = spawn_active_pull(self.active.clone(), key.clone(), reference.to_string())?;
+        guard.insert(key, Arc::clone(&active));
+        Ok(active)
+    }
+}
+
+/// Spawn the standalone OCI helper and return the shared pull state.
+fn spawn_active_pull(
+    registry: PullRegistry,
+    key: String,
+    reference: String,
+) -> Result<Arc<ActivePull>, String> {
+    let helper = crate::pull::oci_helper_binary().map_err(|e| e.to_string())?;
+    let mut child = tokio::process::Command::new(&helper)
+        .arg("stream")
+        .arg(&reference)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn {}: {e}", helper.display()))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "OCI helper did not expose stdout".to_string())?;
+
+    let (tx, _) = broadcast::channel(256);
+    let (done_tx, done_rx) = watch::channel(None);
+    let waiters = Arc::new(AtomicUsize::new(0));
+    let history = Arc::new(Mutex::new(Vec::new()));
+
+    let active = Arc::new(ActivePull {
+        tx: tx.clone(),
+        history: Arc::clone(&history),
+        done_rx,
+        waiters: Arc::clone(&waiters),
+    });
+
+    tokio::spawn(async move {
+        run_active_pull(registry, key, child, stdout, tx, history, done_tx, waiters).await;
+    });
+
+    Ok(active)
+}
+
+/// Drain helper stdout, fan out progress lines, and publish the final result.
+async fn run_active_pull(
+    registry: PullRegistry,
+    key: String,
+    mut child: tokio::process::Child,
+    stdout: tokio::process::ChildStdout,
+    tx: broadcast::Sender<axum::body::Bytes>,
+    history: Arc<Mutex<Vec<axum::body::Bytes>>>,
+    done_tx: watch::Sender<Option<Result<(), String>>>,
+    waiters: Arc<AtomicUsize>,
+) {
+    let mut lines = BufReader::new(stdout).lines();
+    let mut last_error: Option<String> = None;
+    let mut emitted_error_line = false;
+    let mut cancelled = false;
+
+    loop {
+        tokio::select! {
+            line = lines.next_line() => {
+                match line {
+                    Ok(Some(raw_line)) => {
+                        let trimmed = raw_line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        match helper_pull_line(trimmed) {
+                            Ok((bytes, maybe_error)) => {
+                                if let Some(error) = maybe_error {
+                                    last_error = Some(error);
+                                    emitted_error_line = true;
+                                }
+                                publish_pull_bytes(&tx, history.as_ref(), bytes).await;
+                            }
+                            Err(err) => {
+                                last_error = Some(err.clone());
+                                if let Ok(bytes) =
+                                    serialize_pull_line(&OllamaPullStatus::error(&err))
+                                {
+                                    publish_pull_bytes(&tx, history.as_ref(), bytes).await;
+                                    emitted_error_line = true;
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        last_error = Some(format!(
+                            "failed to read OCI pull progress: {err}"
+                        ));
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {
+                if tx.receiver_count() == 0 && waiters.load(Ordering::Relaxed) == 0 {
+                    cancelled = true;
+                    let _ = child.start_kill();
+                }
+            }
+        }
+    }
+
+    let final_result = match child.wait().await {
+        Ok(_status) if cancelled => {
+            Err("OCI pull cancelled because all clients disconnected".to_string())
+        }
+        Ok(status) if status.success() => match last_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        },
+        Ok(status) => {
+            Err(last_error.unwrap_or_else(|| format!("OCI helper exited with status {status}")))
+        }
+        Err(err) => Err(format!("failed to wait for OCI pull helper: {err}")),
+    };
+
+    if let Err(ref message) = final_result {
+        if !emitted_error_line {
+            if let Ok(bytes) = serialize_pull_line(&OllamaPullStatus::error(message)) {
+                publish_pull_bytes(&tx, history.as_ref(), bytes).await;
+            }
+        }
+    }
+
+    let _ = done_tx.send(Some(final_result));
+    let mut guard = registry.lock().await;
+    guard.remove(&key);
+}
+
+/// Parse and re-encode one helper line before exposing it to HTTP clients.
+fn helper_pull_line(line: &str) -> Result<(axum::body::Bytes, Option<String>), String> {
+    let status: OllamaPullStatus =
+        serde_json::from_str(line).map_err(|e| format!("invalid OCI pull progress JSON: {e}"))?;
+    let error = status.error.clone();
+    let bytes = serialize_pull_line(&status)?;
+    Ok((bytes, error))
+}
+
+/// Append one NDJSON line to history and broadcast it in the same order.
+///
+/// The shared history mutex keeps snapshots and broadcasts in lockstep so
+/// late subscribers either see a line in history or receive it from the
+/// channel, but never both.
+async fn publish_pull_bytes(
+    tx: &broadcast::Sender<axum::body::Bytes>,
+    history: &Mutex<Vec<axum::body::Bytes>>,
+    bytes: axum::body::Bytes,
+) {
+    let mut history = history.lock().await;
+    history.push(bytes.clone());
+    let _ = tx.send(bytes);
+}
+
+/// Serialize one pull status object as an NDJSON line.
+fn serialize_pull_line(status: &OllamaPullStatus) -> Result<axum::body::Bytes, String> {
+    let mut data =
+        serde_json::to_vec(status).map_err(|e| format!("failed to encode pull progress: {e}"))?;
+    data.push(b'\n');
+    Ok(axum::body::Bytes::from(data))
+}
+
+/// Wait for the terminal result of an active pull job.
+async fn wait_for_active_pull(active: &ActivePull) -> Result<(), String> {
+    let _guard = PullWaitGuard::new(Arc::clone(&active.waiters));
+    let mut done_rx = active.done_rx.clone();
+
+    loop {
+        if let Some(result) = done_rx.borrow().clone() {
+            return result;
+        }
+        done_rx
+            .changed()
+            .await
+            .map_err(|_| "OCI pull result channel closed unexpectedly".to_string())?;
+    }
+}
+
+/// Convert a broadcast receiver into an NDJSON response body.
+fn make_ollama_pull_stream(
+    history: Vec<axum::body::Bytes>,
+    mut rx: broadcast::Receiver<axum::body::Bytes>,
+) -> impl Stream<Item = Result<axum::body::Bytes, Infallible>> {
+    async_stream::stream! {
+        for bytes in history {
+            yield Ok(bytes);
+        }
+
+        loop {
+            match rx.recv().await {
+                Ok(bytes) => yield Ok(bytes),
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    }
 }
 
 fn audio_error(message: impl Into<String>) -> (StatusCode, Json<ErrorResponse>) {
@@ -1478,6 +1827,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         default_params,
         serve_args: args.clone(),
         http_client: reqwest::Client::new(),
+        pull_manager: PullManager::default(),
     });
 
     // If a model was specified on the CLI, start loading it in the background
@@ -1549,6 +1899,7 @@ pub async fn run(args: ServeArgs) -> Result<()> {
         .route("/api/tags", get(ollama_tags).head(ollama_tags))
         .route("/api/ps", get(ollama_ps))
         .route("/api/show", post(ollama_show))
+        .route("/api/pull", post(ollama_pull))
         .route("/api/generate", post(ollama_generate))
         .route("/api/chat", post(ollama_chat))
         .route("/api/embed", post(ollama_embed))
@@ -3455,6 +3806,67 @@ async fn ollama_show(
     }))
 }
 
+/// `POST /api/pull` — pull one OCI model with Ollama-compatible progress.
+async fn ollama_pull(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<OllamaPullRequest>,
+) -> Result<Response, OllamaHttpError> {
+    let requested = req.requested_model().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "`model` or `name` is required"
+            })),
+        )
+    })?;
+
+    if crate::pull::classify_reference(requested) != crate::pull::RefKind::Oci {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": concat!(
+                    "/api/pull only supports OCI references. ",
+                    "Use a single-word model like `gemma3` or ",
+                    "an explicit registry reference like ",
+                    "`docker.io/ai/gemma3:latest`. ",
+                    "Bare `org/model` references are treated as ",
+                    "Hugging Face models."
+                )
+            })),
+        ));
+    }
+
+    let active = state
+        .pull_manager
+        .get_or_start(requested)
+        .await
+        .map_err(|message| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": message })),
+            )
+        })?;
+
+    if req.stream == Some(false) {
+        wait_for_active_pull(&active).await.map_err(|message| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": message })),
+            )
+        })?;
+        return Ok(Json(OllamaPullStatus::success()).into_response());
+    }
+
+    let (history, rx) = active.snapshot_stream().await;
+    let stream = make_ollama_pull_stream(history, rx);
+
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, "application/x-ndjson")],
+        axum::body::Body::from_stream(stream),
+    )
+        .into_response())
+}
+
 /// Return the RFC3339 timestamp for right now (UTC).
 fn rfc3339_now() -> String {
     // Produce a simple ISO-8601 / RFC-3339 timestamp without pulling in chrono.
@@ -4544,6 +4956,84 @@ mod tests {
             tool_calls: None,
             tool_call_id: None,
         }
+    }
+
+    #[test]
+    fn ollama_pull_request_prefers_name_field() {
+        // Prefer the legacy `name` field when both are present.
+        let req = OllamaPullRequest {
+            model: "gemma3".to_string(),
+            name: "custom".to_string(),
+            insecure: false,
+            stream: None,
+        };
+        assert_eq!(req.requested_model(), Some("custom"));
+
+        // Fall back to `model` when `name` is empty.
+        let req = OllamaPullRequest {
+            model: "gemma3".to_string(),
+            name: String::new(),
+            insecure: false,
+            stream: None,
+        };
+        assert_eq!(req.requested_model(), Some("gemma3"));
+    }
+
+    #[test]
+    fn helper_pull_line_round_trips_ollama_status() {
+        // Helper output must remain valid Ollama NDJSON after re-encoding.
+        let line = concat!(
+            r#"{"status":"pulling sha256:deadbeef","digest":"sha256:deadbeef","#,
+            r#""total":42,"completed":7}"#
+        );
+        let (bytes, error) = helper_pull_line(line).unwrap();
+        assert_eq!(error, None);
+
+        let encoded = std::str::from_utf8(&bytes).unwrap();
+        let status: OllamaPullStatus = serde_json::from_str(encoded.trim_end()).unwrap();
+        assert_eq!(status.status.as_deref(), Some("pulling sha256:deadbeef"));
+        assert_eq!(status.digest.as_deref(), Some("sha256:deadbeef"));
+        assert_eq!(status.total, Some(42));
+        assert_eq!(status.completed, Some(7));
+    }
+
+    #[tokio::test]
+    async fn active_pull_snapshot_stream_receives_future_line_once() {
+        // Publish one line before subscribing so it must come from history.
+        let (tx, _) = broadcast::channel(16);
+        let (_done_tx, done_rx) = watch::channel::<Option<Result<(), String>>>(None);
+        let history = Arc::new(Mutex::new(Vec::new()));
+        let active = ActivePull {
+            tx: tx.clone(),
+            history: Arc::clone(&history),
+            done_rx,
+            waiters: Arc::new(AtomicUsize::new(0)),
+        };
+
+        let manifest = serialize_pull_line(&OllamaPullStatus {
+            status: Some("pulling manifest".to_string()),
+            ..OllamaPullStatus::default()
+        })
+        .unwrap();
+        publish_pull_bytes(&tx, history.as_ref(), manifest.clone()).await;
+
+        // Snapshotting should replay history exactly once and subscribe only
+        // to future lines.
+        let (snapshot, mut rx) = active.snapshot_stream().await;
+        assert_eq!(snapshot, vec![manifest]);
+        assert!(matches!(
+            rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+
+        // Publish one future line and confirm the receiver gets it once.
+        let success = serialize_pull_line(&OllamaPullStatus::success()).unwrap();
+        publish_pull_bytes(&tx, history.as_ref(), success.clone()).await;
+        assert_eq!(rx.recv().await.unwrap(), success);
+        assert!(matches!(
+            rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
     }
 
     #[test]

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -907,12 +907,13 @@ pub struct OllamaPullRequest {
 }
 
 impl OllamaPullRequest {
-    /// Return the client-requested model, preferring `name` over `model`.
+    /// Return the client-requested model, preferring `model` (canonical Ollama
+    /// field) over `name` (legacy alias).
     fn requested_model(&self) -> Option<&str> {
-        let preferred = if self.name.trim().is_empty() {
-            self.model.trim()
-        } else {
+        let preferred = if self.model.trim().is_empty() {
             self.name.trim()
+        } else {
+            self.model.trim()
         };
         if preferred.is_empty() {
             None
@@ -1305,6 +1306,7 @@ async fn run_active_pull(
 ) {
     let mut last_error: Option<String> = None;
     let mut emitted_error_line = false;
+    let mut abandoned = false;
 
     loop {
         tokio::select! {
@@ -1339,33 +1341,45 @@ async fn run_active_pull(
                 }
             }
             _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {
-                // If no subscribers remain, stop broadcasting.  The Go pull
-                // continues to completion in the background but we no longer
-                // buffer its output.
-                if tx.receiver_count() == 0 && waiters.load(Ordering::Relaxed) == 0 {
-                    line_rx.close();
-                    break;
+                // If no subscribers remain, stop broadcasting.  Hold the
+                // registry lock while checking so that `get_or_start` cannot
+                // hand out this `ActivePull` after the decision to abandon.
+                if tx.receiver_count() == 0 {
+                    let mut guard = registry.lock().await;
+                    // Re-check under the lock — a new client may have arrived
+                    // between the first check and acquiring the lock.
+                    if tx.receiver_count() == 0 && waiters.load(Ordering::Acquire) == 0 {
+                        guard.remove(&key);
+                        line_rx.close();
+                        abandoned = true;
+                        break;
+                    }
                 }
             }
         }
     }
 
-    let final_result = match last_error {
-        Some(error) => Err(error),
-        None => Ok(()),
-    };
+    // When abandoned, `done_tx` drops without sending a result.  Any late
+    // waiter that somehow obtained the `ActivePull` before the registry
+    // removal will see a channel-closed error rather than spurious success.
+    if !abandoned {
+        let final_result = match last_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        };
 
-    if let Err(ref message) = final_result {
-        if !emitted_error_line {
-            if let Ok(bytes) = serialize_pull_line(&OllamaPullStatus::error(message)) {
-                publish_pull_bytes(&tx, history.as_ref(), bytes).await;
+        if let Err(ref message) = final_result {
+            if !emitted_error_line {
+                if let Ok(bytes) = serialize_pull_line(&OllamaPullStatus::error(message)) {
+                    publish_pull_bytes(&tx, history.as_ref(), bytes).await;
+                }
             }
         }
-    }
 
-    let _ = done_tx.send(Some(final_result));
-    let mut guard = registry.lock().await;
-    guard.remove(&key);
+        let _ = done_tx.send(Some(final_result));
+        let mut guard = registry.lock().await;
+        guard.remove(&key);
+    }
 }
 
 /// Parse and re-encode one helper line before exposing it to HTTP clients.
@@ -1646,7 +1660,7 @@ async fn spawn_worker(
     let mut child = std::process::Command::new(&exe)
         .args(&args)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::inherit())
         .spawn()
         .map_err(|e| {
             (
@@ -5347,24 +5361,33 @@ mod tests {
     }
 
     #[test]
-    fn ollama_pull_request_prefers_name_field() {
-        // Prefer the legacy `name` field when both are present.
+    fn ollama_pull_request_prefers_model_field() {
+        // Prefer the canonical `model` field when both are present.
         let req = OllamaPullRequest {
             model: "gemma3".to_string(),
             name: "custom".to_string(),
             insecure: false,
             stream: None,
         };
+        assert_eq!(req.requested_model(), Some("gemma3"));
+
+        // Fall back to `name` when `model` is empty.
+        let req = OllamaPullRequest {
+            model: String::new(),
+            name: "custom".to_string(),
+            insecure: false,
+            stream: None,
+        };
         assert_eq!(req.requested_model(), Some("custom"));
 
-        // Fall back to `model` when `name` is empty.
+        // Return None when both are empty.
         let req = OllamaPullRequest {
-            model: "gemma3".to_string(),
+            model: String::new(),
             name: String::new(),
             insecure: false,
             stream: None,
         };
-        assert_eq!(req.requested_model(), Some("gemma3"));
+        assert_eq!(req.requested_model(), None);
     }
 
     #[test]

--- a/oci-models/common.go
+++ b/oci-models/common.go
@@ -12,6 +12,29 @@ import (
 	"golang.org/x/term"
 )
 
+// ollamaPullStatus matches the NDJSON objects emitted by Ollama's /api/pull.
+type ollamaPullStatus struct {
+	Status    string `json:"status,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	Total     uint64 `json:"total,omitempty"`
+	Completed uint64 `json:"completed,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// shortDigest shortens a SHA-256 digest for Ollama-style progress messages.
+func shortDigest(digest string) string {
+	const prefix = "sha256:"
+	const shortLen = 12
+
+	if len(digest) >= len(prefix)+shortLen && digest[:len(prefix)] == prefix {
+		return digest[len(prefix) : len(prefix)+shortLen]
+	}
+	if len(digest) > shortLen {
+		return digest[:shortLen]
+	}
+	return digest
+}
+
 // getStorePath mirrors envconfig.ModelsPath() from model-runner.
 func getStorePath() (string, error) {
 	if s := os.Getenv("MODELS_PATH"); s != "" {

--- a/oci-models/lib.go
+++ b/oci-models/lib.go
@@ -6,18 +6,32 @@ package main
 
 /*
 #include <stdlib.h>
+
+// Callback type for streaming pull progress.  Each invocation passes one
+// NDJSON line (NUL-terminated) and the opaque context pointer the caller
+// supplied to oci_pull_stream.
+typedef void (*oci_progress_fn)(const char* line, void* ctx);
+
+// C trampoline — cgo cannot call C function pointers directly from Go.
+static inline void invoke_progress(oci_progress_fn fn, const char* line, void* ctx) {
+	fn(line, ctx);
+}
 */
 import "C"
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
 	"unsafe"
 
 	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/pkg/distribution/oci"
 )
 
 // lastError stores the most recent error message.  Protected by a mutex
@@ -98,6 +112,112 @@ func oci_pull(reference *C.char) *C.char {
 	return C.CString(bundle.RootDir())
 }
 
+// oci_pull_stream pulls an OCI model and streams Ollama-compatible NDJSON
+// progress to the given callback.  Each callback invocation receives one
+// complete NDJSON line.  Returns 0 on success, -1 on error.  On error the
+// callback will have received an NDJSON object with an "error" field and
+// oci_last_error will contain the message.
+//
+//export oci_pull_stream
+func oci_pull_stream(reference *C.char, callback C.oci_progress_fn, ctx unsafe.Pointer) C.int {
+	ref := C.GoString(reference)
+
+	client, err := newClient()
+	if err != nil {
+		emitCallback(callback, ctx, ollamaPullStatus{Error: fmt.Sprintf("client: %v", err)})
+		setLastError(fmt.Errorf("client: %w", err))
+		return -1
+	}
+
+	pr, pw := io.Pipe()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- streamProgressToCallback(pr, callback, ctx)
+	}()
+
+	pullErr := client.PullModel(context.Background(), ref, pw)
+	pw.Close()
+	progressErr := <-done
+
+	if pullErr != nil {
+		emitCallback(callback, ctx, ollamaPullStatus{Error: fmt.Sprintf("pull: %v", pullErr)})
+		setLastError(fmt.Errorf("pull: %w", pullErr))
+		return -1
+	}
+	if progressErr != nil {
+		emitCallback(callback, ctx, ollamaPullStatus{Error: fmt.Sprintf("progress: %v", progressErr)})
+		setLastError(fmt.Errorf("progress: %w", progressErr))
+		return -1
+	}
+
+	// Emit the final Ollama-compatible status sequence.
+	for _, status := range []string{
+		"verifying sha256 digest",
+		"writing manifest",
+		"removing any unused layers",
+		"success",
+	} {
+		emitCallback(callback, ctx, ollamaPullStatus{Status: status})
+	}
+
+	setLastError(nil)
+	return 0
+}
+
+// emitCallback serializes a pull status as JSON and invokes the C callback.
+func emitCallback(callback C.oci_progress_fn, ctx unsafe.Pointer, status ollamaPullStatus) {
+	data, err := json.Marshal(status)
+	if err != nil {
+		return
+	}
+	cLine := C.CString(string(data))
+	C.invoke_progress(callback, cLine, ctx)
+	C.free(unsafe.Pointer(cLine))
+}
+
+// streamProgressToCallback reads Docker Model Runner progress messages from r
+// and emits Ollama-compatible NDJSON to the C callback.
+func streamProgressToCallback(r io.Reader, callback C.oci_progress_fn, ctx unsafe.Pointer) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	emittedManifest := false
+	for scanner.Scan() {
+		var msg oci.ProgressMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			return fmt.Errorf("decode progress: %w", err)
+		}
+
+		switch msg.Type {
+		case oci.TypeProgress:
+			if !emittedManifest {
+				emitCallback(callback, ctx, ollamaPullStatus{Status: "pulling manifest"})
+				emittedManifest = true
+			}
+			if msg.Layer.ID == "" {
+				continue
+			}
+			emitCallback(callback, ctx, ollamaPullStatus{
+				Status:    fmt.Sprintf("pulling %s", shortDigest(msg.Layer.ID)),
+				Digest:    msg.Layer.ID,
+				Total:     msg.Layer.Size,
+				Completed: msg.Layer.Current,
+			})
+		case oci.TypeWarning:
+			emitCallback(callback, ctx, ollamaPullStatus{Status: msg.Message})
+		case oci.TypeError:
+			return fmt.Errorf("%s", msg.Message)
+		case oci.TypeSuccess:
+			// Ignore; final sequence emitted after PullModel returns.
+		default:
+			return fmt.Errorf("unsupported progress message type %q", msg.Type)
+		}
+	}
+
+	return scanner.Err()
+}
+
 // oci_bundle returns the bundle path for an already-pulled model.
 // Returns NULL if the model is not in the local store (check oci_last_error
 // for details).  Caller must free the returned string with oci_free_string.
@@ -122,6 +242,39 @@ func oci_bundle(reference *C.char) *C.char {
 	return C.CString(bundle.RootDir())
 }
 
+// oci_list returns all local OCI models as tab-separated "tag\tid\n" lines.
+// Returns NULL on error (check oci_last_error for details).  Caller must free
+// the returned string with oci_free_string.
+//
+//export oci_list
+func oci_list() *C.char {
+	client, err := newClient()
+	if err != nil {
+		setLastError(fmt.Errorf("client: %w", err))
+		return nil
+	}
+
+	models, err := client.ListModels()
+	if err != nil {
+		setLastError(fmt.Errorf("list: %w", err))
+		return nil
+	}
+
+	var buf strings.Builder
+	for _, m := range models {
+		id, err := m.ID()
+		if err != nil {
+			continue
+		}
+		for _, tag := range m.Tags() {
+			fmt.Fprintf(&buf, "%s\t%s\n", tag, id)
+		}
+	}
+
+	setLastError(nil)
+	return C.CString(buf.String())
+}
+
 // oci_last_error returns the last error message, or NULL if no error.
 // The returned string must be freed by the caller with oci_free_string.
 //
@@ -136,7 +289,7 @@ func oci_last_error() *C.char {
 }
 
 // oci_free_string frees a string previously returned by oci_pull, oci_bundle,
-// or oci_last_error.
+// oci_list, or oci_last_error.
 //
 //export oci_free_string
 func oci_free_string(s *C.char) {

--- a/oci-models/main.go
+++ b/oci-models/main.go
@@ -26,15 +26,6 @@ import (
 	"github.com/docker/model-runner/pkg/distribution/oci"
 )
 
-// ollamaPullStatus matches the NDJSON objects emitted by Ollama's /api/pull.
-type ollamaPullStatus struct {
-	Status    string `json:"status,omitempty"`
-	Digest    string `json:"digest,omitempty"`
-	Total     uint64 `json:"total,omitempty"`
-	Completed uint64 `json:"completed,omitempty"`
-	Error     string `json:"error,omitempty"`
-}
-
 // cmdPull pulls a model and prints its bundle directory to stdout.
 func cmdPull(ref string) error {
 	client, err := newClient()
@@ -225,20 +216,6 @@ func writeStreamError(err error) error {
 	}
 	_ = writePullStatus(ollamaPullStatus{Error: err.Error()})
 	return err
-}
-
-// shortDigest shortens a SHA-256 digest for Ollama-style progress messages.
-func shortDigest(digest string) string {
-	const prefix = "sha256:"
-	const shortLen = 12
-
-	if len(digest) >= len(prefix)+shortLen && digest[:len(prefix)] == prefix {
-		return digest[len(prefix) : len(prefix)+shortLen]
-	}
-	if len(digest) > shortLen {
-		return digest[:shortLen]
-	}
-	return digest
 }
 
 // usage prints CLI usage help to stderr.

--- a/oci-models/main.go
+++ b/oci-models/main.go
@@ -8,48 +8,58 @@
 //
 // Commands:
 //
-//	inferrs-oci-models pull  <reference>   Pull a model and print the bundle path.
-//	inferrs-oci-models bundle <reference>  Print the bundle path for an already-pulled model.
-//	inferrs-oci-models list                List all models in the store (tag\tid).
+//	inferrs-oci-models pull   <reference>   Pull a model and print the bundle path.
+//	inferrs-oci-models stream <reference>   Pull a model and emit Ollama NDJSON progress.
+//	inferrs-oci-models bundle <reference>   Print the bundle path for an already-pulled model.
+//	inferrs-oci-models list                 List all models in the store (tag\tid).
 package main
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/docker/model-runner/cmd/cli/desktop"
+	"github.com/docker/model-runner/pkg/distribution/oci"
 )
 
+// ollamaPullStatus matches the NDJSON objects emitted by Ollama's /api/pull.
+type ollamaPullStatus struct {
+	Status    string `json:"status,omitempty"`
+	Digest    string `json:"digest,omitempty"`
+	Total     uint64 `json:"total,omitempty"`
+	Completed uint64 `json:"completed,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// cmdPull pulls a model and prints its bundle directory to stdout.
 func cmdPull(ref string) error {
 	client, err := newClient()
 	if err != nil {
 		return err
 	}
 
-	// Create a pipe: PullModel writes JSON progress to pw,
-	// DisplayProgress reads from pr and renders Docker-style progress bars.
+	// Create a pipe: PullModel writes JSON progress to pw, and DMR's progress
+	// printer renders Docker-style progress bars from pr.
 	pr, pw := io.Pipe()
 
 	type pullResult struct {
-		msg      string
-		progress bool
-		err      error
+		msg string
+		err error
 	}
 	done := make(chan pullResult, 1)
 
 	go func() {
-		// Use DMR's exact progress rendering (Docker-style multi-line bars).
-		msg, progress, err := desktop.DisplayProgress(pr, &stderrPrinter{})
-		done <- pullResult{msg, progress, err}
+		msg, _, err := desktop.DisplayProgress(pr, &stderrPrinter{})
+		done <- pullResult{msg: msg, err: err}
 	}()
 
-	// Pull the model.
+	// Pull the model and wait until the progress renderer drains the pipe.
 	pullErr := client.PullModel(context.Background(), ref, pw)
-	pw.Close()
-
-	// Wait for progress rendering to finish.
+	_ = pw.Close()
 	result := <-done
 	if pullErr != nil {
 		return fmt.Errorf("pull: %w", pullErr)
@@ -58,22 +68,60 @@ func cmdPull(ref string) error {
 		return fmt.Errorf("progress: %w", result.err)
 	}
 
-	// Print final message from progress stream (e.g. "Model pulled successfully").
+	// Print the final helper message, if any, before returning the bundle path.
 	if result.msg != "" {
 		fmt.Fprintf(os.Stderr, "%s\n", result.msg)
 	}
 
-	// Ensure the bundle is created and print its root directory.
 	bundle, err := client.GetBundle(ref)
 	if err != nil {
 		return fmt.Errorf("bundle: %w", err)
 	}
 
-	// stdout: the bundle path — this is what the Rust caller reads.
 	fmt.Println(bundle.RootDir())
 	return nil
 }
 
+// cmdStream pulls a model and emits Ollama-compatible NDJSON progress.
+func cmdStream(ref string) error {
+	client, err := newClient()
+	if err != nil {
+		return err
+	}
+
+	pr, pw := io.Pipe()
+	done := make(chan error, 1)
+
+	go func() {
+		done <- forwardPullProgress(pr)
+	}()
+
+	pullErr := client.PullModel(context.Background(), ref, pw)
+	_ = pw.Close()
+	progressErr := <-done
+
+	if pullErr != nil {
+		return writeStreamError(fmt.Errorf("pull: %w", pullErr))
+	}
+	if progressErr != nil {
+		return writeStreamError(fmt.Errorf("progress: %w", progressErr))
+	}
+
+	for _, status := range []string{
+		"verifying sha256 digest",
+		"writing manifest",
+		"removing any unused layers",
+		"success",
+	} {
+		if err := writePullStatus(ollamaPullStatus{Status: status}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cmdBundle prints the bundle directory of an already-pulled model.
 func cmdBundle(ref string) error {
 	client, err := newClient()
 	if err != nil {
@@ -89,6 +137,7 @@ func cmdBundle(ref string) error {
 	return nil
 }
 
+// cmdList prints local OCI models in a simple tab-separated format.
 func cmdList() error {
 	client, err := newClient()
 	if err != nil {
@@ -112,14 +161,106 @@ func cmdList() error {
 	return nil
 }
 
+// forwardPullProgress converts DMR OCI progress messages into Ollama NDJSON.
+func forwardPullProgress(r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	emittedManifest := false
+	for scanner.Scan() {
+		var msg oci.ProgressMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			return fmt.Errorf("decode progress: %w", err)
+		}
+
+		switch msg.Type {
+		case oci.TypeProgress:
+			if !emittedManifest {
+				if err := writePullStatus(
+					ollamaPullStatus{Status: "pulling manifest"},
+				); err != nil {
+					return err
+				}
+				emittedManifest = true
+			}
+			if msg.Layer.ID == "" {
+				continue
+			}
+			if err := writePullStatus(ollamaPullStatus{
+				Status:    fmt.Sprintf("pulling %s", shortDigest(msg.Layer.ID)),
+				Digest:    msg.Layer.ID,
+				Total:     msg.Layer.Size,
+				Completed: msg.Layer.Current,
+			}); err != nil {
+				return err
+			}
+		case oci.TypeWarning:
+			if err := writePullStatus(
+				ollamaPullStatus{Status: msg.Message},
+			); err != nil {
+				return err
+			}
+		case oci.TypeError:
+			return fmt.Errorf("%s", msg.Message)
+		case oci.TypeSuccess:
+			// Ignore the raw success event. The helper emits the final
+			// Ollama-compatible completion sequence after PullModel returns.
+		default:
+			return fmt.Errorf("unsupported progress message type %q", msg.Type)
+		}
+	}
+
+	return scanner.Err()
+}
+
+// writePullStatus writes one Ollama pull status object to stdout.
+func writePullStatus(status ollamaPullStatus) error {
+	return json.NewEncoder(os.Stdout).Encode(status)
+}
+
+// writeStreamError writes an Ollama-compatible error object and returns it.
+func writeStreamError(err error) error {
+	if err == nil {
+		return nil
+	}
+	_ = writePullStatus(ollamaPullStatus{Error: err.Error()})
+	return err
+}
+
+// shortDigest shortens a SHA-256 digest for Ollama-style progress messages.
+func shortDigest(digest string) string {
+	const prefix = "sha256:"
+	const shortLen = 12
+
+	if len(digest) >= len(prefix)+shortLen && digest[:len(prefix)] == prefix {
+		return digest[len(prefix) : len(prefix)+shortLen]
+	}
+	if len(digest) > shortLen {
+		return digest[:shortLen]
+	}
+	return digest
+}
+
+// usage prints CLI usage help to stderr.
 func usage() {
 	fmt.Fprintf(os.Stderr, "Usage: inferrs-oci-models <command> [args]\n\n")
 	fmt.Fprintf(os.Stderr, "Commands:\n")
-	fmt.Fprintf(os.Stderr, "  pull  <reference>   Pull a model and print bundle path\n")
-	fmt.Fprintf(os.Stderr, "  bundle <reference>  Print bundle path for existing model\n")
-	fmt.Fprintf(os.Stderr, "  list                List all models in the store\n")
+	fmt.Fprintf(
+		os.Stderr,
+		"  pull   <reference>   Pull a model and print bundle path\n",
+	)
+	fmt.Fprintf(
+		os.Stderr,
+		"  stream <reference>   Pull a model and emit Ollama NDJSON progress\n",
+	)
+	fmt.Fprintf(
+		os.Stderr,
+		"  bundle <reference>   Print bundle path for existing model\n",
+	)
+	fmt.Fprintf(os.Stderr, "  list                 List all models in the store\n")
 }
 
+// main dispatches the requested helper subcommand.
 func main() {
 	if len(os.Args) < 2 {
 		usage()
@@ -134,6 +275,12 @@ func main() {
 			os.Exit(1)
 		}
 		err = cmdPull(os.Args[2])
+	case "stream":
+		if len(os.Args) < 3 {
+			fmt.Fprintf(os.Stderr, "Usage: inferrs-oci-models stream <reference>\n")
+			os.Exit(1)
+		}
+		err = cmdStream(os.Args[2])
 	case "bundle":
 		if len(os.Args) < 3 {
 			fmt.Fprintf(os.Stderr, "Usage: inferrs-oci-models bundle <reference>\n")


### PR DESCRIPTION
## feat: OCI model pull with streaming progress via `/api/pull`

Add Ollama-compatible `POST /api/pull` endpoint to the HTTP server with streaming NDJSON progress, and refactor the CLI `inferrs pull` to delegate OCI pulls through the server.

### Changes

- **Server (`server.rs`)**: New `POST /api/pull` endpoint that streams Ollama-compatible NDJSON progress lines. Concurrent pulls to the same reference are deduplicated.
- **Pull (`pull.rs`)**: 
  - OCI pulls now go through the server's `/api/pull` instead of calling the Go library directly. If the server isn't running, it is auto-started (same pattern as `inferrs run`).
  - Added `oci_pull_stream_start()` FFI streaming callback for the server to use the Go shared library without spawning a subprocess.
  - Added `normalize_oci_reference()` for consistent reference handling.
  - Added `oci_list_models()` to list locally cached OCI models.
- **Go library (`oci-models/`)**: New `oci_pull_stream` and `oci_list` C exports with callback-based streaming progress.
- **Makefile**: Standardized helper binary naming; added cross-platform support.
- **CLI**: `inferrs pull` is now async; added `--host`/`--port` flags for server connection.

---

¿Te parece bien esta descripción o quieres que ajuste algo (más corta, diferente formato, en inglés/español, etc.)? Si estás conforme, puedes **toggle to Act mode** y la creo/actualizo donde necesites.