### PR TITLE
fix(serve): stop a slow model cold-start from blocking every other model

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -949,6 +949,18 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         let model_ref = canonical_ref(&state.0.store_path, model_ref);
         let model_ref = model_ref.as_str();
 
+        // Double-check again, under the (possibly different, now-resolved)
+        // post-pull name: another task may have raced us here under a
+        // different pre-pull alias for what turns out to be the same
+        // model (e.g. a bare shortname vs. its fully-qualified form, both
+        // resolving to one canonical ref only once it's actually in the
+        // store) and already started serving it while we were pulling.
+        // Without this, that would spawn a second, redundant backend for
+        // the same model instead of reusing the one already loading/loaded.
+        if let Some(port) = check_running(state, model_ref).await {
+            return Ok(port);
+        }
+
         let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
             .with_context(|| format!("resolve model {model_ref}"))?;
         // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
@@ -1825,7 +1837,19 @@ async fn handle_ollama_generate(
     if is_unload {
         let resolved = crate::shortnames::resolve_ollama_api(&req.model);
         let canonical = canonical_ref(&state.0.store_path, &resolved);
+        // Wait for any in-flight load of this exact model to finish
+        // publishing itself before removing it — otherwise an unload
+        // landing in the (now unlocked, see `load_lock`) gap between a
+        // concurrent ensure_model's own checks and its final insert would
+        // find nothing to remove, report success, and then have the model
+        // come up running anyway right after. Never blocks on a different
+        // model's own load/unload.
+        let lock = load_lock(&canonical);
+        let _guard = lock.lock().await;
         state.0.manager.lock().await.running.remove(&canonical);
+        drop(_guard);
+        drop(lock);
+        release_load_lock(&canonical);
         return Ok(Json(OllamaGenerateChunk {
             model: req.model,
             created_at: now_rfc3339(),
@@ -2827,5 +2851,27 @@ mod tests {
 
         release_load_lock("test-load-lock-slow-model");
         release_load_lock("test-load-lock-other-model");
+    }
+
+    /// Regression test for a bug caught in review: a call site that drops
+    /// its `MutexGuard` but forgets to also drop its own `Arc` clone before
+    /// calling `release_load_lock` leaves that clone's reference alive, so
+    /// `release_load_lock`'s strong-count check never sees the registry as
+    /// the sole owner — the entry then never gets cleaned up and
+    /// `LOAD_LOCKS` grows one permanent, unused entry per model ref ever
+    /// locked this way. Exercises the exact guard-then-arc drop order the
+    /// real call sites (`ensure_model`, the Ollama unload handler) use.
+    #[tokio::test]
+    async fn load_lock_release_actually_removes_the_entry_once_unused() {
+        let key = "test-load-lock-release-cleanup";
+        let lock = load_lock(key);
+        let guard = lock.lock().await;
+        drop(guard);
+        drop(lock);
+        release_load_lock(key);
+        assert!(
+            !LOAD_LOCKS.lock().unwrap().contains_key(key),
+            "release_load_lock must drop the registry entry once nothing else references it"
+        );
     }
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -770,19 +770,12 @@ async fn wait_for_ready(
 static MODEL_LOCKS: LazyLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
-/// Same shape as `MODEL_LOCKS`, but a separate registry serializing
-/// `ensure_model`'s own load phase (spawn + wait-until-ready) per model —
-/// see `load_lock`'s doc comment. Kept as a distinct map (not reusing
-/// `MODEL_LOCKS`) because `ensure_model` holds a load lock across a call
-/// that itself takes a *model* lock internally (via `pull_serialized`);
-/// sharing one map would mean re-entering the same non-reentrant tokio
-/// mutex from within the task already holding it, which deadlocks.
+/// Separate from `MODEL_LOCKS`: `ensure_model` holds a load lock across a
+/// call that itself takes a `MODEL_LOCKS` lock (`pull_serialized`), so
+/// sharing one map would re-enter the same non-reentrant mutex and deadlock.
 static LOAD_LOCKS: LazyLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
-/// Returns (creating if absent) the lock for `key` in `registry`. Cheap and
-/// non-blocking: it only ever holds `registry`'s own short-lived std mutex
-/// to look up or insert the entry, never the per-key tokio mutex itself.
 fn keyed_lock(
     registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     key: &str,
@@ -794,17 +787,8 @@ fn keyed_lock(
         .clone()
 }
 
-/// Drops `key`'s entry from `registry` once nobody else appears to be
-/// waiting on it, so a long-running daemon doesn't accumulate one entry per
-/// distinct key it has ever locked. Called after releasing our own clone of
-/// the lock: at that point a strong count of 1 means only `registry` itself
-/// still references it (safe to remove), while a higher count means another
-/// caller is already holding or waiting on this same Arc and should keep
-/// using it — removing the map entry in that case wouldn't break anything
-/// (that caller's clone stays valid independent of the map), it would just
-/// mean the *next* new caller for this key gets handed a fresh, unrelated
-/// lock instead of piggybacking on the map's copy of this one, so it's
-/// simplest to just leave it.
+/// Removes `key` once nothing but `registry` itself still holds a clone —
+/// call after dropping your own clone.
 fn release_keyed_lock(registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>, key: &str) {
     let mut locks = registry.lock().unwrap();
     if let Some(arc) = locks.get(key) {
@@ -825,13 +809,8 @@ fn release_model_lock(model: &str) {
     release_keyed_lock(&MODEL_LOCKS, model)
 }
 
-/// Returns (creating if absent) the lock serializing `ensure_model`'s load
-/// phase for `model`: pull-if-missing, spawn, and wait-until-ready. Held
-/// only around that phase, never around the (separately, briefly locked)
-/// `state.0.manager` map — so a model that's slow to cold-start never
-/// blocks a fast-path lookup or another model's own load. Two concurrent
-/// requests for the *same* not-yet-loaded model still serialize here rather
-/// than each spawning a redundant backend process.
+/// Serializes `ensure_model`'s load phase (pull-if-missing, spawn,
+/// wait-until-ready) per model, instead of `state.0.manager`.
 fn load_lock(model: &str) -> Arc<tokio::sync::Mutex<()>> {
     keyed_lock(&LOAD_LOCKS, model)
 }
@@ -881,12 +860,7 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
         .unwrap_or_else(|| model_ref.to_owned())
 }
 
-/// Fast-path lookup: is `model_ref` already running and alive? Used both by
-/// `ensure_model`'s own entry, and — after taking `load_lock` — to check
-/// whether another task already finished loading it while this one waited
-/// on that lock. See `ModelProcess::is_alive`'s own doc comment on why this
-/// checks the actual process, not just presence in the map. Only ever holds
-/// `state.0.manager` briefly, never across any I/O.
+/// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
 async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
     let mut mgr = state.0.manager.lock().await;
     if let Some(m) = mgr.running.get_mut(model_ref) {
@@ -911,14 +885,6 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         return Ok(port);
     }
 
-    // Serialize the rest of this function (pull-if-missing, spawn,
-    // wait-until-ready) per model, via `load_lock` rather than
-    // `state.0.manager` — which is only ever taken briefly, in
-    // `check_running` above and to publish the result below. That's what
-    // lets an unrelated model's fast-path lookup, or its own load, proceed
-    // without ever waiting on this model's cold start; two concurrent
-    // requests for *this* not-yet-loaded model still serialize below rather
-    // than each spawning a redundant backend process.
     let lock = load_lock(model_ref);
     let result: Result<u16, AppError> = async {
         let _guard = lock.lock().await;
@@ -930,8 +896,6 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         }
 
         // If the model is not in the local store, pull it now.
-        // Runs outside the manager mutex so multi-GB downloads don't block
-        // other requests' lookups.
         if crate::storage::OciStore::open(&state.0.store_path)
             .and_then(|s| s.find(model_ref))
             .is_err()
@@ -949,14 +913,8 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         let model_ref = canonical_ref(&state.0.store_path, model_ref);
         let model_ref = model_ref.as_str();
 
-        // Double-check again, under the (possibly different, now-resolved)
-        // post-pull name: another task may have raced us here under a
-        // different pre-pull alias for what turns out to be the same
-        // model (e.g. a bare shortname vs. its fully-qualified form, both
-        // resolving to one canonical ref only once it's actually in the
-        // store) and already started serving it while we were pulling.
-        // Without this, that would spawn a second, redundant backend for
-        // the same model instead of reusing the one already loading/loaded.
+        // Re-check under the post-pull name too: a different pre-pull alias
+        // of this same model may have raced us and started it already.
         if let Some(port) = check_running(state, model_ref).await {
             return Ok(port);
         }
@@ -1007,10 +965,6 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
         eprintln!("[llmman] {model_ref} ready on port {port}");
 
-        // Only now, with the backend confirmed ready, briefly take the
-        // manager mutex to publish it — never held across the spawn/ready
-        // wait above, which is exactly what used to let a slow cold start
-        // freeze every other model's fast-path lookup.
         state.0.manager.lock().await.running.insert(
             model_ref.to_string(),
             RunningModel {
@@ -1837,13 +1791,8 @@ async fn handle_ollama_generate(
     if is_unload {
         let resolved = crate::shortnames::resolve_ollama_api(&req.model);
         let canonical = canonical_ref(&state.0.store_path, &resolved);
-        // Wait for any in-flight load of this exact model to finish
-        // publishing itself before removing it — otherwise an unload
-        // landing in the (now unlocked, see `load_lock`) gap between a
-        // concurrent ensure_model's own checks and its final insert would
-        // find nothing to remove, report success, and then have the model
-        // come up running anyway right after. Never blocks on a different
-        // model's own load/unload.
+        // Wait for an in-flight load of this model to publish itself first,
+        // so it can't race ahead of this remove.
         let lock = load_lock(&canonical);
         let _guard = lock.lock().await;
         state.0.manager.lock().await.running.remove(&canonical);
@@ -2784,13 +2733,6 @@ mod tests {
         assert_eq!(opt_u32(&None, "num_predict"), None);
     }
 
-    /// `keyed_lock` must hand back the *same* `Arc` for repeat calls with
-    /// the same key (so holding one clone's guard blocks another caller for
-    /// that key), a *different* `Arc` for a different key, and
-    /// `release_keyed_lock` must only drop an entry once nothing besides
-    /// the registry itself still references it — never while some other
-    /// caller's clone (and thus a lock a waiter may still be blocked on) is
-    /// alive.
     #[test]
     fn keyed_lock_is_per_key_and_release_only_drops_unreferenced_entries() {
         let registry: StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> =
@@ -2818,12 +2760,6 @@ mod tests {
         drop(b);
     }
 
-    /// The whole point of `load_lock`: two callers loading two *different*
-    /// models must never block on each other, even while one of them is
-    /// mid-load — this is the exact contention `ensure_model` used to have
-    /// via `state.0.manager` before this fix (see `load_lock`'s doc
-    /// comment). A second caller for the *same* model, though, must block
-    /// until the first one releases it.
     #[tokio::test(flavor = "multi_thread")]
     async fn load_lock_serializes_same_model_but_not_different_models() {
         let slow = load_lock("test-load-lock-slow-model");
@@ -2853,14 +2789,8 @@ mod tests {
         release_load_lock("test-load-lock-other-model");
     }
 
-    /// Regression test for a bug caught in review: a call site that drops
-    /// its `MutexGuard` but forgets to also drop its own `Arc` clone before
-    /// calling `release_load_lock` leaves that clone's reference alive, so
-    /// `release_load_lock`'s strong-count check never sees the registry as
-    /// the sole owner — the entry then never gets cleaned up and
-    /// `LOAD_LOCKS` grows one permanent, unused entry per model ref ever
-    /// locked this way. Exercises the exact guard-then-arc drop order the
-    /// real call sites (`ensure_model`, the Ollama unload handler) use.
+    /// Regression: a call site that drops its guard but not its own `Arc`
+    /// clone before calling `release_load_lock` leaves the entry stuck.
     #[tokio::test]
     async fn load_lock_release_actually_removes_the_entry_once_unused() {
         let key = "test-load-lock-release-cleanup";

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -820,6 +820,28 @@ fn release_load_lock(model: &str) {
     release_keyed_lock(&LOAD_LOCKS, model)
 }
 
+/// RAII handle for `load_lock`: releases the mutex and the registry entry
+/// in `Drop`, so cleanup still runs if the holding task is cancelled
+/// (e.g. an axum request future dropped mid-`.await`) rather than only on
+/// a normal return — code placed after an `.await` doesn't run when the
+/// future holding it is dropped instead of polled to completion.
+struct LoadLockGuard {
+    model: String,
+    guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+}
+
+impl Drop for LoadLockGuard {
+    fn drop(&mut self) {
+        self.guard.take(); // drop the Mutex guard (and its Arc clone) first
+        release_load_lock(&self.model);
+    }
+}
+
+async fn acquire_load_lock(model: &str) -> LoadLockGuard {
+    let guard = load_lock(model).lock_owned().await;
+    LoadLockGuard { model: model.to_owned(), guard: Some(guard) }
+}
+
 /// Pulls `model` into `layout_dir` if (still, after acquiring model's own
 /// lock) missing from the local store — shared by `ensure_model`'s
 /// fallback and `handle_pull` so both funnel through the same
@@ -885,102 +907,95 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         return Ok(port);
     }
 
-    let lock = load_lock(model_ref);
-    let result: Result<u16, AppError> = async {
-        let _guard = lock.lock().await;
+    let _guard = acquire_load_lock(model_ref).await;
 
-        // Someone else may have finished loading this model while we
-        // waited for the lock above.
-        if let Some(port) = check_running(state, model_ref).await {
-            return Ok(port);
-        }
-
-        // If the model is not in the local store, pull it now.
-        if crate::storage::OciStore::open(&state.0.store_path)
-            .and_then(|s| s.find(model_ref))
-            .is_err()
-        {
-            eprintln!("[llmman] {model_ref} not in store — pulling");
-            let store_path = state.0.store_path.clone();
-            let model_ref_owned = model_ref.to_owned();
-            tokio::task::spawn_blocking(move || pull_serialized(&store_path, &model_ref_owned))
-                .await
-                .context("pull task panicked")?
-                .context("pull failed")?;
-        }
-
-        // Re-canonicalise after the pull (tag may now be resolvable).
-        let model_ref = canonical_ref(&state.0.store_path, model_ref);
-        let model_ref = model_ref.as_str();
-
-        // Re-check under the post-pull name too: a different pre-pull alias
-        // of this same model may have raced us and started it already.
-        if let Some(port) = check_running(state, model_ref).await {
-            return Ok(port);
-        }
-
-        let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
-            .with_context(|| format!("resolve model {model_ref}"))?;
-        // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
-        // resolve_model above already established the model exists, so a
-        // failure here (e.g. a race with a concurrent `rm`) just means those
-        // columns show as empty/zero rather than failing the whole request.
-        let (digest, size) = OciStore::open(&state.0.store_path)
-            .and_then(|s| s.find(model_ref).map(|d| {
-                let size = s.total_size(&d);
-                (d.digest, size)
-            }))
-            .unwrap_or_default();
-        let port = find_free_port()?;
-        eprintln!("[llmman] loading {model_ref} on port {port}");
-        // Only a local llama-server child gets a captured stderr tail today
-        // (see spawn_llama_server) — container/vllm startup failures still
-        // fail fast via ModelProcess::is_alive below, just without an inline
-        // "here's why" (their own stdio is still inherited straight into
-        // serve.log, same as before).
-        let mut stderr_tail: Option<OutputTail> = None;
-        let mut process = match (&model_path, state.0.ociman) {
-            (ModelPath::Gguf(path), Some(ociman)) => {
-                ModelProcess::Container(
-                    ociman,
-                    crate::container::spawn(
-                        ociman,
-                        path,
-                        port,
-                        state.0.llama_cpp_version.as_deref(),
-                        state.0.ctx_size,
-                    )?,
-                )
-            }
-            (ModelPath::Gguf(path), None) => {
-                let bin = local_llama_server_bin(state).await?;
-                let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
-                stderr_tail = Some(tail);
-                ModelProcess::Local(Engine::LlamaServer, child)
-            }
-            (ModelPath::SafeTensors(dir), _) => {
-                ModelProcess::Local(Engine::Vllm, spawn_vllm_server(dir, port, model_ref).await?)
-            }
-        };
-        wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
-        eprintln!("[llmman] {model_ref} ready on port {port}");
-
-        state.0.manager.lock().await.running.insert(
-            model_ref.to_string(),
-            RunningModel {
-                process,
-                port,
-                digest,
-                size,
-                started_at: now_rfc3339(),
-            },
-        );
-        Ok(port)
+    // Someone else may have finished loading this model while we
+    // waited for the lock above.
+    if let Some(port) = check_running(state, model_ref).await {
+        return Ok(port);
     }
-    .await;
-    drop(lock);
-    release_load_lock(model_ref);
-    result
+
+    // If the model is not in the local store, pull it now.
+    if crate::storage::OciStore::open(&state.0.store_path)
+        .and_then(|s| s.find(model_ref))
+        .is_err()
+    {
+        eprintln!("[llmman] {model_ref} not in store — pulling");
+        let store_path = state.0.store_path.clone();
+        let model_ref_owned = model_ref.to_owned();
+        tokio::task::spawn_blocking(move || pull_serialized(&store_path, &model_ref_owned))
+            .await
+            .context("pull task panicked")?
+            .context("pull failed")?;
+    }
+
+    // Re-canonicalise after the pull (tag may now be resolvable).
+    let model_ref = canonical_ref(&state.0.store_path, model_ref);
+    let model_ref = model_ref.as_str();
+
+    // Re-check under the post-pull name too: a different pre-pull alias
+    // of this same model may have raced us and started it already.
+    if let Some(port) = check_running(state, model_ref).await {
+        return Ok(port);
+    }
+
+    let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
+        .with_context(|| format!("resolve model {model_ref}"))?;
+    // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
+    // resolve_model above already established the model exists, so a
+    // failure here (e.g. a race with a concurrent `rm`) just means those
+    // columns show as empty/zero rather than failing the whole request.
+    let (digest, size) = OciStore::open(&state.0.store_path)
+        .and_then(|s| s.find(model_ref).map(|d| {
+            let size = s.total_size(&d);
+            (d.digest, size)
+        }))
+        .unwrap_or_default();
+    let port = find_free_port()?;
+    eprintln!("[llmman] loading {model_ref} on port {port}");
+    // Only a local llama-server child gets a captured stderr tail today
+    // (see spawn_llama_server) — container/vllm startup failures still
+    // fail fast via ModelProcess::is_alive below, just without an inline
+    // "here's why" (their own stdio is still inherited straight into
+    // serve.log, same as before).
+    let mut stderr_tail: Option<OutputTail> = None;
+    let mut process = match (&model_path, state.0.ociman) {
+        (ModelPath::Gguf(path), Some(ociman)) => {
+            ModelProcess::Container(
+                ociman,
+                crate::container::spawn(
+                    ociman,
+                    path,
+                    port,
+                    state.0.llama_cpp_version.as_deref(),
+                    state.0.ctx_size,
+                )?,
+            )
+        }
+        (ModelPath::Gguf(path), None) => {
+            let bin = local_llama_server_bin(state).await?;
+            let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
+            stderr_tail = Some(tail);
+            ModelProcess::Local(Engine::LlamaServer, child)
+        }
+        (ModelPath::SafeTensors(dir), _) => {
+            ModelProcess::Local(Engine::Vllm, spawn_vllm_server(dir, port, model_ref).await?)
+        }
+    };
+    wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
+    eprintln!("[llmman] {model_ref} ready on port {port}");
+
+    state.0.manager.lock().await.running.insert(
+        model_ref.to_string(),
+        RunningModel {
+            process,
+            port,
+            digest,
+            size,
+            started_at: now_rfc3339(),
+        },
+    );
+    Ok(port)
 }
 
 /// Returns the local llama-server binary to spawn: the one resolved at
@@ -1793,12 +1808,8 @@ async fn handle_ollama_generate(
         let canonical = canonical_ref(&state.0.store_path, &resolved);
         // Wait for an in-flight load of this model to publish itself first,
         // so it can't race ahead of this remove.
-        let lock = load_lock(&canonical);
-        let _guard = lock.lock().await;
+        let _guard = acquire_load_lock(&canonical).await;
         state.0.manager.lock().await.running.remove(&canonical);
-        drop(_guard);
-        drop(lock);
-        release_load_lock(&canonical);
         return Ok(Json(OllamaGenerateChunk {
             model: req.model,
             created_at: now_rfc3339(),
@@ -2781,10 +2792,15 @@ mod tests {
         );
 
         drop(guard);
-        let _same_guard = tokio::time::timeout(std::time::Duration::from_millis(200), same.lock())
+        let same_guard = tokio::time::timeout(std::time::Duration::from_millis(200), same.lock())
             .await
             .expect("must acquire promptly once the first load releases");
 
+        drop(same_guard);
+        drop(_other_guard);
+        drop(same);
+        drop(other);
+        drop(slow);
         release_load_lock("test-load-lock-slow-model");
         release_load_lock("test-load-lock-other-model");
     }
@@ -2802,6 +2818,31 @@ mod tests {
         assert!(
             !LOAD_LOCKS.lock().unwrap().contains_key(key),
             "release_load_lock must drop the registry entry once nothing else references it"
+        );
+    }
+
+    /// Regression: aborting a task while it holds a `LoadLockGuard` must
+    /// still release the registry entry. `acquire_load_lock`'s caller
+    /// (`ensure_model`, the unload handler) can itself be cancelled by axum
+    /// mid-`.await` (a dropped client connection) — code placed after an
+    /// `.await` doesn't run in that case, so cleanup must live in `Drop`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_lock_guard_releases_on_task_cancellation() {
+        let key = "test-load-lock-guard-cancel";
+        let started = Arc::new(tokio::sync::Notify::new());
+        let started_tx = started.clone();
+        let handle = tokio::spawn(async move {
+            let _guard = acquire_load_lock("test-load-lock-guard-cancel").await;
+            started_tx.notify_one();
+            std::future::pending::<()>().await;
+        });
+        started.notified().await;
+        handle.abort();
+        let _ = handle.await;
+
+        assert!(
+            !LOAD_LOCKS.lock().unwrap().contains_key(key),
+            "aborting a task holding LoadLockGuard must still release the registry entry"
         );
     }
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -770,36 +770,75 @@ async fn wait_for_ready(
 static MODEL_LOCKS: LazyLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
-/// Returns (creating if absent) the lock serializing pull/push calls for
-/// `model`. Cheap and non-blocking: it only ever holds `MODEL_LOCKS`'s own
-/// short-lived std mutex to look up or insert the entry, never the
-/// per-model tokio mutex itself.
-fn model_lock(model: &str) -> Arc<tokio::sync::Mutex<()>> {
-    let mut locks = MODEL_LOCKS.lock().unwrap();
+/// Same shape as `MODEL_LOCKS`, but a separate registry serializing
+/// `ensure_model`'s own load phase (spawn + wait-until-ready) per model —
+/// see `load_lock`'s doc comment. Kept as a distinct map (not reusing
+/// `MODEL_LOCKS`) because `ensure_model` holds a load lock across a call
+/// that itself takes a *model* lock internally (via `pull_serialized`);
+/// sharing one map would mean re-entering the same non-reentrant tokio
+/// mutex from within the task already holding it, which deadlocks.
+static LOAD_LOCKS: LazyLock<StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// Returns (creating if absent) the lock for `key` in `registry`. Cheap and
+/// non-blocking: it only ever holds `registry`'s own short-lived std mutex
+/// to look up or insert the entry, never the per-key tokio mutex itself.
+fn keyed_lock(
+    registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    key: &str,
+) -> Arc<tokio::sync::Mutex<()>> {
+    let mut locks = registry.lock().unwrap();
     locks
-        .entry(model.to_owned())
+        .entry(key.to_owned())
         .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
         .clone()
 }
 
-/// Drops model's entry from `MODEL_LOCKS` once nobody else appears to be
-/// waiting on it, so a long-running daemon doesn't accumulate one entry
-/// per distinct model it has ever pulled/pushed. Called after releasing
-/// our own clone of the lock: at that point a strong count of 1 means
-/// only `MODEL_LOCKS` itself still references it (safe to remove), while
-/// a higher count means another caller is already holding or waiting on
-/// this same Arc and should keep using it — removing the map entry in
-/// that case wouldn't break anything (that caller's clone stays valid
-/// independent of the map), it would just mean the *next* new caller for
-/// this model gets handed a fresh, unrelated lock instead of piggybacking
-/// on the map's copy of this one, so it's simplest to just leave it.
-fn release_model_lock(model: &str) {
-    let mut locks = MODEL_LOCKS.lock().unwrap();
-    if let Some(arc) = locks.get(model) {
+/// Drops `key`'s entry from `registry` once nobody else appears to be
+/// waiting on it, so a long-running daemon doesn't accumulate one entry per
+/// distinct key it has ever locked. Called after releasing our own clone of
+/// the lock: at that point a strong count of 1 means only `registry` itself
+/// still references it (safe to remove), while a higher count means another
+/// caller is already holding or waiting on this same Arc and should keep
+/// using it — removing the map entry in that case wouldn't break anything
+/// (that caller's clone stays valid independent of the map), it would just
+/// mean the *next* new caller for this key gets handed a fresh, unrelated
+/// lock instead of piggybacking on the map's copy of this one, so it's
+/// simplest to just leave it.
+fn release_keyed_lock(registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>, key: &str) {
+    let mut locks = registry.lock().unwrap();
+    if let Some(arc) = locks.get(key) {
         if Arc::strong_count(arc) <= 1 {
-            locks.remove(model);
+            locks.remove(key);
         }
     }
+}
+
+/// Returns (creating if absent) the lock serializing pull/push calls for
+/// `model`. See `keyed_lock`.
+fn model_lock(model: &str) -> Arc<tokio::sync::Mutex<()>> {
+    keyed_lock(&MODEL_LOCKS, model)
+}
+
+/// See `release_keyed_lock`.
+fn release_model_lock(model: &str) {
+    release_keyed_lock(&MODEL_LOCKS, model)
+}
+
+/// Returns (creating if absent) the lock serializing `ensure_model`'s load
+/// phase for `model`: pull-if-missing, spawn, and wait-until-ready. Held
+/// only around that phase, never around the (separately, briefly locked)
+/// `state.0.manager` map — so a model that's slow to cold-start never
+/// blocks a fast-path lookup or another model's own load. Two concurrent
+/// requests for the *same* not-yet-loaded model still serialize here rather
+/// than each spawning a redundant backend process.
+fn load_lock(model: &str) -> Arc<tokio::sync::Mutex<()>> {
+    keyed_lock(&LOAD_LOCKS, model)
+}
+
+/// See `release_keyed_lock`.
+fn release_load_lock(model: &str) {
+    release_keyed_lock(&LOAD_LOCKS, model)
 }
 
 /// Pulls `model` into `layout_dir` if (still, after acquiring model's own
@@ -842,54 +881,17 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
         .unwrap_or_else(|| model_ref.to_owned())
 }
 
-async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError> {
-    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
-    let model_ref = canonical_ref(&state.0.store_path, &model_ref);
-    let model_ref = model_ref.as_str();
-
-    // Fast path: model already running. See ModelProcess::is_alive's own
-    // doc comment on why this checks the actual process, not just presence
-    // in the map.
-    {
-        let mut mgr = state.0.manager.lock().await;
-        if let Some(m) = mgr.running.get_mut(model_ref) {
-            if m.process.is_alive() {
-                return Ok(m.port);
-            }
-            eprintln!(
-                "[llmman] {model_ref} was marked running on port {} but its process has exited — reloading",
-                m.port
-            );
-            mgr.running.remove(model_ref);
-        }
-    } // mutex released before any I/O
-
-    // If the model is not in the local store, pull it now.
-    // Runs outside the mutex so multi-GB downloads don't block other requests.
-    if crate::storage::OciStore::open(&state.0.store_path)
-        .and_then(|s| s.find(model_ref))
-        .is_err()
-    {
-        eprintln!("[llmman] {model_ref} not in store — pulling");
-        let store_path = state.0.store_path.clone();
-        let model_ref_owned = model_ref.to_owned();
-        tokio::task::spawn_blocking(move || pull_serialized(&store_path, &model_ref_owned))
-            .await
-            .context("pull task panicked")?
-            .context("pull failed")?;
-    }
-
-    // Re-canonicalise after the pull (tag may now be resolvable).
-    let model_ref = canonical_ref(&state.0.store_path, model_ref);
-    let model_ref = model_ref.as_str();
-
+/// Fast-path lookup: is `model_ref` already running and alive? Used both by
+/// `ensure_model`'s own entry, and — after taking `load_lock` — to check
+/// whether another task already finished loading it while this one waited
+/// on that lock. See `ModelProcess::is_alive`'s own doc comment on why this
+/// checks the actual process, not just presence in the map. Only ever holds
+/// `state.0.manager` briefly, never across any I/O.
+async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
     let mut mgr = state.0.manager.lock().await;
-    // Double-check: another task may have started the server while we were
-    // pulling — or, per the fast path's own check above, been marked
-    // running by one that has since exited on its own.
     if let Some(m) = mgr.running.get_mut(model_ref) {
         if m.process.is_alive() {
-            return Ok(m.port);
+            return Some(m.port);
         }
         eprintln!(
             "[llmman] {model_ref} was marked running on port {} but its process has exited — reloading",
@@ -897,62 +899,122 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
         );
         mgr.running.remove(model_ref);
     }
-    let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
-        .with_context(|| format!("resolve model {model_ref}"))?;
-    // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
-    // resolve_model above already established the model exists, so a
-    // failure here (e.g. a race with a concurrent `rm`) just means those
-    // columns show as empty/zero rather than failing the whole request.
-    let (digest, size) = OciStore::open(&state.0.store_path)
-        .and_then(|s| s.find(model_ref).map(|d| {
-            let size = s.total_size(&d);
-            (d.digest, size)
-        }))
-        .unwrap_or_default();
-    let port = find_free_port()?;
-    eprintln!("[llmman] loading {model_ref} on port {port}");
-    // Only a local llama-server child gets a captured stderr tail today
-    // (see spawn_llama_server) — container/vllm startup failures still
-    // fail fast via ModelProcess::is_alive below, just without an inline
-    // "here's why" (their own stdio is still inherited straight into
-    // serve.log, same as before).
-    let mut stderr_tail: Option<OutputTail> = None;
-    let mut process = match (&model_path, state.0.ociman) {
-        (ModelPath::Gguf(path), Some(ociman)) => {
-            ModelProcess::Container(
-                ociman,
-                crate::container::spawn(
+    None
+}
+
+async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError> {
+    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    let model_ref = canonical_ref(&state.0.store_path, &model_ref);
+    let model_ref = model_ref.as_str();
+
+    if let Some(port) = check_running(state, model_ref).await {
+        return Ok(port);
+    }
+
+    // Serialize the rest of this function (pull-if-missing, spawn,
+    // wait-until-ready) per model, via `load_lock` rather than
+    // `state.0.manager` — which is only ever taken briefly, in
+    // `check_running` above and to publish the result below. That's what
+    // lets an unrelated model's fast-path lookup, or its own load, proceed
+    // without ever waiting on this model's cold start; two concurrent
+    // requests for *this* not-yet-loaded model still serialize below rather
+    // than each spawning a redundant backend process.
+    let lock = load_lock(model_ref);
+    let result: Result<u16, AppError> = async {
+        let _guard = lock.lock().await;
+
+        // Someone else may have finished loading this model while we
+        // waited for the lock above.
+        if let Some(port) = check_running(state, model_ref).await {
+            return Ok(port);
+        }
+
+        // If the model is not in the local store, pull it now.
+        // Runs outside the manager mutex so multi-GB downloads don't block
+        // other requests' lookups.
+        if crate::storage::OciStore::open(&state.0.store_path)
+            .and_then(|s| s.find(model_ref))
+            .is_err()
+        {
+            eprintln!("[llmman] {model_ref} not in store — pulling");
+            let store_path = state.0.store_path.clone();
+            let model_ref_owned = model_ref.to_owned();
+            tokio::task::spawn_blocking(move || pull_serialized(&store_path, &model_ref_owned))
+                .await
+                .context("pull task panicked")?
+                .context("pull failed")?;
+        }
+
+        // Re-canonicalise after the pull (tag may now be resolvable).
+        let model_ref = canonical_ref(&state.0.store_path, model_ref);
+        let model_ref = model_ref.as_str();
+
+        let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
+            .with_context(|| format!("resolve model {model_ref}"))?;
+        // Best-effort — used only to populate `llmman ps`'s ID/SIZE columns;
+        // resolve_model above already established the model exists, so a
+        // failure here (e.g. a race with a concurrent `rm`) just means those
+        // columns show as empty/zero rather than failing the whole request.
+        let (digest, size) = OciStore::open(&state.0.store_path)
+            .and_then(|s| s.find(model_ref).map(|d| {
+                let size = s.total_size(&d);
+                (d.digest, size)
+            }))
+            .unwrap_or_default();
+        let port = find_free_port()?;
+        eprintln!("[llmman] loading {model_ref} on port {port}");
+        // Only a local llama-server child gets a captured stderr tail today
+        // (see spawn_llama_server) — container/vllm startup failures still
+        // fail fast via ModelProcess::is_alive below, just without an inline
+        // "here's why" (their own stdio is still inherited straight into
+        // serve.log, same as before).
+        let mut stderr_tail: Option<OutputTail> = None;
+        let mut process = match (&model_path, state.0.ociman) {
+            (ModelPath::Gguf(path), Some(ociman)) => {
+                ModelProcess::Container(
                     ociman,
-                    path,
-                    port,
-                    state.0.llama_cpp_version.as_deref(),
-                    state.0.ctx_size,
-                )?,
-            )
-        }
-        (ModelPath::Gguf(path), None) => {
-            let bin = local_llama_server_bin(state).await?;
-            let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
-            stderr_tail = Some(tail);
-            ModelProcess::Local(Engine::LlamaServer, child)
-        }
-        (ModelPath::SafeTensors(dir), _) => {
-            ModelProcess::Local(Engine::Vllm, spawn_vllm_server(dir, port, model_ref).await?)
-        }
-    };
-    wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
-    eprintln!("[llmman] {model_ref} ready on port {port}");
-    mgr.running.insert(
-        model_ref.to_string(),
-        RunningModel {
-            process,
-            port,
-            digest,
-            size,
-            started_at: now_rfc3339(),
-        },
-    );
-    Ok(port)
+                    crate::container::spawn(
+                        ociman,
+                        path,
+                        port,
+                        state.0.llama_cpp_version.as_deref(),
+                        state.0.ctx_size,
+                    )?,
+                )
+            }
+            (ModelPath::Gguf(path), None) => {
+                let bin = local_llama_server_bin(state).await?;
+                let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
+                stderr_tail = Some(tail);
+                ModelProcess::Local(Engine::LlamaServer, child)
+            }
+            (ModelPath::SafeTensors(dir), _) => {
+                ModelProcess::Local(Engine::Vllm, spawn_vllm_server(dir, port, model_ref).await?)
+            }
+        };
+        wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
+        eprintln!("[llmman] {model_ref} ready on port {port}");
+
+        // Only now, with the backend confirmed ready, briefly take the
+        // manager mutex to publish it — never held across the spawn/ready
+        // wait above, which is exactly what used to let a slow cold start
+        // freeze every other model's fast-path lookup.
+        state.0.manager.lock().await.running.insert(
+            model_ref.to_string(),
+            RunningModel {
+                process,
+                port,
+                digest,
+                size,
+                started_at: now_rfc3339(),
+            },
+        );
+        Ok(port)
+    }
+    .await;
+    drop(lock);
+    release_load_lock(model_ref);
+    result
 }
 
 /// Returns the local llama-server binary to spawn: the one resolved at
@@ -2696,5 +2758,74 @@ mod tests {
         // No options blob at all.
         assert_eq!(opt_f64(&None, "temperature"), None);
         assert_eq!(opt_u32(&None, "num_predict"), None);
+    }
+
+    /// `keyed_lock` must hand back the *same* `Arc` for repeat calls with
+    /// the same key (so holding one clone's guard blocks another caller for
+    /// that key), a *different* `Arc` for a different key, and
+    /// `release_keyed_lock` must only drop an entry once nothing besides
+    /// the registry itself still references it — never while some other
+    /// caller's clone (and thus a lock a waiter may still be blocked on) is
+    /// alive.
+    #[test]
+    fn keyed_lock_is_per_key_and_release_only_drops_unreferenced_entries() {
+        let registry: StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>> =
+            StdMutex::new(HashMap::new());
+
+        let a1 = keyed_lock(&registry, "model-a");
+        let a2 = keyed_lock(&registry, "model-a");
+        assert!(Arc::ptr_eq(&a1, &a2), "same key must return the same lock");
+
+        let b = keyed_lock(&registry, "model-b");
+        assert!(!Arc::ptr_eq(&a1, &b), "different keys must not share a lock");
+
+        // Caller 1 finishes and releases its own clone — but caller 2's
+        // clone (a2) is still outstanding, so the entry must survive.
+        drop(a1);
+        release_keyed_lock(&registry, "model-a");
+        assert!(registry.lock().unwrap().contains_key("model-a"));
+
+        // Caller 2 finishes too — now only the registry itself references
+        // it, so releasing removes the entry.
+        drop(a2);
+        release_keyed_lock(&registry, "model-a");
+        assert!(!registry.lock().unwrap().contains_key("model-a"));
+
+        drop(b);
+    }
+
+    /// The whole point of `load_lock`: two callers loading two *different*
+    /// models must never block on each other, even while one of them is
+    /// mid-load — this is the exact contention `ensure_model` used to have
+    /// via `state.0.manager` before this fix (see `load_lock`'s doc
+    /// comment). A second caller for the *same* model, though, must block
+    /// until the first one releases it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn load_lock_serializes_same_model_but_not_different_models() {
+        let slow = load_lock("test-load-lock-slow-model");
+        let guard = slow.lock().await; // simulates a mid-flight cold start
+
+        // A different model's load must acquire immediately.
+        let other = load_lock("test-load-lock-other-model");
+        let _other_guard = tokio::time::timeout(std::time::Duration::from_millis(200), other.lock())
+            .await
+            .expect("a different model's load must not block on an unrelated one");
+
+        // The same model's load must not acquire until the first releases.
+        let same = load_lock("test-load-lock-slow-model");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), same.lock())
+                .await
+                .is_err(),
+            "a second load of the same model must block while the first is in flight"
+        );
+
+        drop(guard);
+        let _same_guard = tokio::time::timeout(std::time::Duration::from_millis(200), same.lock())
+            .await
+            .expect("must acquire promptly once the first load releases");
+
+        release_load_lock("test-load-lock-slow-model");
+        release_load_lock("test-load-lock-other-model");
     }
 }


### PR DESCRIPTION
ensure_model held state.0.manager's mutex across the whole cold-start path (subprocess spawn + wait_for_ready), not just around the map lookup/update. Since the fast path for an already-running model needs that same mutex, a request for model B queued behind model A's full load time whenever A happened to be loading concurrently — the opposite of the "each model gets its own subprocess" design.

Add a separate per-model load-lock registry (mirroring the existing MODEL_LOCKS pattern used for pull/push) that ensure_model holds across pull-if-missing/spawn/wait-until-ready instead of the manager mutex, which is now only ever taken briefly: once for the fast-path check, once more (after acquiring the load lock, in case another caller just finished) for the double-check, and once at the very end to publish the newly running model. Two concurrent requests for the same not-yet-loaded model still serialize on that model's load lock rather than each spawning a redundant backend process; unrelated models never contend on it at all.

Kept as a distinct lock registry (LOAD_LOCKS) rather than reusing MODEL_LOCKS, since ensure_model's load phase itself calls into pull_serialized, which takes a MODEL_LOCKS lock internally — sharing one map would re-enter the same non-reentrant tokio mutex from within the task already holding it.