### PR TITLE
test(e2e): give the opencode hang failure mode more retry headroom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,14 +292,16 @@ jobs:
     # windows-2025/windows-11-arm runs that setup+build overhead alone
     # (checkout, toolchains, npm installs, cargo build) already consumes
     # 5-8 of those minutes on Windows, before any of tests/launch_e2e.rs's
-    # own three tests even start — and one of those three can, in the
-    # worst case, legitimately need up to MAX_ATTEMPTS * TIMEOUT (launch_
-    # e2e.rs's own retry budget for the endless-agent-loop failure mode:
-    # 4 * 600s = 40 minutes, bumped from 3 attempts after CI run
-    # 32376290299 exhausted all 3 on two platforms at once). 60 leaves
+    # own three tests even start. Those three tests run serialized
+    # (--test-threads=1 + lock_serial()), so the real worst case sums all
+    # three's own retry budgets, not just one: claude and codex each cap
+    # at DEFAULT_MAX_ATTEMPTS * TIMEOUT (3 * 600s = 30 min), opencode at
+    # OPENCODE_MAX_ATTEMPTS * TIMEOUT (4 * 600s = 40 min, bumped after CI
+    # run 32376290299 exhausted 3/3 attempts on two platforms at once for
+    # opencode specifically) — 8 + 30 + 40 + 30 = 108 minutes. 120 leaves
     # real headroom for that worst case across every platform, not just
     # the fastest one.
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,12 +292,14 @@ jobs:
     # windows-2025/windows-11-arm runs that setup+build overhead alone
     # (checkout, toolchains, npm installs, cargo build) already consumes
     # 5-8 of those minutes on Windows, before any of tests/launch_e2e.rs's
-    # own three tests even start — and each of those three can, in the
-    # worst case, legitimately need up to TIMEOUT (600s each for its own
-    # warm_model()/launch calls; only the first test pays warm_model()'s
-    # cost, per WARM's own Once). 45 leaves real headroom for that
-    # worst case across every platform, not just the fastest one.
-    timeout-minutes: 45
+    # own three tests even start — and one of those three can, in the
+    # worst case, legitimately need up to MAX_ATTEMPTS * TIMEOUT (launch_
+    # e2e.rs's own retry budget for the endless-agent-loop failure mode:
+    # 4 * 600s = 40 minutes, bumped from 3 attempts after CI run
+    # 32376290299 exhausted all 3 on two platforms at once). 60 leaves
+    # real headroom for that worst case across every platform, not just
+    # the fastest one.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -549,7 +549,14 @@ fn run_launch(
 /// `llmman launch <integration> ...` invocation, against a fresh `HOME`
 /// each time, before giving up — see that function's own doc comment for
 /// why this exists at all.
-const MAX_ATTEMPTS: u32 = 3;
+///
+/// Was 3 until CI run 32376290299 (PR #256) hit the endless-agent-loop
+/// failure mode (see `launch_and_assert`'s doc comment) on two independent
+/// platforms (Windows/docker, Linux/podman) in the very same run — for
+/// `opencode` specifically, 3 attempts isn't reliably enough headroom.
+/// Bumped to 4; see ci.yml's `timeout-minutes` comment on the E2E job,
+/// which this changes the worst-case budget for.
+const MAX_ATTEMPTS: u32 = 4;
 
 /// Runs `llmman launch <integration> --model qwen3.5:0.8b -- <extra_args>`
 /// (via [`run_launch`], against a fresh temp `HOME` each attempt) and

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -549,19 +549,24 @@ fn run_launch(
 /// `llmman launch <integration> ...` invocation, against a fresh `HOME`
 /// each time, before giving up — see that function's own doc comment for
 /// why this exists at all.
-///
-/// Was 3 until CI run 32376290299 (PR #256) hit the endless-agent-loop
-/// failure mode (see `launch_and_assert`'s doc comment) on two independent
-/// platforms (Windows/docker, Linux/podman) in the very same run — for
-/// `opencode` specifically, 3 attempts isn't reliably enough headroom.
-/// Bumped to 4; see ci.yml's `timeout-minutes` comment on the E2E job,
-/// which this changes the worst-case budget for.
-const MAX_ATTEMPTS: u32 = 4;
+const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+
+/// `opencode`-only override: CI run 32376290299 (PR #256) hit the
+/// endless-agent-loop failure mode (see `launch_and_assert`'s doc comment)
+/// on two independent platforms (Windows/docker, Linux/podman) in the very
+/// same run, for `opencode` specifically — `DEFAULT_MAX_ATTEMPTS` isn't
+/// reliably enough headroom for it. `claude`/`codex` have never been
+/// observed hitting this failure mode, so they keep the default rather
+/// than everyone paying for a bigger worst-case retry budget. See ci.yml's
+/// `timeout-minutes` comment on the E2E job, which this changes the
+/// worst-case budget for.
+const OPENCODE_MAX_ATTEMPTS: u32 = 4;
 
 /// Runs `llmman launch <integration> --model qwen3.5:0.8b -- <extra_args>`
 /// (via [`run_launch`], against a fresh temp `HOME` each attempt) and
 /// asserts it succeeded and that the model's real answer shows up in
-/// stdout — retrying up to [`MAX_ATTEMPTS`] times, but *only* for the
+/// stdout — retrying up to `max_attempts` times (see
+/// `DEFAULT_MAX_ATTEMPTS`/`OPENCODE_MAX_ATTEMPTS`), but *only* for the
 /// two failure shapes small-model sampling variance alone can produce:
 ///
 ///   - the launch exited successfully and merely didn't happen to answer
@@ -595,18 +600,18 @@ const MAX_ATTEMPTS: u32 = 4;
 /// to the same red result while masking nothing — which keeps this from
 /// hiding the actual API-compat bugs this suite exists to catch (see
 /// that same doc comment).
-fn launch_and_assert(integration: &str, extra_args: &[&str]) {
+fn launch_and_assert(integration: &str, extra_args: &[&str], max_attempts: u32) {
     let mut last_failure = None;
-    for attempt in 1..=MAX_ATTEMPTS {
+    for attempt in 1..=max_attempts {
         let home = fresh_home(integration);
         let output = match run_launch(&home, integration, extra_args) {
             Ok(output) => output,
             Err(timed_out) => {
                 eprintln!(
-                    "[test] {integration}: attempt {attempt}/{MAX_ATTEMPTS} timed out \
+                    "[test] {integration}: attempt {attempt}/{max_attempts} timed out \
                      (small-model sampling variance can degenerate into an endless agent \
                      loop — see launch_and_assert's own doc comment); {}\n{}",
-                    if attempt < MAX_ATTEMPTS { "retrying with a fresh HOME" } else { "giving up" },
+                    if attempt < max_attempts { "retrying with a fresh HOME" } else { "giving up" },
                     timed_out.message
                 );
                 last_failure = Some(timed_out.message);
@@ -625,10 +630,10 @@ fn launch_and_assert(integration: &str, extra_args: &[&str]) {
             return;
         }
         eprintln!(
-            "[test] {integration}: attempt {attempt}/{MAX_ATTEMPTS} succeeded but the reply \
+            "[test] {integration}: attempt {attempt}/{max_attempts} succeeded but the reply \
              didn't contain \"pong\" (small-model sampling variance — see launch_and_assert's \
              own doc comment); {}",
-            if attempt < MAX_ATTEMPTS { "retrying with a fresh HOME" } else { "giving up" }
+            if attempt < max_attempts { "retrying with a fresh HOME" } else { "giving up" }
         );
         last_failure = Some(format!(
             "expected {integration}'s reply to contain \"pong\"\n\
@@ -636,7 +641,7 @@ fn launch_and_assert(integration: &str, extra_args: &[&str]) {
         ));
     }
     let last_failure = last_failure.expect("loop runs at least once, so this is always set");
-    panic!("{integration} failed all {MAX_ATTEMPTS} attempts; last failure:\n{last_failure}");
+    panic!("{integration} failed all {max_attempts} attempts; last failure:\n{last_failure}");
 }
 
 #[test]
@@ -656,7 +661,7 @@ fn launch_claude_with_model() {
     // `-p`/`--print`: Claude Code's non-interactive one-shot mode — the
     // scriptable equivalent of typing a message into the interactive TUI
     // `llmman launch claude --model qwen3.5:0.8b` would otherwise open.
-    launch_and_assert("claude", &["-p", PROMPT]);
+    launch_and_assert("claude", &["-p", PROMPT], DEFAULT_MAX_ATTEMPTS);
 }
 
 #[test]
@@ -681,7 +686,11 @@ fn launch_opencode_with_model() {
     // step in one environment during development; keep this on so a CI
     // failure's logs show exactly what opencode was doing right up to a
     // timeout, instead of just the banner and silence.
-    launch_and_assert("opencode", &["run", PROMPT, "--print-logs", "--log-level", "DEBUG"]);
+    launch_and_assert(
+        "opencode",
+        &["run", PROMPT, "--print-logs", "--log-level", "DEBUG"],
+        OPENCODE_MAX_ATTEMPTS,
+    );
 }
 
 #[test]
@@ -699,6 +708,6 @@ fn launch_codex_with_model() {
     }
 
     // `exec <prompt>`: codex's non-interactive one-shot mode.
-    launch_and_assert("codex", &["exec", PROMPT]);
+    launch_and_assert("codex", &["exec", PROMPT], DEFAULT_MAX_ATTEMPTS);
 }
 


### PR DESCRIPTION
CI run 32376290299 (PR #256, an unrelated 2-file llama_release.rs fix) hit launch_e2e.rs's already-documented endless-agent-loop failure mode (the model's sampling degenerating into a runaway decode loop that burns the whole 600s TIMEOUT, not a bad reply) on two independent platforms — Windows/docker and Linux/podman — in the same run, and exhausted all 3 retry attempts on both. That's for opencode specifically; claude and codex passed everywhere in the same run.

Bumped launch_e2e.rs's MAX_ATTEMPTS from 3 to 4. Since one test can now legitimately need up to 4 * 600s = 40 minutes in the worst case (vs. 30 before), raised the E2E job's timeout-minutes from 45 to 60 to keep the same headroom the original budget was reasoned out for — without this, a future run hitting the same failure mode across retries risks the outer job timeout hard-killing it mid-retry instead of letting launch_and_assert's own "giving up" path produce a clean panic and backtrace.