### PR TITLE
 Qwen: add Mixture-of-Experts (MoE) FFN support

### DIFF
--- a/inferrs-models/src/config.rs
+++ b/inferrs-models/src/config.rs
@@ -240,6 +240,15 @@ pub struct TextConfig {
     // Qwen3.5 MTP fields
     pub mtp_num_hidden_layers: Option<usize>,
 
+    // Qwen3.5 MoE fields (num_experts and moe_intermediate_size are shared with Gemma4 below)
+    pub num_experts_per_tok: Option<usize>,
+    pub decoder_sparse_step: Option<usize>,
+    pub mlp_only_layers: Option<Vec<usize>>,
+    pub norm_topk_prob: Option<bool>,
+    /// Qwen3.5 MoE shared-expert branch: hidden dim of the dense expert that
+    /// runs in parallel with the sparse experts. None = no shared expert.
+    pub shared_expert_intermediate_size: Option<usize>,
+
     // Gemma4-specific text_config fields
     pub global_head_dim: Option<usize>,
     pub sliding_window: Option<usize>,
@@ -330,7 +339,7 @@ impl RawConfig {
     pub fn detect_architecture(&self) -> Result<ModelArchitecture> {
         if let Some(archs) = &self.architectures {
             for arch in archs {
-                if arch.contains("Qwen3_5") {
+                if arch.contains("Qwen3_5") || arch.contains("Qwen3_5Moe") {
                     return Ok(ModelArchitecture::Qwen35);
                 }
                 if arch.contains("Qwen3") {
@@ -358,7 +367,7 @@ impl RawConfig {
             match model_type.as_str() {
                 "qwen2" | "qwen2_5" => return Ok(ModelArchitecture::Qwen2),
                 "qwen3" => return Ok(ModelArchitecture::Qwen3),
-                "qwen3_5" => return Ok(ModelArchitecture::Qwen35),
+                "qwen3_5" | "qwen3_5_moe" => return Ok(ModelArchitecture::Qwen35),
                 "gemma4" => return Ok(ModelArchitecture::Gemma4),
                 "gemma3" => return Ok(ModelArchitecture::Gemma3),
                 "gemma2" => return Ok(ModelArchitecture::Gemma2),
@@ -683,6 +692,14 @@ impl RawConfig {
             device,
             turbo_quant_bits,
             mtp_num_hidden_layers: tc.and_then(|t| t.mtp_num_hidden_layers).unwrap_or(0),
+            // num_experts and moe_intermediate_size are stored in TextConfig shared fields.
+            num_experts: tc.and_then(|t| t.num_experts),
+            num_experts_per_tok: tc.and_then(|t| t.num_experts_per_tok),
+            moe_intermediate_size: tc.and_then(|t| t.moe_intermediate_size),
+            decoder_sparse_step: tc.and_then(|t| t.decoder_sparse_step),
+            mlp_only_layers: tc.and_then(|t| t.mlp_only_layers.clone()),
+            norm_topk_prob: tc.and_then(|t| t.norm_topk_prob),
+            shared_expert_intermediate_size: tc.and_then(|t| t.shared_expert_intermediate_size),
         }
     }
 

--- a/inferrs-models/src/models/gemma4_moe.rs
+++ b/inferrs-models/src/models/gemma4_moe.rs
@@ -23,9 +23,9 @@
 
 use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::{rms_norm, Activation, RmsNorm, VarBuilder};
-use std::sync::Arc;
 
 use crate::models::gemma4::Gemma4Config;
+use crate::models::moe_utils::{split_expert_qtensor, MoeExpertWeights};
 use crate::models::quantized_linear::{qlinear_b, QGgufVarBuilder, QLinear};
 
 // ---------------------------------------------------------------------------
@@ -47,76 +47,6 @@ pub(super) fn rms_norm_no_scale(xs: &Tensor, eps: f64) -> Result<Tensor> {
     } else {
         normed.to_dtype(orig_dtype)
     }
-}
-
-/// Per-expert weight storage: either a Vec of per-expert QTensors (GGUF path)
-/// or a single fused dense tensor `[num_experts, rows, cols]` (safetensors path).
-#[derive(Debug, Clone)]
-enum MoeExpertWeights {
-    /// GGUF path: one `Arc<QTensor>` per expert, shape `[rows, cols]`, on the
-    /// target device (Metal/CUDA/CPU).  `QLinear::from_qtensor` wraps each one
-    /// directly so the Metal GEMV kernel fires without a BF16 intermediate.
-    Quantized(Vec<Arc<candle_core::quantized::QTensor>>),
-    /// Safetensors path: fused dense tensor `[num_experts, rows, cols]`.
-    Dense(Tensor),
-}
-
-impl MoeExpertWeights {
-    /// Return a `QLinear` for a single expert.
-    ///
-    /// On the GGUF path the per-expert `Arc<QTensor>` is stored on the target
-    /// device (Metal/CUDA/CPU), so `QLinear::forward` dispatches directly to the
-    /// Metal/CUDA quantized GEMV kernel (Q8_0, Q4K, …) — no BF16 intermediate.
-    /// On the safetensors path the dense weight slice is wrapped as `QMatMul::Tensor`.
-    fn expert_linear(&self, expert_idx: usize) -> Result<QLinear> {
-        match self {
-            Self::Quantized(qtensors) => QLinear::from_qtensor(qtensors[expert_idx].clone(), None),
-            Self::Dense(t) => Ok(QLinear::from_tensor(
-                t.narrow(0, expert_idx, 1)?.squeeze(0)?,
-                None,
-            )),
-        }
-    }
-}
-
-/// Split a fused `[num_experts, rows, cols]` QTensor into per-expert QTensors.
-///
-/// The fused QTensor's raw bytes are laid out in expert-major order; we slice
-/// off `bytes_per_expert` bytes for each expert and build a `QTensor` of shape
-/// `(rows, cols)`.  Both `rows × cols` must be a multiple of the quantization
-/// block size.
-fn split_expert_qtensor(
-    qt: Arc<candle_core::quantized::QTensor>,
-    num_experts: usize,
-    per_expert_shape: (usize, usize),
-    device: &Device,
-) -> Result<MoeExpertWeights> {
-    use candle_core::quantized::{QStorage, QTensor};
-    use std::borrow::Cow;
-
-    let raw = qt.data()?;
-    if raw.len() % num_experts != 0 {
-        candle_core::bail!(
-            "split_expert_qtensor: raw byte count {} is not divisible by num_experts {}",
-            raw.len(),
-            num_experts
-        );
-    }
-    let dtype_q = qt.dtype();
-    let bytes_per_expert = raw.len() / num_experts;
-
-    let mut experts = Vec::with_capacity(num_experts);
-    for e in 0..num_experts {
-        let start = e * bytes_per_expert;
-        let end = start + bytes_per_expert;
-        // Use Cow::Borrowed so the original bytes stay alive through `qt`
-        // while `from_data` → `as_t_slice` reads them via a raw pointer.
-        // Using Cow::Owned would free the allocation inside `as_t_slice`
-        // (before `.to_vec()` copies it out), which is use-after-free.
-        let storage = QStorage::from_data(Cow::Borrowed(&raw[start..end]), device, dtype_q)?;
-        experts.push(Arc::new(QTensor::new(storage, per_expert_shape)?));
-    }
-    Ok(MoeExpertWeights::Quantized(experts))
 }
 
 // ---------------------------------------------------------------------------
@@ -490,97 +420,6 @@ mod tests {
         let vals: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
         for (i, v) in vals.iter().enumerate() {
             assert!((v - 1.0).abs() < 1e-5, "element {i}: expected 1.0, got {v}");
-        }
-    }
-
-    // ── split_expert_qtensor ──────────────────────────────────────────────────
-
-    /// Build a Q8_0 QTensor whose raw bytes are filled with a known pattern,
-    /// split it into `num_experts` per-expert tensors, and verify each expert
-    /// gets exactly its own byte slice.
-    ///
-    /// Q8_0 block layout: 32 i8 values (32 bytes) + 1 f16 scale (2 bytes) = 34
-    /// bytes per block.  We use shape (num_experts * rows, block_size) so that:
-    ///   - each expert gets `rows` rows of `block_size` elements
-    ///   - total elements = num_experts * rows * block_size, all divisible by 32
-    #[test]
-    fn split_expert_qtensor_byte_layout() {
-        use candle_core::quantized::{GgmlDType, QTensor};
-
-        let num_experts = 4usize;
-        let rows_per_expert = 2usize; // 2 rows per expert
-        let cols = 64usize; // 64 cols (2 Q8_0 blocks of 32 per row)
-        let total_rows = num_experts * rows_per_expert;
-
-        // Build a dense F32 tensor with a recognisable per-expert pattern:
-        // expert e fills its rows with float value (e + 1) as f32.
-        let data: Vec<f32> = (0..num_experts)
-            .flat_map(|e| std::iter::repeat((e + 1) as f32).take(rows_per_expert * cols))
-            .collect();
-        let t = Tensor::from_vec(data, (total_rows, cols), &cpu()).unwrap();
-
-        // Quantize to Q8_0 to get a real QTensor.
-        let qt = std::sync::Arc::new(QTensor::quantize(&t, GgmlDType::Q8_0).unwrap());
-
-        // Split.
-        let weights =
-            split_expert_qtensor(qt, num_experts, (rows_per_expert, cols), &cpu()).unwrap();
-
-        let qtensors = match weights {
-            MoeExpertWeights::Quantized(v) => v,
-            MoeExpertWeights::Dense(_) => panic!("expected Quantized variant"),
-        };
-
-        assert_eq!(qtensors.len(), num_experts);
-
-        // Dequantize each expert and verify values are close to (e+1).
-        for (e, qt_e) in qtensors.iter().enumerate() {
-            assert_eq!(
-                qt_e.shape().dims(),
-                &[rows_per_expert, cols],
-                "expert {e} has wrong shape"
-            );
-            let dequant = qt_e.dequantize(&cpu()).unwrap();
-            let vals: Vec<f32> = dequant.flatten_all().unwrap().to_vec1().unwrap();
-            let expected = (e + 1) as f32;
-            for (i, v) in vals.iter().enumerate() {
-                assert!(
-                    (v - expected).abs() < 0.15, // Q8_0 max error ≈ 0.1
-                    "expert {e} element {i}: expected ~{expected}, got {v}"
-                );
-            }
-        }
-    }
-
-    // ── MoeExpertWeights::expert_linear (Dense path) ──────────────────────────
-
-    /// expert_linear on a Dense tensor must return the correct row slice.
-    /// We use a (4, 3, 2) tensor (4 experts, 3×2 weight each) and verify
-    /// expert 2 returns exactly the values from rows 6..9.
-    #[test]
-    fn moe_expert_weights_dense_slice_correctness() {
-        // Fill each expert e with float value (e as f32) so we can easily
-        // identify which slice we got.
-        let data: Vec<f32> = (0..4)
-            .flat_map(|e| std::iter::repeat(e as f32).take(3 * 2))
-            .collect();
-        let t = Tensor::from_vec(data, (4usize, 3usize, 2usize), &cpu()).unwrap();
-        let weights = MoeExpertWeights::Dense(t);
-
-        for e in 0..4usize {
-            let ql = weights.expert_linear(e).unwrap();
-            // Forward a ones input [1, 2] — result is sum of the row weights.
-            let input = Tensor::ones((1usize, 2usize), DType::F32, &cpu()).unwrap();
-            let out = ql.forward(&input).unwrap();
-            let vals: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
-            // Each weight is (e as f32); input is all-ones; out = sum over cols = 2 * e.
-            let expected = 2.0 * e as f32;
-            for (i, v) in vals.iter().enumerate() {
-                assert!(
-                    (v - expected).abs() < 1e-4,
-                    "expert {e} output[{i}]: expected {expected}, got {v}"
-                );
-            }
         }
     }
 

--- a/inferrs-models/src/models/mod.rs
+++ b/inferrs-models/src/models/mod.rs
@@ -6,10 +6,12 @@
 pub mod attention_utils;
 pub mod gemma4;
 mod gemma4_moe;
+mod moe_utils;
 pub mod quantized_linear;
 pub mod qwen3;
 pub mod qwen3_5;
 pub mod qwen3_5_linear_attn_scan;
+mod qwen3_5_moe;
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor};
@@ -928,6 +930,16 @@ fn gguf_rename_layer_suffix(suffix: &str, arch: &ModelArchitecture) -> String {
         "linear_attn.in_proj_b.weight" => "linear_attn_in_proj_b.weight",
         "linear_attn.out_proj.weight" => "linear_attn_out_proj.weight",
 
+        // ── Qwen3.5 MoE (sparse FFN layers) ──────────────────────────────
+        "mlp.gate.weight" => "ffn_gate_inp.weight",
+        "mlp.experts.gate_up_proj" => "ffn_gate_exps.weight",
+        "mlp.experts.down_proj" => "ffn_down_exps.weight",
+        // Qwen3.5 MoE shared expert (dense branch running in parallel).
+        "mlp.shared_expert.gate_proj.weight" => "ffn_gate_shexp.weight",
+        "mlp.shared_expert.up_proj.weight" => "ffn_up_shexp.weight",
+        "mlp.shared_expert.down_proj.weight" => "ffn_down_shexp.weight",
+        "mlp.shared_expert_gate.weight" => "ffn_gate_inp_shexp.weight",
+
         // Fallback: pass through the suffix unchanged so that `blk.{idx}.`
         // prefix is still applied.  This handles any tensors not explicitly
         // listed above without causing a lookup failure.
@@ -1013,6 +1025,15 @@ fn gguf_reverse_layer_suffix(suffix: &str, arch: &ModelArchitecture) -> String {
         "proj.weight" => "per_layer_projection.weight",
         "post_norm.weight" => "post_per_layer_input_norm.weight",
         "layer_output_scale.weight" => "layer_scalar",
+        // ── Qwen3.5 MoE ──────────────────────────────────────────────────
+        "ffn_gate_inp.weight" => "mlp.gate.weight",
+        "ffn_gate_exps.weight" => "mlp.experts.gate_up_proj",
+        "ffn_down_exps.weight" => "mlp.experts.down_proj",
+        // Qwen3.5 MoE shared expert.
+        "ffn_gate_shexp.weight" => "mlp.shared_expert.gate_proj.weight",
+        "ffn_up_shexp.weight" => "mlp.shared_expert.up_proj.weight",
+        "ffn_down_shexp.weight" => "mlp.shared_expert.down_proj.weight",
+        "ffn_gate_inp_shexp.weight" => "mlp.shared_expert_gate.weight",
         // Passthrough for unknown suffixes
         other => return other.to_string(),
     };

--- a/inferrs-models/src/models/moe_utils.rs
+++ b/inferrs-models/src/models/moe_utils.rs
@@ -1,0 +1,162 @@
+//! Shared helpers for Mixture-of-Experts FFN components.
+//!
+//! Both the Gemma4 MoE path (`gemma4_moe.rs`) and the Qwen3.5 MoE path
+//! (`qwen3_5_moe.rs`) need the same primitive: a uniform "per-expert weight"
+//! storage that can be either a list of quantized `QTensor`s (one per expert,
+//! on the target device) or a fused dense tensor of shape
+//! `[num_experts, rows, cols]` (safetensors path), plus the logic to slice a
+//! fused GGUF QTensor into per-expert QTensors.
+//!
+//! These primitives live here so the two MoE implementations stay in sync —
+//! any future change (new quant format, new backend split, ...) is made once.
+
+use candle_core::{Device, Result, Tensor};
+use std::sync::Arc;
+
+use crate::models::quantized_linear::QLinear;
+
+/// Per-expert weight storage: either a Vec of per-expert QTensors (GGUF path)
+/// or a single fused dense tensor `[num_experts, rows, cols]` (safetensors path).
+#[derive(Debug, Clone)]
+pub(crate) enum MoeExpertWeights {
+    /// GGUF path: one `Arc<QTensor>` per expert, shape `[rows, cols]`, on the
+    /// target device (Metal/CUDA/CPU).  `QLinear::from_qtensor` wraps each one
+    /// directly so the Metal GEMV kernel fires without a BF16 intermediate.
+    Quantized(Vec<Arc<candle_core::quantized::QTensor>>),
+    /// Safetensors path: fused dense tensor `[num_experts, rows, cols]`.
+    Dense(Tensor),
+}
+
+impl MoeExpertWeights {
+    /// Return a `QLinear` for a single expert.
+    ///
+    /// On the GGUF path the per-expert `Arc<QTensor>` is stored on the target
+    /// device (Metal/CUDA/CPU), so `QLinear::forward` dispatches directly to the
+    /// Metal/CUDA quantized GEMV kernel (Q8_0, Q4K, …) — no BF16 intermediate.
+    /// On the safetensors path the dense weight slice is wrapped as `QMatMul::Tensor`.
+    pub(crate) fn expert_linear(&self, expert_idx: usize) -> Result<QLinear> {
+        match self {
+            Self::Quantized(qtensors) => QLinear::from_qtensor(qtensors[expert_idx].clone(), None),
+            Self::Dense(t) => Ok(QLinear::from_tensor(
+                t.narrow(0, expert_idx, 1)?.squeeze(0)?,
+                None,
+            )),
+        }
+    }
+}
+
+/// Split a fused `[num_experts, rows, cols]` QTensor into per-expert QTensors.
+///
+/// The fused QTensor's raw bytes are laid out in expert-major order; we slice
+/// off `bytes_per_expert` bytes for each expert and build a `QTensor` of shape
+/// `(rows, cols)`.  Both `rows × cols` must be a multiple of the quantization
+/// block size.
+pub(crate) fn split_expert_qtensor(
+    qt: Arc<candle_core::quantized::QTensor>,
+    num_experts: usize,
+    per_expert_shape: (usize, usize),
+    device: &Device,
+) -> Result<MoeExpertWeights> {
+    use candle_core::quantized::{QStorage, QTensor};
+    use std::borrow::Cow;
+
+    let raw = qt.data()?;
+    if raw.len() % num_experts != 0 {
+        candle_core::bail!(
+            "split_expert_qtensor: raw byte count {} is not divisible by num_experts {}",
+            raw.len(),
+            num_experts
+        );
+    }
+    let dtype_q = qt.dtype();
+    let bytes_per_expert = raw.len() / num_experts;
+
+    let mut experts = Vec::with_capacity(num_experts);
+    for e in 0..num_experts {
+        let start = e * bytes_per_expert;
+        let end = start + bytes_per_expert;
+        // MUST be Cow::Borrowed, not Cow::Owned. `from_data` copies the bytes
+        // into the target storage (CPU `to_vec`, Metal `new_buffer_with_data`,
+        // CUDA `memcpy_htod`) before returning, so `raw` outliving this call
+        // is sufficient. The trap: candle's `as_t_slice(data: Cow) -> &[T]`
+        // takes the Cow by value and returns a raw-pointer slice into it —
+        // with Cow::Owned the Vec is freed when the parameter drops, leaving
+        // the caller (`to_vec` / `new_buffer_with_data` / `memcpy_htod`) to
+        // read freed memory. Borrowed is a no-op drop, so it's safe.
+        let storage = QStorage::from_data(Cow::Borrowed(&raw[start..end]), device, dtype_q)?;
+        experts.push(Arc::new(QTensor::new(storage, per_expert_shape)?));
+    }
+    Ok(MoeExpertWeights::Quantized(experts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{DType, Device, Module, Tensor};
+
+    fn cpu() -> Device {
+        Device::Cpu
+    }
+
+    #[test]
+    fn split_expert_qtensor_byte_layout() {
+        use candle_core::quantized::{GgmlDType, QTensor};
+
+        let num_experts = 4usize;
+        let rows_per_expert = 2usize;
+        let cols = 64usize;
+        let total_rows = num_experts * rows_per_expert;
+
+        let data: Vec<f32> = (0..num_experts)
+            .flat_map(|e| std::iter::repeat((e + 1) as f32).take(rows_per_expert * cols))
+            .collect();
+        let t = Tensor::from_vec(data, (total_rows, cols), &cpu()).unwrap();
+        let qt = std::sync::Arc::new(QTensor::quantize(&t, GgmlDType::Q8_0).unwrap());
+
+        let weights =
+            split_expert_qtensor(qt, num_experts, (rows_per_expert, cols), &cpu()).unwrap();
+
+        let qtensors = match weights {
+            MoeExpertWeights::Quantized(v) => v,
+            MoeExpertWeights::Dense(_) => panic!("expected Quantized variant"),
+        };
+
+        assert_eq!(qtensors.len(), num_experts);
+
+        for (e, qt_e) in qtensors.iter().enumerate() {
+            assert_eq!(qt_e.shape().dims(), &[rows_per_expert, cols]);
+            let dequant = qt_e.dequantize(&cpu()).unwrap();
+            let vals: Vec<f32> = dequant.flatten_all().unwrap().to_vec1().unwrap();
+            let expected = (e + 1) as f32;
+            for (i, v) in vals.iter().enumerate() {
+                assert!(
+                    (v - expected).abs() < 0.15,
+                    "expert {e} element {i}: expected ~{expected}, got {v}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn moe_expert_weights_dense_slice_correctness() {
+        let data: Vec<f32> = (0..4)
+            .flat_map(|e| std::iter::repeat(e as f32).take(3 * 2))
+            .collect();
+        let t = Tensor::from_vec(data, (4usize, 3usize, 2usize), &cpu()).unwrap();
+        let weights = MoeExpertWeights::Dense(t);
+
+        for e in 0..4usize {
+            let ql = weights.expert_linear(e).unwrap();
+            let input = Tensor::ones((1usize, 2usize), DType::F32, &cpu()).unwrap();
+            let out = ql.forward(&input).unwrap();
+            let vals: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+            let expected = 2.0 * e as f32;
+            for (i, v) in vals.iter().enumerate() {
+                assert!(
+                    (v - expected).abs() < 1e-4,
+                    "expert {e} output[{i}]: expected {expected}, got {v}"
+                );
+            }
+        }
+    }
+}

--- a/inferrs-models/src/models/qwen3_5.rs
+++ b/inferrs-models/src/models/qwen3_5.rs
@@ -20,6 +20,7 @@ use crate::models::attention_utils::{
 };
 use crate::models::quantized_linear::{qlinear_b, QGgufVarBuilder, QLinear};
 use crate::models::qwen3_5_linear_attn_scan::{gated_delta_rule_chunked, sequential_step};
+use crate::models::qwen3_5_moe::Qwen3MoeSparseBlock;
 use crate::turbo_quant::{TurboQuantConfig, TurboQuantKvCache};
 
 fn rms_norm_with_offset(size: usize, eps: f64, vb: VarBuilder, offset: f64) -> Result<RmsNorm> {
@@ -65,6 +66,19 @@ pub struct Qwen35Config {
     pub turbo_quant_bits: Option<u8>,
     /// Number of MTP transformer blocks embedded in the model weights (0 = none).
     pub mtp_num_hidden_layers: usize,
+    // MoE fields — all None when the model is dense.
+    pub num_experts: Option<usize>,
+    pub num_experts_per_tok: Option<usize>,
+    pub moe_intermediate_size: Option<usize>,
+    /// How often a layer uses sparse MoE instead of dense MLP (1 = every layer).
+    pub decoder_sparse_step: Option<usize>,
+    /// Layer indices forced to use a dense MLP even when MoE is enabled.
+    pub mlp_only_layers: Option<Vec<usize>>,
+    /// Normalize top-k routing probabilities to sum to 1 after selection.
+    pub norm_topk_prob: Option<bool>,
+    /// Hidden dim of the Qwen3.5 MoE shared-expert branch. None = no shared expert
+    /// (plain Qwen3 MoE behaviour).
+    pub shared_expert_intermediate_size: Option<usize>,
 }
 
 // ---------------------------------------------------------------------------
@@ -892,14 +906,14 @@ enum LayerAttn {
     Linear(Box<LinearAttn>),
 }
 
-struct QMlp {
+pub(super) struct QMlp {
     gate_proj: QLinear,
     up_proj: QLinear,
     down_proj: QLinear,
 }
 
 impl QMlp {
-    fn new(
+    pub(super) fn new(
         hidden_size: usize,
         intermediate_size: usize,
         vb: VarBuilder,
@@ -930,7 +944,7 @@ impl QMlp {
         })
     }
 
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+    pub(super) fn forward(&self, x: &Tensor) -> Result<Tensor> {
         // On the quantized (GGUF) Metal/CPU path, pre-convert x to F32 once and share
         // the conversion across gate_proj and up_proj (saves 2 BF16→F32 dispatches/call).
         // CUDA (BF16 fast-path) and dense safetensors fall through to the standard path.
@@ -1046,19 +1060,27 @@ fn gqa_attention_no_expand(
         .map_err(Into::into)
 }
 
+enum MlpVariant {
+    Dense(QMlp),
+    Sparse(Qwen3MoeSparseBlock),
+}
+
 struct DecoderLayer {
     attn: LayerAttn,
-    mlp: QMlp,
+    mlp: MlpVariant,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
 
 impl DecoderLayer {
+    /// `layer_idx` is `Some(i)` for main model layers (used to decide Dense vs Sparse MoE)
+    /// and `None` for auxiliary layers like MTP that should always use a dense MLP.
     fn new(
         cfg: &Qwen35Config,
         vb: VarBuilder,
         qvb: Option<&QGgufVarBuilder>,
         is_full_attention: bool,
+        layer_idx: Option<usize>,
         tq_cfg: Option<&TurboQuantConfig>,
     ) -> Result<Self> {
         let attn = if is_full_attention {
@@ -1075,14 +1097,48 @@ impl DecoderLayer {
                 qvb.map(|q| q.pp("linear_attn")).as_ref(),
             )?))
         };
-        Ok(Self {
-            attn,
-            mlp: QMlp::new(
+
+        let use_moe = cfg.num_experts.is_some() && {
+            match layer_idx {
+                None => false, // MTP / auxiliary layers always use dense MLP
+                Some(idx) => {
+                    // `decoder_sparse_step` = N means "every N-th layer is MoE,
+                    // the rest are dense MLP". N=1 (default) means every layer
+                    // is MoE, matching the pure Qwen3.5 MoE reference. N=0 is
+                    // invalid (would mean "never sparse" but is never emitted
+                    // by HF configs); we normalize it to 1 to avoid a div-by-0.
+                    // The `(idx + 1) % step` offset matches HF's
+                    // `Qwen3MoeDecoderLayer.__init__`; for N > 1 this picks
+                    // layers N-1, 2N-1, … as sparse (disjoint from `idx % step`).
+                    let step = cfg.decoder_sparse_step.unwrap_or(1).max(1);
+                    let is_sparse_step = (idx + 1) % step == 0;
+                    let not_mlp_only = cfg
+                        .mlp_only_layers
+                        .as_ref()
+                        .is_none_or(|list| !list.contains(&idx));
+                    is_sparse_step && not_mlp_only
+                }
+            }
+        };
+
+        let mlp = if use_moe {
+            MlpVariant::Sparse(Qwen3MoeSparseBlock::new(
+                cfg,
+                vb.pp("mlp"),
+                qvb.map(|q| q.pp("mlp")).as_ref(),
+            )?)
+        } else {
+            MlpVariant::Dense(QMlp::new(
                 cfg.hidden_size,
                 cfg.intermediate_size,
                 vb.pp("mlp"),
                 qvb.map(|q| q.pp("mlp")).as_ref(),
-            )?,
+            )?)
+        };
+
+        Ok(Self {
+            attn,
+            mlp,
             input_layernorm: rms_norm_with_offset(
                 cfg.hidden_size,
                 cfg.rms_norm_eps,
@@ -1114,7 +1170,10 @@ impl DecoderLayer {
         let x = (residual + attn_out)?;
         let residual = x.clone();
         let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
+        let mlp_out = match &self.mlp {
+            MlpVariant::Dense(m) => m.forward(&normed)?,
+            MlpVariant::Sparse(m) => m.forward(&normed)?,
+        };
         (residual + mlp_out).map_err(Into::into)
     }
 
@@ -1143,7 +1202,10 @@ impl DecoderLayer {
         let x = (residual + attn_out)?;
         let residual = x.clone();
         let normed = self.post_attention_layernorm.forward(&x)?;
-        let mlp_out = self.mlp.forward(&normed)?;
+        let mlp_out = match &self.mlp {
+            MlpVariant::Dense(m) => m.forward(&normed)?,
+            MlpVariant::Sparse(m) => m.forward(&normed)?,
+        };
         (residual + mlp_out).map_err(Into::into)
     }
 
@@ -1273,7 +1335,7 @@ impl Qwen35Model {
                 .into_iter()
                 .enumerate()
                 .map(|(i, (vb, qvb, is_full))| {
-                    DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, tq_cfg.as_ref())
+                    DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, Some(i), tq_cfg.as_ref())
                         .with_context(|| format!("loading layer {i}"))
                 })
                 .collect::<Result<Vec<_>>>()?;
@@ -1285,8 +1347,15 @@ impl Qwen35Model {
                         .into_par_iter()
                         .enumerate()
                         .map(|(i, (vb, qvb, is_full))| {
-                            DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, tq_cfg.as_ref())
-                                .with_context(|| format!("loading layer {i}"))
+                            DecoderLayer::new(
+                                cfg,
+                                vb,
+                                qvb.as_ref(),
+                                is_full,
+                                Some(i),
+                                tq_cfg.as_ref(),
+                            )
+                            .with_context(|| format!("loading layer {i}"))
                         })
                         .collect::<Result<Vec<_>>>()
                 },
@@ -1528,7 +1597,8 @@ impl MtpModule {
             mtp_qvb.as_ref().map(|q| q.pp("fc")).as_ref(),
         )?;
 
-        // The MTP block is always a full-attention layer, under mtp.layers.0.*
+        // The MTP block is always a full-attention layer with dense MLP, under mtp.layers.0.*
+        // layer_idx=None forces the dense MLP path regardless of MoE config.
         let layer_vb = mtp_vb.pp("layers").pp("0");
         let layer_qvb = mtp_qvb.as_ref().map(|q| q.pp("layers").pp("0"));
         let block = DecoderLayer::new(
@@ -1536,6 +1606,7 @@ impl MtpModule {
             layer_vb,
             layer_qvb.as_ref(),
             true, // is_full_attention
+            None, // force dense MLP (MTP weights have no expert tensors)
             None, // no TurboQuant for MTP block
         )?;
 

--- a/inferrs-models/src/models/qwen3_5_moe.rs
+++ b/inferrs-models/src/models/qwen3_5_moe.rs
@@ -1,0 +1,458 @@
+//! Sparse MoE FFN components for the Qwen3.5 MoE variant.
+//!
+//! Exposes three `pub(super)` structs used by `DecoderLayer` in `qwen3_5.rs`:
+//!
+//! * [`Qwen3MoeRouter`]      — maps hidden states to top-k expert routing weights/indices.
+//! * [`Qwen3MoeExperts`]     — per-expert FFN dispatch (gate+up SwiGLU + down projection).
+//! * [`Qwen3MoeSparseBlock`] — combines router + experts + optional sigmoid-gated shared dense MLP
+//!   (present on Qwen3.5 MoE checkpoints, absent on plain Qwen3 MoE).
+//!
+//! ## Weight layout
+//!
+//! Expert weights are stored fused: `gate_up_proj` is `[num_experts, 2*moe_intermediate, hidden]`
+//! and `down_proj` is `[num_experts, hidden, moe_intermediate]`.
+//!
+//! On the GGUF (inferrs-quantized) path each expert's slice is stored as an
+//! `Arc<QTensor>` on the target device so the Metal/CUDA quantized GEMV kernel
+//! fires directly without a BF16 intermediate.
+//!
+//! ## HuggingFace weight names (under the layer's `mlp.*` VarBuilder prefix)
+//!
+//!   `gate.weight`              — router projection `[num_experts, hidden]`
+//!   `experts.gate_up_proj`     — fused experts gate+up `[num_experts, 2*intermediate, hidden]`
+//!   `experts.down_proj`        — fused experts down    `[num_experts, hidden, intermediate]`
+//!
+//! ## External llama.cpp GGUF names (per layer block `blk.N.*`)
+//!
+//!   `ffn_gate_inp.weight`  → `mlp.gate.weight`
+//!   `ffn_gate_exps.weight` → `mlp.experts.gate_up_proj`
+//!   `ffn_down_exps.weight` → `mlp.experts.down_proj`
+//!
+//! ## Known performance limitations
+//!
+//! This implementation mirrors the Gemma4 MoE pattern and inherits its two
+//! main throughput ceilings. Both are acceptable for decode but measurable on
+//! long prefill, and the cost scales with `num_experts` (Qwen3.5 MoE ships up
+//! to 256 experts versus Gemma4's 8, so the constants here are ~32× heavier).
+//!
+//! **1. Sequential per-expert dispatch.** `Qwen3MoeExperts::forward` iterates
+//! `num_experts` times, calling one quantized GEMV per active expert. The
+//! HuggingFace reference uses the same per-expert loop with `index_add_` under
+//! the hood, but a fused scatter-gather kernel (Metal/CUDA) would let all
+//! active experts run in a single dispatch. That kernel is future work.
+//!
+//! **2. GPU→CPU routing sync.** `top_k_indices` and `top_k_weights` are read
+//! back to CPU (`to_vec1`) to build per-expert token lists before dispatch.
+//! On single-token decode this is a handful of values and negligible; on
+//! prefill with long sequences it adds one host-read per MoE layer. A pure
+//! on-device dispatch (e.g. expert_mask + `index_add` on GPU, as PyTorch does)
+//! would remove the sync at the cost of implementing scatter-gather in the
+//! kernel layer.
+//!
+//! See `models/gemma4_moe.rs` for the same tradeoff documented on the
+//! Gemma4 code path.
+
+use candle_core::{DType, Device, Result, Tensor, D};
+use candle_nn::VarBuilder;
+
+use crate::models::moe_utils::{split_expert_qtensor, MoeExpertWeights};
+use crate::models::quantized_linear::{qlinear_b, QGgufVarBuilder, QLinear};
+use crate::models::qwen3_5::{QMlp, Qwen35Config};
+
+// ---------------------------------------------------------------------------
+// Qwen3MoeRouter
+// ---------------------------------------------------------------------------
+
+/// Expert router: linear projection → softmax → top-k selection.
+///
+/// Simpler than `Gemma4MoeRouter` — no learned `scale` or `per_expert_scale`.
+/// Matches `Qwen3MoeTopKRouter` in HuggingFace transformers.
+#[derive(Debug, Clone)]
+pub(super) struct Qwen3MoeRouter {
+    proj: QLinear,
+    top_k: usize,
+    norm_topk_prob: bool,
+}
+
+impl Qwen3MoeRouter {
+    /// `vb` should be pointing at the `gate` sub-module (i.e. `vb.pp("gate")`).
+    pub(super) fn new(
+        cfg: &Qwen35Config,
+        vb: VarBuilder,
+        qvb: Option<&QGgufVarBuilder>,
+    ) -> Result<Self> {
+        let num_experts = cfg.num_experts.unwrap_or(256);
+        let proj = qlinear_b(cfg.hidden_size, num_experts, false, vb, qvb)?;
+        Ok(Self {
+            proj,
+            top_k: cfg.num_experts_per_tok.unwrap_or(8),
+            // Qwen3.5 MoE always normalizes top-k weights (matches HF reference).
+            // The config flag is only present as an escape hatch for Qwen3 MoE
+            // checkpoints where the tuned behaviour is explicitly False.
+            norm_topk_prob: cfg.norm_topk_prob.unwrap_or(true),
+        })
+    }
+
+    /// Returns `(top_k_weights, top_k_indices)`, both `[seq, top_k]`.
+    pub(super) fn forward(&self, hidden: &Tensor) -> Result<(Tensor, Tensor)> {
+        let in_dtype = hidden.dtype();
+        // [seq, num_experts]
+        let logits = hidden.apply(&self.proj)?;
+        // Softmax in F32 to match HF reference (F.softmax(..., dtype=torch.float)).
+        // With up to 256 experts and BF16 logits, lower-precision softmax degrades
+        // routing quality — the probability differences between tail experts can
+        // fall below BF16's ~1e-2 relative precision.
+        let probs = candle_nn::ops::softmax(&logits.to_dtype(DType::F32)?, D::Minus1)?;
+        let top_k_indices = probs
+            .arg_sort_last_dim(false)? // descending: largest first
+            .narrow(D::Minus1, 0, self.top_k)?
+            .contiguous()?;
+        let top_k_weights = probs.gather(&top_k_indices, D::Minus1)?;
+        let top_k_weights = if self.norm_topk_prob {
+            let sum = top_k_weights.sum_keepdim(D::Minus1)?;
+            top_k_weights.broadcast_div(&sum)?
+        } else {
+            top_k_weights
+        };
+        Ok((top_k_weights.to_dtype(in_dtype)?, top_k_indices))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Qwen3MoeExperts
+// ---------------------------------------------------------------------------
+
+/// Fused expert weight matrices for all `num_experts` experts.
+///
+/// Gate and up projections are stored fused: `[num_experts, 2*moe_intermediate, hidden]`.
+#[derive(Debug, Clone)]
+pub(super) struct Qwen3MoeExperts {
+    gate_up_proj: MoeExpertWeights,
+    down_proj: MoeExpertWeights,
+    num_experts: usize,
+    moe_intermediate_size: usize,
+}
+
+impl Qwen3MoeExperts {
+    /// `vb` should be pointing at the `experts` sub-module (i.e. `vb.pp("experts")`).
+    pub(super) fn new(
+        cfg: &Qwen35Config,
+        vb: VarBuilder,
+        qvb: Option<&QGgufVarBuilder>,
+    ) -> Result<Self> {
+        let device = vb.device();
+        let num_experts = cfg.num_experts.unwrap_or(256);
+        let moe_intermediate_size = cfg.moe_intermediate_size.unwrap_or(2048);
+        let hidden_size = cfg.hidden_size;
+        let dtype = cfg.dtype;
+
+        let (gate_up_proj, down_proj) = if let Some(q) = qvb {
+            let gate_up_proj = match q.get_qtensor_named("gate_up_proj") {
+                Some(qt) => split_expert_qtensor(
+                    qt,
+                    num_experts,
+                    (2 * moe_intermediate_size, hidden_size),
+                    device,
+                )?,
+                None => MoeExpertWeights::Dense(
+                    vb.get(
+                        (num_experts, 2 * moe_intermediate_size, hidden_size),
+                        "gate_up_proj",
+                    )?
+                    .to_dtype(dtype)?,
+                ),
+            };
+            let down_proj = match q.get_qtensor_named("down_proj") {
+                Some(qt) => split_expert_qtensor(
+                    qt,
+                    num_experts,
+                    (hidden_size, moe_intermediate_size),
+                    device,
+                )?,
+                None => MoeExpertWeights::Dense(
+                    vb.get(
+                        (num_experts, hidden_size, moe_intermediate_size),
+                        "down_proj",
+                    )?
+                    .to_dtype(dtype)?,
+                ),
+            };
+            (gate_up_proj, down_proj)
+        } else {
+            let gate_up = vb
+                .get(
+                    (num_experts, 2 * moe_intermediate_size, hidden_size),
+                    "gate_up_proj",
+                )?
+                .to_dtype(dtype)?;
+            let down = vb
+                .get(
+                    (num_experts, hidden_size, moe_intermediate_size),
+                    "down_proj",
+                )?
+                .to_dtype(dtype)?;
+            (
+                MoeExpertWeights::Dense(gate_up),
+                MoeExpertWeights::Dense(down),
+            )
+        };
+
+        Ok(Self {
+            gate_up_proj,
+            down_proj,
+            num_experts,
+            moe_intermediate_size,
+        })
+    }
+
+    /// Dispatch tokens to their selected experts, compute SwiGLU FFNs, scatter-add.
+    ///
+    /// `hidden`:        `[seq, hidden]`
+    /// `top_k_indices`: `[seq, top_k]` u32
+    /// `top_k_weights`: `[seq, top_k]`
+    pub(super) fn forward(
+        &self,
+        hidden: &Tensor,
+        top_k_indices: &Tensor,
+        top_k_weights: &Tensor,
+    ) -> Result<Tensor> {
+        let seq_len = hidden.dim(0)?;
+        let hidden_size = hidden.dim(1)?;
+        let dtype = hidden.dtype();
+        let device = hidden.device();
+        let top_k = top_k_indices.dim(1)?;
+
+        let indices_vec = top_k_indices
+            .to_dtype(DType::U32)?
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<u32>()?;
+        let weights_vec = top_k_weights
+            .to_dtype(DType::F32)?
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+
+        let mut expert_tokens: Vec<Vec<(u32, f32)>> = vec![Vec::new(); self.num_experts];
+        for t in 0..seq_len {
+            for k in 0..top_k {
+                let eidx = indices_vec[t * top_k + k] as usize;
+                let w = weights_vec[t * top_k + k];
+                expert_tokens[eidx].push((t as u32, w));
+            }
+        }
+
+        let mut result = Tensor::zeros((seq_len, hidden_size), dtype, device)?;
+
+        for (expert_idx, tokens) in expert_tokens.iter().enumerate() {
+            if tokens.is_empty() {
+                continue;
+            }
+            let n = tokens.len();
+            let (tok_pos, tok_weights): (Vec<u32>, Vec<f32>) =
+                tokens.iter().map(|&(t, w)| (t, w)).unzip();
+
+            let idx_tensor = Tensor::from_vec(tok_pos, n, device)?;
+            let current = hidden.index_select(&idx_tensor, 0)?; // [n, hidden]
+
+            let gate_up_linear = self.gate_up_proj.expert_linear(expert_idx)?;
+            let gate_up_out = current.apply(&gate_up_linear)?; // [n, 2*intermediate]
+
+            let gate = gate_up_out.narrow(1, 0, self.moe_intermediate_size)?;
+            let up =
+                gate_up_out.narrow(1, self.moe_intermediate_size, self.moe_intermediate_size)?;
+            let hidden_act = (gate.silu()? * up)?;
+
+            let down_linear = self.down_proj.expert_linear(expert_idx)?;
+            let expert_out = hidden_act.apply(&down_linear)?; // [n, hidden]
+
+            let w_tensor = Tensor::from_vec(tok_weights, n, device)?
+                .to_dtype(dtype)?
+                .unsqueeze(1)?; // [n, 1]
+            let expert_out_scaled = expert_out.broadcast_mul(&w_tensor)?;
+            result = result.index_add(&idx_tensor, &expert_out_scaled, 0)?;
+        }
+
+        Ok(result)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Qwen3MoeSparseBlock
+// ---------------------------------------------------------------------------
+
+/// The full sparse MoE block: router + experts + optional shared expert.
+///
+/// Qwen3.5 MoE runs every token through **both** the top-k sparse experts
+/// and a single dense *shared expert* gated by a sigmoid of a per-token
+/// scalar, then sums the two outputs:
+///
+/// ```text
+///     sparse_out + sigmoid(shared_expert_gate(x)) * shared_expert(x)
+/// ```
+///
+/// When `shared_expert_intermediate_size` is `None` in the config (e.g. plain
+/// Qwen3 MoE checkpoints), `shared_expert` / `shared_expert_gate` are absent
+/// and the block degrades to a pure sparse-only MoE.
+pub(super) struct Qwen3MoeSparseBlock {
+    router: Qwen3MoeRouter,
+    experts: Qwen3MoeExperts,
+    shared_expert: Option<QMlp>,
+    shared_expert_gate: Option<QLinear>,
+}
+
+impl Qwen3MoeSparseBlock {
+    /// `vb` should be pointing at the `mlp` sub-module (same prefix as `QMlp`).
+    pub(super) fn new(
+        cfg: &Qwen35Config,
+        vb: VarBuilder,
+        qvb: Option<&QGgufVarBuilder>,
+    ) -> Result<Self> {
+        let router = Qwen3MoeRouter::new(cfg, vb.pp("gate"), qvb.map(|q| q.pp("gate")).as_ref())?;
+        let experts =
+            Qwen3MoeExperts::new(cfg, vb.pp("experts"), qvb.map(|q| q.pp("experts")).as_ref())?;
+
+        // Optional shared expert branch (Qwen3.5 MoE). Only built when the
+        // config reports a shared_expert_intermediate_size — plain Qwen3 MoE
+        // checkpoints set this to None and skip the branch entirely.
+        let (shared_expert, shared_expert_gate) =
+            if let Some(shared_intermediate) = cfg.shared_expert_intermediate_size {
+                // QMlp::new returns anyhow::Result (qwen3_5.rs uses anyhow),
+                // while this module uses candle_core::Result — wrap via Msg.
+                let se = QMlp::new(
+                    cfg.hidden_size,
+                    shared_intermediate,
+                    vb.pp("shared_expert"),
+                    qvb.map(|q| q.pp("shared_expert")).as_ref(),
+                )
+                .map_err(|e| candle_core::Error::Msg(format!("shared_expert: {e}")))?;
+                let seg = qlinear_b(
+                    cfg.hidden_size,
+                    1,
+                    false,
+                    vb.pp("shared_expert_gate"),
+                    qvb.map(|q| q.pp("shared_expert_gate")).as_ref(),
+                )?;
+                (Some(se), Some(seg))
+            } else {
+                (None, None)
+            };
+
+        Ok(Self {
+            router,
+            experts,
+            shared_expert,
+            shared_expert_gate,
+        })
+    }
+
+    /// Forward pass. Accepts any shape `[..., hidden]`, returns the same shape.
+    pub(super) fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
+        let orig_shape = hidden.shape().clone();
+        let h = *orig_shape.dims().last().unwrap();
+        let flat = hidden.reshape(((), h))?; // [batch*seq, hidden]
+
+        let (top_k_weights, top_k_indices) = self.router.forward(&flat)?;
+        let sparse_out = self
+            .experts
+            .forward(&flat, &top_k_indices, &top_k_weights)?;
+
+        // Shared expert branch (Qwen3.5): sigmoid-gated dense MLP added on top.
+        let output = match (&self.shared_expert, &self.shared_expert_gate) {
+            (Some(se), Some(seg)) => {
+                // QMlp::forward returns anyhow::Result — convert for this module.
+                let shared_out = se
+                    .forward(&flat)
+                    .map_err(|e| candle_core::Error::Msg(format!("shared_expert forward: {e}")))?;
+                let gate_logits = flat.apply(seg)?; // [seq, 1]
+                let gate_act = candle_nn::ops::sigmoid(&gate_logits)?;
+                let shared_weighted = shared_out.broadcast_mul(&gate_act)?;
+                (sparse_out + shared_weighted)?
+            }
+            _ => sparse_out,
+        };
+
+        output.reshape(&orig_shape)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    fn cpu() -> Device {
+        Device::Cpu
+    }
+
+    // ── Router: top-k weights sum invariant ──────────────────────────────────
+
+    /// With norm_topk_prob=true, each token's selected weights must sum to 1.0.
+    #[test]
+    fn router_topk_weights_sum_to_one_when_normed() {
+        use crate::models::quantized_linear::QLinear;
+
+        let num_experts = 8usize;
+        let hidden = 16usize;
+        let top_k = 3usize;
+        let dev = cpu();
+
+        let proj_w = Tensor::randn(0f32, 1.0, (num_experts, hidden), &dev).unwrap();
+        let proj = QLinear::from_tensor(proj_w, None);
+
+        let router = Qwen3MoeRouter {
+            proj,
+            top_k,
+            norm_topk_prob: true,
+        };
+
+        let hidden_states = Tensor::randn(0f32, 1.0, (2usize, hidden), &dev).unwrap();
+        let (weights, _indices) = router.forward(&hidden_states).unwrap();
+
+        let sums: Vec<f32> = weights.sum(D::Minus1).unwrap().to_vec1().unwrap();
+
+        for (tok, s) in sums.iter().enumerate() {
+            assert!(
+                (s - 1.0).abs() < 1e-5,
+                "token {tok}: top-k weights sum to {s}, expected 1.0"
+            );
+        }
+    }
+
+    /// With norm_topk_prob=false, weights are raw softmax probs (sum < 1.0 is ok).
+    #[test]
+    fn router_topk_weights_no_renorm() {
+        use crate::models::quantized_linear::QLinear;
+
+        let num_experts = 8usize;
+        let hidden = 16usize;
+        let top_k = 3usize;
+        let dev = cpu();
+
+        let proj_w = Tensor::randn(0f32, 1.0, (num_experts, hidden), &dev).unwrap();
+        let proj = QLinear::from_tensor(proj_w, None);
+
+        let router = Qwen3MoeRouter {
+            proj,
+            top_k,
+            norm_topk_prob: false,
+        };
+
+        let hidden_states = Tensor::randn(0f32, 1.0, (1usize, hidden), &dev).unwrap();
+        let (weights, indices) = router.forward(&hidden_states).unwrap();
+
+        // Shapes must be correct.
+        assert_eq!(weights.dims(), &[1, top_k]);
+        assert_eq!(indices.dims(), &[1, top_k]);
+
+        // All weights must be in (0, 1).
+        let vals: Vec<f32> = weights.flatten_all().unwrap().to_vec1().unwrap();
+        for v in &vals {
+            assert!(*v > 0.0 && *v < 1.0, "weight {v} not in (0,1)");
+        }
+    }
+}


### PR DESCRIPTION
TLDR: full support of qwen 3.5 MoE, sharing the code with gemma 4. More perf optimisations coming later but there is already a lot of work in this PR. We are close to a full Qwen 3.6 support

---

Adds sparse MoE FFN layers to the Qwen3.5 architecture, including the Qwen3.5-specific shared-expert branch (a dense MLP gated by sigmoid of a per-token scalar, summed with the top-k sparse expert output).

Mirrors the pattern already established for Gemma4 MoE: expert weights stored fused on the target device for Metal/CUDA quantized GEMV, top-k routing with optional norm, per-expert dispatch loop.