### PR TITLE
Qwen: Zero-copy mmap loading across all GGUF

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,7 @@ dependencies = [
  "candle-transformers",
  "half",
  "libloading 0.8.9",
+ "memmap2",
  "rayon",
  "serde",
  "serde_json",

--- a/candle-core/src/quantized/gguf_file.rs
+++ b/candle-core/src/quantized/gguf_file.rs
@@ -79,6 +79,46 @@ impl TensorInfo {
             device,
         )
     }
+
+    /// Zero-copy variant of [`Self::read`]: `data` is a slice covering the full
+    /// GGUF file (typically a memory-mapped region). The tensor is built directly
+    /// from `&data[tensor_data_offset + self.offset ..]`, skipping the
+    /// `Vec<u8>` allocation and the syscall that `read` would otherwise perform.
+    pub fn read_from_slice(
+        &self,
+        data: &[u8],
+        tensor_data_offset: u64,
+        device: &Device,
+    ) -> Result<QTensor> {
+        let tensor_elems = self.shape.elem_count();
+        let block_size = self.ggml_dtype.block_size();
+        if !tensor_elems.is_multiple_of(block_size) {
+            crate::bail!(
+            "the number of elements {tensor_elems} is not divisible by the block size {block_size}"
+        )
+        }
+        let size_in_bytes = tensor_elems / block_size * self.ggml_dtype.type_size();
+        let start_u64 = tensor_data_offset
+            .checked_add(self.offset)
+            .ok_or_else(|| crate::Error::Msg("gguf tensor offset overflow".into()))?;
+        let end_u64 = start_u64
+            .checked_add(size_in_bytes as u64)
+            .ok_or_else(|| crate::Error::Msg("gguf tensor slice overflow".into()))?;
+        if end_u64 > data.len() as u64 {
+            crate::bail!(
+                "gguf tensor slice out of bounds: need {end_u64} bytes, have {}",
+                data.len()
+            );
+        }
+        let start = start_u64 as usize;
+        let end = end_u64 as usize;
+        super::ggml_file::qtensor_from_ggml(
+            self.ggml_dtype,
+            &data[start..end],
+            self.shape.dims().to_vec(),
+            device,
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -478,6 +518,21 @@ impl Content {
             None => crate::bail!("cannot find tensor info for {name}"),
         };
         tensor_info.read(reader, self.tensor_data_offset, device)
+    }
+
+    /// Zero-copy variant of [`Self::tensor`]: loads a tensor directly from a
+    /// slice covering the full GGUF file (typically a memory-mapped region).
+    pub fn tensor_from_slice(
+        &self,
+        data: &[u8],
+        name: &str,
+        device: &Device,
+    ) -> Result<QTensor> {
+        let tensor_info = match self.tensor_infos.get(name) {
+            Some(tensor_info) => tensor_info,
+            None => crate::bail!("cannot find tensor info for {name}"),
+        };
+        tensor_info.read_from_slice(data, self.tensor_data_offset, device)
     }
 }
 

--- a/inferrs-models/Cargo.toml
+++ b/inferrs-models/Cargo.toml
@@ -29,6 +29,7 @@ candle-nn = { workspace = true }
 candle-transformers = { workspace = true }
 half = { version = "2.5", features = ["num-traits"] }
 libloading = "0.8"
+memmap2 = "0.9"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/inferrs-models/src/models/gemma4.rs
+++ b/inferrs-models/src/models/gemma4.rs
@@ -67,13 +67,14 @@ const PLI_EMBED_CACHE_SIZE: usize = 1024;
 enum PliEmbeddingTable {
     /// GGUF-file-backed on-demand row lookup (zero CPU RAM for the table).
     ///
-    /// Rows are read directly from the GGUF file as needed, with results
-    /// cached by token ID (via the model-level `pli_embed_cache`).  This
+    /// Rows are read directly from the memory-mapped GGUF file as needed, with
+    /// results cached by token ID (via the model-level `pli_embed_cache`). This
     /// keeps the PLI embedding table out of CPU RAM entirely, reducing peak
     /// RSS by ~1.9 GB compared to the `Quantized` variant.
     GgufFile {
-        /// GGUF file, shared among all model components.
-        file: Arc<std::sync::Mutex<std::fs::File>>,
+        /// Memory-mapped GGUF file, kept alive for the lifetime of all row
+        /// lookups. Mmap is `Sync`, so no lock is needed on the hot path.
+        mmap: Arc<memmap2::Mmap>,
         /// Absolute file offset where tensor data starts.
         tensor_offset: u64,
         #[allow(dead_code)]
@@ -108,8 +109,16 @@ impl PliEmbeddingTable {
     fn from_gguf_file(gguf_path: &std::path::Path) -> candle_core::Result<Option<Self>> {
         use candle_core::quantized::gguf_file;
 
-        let mut file = std::fs::File::open(gguf_path).map_err(candle_core::Error::from)?;
-        let content = gguf_file::Content::read(&mut file)?;
+        let file = std::fs::File::open(gguf_path).map_err(candle_core::Error::from)?;
+        // SAFETY: mmap stays alive inside `Arc<Mmap>` for the lifetime of
+        // every row lookup; see `QGgufVarBuilder::from_gguf` for the same
+        // assumption.
+        let mmap = unsafe {
+            memmap2::MmapOptions::new()
+                .map(&file)
+                .map_err(candle_core::Error::from)?
+        };
+        let content = gguf_file::Content::read(&mut std::io::Cursor::new(mmap.as_ref()))?;
 
         // Find the PLI embedding tensor — check both HF and llama.cpp naming.
         let tensor_name = if content
@@ -146,7 +155,7 @@ impl PliEmbeddingTable {
         let tensor_offset = content.tensor_data_offset + info.offset;
 
         Ok(Some(PliEmbeddingTable::GgufFile {
-            file: Arc::new(std::sync::Mutex::new(file)),
+            mmap: Arc::new(mmap),
             tensor_offset,
             vocab_size,
             embed_dim,
@@ -186,11 +195,10 @@ impl PliEmbeddingTable {
     ) -> candle_core::Result<candle_core::Tensor> {
         use candle_core::quantized::{GgmlDType, QStorage, QTensor};
         use std::borrow::Cow;
-        use std::io::{Read, Seek, SeekFrom};
 
         match self {
             PliEmbeddingTable::GgufFile {
-                file,
+                mmap,
                 tensor_offset,
                 row_bytes,
                 dtype_q,
@@ -198,13 +206,27 @@ impl PliEmbeddingTable {
             } => {
                 let n = token_ids.len();
                 let mut row_data: Vec<u8> = vec![0u8; n * row_bytes];
-                let mut f = file.lock().expect("GGUF file lock poisoned");
+                let data = mmap.as_ref();
                 for (i, &tok) in token_ids.iter().enumerate() {
-                    let file_pos = tensor_offset + tok as u64 * *row_bytes as u64;
-                    f.seek(SeekFrom::Start(file_pos))
-                        .map_err(candle_core::Error::from)?;
-                    f.read_exact(&mut row_data[i * row_bytes..(i + 1) * row_bytes])
-                        .map_err(candle_core::Error::from)?;
+                    let row_offset =
+                        (tok as u64).checked_mul(*row_bytes as u64).ok_or_else(|| {
+                            candle_core::Error::Msg("PLI row offset overflow".to_string())
+                        })?;
+                    let start_u64 = (*tensor_offset).checked_add(row_offset).ok_or_else(|| {
+                        candle_core::Error::Msg("PLI row start offset overflow".to_string())
+                    })?;
+                    let end_u64 = start_u64.checked_add(*row_bytes as u64).ok_or_else(|| {
+                        candle_core::Error::Msg("PLI row end offset overflow".to_string())
+                    })?;
+                    if end_u64 > data.len() as u64 {
+                        candle_core::bail!(
+                            "PLI row out of bounds: tok={tok}, need {end_u64} bytes, mmap {}",
+                            data.len()
+                        );
+                    }
+                    let start = start_u64 as usize;
+                    let end = end_u64 as usize;
+                    row_data[i * row_bytes..(i + 1) * row_bytes].copy_from_slice(&data[start..end]);
                 }
                 // For non-quantized dtypes (BF16, F16, F32), `QStorage::from_data`
                 // reinterprets the `Vec<u8>` as typed values via raw pointer cast.

--- a/inferrs-models/src/models/mod.rs
+++ b/inferrs-models/src/models/mod.rs
@@ -639,11 +639,12 @@ impl CausalLM for Qwen35ModelWrapper {
 /// spike and slow startup of the previous eager approach (loading all 2 000+
 /// tensors including multi-gigabyte embedding tables upfront).
 ///
-/// The GGUF file is kept open for the lifetime of the backend; a `Mutex`
-/// around the `BufReader` satisfies the `Sync` requirement of `SimpleBackend`.
+/// The GGUF file is memory-mapped once at construction and kept alive via
+/// `Arc<Mmap>` for the lifetime of the backend. Mmap is immutable and `Sync`,
+/// so no lock is required on the hot path.
 struct GgufBackend {
     content: candle_core::quantized::gguf_file::Content,
-    reader: std::sync::Mutex<std::io::BufReader<std::fs::File>>,
+    mmap: std::sync::Arc<memmap2::Mmap>,
     device: Device,
 }
 
@@ -656,7 +657,6 @@ impl candle_nn::var_builder::SimpleBackend for GgufBackend {
         dtype: DType,
         dev: &Device,
     ) -> candle_core::Result<Tensor> {
-        let mut reader = self.reader.lock().expect("gguf reader lock poisoned");
         // Use `dev` (the VarBuilder's device) for loading the quantized tensor
         // so that if the caller requests CPU placement (e.g. for the enormous
         // embed_tokens_per_layer table) the data never touches GPU memory.
@@ -667,7 +667,7 @@ impl candle_nn::var_builder::SimpleBackend for GgufBackend {
         };
         let qt = self
             .content
-            .tensor(&mut *reader, name, load_dev)
+            .tensor_from_slice(self.mmap.as_ref(), name, load_dev)
             .map_err(|e| {
                 candle_core::Error::CannotFindTensor {
                     path: format!("{name}: {e}"),
@@ -688,7 +688,6 @@ impl candle_nn::var_builder::SimpleBackend for GgufBackend {
     }
 
     fn get_unchecked(&self, name: &str, dtype: DType, dev: &Device) -> candle_core::Result<Tensor> {
-        let mut reader = self.reader.lock().expect("gguf reader lock poisoned");
         let load_dev = if matches!(dev, Device::Cpu) {
             dev
         } else {
@@ -696,7 +695,7 @@ impl candle_nn::var_builder::SimpleBackend for GgufBackend {
         };
         let qt = self
             .content
-            .tensor(&mut *reader, name, load_dev)
+            .tensor_from_slice(self.mmap.as_ref(), name, load_dev)
             .map_err(|e| {
                 candle_core::Error::CannotFindTensor {
                     path: format!("{name}: {e}"),
@@ -892,9 +891,16 @@ fn var_builder_from_gguf(
 
     let file = std::fs::File::open(gguf_path)
         .with_context(|| format!("Cannot open GGUF {}", gguf_path.display()))?;
-    let mut reader = std::io::BufReader::new(file);
+    // SAFETY: kept alive for the lifetime of the backend via `Arc<Mmap>`.
+    // External mutation of the mapped file would be unsound; same assumption
+    // as `VarBuilder::from_mmaped_safetensors`.
+    let mmap = unsafe {
+        memmap2::MmapOptions::new()
+            .map(&file)
+            .with_context(|| format!("Cannot mmap GGUF {}", gguf_path.display()))?
+    };
 
-    let content = gguf_file::Content::read(&mut reader)
+    let content = gguf_file::Content::read(&mut std::io::Cursor::new(mmap.as_ref()))
         .with_context(|| format!("Failed to parse GGUF header in {}", gguf_path.display()))?;
 
     tracing::info!(
@@ -912,7 +918,7 @@ fn var_builder_from_gguf(
 
     let backend = GgufBackend {
         content,
-        reader: std::sync::Mutex::new(reader),
+        mmap: std::sync::Arc::new(mmap),
         device: device.clone(),
     };
 

--- a/inferrs-models/src/models/quantized_linear.rs
+++ b/inferrs-models/src/models/quantized_linear.rs
@@ -268,9 +268,11 @@ impl QLinear {
 // ---------------------------------------------------------------------------
 // QGgufVarBuilder: a lazy VarBuilder for quantized GGUF tensors.
 //
-// Stores the GGUF file handle and metadata; loads a QTensor into device
-// memory only when qlinear_weight is called for a specific projection.
-// A shared cache (Mutex<HashMap>) ensures each tensor is loaded at most once.
+// Memory-maps the GGUF file and loads a QTensor into device memory only when
+// qlinear_weight is called for a specific projection. The mmap path is zero
+// syscalls and zero heap allocation per tensor (vs. the previous seek +
+// read_exact into a fresh Vec<u8>). A shared cache (Mutex<HashMap>) ensures
+// each tensor is loaded at most once.
 // ---------------------------------------------------------------------------
 
 /// A lazy VarBuilder that loads tensors from a GGUF file on demand, retaining
@@ -286,7 +288,11 @@ impl QLinear {
 /// touches device memory or reads from the file.
 #[derive(Clone)]
 pub struct QGgufVarBuilder {
-    file: Arc<std::sync::Mutex<std::fs::File>>,
+    /// Memory-mapped GGUF file. Shared across all `pp`-derived builders; the
+    /// mmap stays alive for the lifetime of the `Arc`. Device uploads (Metal /
+    /// CUDA / CPU copy) happen inside `qtensor_from_ggml`, so tensors on-device
+    /// do not depend on this lifetime.
+    mmap: Arc<memmap2::Mmap>,
     content: Arc<candle_core::quantized::gguf_file::Content>,
     cache: Arc<
         std::sync::Mutex<std::collections::HashMap<String, Arc<candle_core::quantized::QTensor>>>,
@@ -306,10 +312,19 @@ impl QGgufVarBuilder {
         device: &Device,
     ) -> candle_core::Result<Self> {
         use candle_core::quantized::gguf_file;
-        let mut file = std::fs::File::open(p.as_ref()).map_err(candle_core::Error::from)?;
-        let content = gguf_file::Content::read(&mut file)?;
+        let file = std::fs::File::open(p.as_ref()).map_err(candle_core::Error::from)?;
+        // SAFETY: the mmap is kept alive inside `Arc<Mmap>` for the full lifetime
+        // of the VarBuilder. External processes mutating the file while mapped
+        // would be unsound, but that is outside our control and mirrors the
+        // assumption made by `VarBuilder::from_mmaped_safetensors`.
+        let mmap = unsafe {
+            memmap2::MmapOptions::new()
+                .map(&file)
+                .map_err(candle_core::Error::from)?
+        };
+        let content = gguf_file::Content::read(&mut std::io::Cursor::new(mmap.as_ref()))?;
         Ok(Self {
-            file: Arc::new(std::sync::Mutex::new(file)),
+            mmap: Arc::new(mmap),
             content: Arc::new(content),
             cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             name_remap: Arc::new(std::collections::HashMap::new()),
@@ -323,7 +338,7 @@ impl QGgufVarBuilder {
         let mut path = self.path.clone();
         path.push(s.to_string());
         Self {
-            file: self.file.clone(),
+            mmap: self.mmap.clone(),
             content: self.content.clone(),
             cache: self.cache.clone(),
             name_remap: self.name_remap.clone(),
@@ -366,11 +381,9 @@ impl QGgufVarBuilder {
         if !self.content.tensor_infos.contains_key(gguf_name.as_ref()) {
             return Ok(None);
         }
-        let qt = {
-            let mut file = self.file.lock().unwrap();
+        let qt =
             self.content
-                .tensor(&mut *file, gguf_name.as_ref(), &self.device)?
-        };
+                .tensor_from_slice(self.mmap.as_ref(), gguf_name.as_ref(), &self.device)?;
         let qt = Arc::new(qt);
         self.cache
             .lock()
@@ -438,7 +451,7 @@ impl QGgufVarBuilder {
             .map(|gguf_name| (map_fn(gguf_name), gguf_name.clone()))
             .collect();
         Ok(Self {
-            file: self.file.clone(),
+            mmap: self.mmap.clone(),
             content: self.content.clone(),
             cache: self.cache.clone(),
             name_remap: Arc::new(remap),

--- a/inferrs-models/src/models/qwen3_5.rs
+++ b/inferrs-models/src/models/qwen3_5.rs
@@ -10,7 +10,6 @@
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{embedding, Embedding, Init, RmsNorm, VarBuilder};
-use rayon::prelude::*;
 use std::sync::Arc;
 
 use crate::kv_cache::{BlockTable, PagedKvStore};
@@ -1313,10 +1312,12 @@ impl Qwen35Model {
             }
         });
 
-        // Pre-extract per-layer VarBuilders (sequential, trivial cost) then
-        // construct all layers + lm_head in parallel via rayon::join.
-        // VarBuilder is Send (Arc<TensorData<Box<dyn SimpleBackend>>> where
-        // SimpleBackend: Send + Sync). QGgufVarBuilder is Send (Arc<Mutex<>>).
+        // Pre-extract per-layer VarBuilders and build layers + lm_head
+        // sequentially. Both safetensors and GGUF paths are now mmap-backed
+        // (zero syscalls / zero heap alloc per tensor), so the previous
+        // rayon::join parallelism is no longer load-bound — and removing it
+        // eliminates the Metal command-encoder thread-safety SIGSEGV that
+        // forced a conditional branch.
         let layer_specs: Vec<_> = cfg
             .layer_types
             .iter()
@@ -1329,16 +1330,6 @@ impl Qwen35Model {
             .collect();
 
         let norm_vb = lm_vb.pp("norm");
-
-        // Build layers and lm_head.
-        // Metal's command encoder is not thread-safe: concurrent rayon threads
-        // calling dequantize → wait_until_completed on the shared encoder corrupts
-        // the heap and causes a SIGSEGV.  On Metal, both closures run sequentially;
-        // on CPU/CUDA, rayon::join parallelizes them.
-        let on_metal = matches!(
-            embed_tokens.embeddings().device(),
-            candle_core::Device::Metal(_)
-        );
 
         // Resolve the lm_head weight.
         //
@@ -1428,39 +1419,15 @@ impl Qwen35Model {
             QLinear::from_tensor(dense, None)
         };
 
-        let (layers_result, lm_head) = if on_metal {
-            let layers: Vec<_> = layer_specs
-                .into_iter()
-                .enumerate()
-                .map(|(i, (vb, qvb, is_full))| {
-                    DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, Some(i), tq_cfg.as_ref())
-                        .with_context(|| format!("loading layer {i}"))
-                })
-                .collect::<Result<Vec<_>>>()?;
-            (Ok(layers), build_lm_head())
-        } else {
-            rayon::join(
-                || -> Result<Vec<DecoderLayer>> {
-                    layer_specs
-                        .into_par_iter()
-                        .enumerate()
-                        .map(|(i, (vb, qvb, is_full))| {
-                            DecoderLayer::new(
-                                cfg,
-                                vb,
-                                qvb.as_ref(),
-                                is_full,
-                                Some(i),
-                                tq_cfg.as_ref(),
-                            )
-                            .with_context(|| format!("loading layer {i}"))
-                        })
-                        .collect::<Result<Vec<_>>>()
-                },
-                build_lm_head,
-            )
-        };
-        let layers = layers_result?;
+        let layers: Vec<DecoderLayer> = layer_specs
+            .into_iter()
+            .enumerate()
+            .map(|(i, (vb, qvb, is_full))| {
+                DecoderLayer::new(cfg, vb, qvb.as_ref(), is_full, Some(i), tq_cfg.as_ref())
+                    .with_context(|| format!("loading layer {i}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let lm_head = build_lm_head();
 
         let norm = rms_norm_with_offset(cfg.hidden_size, cfg.rms_norm_eps, norm_vb, 1.0)?;
 


### PR DESCRIPTION
TLDR: https://github.com/ericcurtin/inferrs/pull/188 was a poorly engineered solution due to skills issues (i'm here to learn), causing segfault on metal and stability issues in WSL2 on larger models. This PR has been inspired by the work from @ericcurtin on https://github.com/ericcurtin/inferrs/pull/210 to introduce zero copy loading, removing the usage of `rayon` and while keeping the benefits of reduced loading times

---

- **GGUF zero-copy loading** — replace the per-tensor `seek + read_exact + Vec<u8>` path with a single `memmap2::Mmap` across all GGUF consumers (`QGgufVarBuilder`, `GgufBackend`, `PliEmbeddingTable`). Adds `TensorInfo::read_from_slice` / `Content::tensor_from_slice` in candle-core so callsites receive a direct `&[u8]` slice into the mapped file. Safetensors was already zero-copy; GGUF is now first-class.

- **Drop `rayon::join`** — Qwen3.5 loader no longer parallelises layer construction. The previous parallelism masked I/O cost; with mmap that cost is gone and the `on_metal` SIGSEGV workaround disappears with it.