### PR TITLE
tests: port applicable unit tests from ollama

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2674,4 +2674,208 @@ mod tests {
         consolidate_responses_instructions(&mut req);
         assert_eq!(req, before);
     }
+
+    // -- Tests ported from ollama ---------------------------------------------
+    //
+    // The tests below are ported from ollama's own unit-test suites for the
+    // equivalent conversion logic — file references point at ollama/ollama's
+    // test files — adapted to llmman's own (narrower) semantics where the two
+    // differ; each test's doc comment calls out any such adaptation.
+
+    /// Ported from ollama's openai/openai_test.go
+    /// (TestFromChatRequest_ReasoningEffort), adapted to llmman's narrower
+    /// mapping: only the plain-boolean `think` forms have an equivalent in
+    /// llama-server's `chat_template_kwargs.enable_thinking`; ollama's
+    /// string thinking levels ("low"/"medium"/"high"/"max") have no
+    /// counterpart there and are deliberately a no-op (None), as is an
+    /// absent `think` — the template's own default then applies.
+    #[test]
+    fn think_to_chat_template_kwargs_maps_booleans_and_ignores_levels() {
+        assert_eq!(
+            think_to_chat_template_kwargs(&Some(serde_json::json!(true))),
+            Some(serde_json::json!({ "enable_thinking": true }))
+        );
+        assert_eq!(
+            think_to_chat_template_kwargs(&Some(serde_json::json!(false))),
+            Some(serde_json::json!({ "enable_thinking": false }))
+        );
+        for level in ["low", "medium", "high", "max", "minimal", "none"] {
+            assert_eq!(
+                think_to_chat_template_kwargs(&Some(serde_json::json!(level))),
+                None,
+                "string level {level:?} must be a no-op"
+            );
+        }
+        assert_eq!(think_to_chat_template_kwargs(&None), None);
+    }
+
+    /// Ported from ollama's api/client_test.go (TestClientStream /
+    /// TestClientDo malformed-payload cases) and openai streaming-chunk
+    /// tests: each SSE payload either yields (content, thinking, done) or
+    /// is skipped entirely (None) when malformed — a bad chunk must never
+    /// abort the whole stream.
+    #[test]
+    fn oai_chunk_to_content_ported_ollama_stream_decoding_cases() {
+        // Plain content token, stream not finished.
+        assert_eq!(
+            oai_chunk_to_content(r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#),
+            Some(("hi".into(), None, false))
+        );
+        // finish_reason "stop" marks the stream done.
+        assert_eq!(
+            oai_chunk_to_content(r#"{"choices":[{"delta":{"content":""},"finish_reason":"stop"}]}"#),
+            Some((String::new(), None, true))
+        );
+        // The [DONE] sentinel also marks the stream done.
+        assert_eq!(oai_chunk_to_content("[DONE]"), Some((String::new(), None, true)));
+        // llama-server's two reasoning field spellings both surface as
+        // thinking: "reasoning_content" (Homebrew builds) and "thinking"
+        // (git builds).
+        assert_eq!(
+            oai_chunk_to_content(
+                r#"{"choices":[{"delta":{"reasoning_content":"hmm"},"finish_reason":null}]}"#
+            ),
+            Some((String::new(), Some("hmm".into()), false))
+        );
+        assert_eq!(
+            oai_chunk_to_content(r#"{"choices":[{"delta":{"thinking":"hmm"},"finish_reason":null}]}"#),
+            Some((String::new(), Some("hmm".into()), false))
+        );
+        // An empty reasoning string is filtered out rather than surfaced.
+        assert_eq!(
+            oai_chunk_to_content(
+                r#"{"choices":[{"delta":{"content":"x","reasoning_content":""},"finish_reason":null}]}"#
+            ),
+            Some(("x".into(), None, false))
+        );
+        // Malformed JSON and an empty choices array are skipped, not fatal.
+        assert_eq!(oai_chunk_to_content("not json"), None);
+        assert_eq!(oai_chunk_to_content(r#"{"choices":[]}"#), None);
+    }
+
+    /// Ported from ollama's api/client_test.go (TestClientStream): SSE
+    /// lines split across arbitrary TCP chunk boundaries must be
+    /// reassembled, CRLF line endings trimmed, and a trailing
+    /// unterminated line flushed when the stream ends.
+    #[test]
+    fn bytes_to_lines_ported_ollama_client_stream_chunking() {
+        let chunks: Vec<reqwest::Result<Bytes>> = vec![
+            // One logical line split across two chunks.
+            Ok(Bytes::from("data: {\"a\":")),
+            // ...ending CRLF, plus a complete LF-terminated line.
+            Ok(Bytes::from("1}\r\ndata: {\"b\":2}\n")),
+            // A trailing line with no terminator at all.
+            Ok(Bytes::from("data: tail")),
+        ];
+        let stream = bytes_to_lines(futures::stream::iter(chunks));
+        let lines: Vec<String> = futures::executor::block_on(StreamExt::collect::<Vec<_>>(stream));
+        assert_eq!(
+            lines,
+            vec![
+                "data: {\"a\":1}".to_string(),
+                "data: {\"b\":2}".to_string(),
+                "data: tail".to_string(),
+            ]
+        );
+    }
+
+    /// Ported from ollama's middleware/anthropic_test.go
+    /// (TestAnthropicMessagesMiddleware's plain-string `system` case):
+    /// Anthropic's `system` field is accepted as either a bare string or
+    /// an array of content blocks, and both forms end up as the single
+    /// leading system message.
+    #[test]
+    fn build_anthropic_messages_accepts_a_plain_string_system_field() {
+        let req: AnthropicRequest = serde_json::from_value(serde_json::json!({
+            "model": "docker.io/ai/qwen3.5:0.8b",
+            "system": "you are a helpful assistant",
+            "messages": [{"role": "user", "content": "hi"}]
+        }))
+        .unwrap();
+
+        let messages = build_anthropic_messages(&req);
+
+        assert_eq!(
+            messages,
+            vec![
+                OAIMessage { role: "system".into(), content: "you are a helpful assistant".into() },
+                OAIMessage { role: "user".into(), content: "hi".into() },
+            ]
+        );
+    }
+
+    /// Ported from ollama's middleware/anthropic_test.go content-block
+    /// conversion cases: block-array content joins its text blocks in
+    /// order and ignores non-text block types entirely.
+    #[test]
+    fn anthropic_content_as_text_joins_text_blocks_and_ignores_other_types() {
+        let plain: AnthropicContent = serde_json::from_value(serde_json::json!("plain")).unwrap();
+        assert_eq!(plain.as_text(), "plain");
+
+        let blocks: AnthropicContent = serde_json::from_value(serde_json::json!([
+            {"type": "text", "text": "a"},
+            {"type": "image", "source": {"type": "base64", "data": "zzzz"}},
+            {"type": "text", "text": "b"}
+        ]))
+        .unwrap();
+        assert_eq!(blocks.as_text(), "ab");
+
+        let empty: AnthropicContent = serde_json::from_value(serde_json::json!([])).unwrap();
+        assert_eq!(empty.as_text(), "");
+    }
+
+    /// Ported from ollama's openai/responses_test.go polymorphic-input
+    /// cases: a Responses-API input item's `content` is either a bare
+    /// string or an array of text-bearing blocks (`input_text` /
+    /// `output_text`), and anything else (a function_call item with no
+    /// content, a non-string/array content) yields no text.
+    #[test]
+    fn responses_input_item_text_ported_ollama_polymorphic_input_cases() {
+        assert_eq!(
+            responses_input_item_text(&serde_json::json!({"role": "user", "content": "plain"})),
+            Some("plain".into())
+        );
+        assert_eq!(
+            responses_input_item_text(&serde_json::json!({"role": "user", "content": [
+                {"type": "input_text", "text": "a"},
+                {"type": "output_text", "text": "b"}
+            ]})),
+            Some("ab".into())
+        );
+        // Blocks without a text field contribute nothing.
+        assert_eq!(
+            responses_input_item_text(&serde_json::json!({"content": [{"type": "input_image"}]})),
+            Some(String::new())
+        );
+        assert_eq!(
+            responses_input_item_text(&serde_json::json!({"type": "function_call", "name": "f"})),
+            None
+        );
+        assert_eq!(responses_input_item_text(&serde_json::json!({"content": 42})), None);
+    }
+
+    /// Ported from ollama's server/routes_options_test.go concept
+    /// (api.Options blob -> typed option values): numeric options are
+    /// pulled out of the Ollama `options` blob by key, and missing keys,
+    /// wrong-typed values, or an absent blob all yield None instead of
+    /// erroring.
+    #[test]
+    fn option_extractors_ported_ollama_options_blob_cases() {
+        let opts = Some(serde_json::json!({
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "num_predict": 128,
+            "stop": ["### User:"]
+        }));
+        assert_eq!(opt_f64(&opts, "temperature"), Some(0.5));
+        assert_eq!(opt_f64(&opts, "top_p"), Some(0.9));
+        assert_eq!(opt_u32(&opts, "num_predict"), Some(128));
+        // Missing key.
+        assert_eq!(opt_f64(&opts, "repeat_penalty"), None);
+        // Wrong type for the extractor.
+        assert_eq!(opt_u32(&opts, "stop"), None);
+        // No options blob at all.
+        assert_eq!(opt_f64(&None, "temperature"), None);
+        assert_eq!(opt_u32(&None, "num_predict"), None);
+    }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -99,4 +99,80 @@ mod tests {
         assert_eq!(relative_time_rfc3339(&now), "just now");
         assert_eq!(relative_time_rfc3339("not a timestamp"), "unknown");
     }
+
+    /// Ported from ollama's format/bytes_test.go (TestHumanBytes), adapted
+    /// to this module's own decimal conventions: units are kB/MB/GB with no
+    /// TB tier, and every unit above bytes always renders one decimal place
+    /// ("1.0 kB" where ollama prints "1 KB"), so values that sit just under
+    /// a unit boundary render as e.g. "1000.0 kB" rather than ollama's
+    /// truncated "999 KB".
+    #[test]
+    fn human_size_ported_ollama_humanbytes_boundaries() {
+        // Bytes.
+        assert_eq!(human_size(0), "0 B");
+        assert_eq!(human_size(1), "1 B");
+        assert_eq!(human_size(999), "999 B");
+
+        // Kilobytes.
+        assert_eq!(human_size(1_000), "1.0 kB");
+        assert_eq!(human_size(1_234), "1.2 kB");
+        assert_eq!(human_size(999_999), "1000.0 kB");
+
+        // Megabytes.
+        assert_eq!(human_size(1_000_000), "1.0 MB");
+        assert_eq!(human_size(1_234_567), "1.2 MB");
+
+        // Gigabytes.
+        assert_eq!(human_size(1_000_000_000), "1.0 GB");
+        assert_eq!(human_size(1_234_567_890), "1.2 GB");
+
+        // No TB tier: terabyte-scale sizes keep counting in GB.
+        assert_eq!(human_size(1_000_000_000_000), "1000.0 GB");
+        assert_eq!(human_size(1_500_000_000_000), "1500.0 GB");
+    }
+
+    /// Ported from ollama's format/time_test.go (TestHumanTime) plus its
+    /// humanDuration unit ladder, adapted to this module's own phrasing
+    /// ("just now"/"yesterday"/"N weeks ago" instead of ollama's
+    /// "Less than a second"/"2 days"). Walks every unit boundary in
+    /// relative_time_secs.
+    #[test]
+    fn relative_time_secs_ported_ollama_humantime_unit_ladder() {
+        const DAY: u64 = 86_400;
+        assert_eq!(relative_time_secs(0), "just now");
+        assert_eq!(relative_time_secs(59), "just now");
+        assert_eq!(relative_time_secs(60), "1 minutes ago");
+        assert_eq!(relative_time_secs(120), "2 minutes ago");
+        assert_eq!(relative_time_secs(3_600), "1 hours ago");
+        assert_eq!(relative_time_secs(7_200), "2 hours ago");
+        assert_eq!(relative_time_secs(DAY), "yesterday");
+        assert_eq!(relative_time_secs(2 * DAY - 1), "yesterday");
+        // ollama's "time in the past" case: now - 48h -> "2 days ago".
+        assert_eq!(relative_time_secs(2 * DAY), "2 days ago");
+        assert_eq!(relative_time_secs(6 * DAY), "6 days ago");
+        assert_eq!(relative_time_secs(7 * DAY), "1 week ago");
+        assert_eq!(relative_time_secs(14 * DAY), "2 weeks ago");
+        assert_eq!(relative_time_secs(30 * DAY), "1 month ago");
+        assert_eq!(relative_time_secs(60 * DAY), "2 months ago");
+        assert_eq!(relative_time_secs(365 * DAY), "1 year ago");
+        assert_eq!(relative_time_secs(730 * DAY), "2 years ago");
+        // ollama's "time way in the future" renders "Forever"; this module
+        // has no such cap and just keeps counting years.
+        assert_eq!(relative_time_secs(200 * 365 * DAY), "200 years ago");
+    }
+
+    /// Ported from ollama's format/time_test.go: the zero value renders the
+    /// caller's fallback ("never" there, "unknown" here), and a timestamp
+    /// in the future clamps rather than panicking (ollama phrases it as
+    /// "N days from now"; this module clamps to "just now" since nothing
+    /// it formats — mtimes, daemon start times — can legitimately be in
+    /// the future).
+    #[test]
+    fn relative_time_ported_ollama_humantime_edge_cases() {
+        assert_eq!(relative_time(None), "unknown");
+        let future = SystemTime::now() + std::time::Duration::from_secs(2 * 86_400);
+        assert_eq!(relative_time(Some(future)), "just now");
+        let past = SystemTime::now() - std::time::Duration::from_secs(2 * 86_400);
+        assert_eq!(relative_time(Some(past)), "2 days ago");
+    }
 }

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -244,6 +244,45 @@ mod tests {
         assert!(!is_bare("hf.co/gemma4"));
     }
 
+    /// Ported from ollama's types/model/name_test.go (TestParseNameParts /
+    /// TestNameparseNameDefault): ollama fills an unqualified name out to
+    /// registry.ollama.ai/library/<model>:latest; llmman's equivalents are
+    /// resolve_ollama_api's docker.io/ai/<name> default for bare names and
+    /// resolve's hf.co/<owner>/<repo> default for host-less paths, while
+    /// anything already carrying a host passes through untouched.
+    #[test]
+    fn resolve_fills_in_default_registry_like_ollama_parse_name() {
+        // Bare model name (ollama: "model" -> registry.ollama.ai/library/model:latest).
+        assert_eq!(resolve_ollama_api("mistral"), "docker.io/ai/mistral");
+        assert_eq!(resolve_ollama_api("mistral:7b"), "docker.io/ai/mistral:7b");
+        // namespace/model (ollama: -> registry.ollama.ai/namespace/model).
+        assert_eq!(resolve("namespace/model"), "hf.co/namespace/model");
+        // Fully-qualified references pass through untouched...
+        assert_eq!(resolve("example.com/ns/model:tag"), "example.com/ns/model:tag");
+        // ...including a host:port first component (ollama's
+        // "host:port/namespace/model:tag" case) and localhost.
+        assert_eq!(resolve("example.com:5000/ns/model:tag"), "example.com:5000/ns/model:tag");
+        assert_eq!(resolve("localhost/ns/model"), "localhost/ns/model");
+    }
+
+    /// Ported from ollama's types/model/name_test.go scheme cases
+    /// ("scheme://host/namespace/model:tag" parses with the scheme split
+    /// off): llmman likewise never treats a URI scheme as part of the
+    /// reference — hf:// and huggingface:// are stripped before the normal
+    /// defaulting rules run, modelscope:// is normalised to ms://, and
+    /// object-store schemes pass through verbatim.
+    #[test]
+    fn resolve_splits_uri_schemes_like_ollama_parse_name() {
+        assert_eq!(resolve("hf://owner/repo"), "hf.co/owner/repo");
+        assert_eq!(resolve("huggingface://owner/repo"), "hf.co/owner/repo");
+        assert_eq!(resolve("hf://hf.co/owner/repo"), "hf.co/owner/repo");
+        assert_eq!(resolve("modelscope://owner/repo"), "ms://owner/repo");
+        assert_eq!(resolve("ms://owner/repo"), "ms://owner/repo");
+        assert_eq!(resolve("s3://bucket/key"), "s3://bucket/key");
+        assert_eq!(resolve("gs://bucket/key"), "gs://bucket/key");
+        assert_eq!(resolve("ngc://org/model"), "ngc://org/model");
+    }
+
     #[test]
     fn has_host_requires_a_slash() {
         // No "/" at all: a dotted version number must not be mistaken for

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -657,4 +657,15 @@ mod tests {
         // check above rather than reusing this for both directions.
         assert_eq!(tag_from_ref("0.8b"), "latest");
     }
+
+    /// Ported from ollama's types/model/name_test.go
+    /// ("host:port/namespace/model:tag" and the tagless default): a colon
+    /// inside the host component must never be mistaken for a tag
+    /// separator, and a reference without a tag defaults to "latest".
+    #[test]
+    fn tag_from_ref_ignores_a_port_in_the_host_component() {
+        assert_eq!(tag_from_ref("example.com:5000/ns/model"), "latest");
+        assert_eq!(tag_from_ref("example.com:5000/ns/model:tag"), "tag");
+        assert_eq!(tag_from_ref("localhost:11434/library/mistral:7b"), "7b");
+    }
 }


### PR DESCRIPTION
## What

Ports unit-test tables from ollama's Go test suites into llmman's existing `#[cfg(test)]` modules wherever llmman has equivalent logic (12 new tests, all passing). Expected values are adapted to llmman's own semantics where the two projects deliberately differ, and every ported test's doc comment cites its ollama source file so future drift is easy to audit.

## Ported coverage

| ollama source | llmman target | what |
|---|---|---|
| `format/bytes_test.go`, `format/time_test.go` | `src/fmt.rs` | `human_size` unit boundaries (decimal kB/MB/GB, no TB tier); full `relative_time_secs` unit ladder; zero-value/future-clamp edges |
| `types/model/name_test.go` | `src/shortnames.rs`, `src/storage/oci.rs` | default-registry fill-in for unqualified names; URI scheme splitting; `host:port` colons never mistaken for tag separators |
| `openai/openai_test.go` (reasoning effort) | `src/cmd/serve.rs` | `think_to_chat_template_kwargs`: booleans map to `enable_thinking`, string levels are a documented no-op |
| `api/client_test.go` (stream decoding) | `src/cmd/serve.rs` | `oai_chunk_to_content` ([DONE]/finish_reason, both reasoning field spellings, malformed chunks skipped); `bytes_to_lines` (split-chunk reassembly, CRLF, trailing flush) |
| `middleware/anthropic_test.go` | `src/cmd/serve.rs` | plain-string `system` field; content-block text extraction ignoring non-text blocks |
| `openai/responses_test.go`, `server/routes_options_test.go` | `src/cmd/serve.rs` | polymorphic Responses input content; options-blob numeric extraction |

## Not ported (no llmman equivalent)

Modelfile parsing, scheduler, GGUF read/write, tokenizers, tool-call/think-tag stream parsers, envconfig host parsing — llmman has no corresponding logic to test.

## Verification

`cargo test --bin llmman`: 60 passed, 0 failed, 2 ignored (pre-existing network/hardware tests). No new warnings.