### PR TITLE
Feat/gguf tiled head order

### DIFF
--- a/inferrs-models/src/gptq.rs
+++ b/inferrs-models/src/gptq.rs
@@ -121,15 +121,24 @@ pub fn dequant_gptq_from_bytes(
     // safetensors guarantees ≥8-byte alignment for all tensor data, which
     // satisfies i32 (4 B) and bf16 (2 B). Assert in debug to catch regressions.
     let qweight = unsafe {
-        debug_assert_eq!(qweight_bytes.as_ptr() as usize % std::mem::align_of::<i32>(), 0);
+        debug_assert_eq!(
+            qweight_bytes.as_ptr() as usize % std::mem::align_of::<i32>(),
+            0
+        );
         std::slice::from_raw_parts(qweight_bytes.as_ptr() as *const i32, in_dim / 8 * out_dim)
     };
     let qzeros = unsafe {
-        debug_assert_eq!(qzeros_bytes.as_ptr() as usize % std::mem::align_of::<i32>(), 0);
+        debug_assert_eq!(
+            qzeros_bytes.as_ptr() as usize % std::mem::align_of::<i32>(),
+            0
+        );
         std::slice::from_raw_parts(qzeros_bytes.as_ptr() as *const i32, n_groups * out_dim / 8)
     };
     let scales = unsafe {
-        debug_assert_eq!(scales_bytes.as_ptr() as usize % std::mem::align_of::<bf16>(), 0);
+        debug_assert_eq!(
+            scales_bytes.as_ptr() as usize % std::mem::align_of::<bf16>(),
+            0
+        );
         std::slice::from_raw_parts(scales_bytes.as_ptr() as *const bf16, n_groups * out_dim)
     };
 

--- a/inferrs-models/src/models/mod.rs
+++ b/inferrs-models/src/models/mod.rs
@@ -829,17 +829,9 @@ impl Qwen35NormFixBackend {
             return Ok(tensor);
         }
         let max_v = vals.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
-        let min_v = vals.iter().cloned().fold(f32::INFINITY, f32::min);
         if max_v >= 0.0 {
-            tracing::debug!(
-                "Qwen35 ssm_a appears to be HF `log(A)` (min={min_v:.3}, max={max_v:.3}); no transform"
-            );
             return Ok(tensor);
         }
-        tracing::info!(
-            "Qwen35 ssm_a detected as llama.cpp `-A` (min={min_v:.3}, max={max_v:.3}); \
-             transforming to `A_log = log(-ssm_a)`"
-        );
         // A_log = log(-ssm_a). Both ops preserve dtype.
         tensor.neg()?.log()
     }
@@ -927,14 +919,8 @@ fn var_builder_from_gguf(
     let boxed: Box<dyn candle_nn::var_builder::SimpleBackend + 'static> = if is_external_gguf
         && matches!(arch, ModelArchitecture::Gemma2 | ModelArchitecture::Gemma3)
     {
-        tracing::info!(
-            "{arch:?}: applying GemmaNormFixBackend to correct RMSNorm scale for external GGUF"
-        );
         Box::new(GemmaNormFixBackend { inner: backend })
     } else if is_external_gguf && matches!(arch, ModelArchitecture::Qwen35) {
-        tracing::info!(
-            "Qwen35: applying Qwen35NormFixBackend to correct RMSNorm scale for external GGUF"
-        );
         Box::new(Qwen35NormFixBackend { inner: backend })
     } else {
         Box::new(backend)
@@ -1395,12 +1381,6 @@ pub fn load_model(
             // SSM key/value correlation stays correct.  No-op for symmetric
             // models (ratio=1) since the permutation is identity.
             if is_external_gguf && config.linear_num_value_heads > config.linear_num_key_heads {
-                tracing::info!(
-                    "Qwen3.5: external GGUF detected with asymmetric SSM heads \
-                     ({} key / {} value); switching GQA expansion to GGUF head order",
-                    config.linear_num_key_heads,
-                    config.linear_num_value_heads,
-                );
                 config.gguf_external_head_order = true;
             }
             tracing::info!(

--- a/inferrs-models/src/models/qwen3_5.rs
+++ b/inferrs-models/src/models/qwen3_5.rs
@@ -549,94 +549,14 @@ struct LinearAttn {
     head_v_dim: usize,     // = linear_value_head_dim
     key_dim: usize,        // = n_key_heads   * head_k_dim
     value_dim: usize,      // = n_value_heads * head_v_dim
+    // When true, all value-head-indexed tensors are in GGUF tiled order
+    // (llama.cpp reshape(n_key,ratio).T.flatten()). GQA expansion in forward
+    // uses unsqueeze(2) instead of unsqueeze(3) to match.
+    gguf_external_head_order: bool,
     // Recurrent state: [b, n_value_heads, head_k_dim, head_v_dim], F32
     recurrent_state: Option<Tensor>,
     // Conv state: [b, conv_dim, kernel-1], used for causal padding across calls
     conv_state: Option<Tensor>,
-}
-
-/// Inverse of llama.cpp's `reshape(n_key, ratio).T.flatten()` value-head
-/// permutation applied along the first dim of `t`.
-///
-/// Given a tensor whose leading dim enumerates `n_value_heads` in llama.cpp
-/// order — `[v_{2k}, v_{2k+1}]` groups stored as `[first-of-group..., second-of-group...]`
-/// — returns a new tensor in HF natural order where consecutive positions
-/// correspond to consecutive value-heads.  No-op when `ratio == 1`.
-///
-/// Used to undo the llama.cpp convention for the per-value-head tensors
-/// `ssm_a` (1-D), `ssm_dt.bias` (1-D), `ssm_alpha.weight` / `ssm_beta.weight`
-/// (2-D) so that downstream SSM code sees a single consistent ordering.
-fn unpermute_value_heads(
-    t: Tensor,
-    n_key_heads: usize,
-    n_value_heads: usize,
-    ratio: usize,
-) -> Result<Tensor> {
-    if ratio <= 1 {
-        return Ok(t);
-    }
-    let rest_dims: Vec<usize> = t.dims().iter().skip(1).copied().collect();
-    let mut from_shape = vec![ratio, n_key_heads];
-    from_shape.extend_from_slice(&rest_dims);
-    let mut to_shape = vec![n_value_heads];
-    to_shape.extend_from_slice(&rest_dims);
-    Ok(t.reshape(from_shape)?
-        .transpose(0, 1)?
-        .contiguous()?
-        .reshape(to_shape)?)
-}
-
-/// Inverse of llama.cpp's value-head permutation applied to the *v-portion*
-/// of a packed tensor along `dim` — used for tensors where only a contiguous
-/// slice corresponds to value heads (qkv, conv1d, out_proj value cols).
-///
-/// `dim` is permuted between `start` and `start + n_value_heads * head_v_dim`;
-/// everything outside that range is untouched.  Each head contributes a
-/// contiguous chunk of `head_v_dim` elements along `dim`, so we temporarily
-/// reshape the v-slice to `(n_value_heads, head_v_dim, …rest)`, run
-/// `unpermute_value_heads`, and concatenate the unchanged Q/K prefix back.
-fn unpermute_v_portion(
-    t: &Tensor,
-    dim: usize,
-    start: usize,
-    n_key_heads: usize,
-    n_value_heads: usize,
-    ratio: usize,
-    head_v_dim: usize,
-) -> Result<Tensor> {
-    if ratio <= 1 {
-        return Ok(t.clone());
-    }
-    let value_dim = n_value_heads * head_v_dim;
-    let head_chunk = t.narrow(dim, start, value_dim)?;
-    // Introduce the (n_value, head_v_dim) factorisation on `dim` so that
-    // `unpermute_value_heads` can swap the head axis.
-    let mut split_shape = t.dims().to_vec();
-    split_shape[dim] = n_value_heads;
-    split_shape.insert(dim + 1, head_v_dim);
-    let reshaped = head_chunk.reshape(split_shape)?;
-    // The helper permutes the *leading* dim, so move the head axis to front.
-    let permuted = if dim == 0 {
-        unpermute_value_heads(reshaped, n_key_heads, n_value_heads, ratio)?
-    } else {
-        let mut perm: Vec<usize> = (0..reshaped.rank()).collect();
-        perm[0] = dim;
-        perm[dim] = 0;
-        let moved = reshaped.permute(perm.clone())?.contiguous()?;
-        let unpermuted = unpermute_value_heads(moved, n_key_heads, n_value_heads, ratio)?;
-        unpermuted.permute(perm)?.contiguous()?
-    };
-    // Collapse (n_value, head_v_dim) back into value_dim.
-    let mut flat_shape = t.dims().to_vec();
-    flat_shape[dim] = value_dim;
-    let v_flat = permuted.reshape(flat_shape)?;
-    // Concatenate the untouched Q/K prefix (if any) with the unpermuted V.
-    if start == 0 {
-        Ok(v_flat)
-    } else {
-        let head = t.narrow(dim, 0, start)?;
-        Tensor::cat(&[&head, &v_flat], dim).map_err(Into::into)
-    }
 }
 
 impl LinearAttn {
@@ -652,182 +572,48 @@ impl LinearAttn {
         let hidden = cfg.hidden_size;
         let kernel = cfg.linear_conv_kernel_dim;
 
-        // ── llama.cpp external-GGUF asymmetric-SSM head permutation ─────────
-        //
-        // For asymmetric Qwen3.5 models (n_value_heads > n_key_heads),
-        // llama.cpp's convert_hf_to_gguf.py applies a value-head permutation
-        // `reshape(n_key, ratio).T.flatten()` to **every** tensor whose layout
-        // is indexed by value-heads (the whole `_LinearAttentionVReorderBase`
-        // family).  The complete list, verified against convert_hf_to_gguf.py:
-        //
-        //   1. `ssm_a`                  — 1D [n_value_heads]
-        //   2. `ssm_dt.bias`            — 1D [n_value_heads]
-        //   3. `ssm_alpha.weight`       — rows [n_value_heads, hidden]
-        //   4. `ssm_beta.weight`        — rows [n_value_heads, hidden]
-        //   5. `attn_qkv.weight`        — V rows only (last value_dim of
-        //                                  [conv_dim, hidden]); Q/K untouched
-        //   6. `attn_gate.weight`       — rows [value_dim, hidden]
-        //                                  (i.e. `in_proj_z`, row-permuted in
-        //                                  chunks of head_v_dim)
-        //   7. `ssm_conv1d.weight`      — V channels only (last value_dim of
-        //                                  [conv_dim, kernel]); QK untouched
-        //   8. `ssm_out.weight`         — cols [hidden, value_dim]
-        //
-        // Leaving even *one* of these eight in GGUF order while unpermuting
-        // the others produces mixed-order garbage (`silu(z) * norm(out)` in
-        // particular pairs wrong heads if z is the outlier).  We must
-        // therefore flip all eight atomically.
-        //
-        // For quantized weights we dequantize once, undo the permutation, and
-        // wrap the dense tensor in a `QLinear::Tensor` — the Q4_K / IQ4_XS
-        // block layout can't represent the permuted-then-reordered storage
-        // directly.  Extra VRAM is ~100 MB per SSM layer on a 4B model,
-        // ~200 MB on a 9B — acceptable for correctness.  Symmetric models
-        // (`ratio == 1`) skip the entire branch since the permutation is the
-        // identity.
-        let needs_head_unpermute = cfg.gguf_external_head_order && kv_group_ratio > 1;
-        let qvb_ref = if needs_head_unpermute {
-            Some(qvb.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "external-GGUF asymmetric SSM requires QGgufVarBuilder but none was provided"
-                )
-            })?)
-        } else {
-            None
-        };
-        let dev = vb.device().clone();
+        // All 8 value-head-indexed tensors are loaded in their native storage
+        // order (HF or GGUF tiled).  When gguf_external_head_order is true the
+        // GQA expansion in forward() uses unsqueeze(2) instead of unsqueeze(3)
+        // so q/k tile in the same order as the stored v/z/state tensors.
+        // No dequantization or permutation at load time — zero extra VRAM.
+        let in_proj_a = qlinear_b(
+            hidden,
+            n_value_heads,
+            false,
+            vb.pp("in_proj_a"),
+            qvb.map(|q| q.pp("in_proj_a")).as_ref(),
+        )?;
+        let in_proj_b = qlinear_b(
+            hidden,
+            n_value_heads,
+            false,
+            vb.pp("in_proj_b"),
+            qvb.map(|q| q.pp("in_proj_b")).as_ref(),
+        )?;
+        let in_proj_qkv = qlinear_b(
+            hidden,
+            conv_dim,
+            false,
+            vb.pp("in_proj_qkv"),
+            qvb.map(|q| q.pp("in_proj_qkv")).as_ref(),
+        )?;
+        let in_proj_z = qlinear_b(
+            hidden,
+            value_dim,
+            false,
+            vb.pp("in_proj_z"),
+            qvb.map(|q| q.pp("in_proj_z")).as_ref(),
+        )?;
 
-        // Load a quantized weight via `qvb`, dequantize to F32, apply an
-        // arbitrary transformation (row/col unpermute), and return as a dense
-        // `QLinear::Tensor` wrapper.
-        let load_dense_transformed = |pp: &str,
-                                      transform: &dyn Fn(Tensor) -> Result<Tensor>|
-         -> Result<QLinear> {
-            let qt = qvb_ref
-                .expect("needs_head_unpermute implies qvb_ref is Some")
-                .pp(pp)
-                .get_qtensor()
-                .ok_or_else(|| {
-                    anyhow::anyhow!("external-GGUF asymmetric SSM: `{pp}.weight` not found in qvb")
-                })?;
-            let dense = qt
-                .dequantize(&dev)
-                .with_context(|| format!("dequantize `{pp}.weight`"))?
-                .to_dtype(DType::F32)?;
-            let w = transform(dense).with_context(|| format!("transform `{pp}.weight`"))?;
-            Ok(QLinear::from_tensor(w, None))
-        };
-
-        // (3, 4) in_proj_a / in_proj_b: whole-row per-value-head permutation.
-        let (in_proj_a, in_proj_b) = if needs_head_unpermute {
-            let unperm = |t: Tensor| -> Result<Tensor> {
-                unpermute_value_heads(t, n_key_heads, n_value_heads, kv_group_ratio)
-            };
-            (
-                load_dense_transformed("in_proj_a", &unperm)?,
-                load_dense_transformed("in_proj_b", &unperm)?,
-            )
-        } else {
-            (
-                qlinear_b(
-                    hidden,
-                    n_value_heads,
-                    false,
-                    vb.pp("in_proj_a"),
-                    qvb.map(|q| q.pp("in_proj_a")).as_ref(),
-                )?,
-                qlinear_b(
-                    hidden,
-                    n_value_heads,
-                    false,
-                    vb.pp("in_proj_b"),
-                    qvb.map(|q| q.pp("in_proj_b")).as_ref(),
-                )?,
-            )
-        };
-
-        // (5) in_proj_qkv: only the last value_dim rows (V) are head-permuted
-        // in chunks of head_v_dim.  Q/K rows pass through unchanged.
-        let in_proj_qkv = if needs_head_unpermute {
-            load_dense_transformed("in_proj_qkv", &|t| {
-                unpermute_v_portion(
-                    &t,
-                    0,
-                    2 * key_dim,
-                    n_key_heads,
-                    n_value_heads,
-                    kv_group_ratio,
-                    head_v_dim,
-                )
-            })?
-        } else {
-            qlinear_b(
-                hidden,
-                conv_dim,
-                false,
-                vb.pp("in_proj_qkv"),
-                qvb.map(|q| q.pp("in_proj_qkv")).as_ref(),
-            )?
-        };
-
-        // (6) in_proj_z (= attn_gate): rows [value_dim, hidden] — permuted in
-        // chunks of head_v_dim (see convert_hf_to_gguf.py, `.in_proj_z.`
-        // branch: `_reorder_v_heads(data_torch, 0, num_k_heads, num_v_per_k,
-        // head_v_dim)`).  Missing this fix breaks the SSM gate `silu(z) *
-        // norm(out_flat)` because z ends up in GGUF order while the rest of
-        // the SSM path is in HF order.
-        let in_proj_z = if needs_head_unpermute {
-            load_dense_transformed("in_proj_z", &|t| {
-                unpermute_v_portion(
-                    &t,
-                    0,
-                    0,
-                    n_key_heads,
-                    n_value_heads,
-                    kv_group_ratio,
-                    head_v_dim,
-                )
-            })?
-        } else {
-            qlinear_b(
-                hidden,
-                value_dim,
-                false,
-                vb.pp("in_proj_z"),
-                qvb.map(|q| q.pp("in_proj_z")).as_ref(),
-            )?
-        };
-
-        // (7) conv1d weight: [conv_dim, 1, kernel] depthwise.  External GGUFs
-        // store it as 2D [conv_dim, kernel] (groups=1 squeezed); only the last
-        // value_dim channels (the V portion) are head-permuted.
         let conv1d_weight_raw = vb.get_unchecked("conv1d.weight")?.to_dtype(DType::F32)?;
         let conv1d_weight_2d = if conv1d_weight_raw.rank() == 3 {
             conv1d_weight_raw.reshape((conv_dim, kernel))?
         } else {
             conv1d_weight_raw
         };
-        let conv1d_weight_2d = if needs_head_unpermute {
-            unpermute_v_portion(
-                &conv1d_weight_2d,
-                0,
-                2 * key_dim,
-                n_key_heads,
-                n_value_heads,
-                kv_group_ratio,
-                head_v_dim,
-            )?
-        } else {
-            conv1d_weight_2d
-        };
         let conv1d_weight = conv1d_weight_2d.reshape((conv_dim, 1, kernel))?;
 
-        // A_log, dt_bias, and norm.weight must be kept in F32 for the SSM recurrence.
-        // Both A_log and dt_bias are per-value-head; in an external asymmetric
-        // llama.cpp GGUF they arrive row-permuted (see `unpermute_value_heads`
-        // for the full rationale) and must be brought back to HF natural order
-        // so the rest of the SSM path (v from `attn_qkv`, `ssm_out`, the GQA
-        // expansion) stays consistent.
         let a_log = vb
             .get_with_hints(n_value_heads, "A_log", candle_nn::Init::Const(0.0))?
             .to_dtype(DType::F32)?;
@@ -835,58 +621,26 @@ impl LinearAttn {
         let norm_weight = vb
             .get_with_hints(head_v_dim, "norm.weight", candle_nn::Init::Const(1.0))?
             .to_dtype(DType::F32)?;
-        let a_log = if needs_head_unpermute {
-            unpermute_value_heads(a_log, n_key_heads, n_value_heads, kv_group_ratio)?
-        } else {
-            a_log
-        };
-        let dt_bias = if needs_head_unpermute {
-            unpermute_value_heads(dt_bias, n_key_heads, n_value_heads, kv_group_ratio)?
-        } else {
-            dt_bias
-        };
 
-        // Precompute `a_exp = A_log.exp()` — it's a constant weight, saves one
-        // dispatch per SSM layer per decode token.
+        // Precompute `a_exp = A_log.exp()` — constant weight, saves one dispatch
+        // per SSM layer per decode token.
         let a_exp = a_log.exp()?;
 
-        // (7) out_proj: [hidden, value_dim] — value-head permutation applied
-        // on the *input* dimension (cols).  llama.cpp uses `apply_col_perm()`
-        // here rather than a row permutation.  Unpermute the cols to match
-        // the HF-ordered state that downstream code feeds into out_proj.
-        let out_proj = if needs_head_unpermute {
-            load_dense_transformed("out_proj", &|t| {
-                unpermute_v_portion(
-                    &t,
-                    1,
-                    0,
-                    n_key_heads,
-                    n_value_heads,
-                    kv_group_ratio,
-                    head_v_dim,
-                )
-            })?
-        } else {
-            qlinear_b(
-                value_dim,
-                hidden,
-                false,
-                vb.pp("out_proj"),
-                qvb.map(|q| q.pp("out_proj")).as_ref(),
-            )?
-        };
+        let out_proj = qlinear_b(
+            value_dim,
+            hidden,
+            false,
+            vb.pp("out_proj"),
+            qvb.map(|q| q.pp("out_proj")).as_ref(),
+        )?;
 
-        // Precompute alpha = (1/sqrt(head_k_dim)) * ones[head_k_dim] and the
-        // rescaled eps for the L2-norm-via-rms_norm substitution. See `l2norm`
-        // below for the arithmetic identity that links candle-nn
-        // `rms_norm(x, alpha, eps)` to `x · rsqrt(sum(x²) + cfg.rms_norm_eps)`.
+        // Precompute alpha and eps for the L2-norm-via-rms_norm substitution.
         let l2norm_alpha =
             Tensor::full(1.0f32 / (head_k_dim as f32).sqrt(), head_k_dim, vb.device())?;
         let l2norm_eps_rms = (cfg.rms_norm_eps as f32) / head_k_dim as f32;
 
-        // If both in_proj_a and in_proj_b are dense (non-quantized), concatenate their
-        // weight matrices once at load time so forward can issue a single matmul.
-        // Saves 1 dispatch per SSM layer per decode token.
+        // If both in_proj_a and in_proj_b are dense (non-quantized), concatenate
+        // their weight matrices once at load time — saves 1 dispatch per SSM layer.
         let in_proj_ab_weight = match (in_proj_a.dense_weight(), in_proj_b.dense_weight()) {
             (Some(wa), Some(wb)) => Tensor::cat(&[wa, wb], 0)
                 .and_then(|t| t.to_dtype(DType::F32))
@@ -914,6 +668,7 @@ impl LinearAttn {
             head_v_dim,
             key_dim,
             value_dim,
+            gguf_external_head_order: cfg.gguf_external_head_order,
             recurrent_state: None,
             conv_state: None,
         })
@@ -1022,21 +777,38 @@ impl LinearAttn {
         let q = q.affine(scale, 0.0)?;
 
         // ── Repeat q and k to n_value_heads (GQA-style expansion) ────────────
-        // Each key head serves `kv_group_ratio` value heads. Expand after L2norm
-        // so that each value-head slot gets the same normalized key vector.
+        // Each key head serves `kv_group_ratio` value heads.  The unsqueeze axis
+        // depends on the storage order of the value-head-indexed tensors:
+        //
+        //   HF grouped  — v[p] pairs with k[p / ratio]:  unsqueeze(3) so q/k
+        //                 expand as  [n_key, ratio] → [n_key×ratio = n_val].
+        //   GGUF tiled  — v[p] pairs with k[p % n_key]:  unsqueeze(2) so q/k
+        //                 expand as  [ratio, n_key] → [ratio×n_key = n_val].
         let (q, k) = if self.kv_group_ratio > 1 {
             let ratio = self.kv_group_ratio;
-            // [b, t, n_key_heads, head_k_dim] -> [b, t, n_key_heads, ratio, head_k_dim]
-            //                                  -> [b, t, n_value_heads, head_k_dim]
-            let q = q
-                .unsqueeze(3)?
-                .expand((b, t, self.n_key_heads, ratio, self.head_k_dim))?
-                .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
-            let k = k
-                .unsqueeze(3)?
-                .expand((b, t, self.n_key_heads, ratio, self.head_k_dim))?
-                .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
-            (q, k)
+            if self.gguf_external_head_order {
+                // GGUF tiled: value head at position p pairs with key head p % n_key
+                let q = q
+                    .unsqueeze(2)?
+                    .expand((b, t, ratio, self.n_key_heads, self.head_k_dim))?
+                    .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
+                let k = k
+                    .unsqueeze(2)?
+                    .expand((b, t, ratio, self.n_key_heads, self.head_k_dim))?
+                    .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
+                (q, k)
+            } else {
+                // HF grouped: value head at position p pairs with key head p / ratio
+                let q = q
+                    .unsqueeze(3)?
+                    .expand((b, t, self.n_key_heads, ratio, self.head_k_dim))?
+                    .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
+                let k = k
+                    .unsqueeze(3)?
+                    .expand((b, t, self.n_key_heads, ratio, self.head_k_dim))?
+                    .reshape((b, t, self.n_value_heads, self.head_k_dim))?;
+                (q, k)
+            }
         } else {
             (q, k)
         };

--- a/inferrs/src/bench.rs
+++ b/inferrs/src/bench.rs
@@ -4,9 +4,9 @@
 //! local inference engine and reports throughput and latency statistics.
 //!
 //! Metrics reported per run:
-//!   - Prefill throughput  (prompt tokens / prefill wall-time)
-//!   - Decode  throughput  (output tokens / decode  wall-time)
-//!   - Time to first token (TTFT)   — prefill wall-time
+//!   - Prefill throughput  (prompt tokens / GPU-synchronized prefill wall-time)
+//!   - Decode  throughput  (output tokens / decode wall-time for all N tokens)
+//!   - Time to first token (TTFT)   — prefill + first sample wall-time
 //!   - Mean per-token latency       — decode wall-time / output tokens
 //!   - End-to-end latency           — total wall-time for the request
 
@@ -82,14 +82,19 @@ pub fn run(args: BenchArgs) -> Result<()> {
         top_p: serve.top_p,
         top_k: serve.top_k,
         max_tokens,
+        // Suppress stop tokens so every run generates exactly max_tokens.
+        // Without this, early EOS produces variable n_output and skews throughput.
+        bypass_stop_tokens: true,
         ..SamplingParams::default()
     };
 
     let total_runs = args.warmup + args.runs;
     let mut prefill_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
     let mut decode_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
+    let mut ttft_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
     let mut e2e_ms_samples: Vec<f64> = Vec::with_capacity(args.runs);
-    let mut prompt_tok_samples: Vec<usize> = Vec::with_capacity(args.runs);
+    let mut prefill_tps_samples: Vec<f64> = Vec::with_capacity(args.runs);
+    let mut decode_tps_samples: Vec<f64> = Vec::with_capacity(args.runs);
     let mut output_tok_samples: Vec<usize> = Vec::with_capacity(args.runs);
 
     println!(
@@ -110,7 +115,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
         };
 
         let wall_start = std::time::Instant::now();
-        let (result, prefill_ms, decode_ms) =
+        let (result, prefill_ms, decode_ms, ttft_ms) =
             engine.bench_generate("bench", &prompt_tokens, &sampling_params)?;
         let e2e_ms = wall_start.elapsed().as_secs_f64() * 1000.0;
 
@@ -122,26 +127,27 @@ pub fn run(args: BenchArgs) -> Result<()> {
                 "  [{label}] prefill={prefill_ms:.1}ms  decode={decode_ms:.1}ms  output_tokens={n_output}",
             );
         } else {
-            prefill_ms_samples.push(prefill_ms);
-            decode_ms_samples.push(decode_ms);
-            e2e_ms_samples.push(e2e_ms);
-            prompt_tok_samples.push(n_prompt);
-            output_tok_samples.push(n_output);
-
-            let ttft_ms = prefill_ms;
-            let decode_tps = if decode_ms > 0.0 {
-                n_output as f64 / (decode_ms / 1000.0)
-            } else {
-                0.0
-            };
             let prefill_tps = if prefill_ms > 0.0 {
                 n_prompt as f64 / (prefill_ms / 1000.0)
             } else {
                 0.0
             };
+            let decode_tps = if decode_ms > 0.0 {
+                n_output as f64 / (decode_ms / 1000.0)
+            } else {
+                0.0
+            };
+
+            prefill_ms_samples.push(prefill_ms);
+            decode_ms_samples.push(decode_ms);
+            ttft_ms_samples.push(ttft_ms);
+            e2e_ms_samples.push(e2e_ms);
+            prefill_tps_samples.push(prefill_tps);
+            decode_tps_samples.push(decode_tps);
+            output_tok_samples.push(n_output);
 
             println!(
-                "  [{label}] TTFT={ttft_ms:.1}ms  decode={decode_tps:.1}tok/s  prefill={prefill_tps:.1}tok/s  output_tokens={n_output}",
+                "  [{label}] TTFT={ttft_ms:.1}ms  prefill={prefill_tps:.1}tok/s  decode={decode_tps:.1}tok/s  output_tokens={n_output}",
             );
         }
     }
@@ -155,12 +161,17 @@ pub fn run(args: BenchArgs) -> Result<()> {
 
     let mean_prefill_ms = prefill_ms_samples.iter().sum::<f64>() / n;
     let mean_decode_ms = decode_ms_samples.iter().sum::<f64>() / n;
+    let mean_ttft_ms = ttft_ms_samples.iter().sum::<f64>() / n;
     let mean_e2e_ms = e2e_ms_samples.iter().sum::<f64>() / n;
-    let mean_prompt_toks = prompt_tok_samples.iter().sum::<usize>() as f64 / n;
     let mean_output_toks = output_tok_samples.iter().sum::<usize>() as f64 / n;
 
-    let mean_prefill_tps = mean_prompt_toks / (mean_prefill_ms / 1000.0);
-    let mean_decode_tps = mean_output_toks / (mean_decode_ms / 1000.0);
+    // Use mean-of-rates (not rate-of-means) so each run is equally weighted.
+    let mean_prefill_tps = prefill_tps_samples.iter().sum::<f64>() / n;
+    let mean_decode_tps = decode_tps_samples.iter().sum::<f64>() / n;
+
+    let std_prefill_tps = stddev(&prefill_tps_samples);
+    let std_decode_tps = stddev(&decode_tps_samples);
+
     let mean_per_token_ms = if mean_output_toks > 0.0 {
         mean_decode_ms / mean_output_toks
     } else {
@@ -176,6 +187,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
     // ── KV cache memory estimate ─────────────────────────────────────────────
     let kv_mem_str = {
         let (num_kv_heads, head_dim, num_layers) = raw_config.kv_cache_params(&arch);
+        let actual_seq_len = args.prompt_len + max_tokens;
         // bytes consumed per token across all layers (K + V combined)
         let bytes_per_token: usize = if let Some(bits) = serve.turbo_quant.0 {
             // PolarQuant: (head_dim-1) packed angle indices + one f32 root norm per token
@@ -187,12 +199,7 @@ pub fn run(args: BenchArgs) -> Result<()> {
             let bytes_per_element = dtype.size_in_bytes();
             head_dim * 2 * num_kv_heads * num_layers * bytes_per_element
         };
-        let effective_seq_len = if max_seq_len == usize::MAX {
-            args.prompt_len + max_tokens
-        } else {
-            max_seq_len
-        };
-        let total_bytes = bytes_per_token * effective_seq_len;
+        let total_bytes = bytes_per_token * actual_seq_len;
         format_bytes(total_bytes as u64)
     };
 
@@ -201,18 +208,35 @@ pub fn run(args: BenchArgs) -> Result<()> {
         "── Results ({} runs) ──────────────────────────────────────────",
         args.runs
     );
-    println!("  Prompt tokens (avg)     : {mean_prompt_toks:.0}");
     println!("  Output tokens (avg)     : {mean_output_toks:.0}");
-    println!("  KV cache memory         : {kv_mem_str}");
-    println!("  Prefill throughput      : {mean_prefill_tps:.1} tok/s");
-    println!("  Decode  throughput      : {mean_decode_tps:.1} tok/s");
-    println!("  Time to first token     : {mean_prefill_ms:.1} ms");
+    println!("  KV cache memory (est.)  : {kv_mem_str}");
+    println!("  Prefill throughput      : {mean_prefill_tps:.1} tok/s  (σ={std_prefill_tps:.1})");
+    println!("  Decode  throughput      : {mean_decode_tps:.1} tok/s  (σ={std_decode_tps:.1})");
+    println!(
+        "  Time to first token     : {mean_ttft_ms:.1} ms  (prefill: {mean_prefill_ms:.1} ms)"
+    );
     println!("  Per-token latency (avg) : {mean_per_token_ms:.2} ms/tok");
     println!("  End-to-end latency (avg): {mean_e2e_ms:.1} ms");
     println!("  End-to-end p50          : {p50:.1} ms");
     println!("  End-to-end p90          : {p90:.1} ms");
 
     Ok(())
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+fn stddev(xs: &[f64]) -> f64 {
+    if xs.len() < 2 {
+        return 0.0;
+    }
+    let m = mean(xs);
+    let variance = xs.iter().map(|x| (x - m).powi(2)).sum::<f64>() / (xs.len() - 1) as f64;
+    variance.sqrt()
 }
 
 fn percentile(sorted: &[f64], p: f64) -> f64 {

--- a/inferrs/src/engine.rs
+++ b/inferrs/src/engine.rs
@@ -2550,30 +2550,51 @@ impl Engine {
 
     /// Run a single generation and return the result plus timing breakdown.
     ///
-    /// Returns `(result, prefill_ms, decode_ms)` where:
-    /// - `prefill_ms` is the wall time for the prefill forward pass
-    /// - `decode_ms`  is the wall time for all decode steps combined
+    /// Returns `(result, prefill_ms, decode_ms, ttft_ms)` where:
+    /// - `prefill_ms` is the GPU-synchronized wall time for the prefill forward pass
+    /// - `decode_ms`  is the wall time for all N output tokens (first token included)
+    /// - `ttft_ms`    is the wall time from request start to first token available
     pub fn bench_generate(
         &mut self,
         _request_id: &str,
         prompt_tokens: &[u32],
         sampling_params: &SamplingParams,
-    ) -> Result<(GenerationResult, f64, f64)> {
+    ) -> Result<(GenerationResult, f64, f64, f64)> {
         let mut output_tokens: Vec<u32> = Vec::new();
         let mut all_tokens: Vec<u32> = prompt_tokens.to_vec();
 
         let prefill_start = Instant::now();
 
         let logits = self.run_prefill(prompt_tokens)?;
-
+        // Synchronize so prefill_ms reflects actual GPU computation, not just
+        // kernel-dispatch latency (GPU ops are async without an explicit sync).
+        self.device.synchronize()?;
         let prefill_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
 
+        // Time all output tokens in decode_ms — including the first token sampled
+        // from prefill logits — to match llama.cpp's n_eval / n_p_eval convention.
+        let max_stop_len = sampling_params
+            .stop_strings
+            .iter()
+            .map(|s| s.len())
+            .max()
+            .unwrap_or(0);
+        let mut decoded_suffix = String::new();
+
+        let decode_start = Instant::now();
         let (mut token_id, _) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
         output_tokens.push(token_id);
         all_tokens.push(token_id);
+        let ttft_ms = prefill_start.elapsed().as_secs_f64() * 1000.0;
 
-        let decode_start = Instant::now();
-        let mut finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params, "");
+        let decoded_text = self.tokenizer.decode(&[token_id], true).unwrap_or_default();
+        update_decoded_suffix(&mut decoded_suffix, &decoded_text, max_stop_len * 2);
+        let mut finish_reason = self.check_stop(
+            token_id,
+            output_tokens.len(),
+            sampling_params,
+            &decoded_suffix,
+        );
 
         while finish_reason.is_none() {
             let seqlen_offset = prompt_tokens.len() + output_tokens.len() - 1;
@@ -2582,9 +2603,17 @@ impl Engine {
             (token_id, _) = sampler::sample_token(&logits, sampling_params, &all_tokens)?;
             output_tokens.push(token_id);
             all_tokens.push(token_id);
-            finish_reason = self.check_stop(token_id, output_tokens.len(), sampling_params, "");
+            let decoded_text = self.tokenizer.decode(&[token_id], true).unwrap_or_default();
+            update_decoded_suffix(&mut decoded_suffix, &decoded_text, max_stop_len * 2);
+            finish_reason = self.check_stop(
+                token_id,
+                output_tokens.len(),
+                sampling_params,
+                &decoded_suffix,
+            );
         }
 
+        self.device.synchronize()?;
         let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
 
         self.free_paged_blocks();
@@ -2607,6 +2636,7 @@ impl Engine {
             },
             prefill_ms,
             decode_ms,
+            ttft_ms,
         ))
     }
 
@@ -2617,14 +2647,16 @@ impl Engine {
         params: &SamplingParams,
         decoded_suffix: &str,
     ) -> Option<String> {
-        if self.stop_token_ids.contains(&token_id)
-            || params.extra_stop_token_ids.contains(&token_id)
-        {
-            return Some("stop".to_string());
-        }
-        for stop in &params.stop_strings {
-            if !stop.is_empty() && decoded_suffix.ends_with(stop.as_str()) {
+        if !params.bypass_stop_tokens {
+            if self.stop_token_ids.contains(&token_id)
+                || params.extra_stop_token_ids.contains(&token_id)
+            {
                 return Some("stop".to_string());
+            }
+            for stop in &params.stop_strings {
+                if !stop.is_empty() && decoded_suffix.ends_with(stop.as_str()) {
+                    return Some("stop".to_string());
+                }
             }
         }
         if num_output_tokens >= params.max_tokens {

--- a/inferrs/src/sampler.rs
+++ b/inferrs/src/sampler.rs
@@ -67,6 +67,10 @@ pub struct SamplingParams {
     pub top_logprobs: u8,
     /// Structured output grammar mode.
     pub grammar_mode: GrammarMode,
+    /// When true, stop tokens and stop strings are ignored so generation runs
+    /// until `max_tokens` is reached.  Used by `inferrs bench` to ensure every
+    /// run produces exactly `max_tokens` output tokens for consistent metrics.
+    pub bypass_stop_tokens: bool,
 }
 
 /// Structured output constraint mode.
@@ -102,6 +106,7 @@ impl Default for SamplingParams {
             logprobs: false,
             top_logprobs: 0,
             grammar_mode: GrammarMode::None,
+            bypass_stop_tokens: false,
         }
     }
 }

--- a/inferrs/src/server.rs
+++ b/inferrs/src/server.rs
@@ -3634,6 +3634,7 @@ fn build_sampling_params_with_grammar(
         extra_stop_token_ids,
         stop_strings,
         grammar_mode,
+        bypass_stop_tokens: false,
     }
 }
 


### PR DESCRIPTION
TLDR: `Qwen3.5-9B-IQ4_XS-GGUF` (and more broadly, all external GGUF but this is my test) VRAM usage dropped from 13gb to 7gb, aligned with llama cpp usage (6.5Gb)

---


Two independent fixes shipped together.

### GGUF tiled head order

External asymmetric Qwen3.5 GGUFs (llama.cpp convert) were loaded by dequantizing and unpermuting 8 SSM tensors per layer at init time. The fix keeps all tensors in their native quantized GGUF tiled order and instead branches the GQA expansion in `LinearAttn::forward` — `unsqueeze(2)` for tiled layout vs the existing `unsqueeze(3)` for HF grouped. Zero extra VRAM, projections stay quantized, single-file diff.

### `inferrs bench` timing correctness

The prefill throughput metric was meaningless: `prefill_ms` was captured without `device.synchronize()`, so it measured kernel-dispatch latency only, not actual GPU compute. Fixed along with three related issues: TTFT is now measured to first token (prefill + first sample), decode timer covers all N output tokens consistently, and `bypass_stop_tokens` ensures every run generates exactly `max_tokens` for stable comparisons.
