### PR TITLE
docs: document llmman launch command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ Models are packaged as standard OCI artifacts and stored in any compatible regis
 | Command | Description |
 |---------|-------------|
 | `serve`   | Start an inference server (Ollama / OpenAI / Anthropic APIs) |
+| `launch`  | Launch an integration (Claude Code, OpenCode, …) |
+| `run`     | Run a model interactively or with a one-shot prompt |
 | `pull`    | Pull a model from a registry or HuggingFace |
 | `list`    | List locally stored models |
+| `ps`      | List models currently loaded |
 | `build`   | Package model files into a local OCI image |
 | `push`    | Push a local image to a registry |
 | `transfer` | Transfer an image directly from one location to another (e.g. HuggingFace to an OCI registry) |
@@ -84,6 +87,16 @@ OLLAMA_HOST=127.0.0.1:17434 ollama run unsloth/Qwen3.5-0.8B-GGUF
 Or with any Ollama, Anthropic or OpenAI-compatible client.
 
 Models are loaded on demand. Each model gets its own `llama-server` subprocess on a random loopback port; subsequent requests reuse the running process.
+
+### Launch an integration
+
+Point an integration at a model in one step. `llmman launch` starts `serve` in the background if it isn't already running (preloading the requested model), then sets the right environment variables and execs the integration:
+
+```
+llmman launch claude --model gemma4
+```
+
+Run `llmman launch` with no arguments to list the supported integrations (Claude Code, OpenCode) and whether each is installed. Any extra arguments after `--` are forwarded to the integration's own CLI.
 
 Short names work with all commands: `pull`, `push`, `transfer`, `rm`, `tag`, `inspect`, and `serve`.
 


### PR DESCRIPTION
## What
Adds `llmman launch` to README.md — the commands table and a new "Launch an integration" quick-start section — since it was completely undocumented despite being a supported subcommand (`src/cmd/launch.rs`) for launching AI coding-assistant integrations (Claude Code, OpenCode, Codex CLI, Cline, Aider, GitHub Copilot CLI, Kimi Code CLI, Gemini CLI) against a local `llmman serve`.

While auditing the commands table I noticed `run` and `ps` were also missing rows despite existing in the CLI (`src/main.rs`), so I added those too for completeness.

## Why
Users browsing the README had no way to discover `llmman launch`, one of the more useful features for wiring up coding assistants to a local model.

## Changes
- Add `launch`, `run`, and `ps` rows to the commands table.
- Add a "Launch an integration" quick-start section with a usage example.
