### PR TITLE
test(e2e): install llmman via install.sh/install.ps1 before e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,118 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
 
+      # ── Install llmman via the real install script ───────────────────────
+      # Runs the actual install.sh (Unix) / install.ps1 (Windows) a real
+      # user's `curl ... | sh` / `irm ... | iex` runs, pointed (via
+      # LLMMAN_BASE_URL — an env override added to both scripts
+      # specifically for this) at a throwaway local HTTP server serving
+      # *this job's own* just-built binary from the step above, instead of
+      # a real GitHub release: a release for a commit/PR still under test
+      # wouldn't exist yet, and even on `main` a real release still lags
+      # one full CI run behind whatever's actually being tested right now.
+      # Every other part of the install — OS/arch detection, the download
+      # itself, the `--version` smoke check, and the final
+      # install-directory copy — runs completely unmodified, so this is a
+      # real test of the install script's own logic, not a stand-in for
+      # it. `tests/launch_e2e.rs` (next step) then runs the resulting
+      # *installed* binary (via LLMMAN_E2E_BIN, set below) instead of the
+      # one `cargo build` itself dropped in target/, so the whole e2e
+      # suite ends up testing the same artifact a real install actually
+      # produces.
+      #
+      # `shell: bash` throughout (including the Windows entries, same as
+      # the "Install llama-server" step above): install.ps1 itself still
+      # needs real PowerShell, invoked here as `pwsh -NoProfile -File`
+      # from within this bash script — the same pattern that step already
+      # uses for `powershell -NoProfile -Command` — rather than a second,
+      # Windows-only `shell: pwsh` step, since everything else here (the
+      # local server, the download readiness poll) is identical on every
+      # OS.
+      - name: Install llmman (via install script)
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="${{ matrix.target }}"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            asset="llmman-$target.exe"
+            bin="target/$target/release/llmman.exe"
+          else
+            asset="llmman-$target"
+            bin="target/$target/release/llmman"
+          fi
+
+          # Mirrors the one path shape both scripts ever request
+          # ("<base>/latest/download/<asset>" — neither script is given
+          # LLMMAN_VERSION here, so both take their own "latest" branch),
+          # so the download step below is exercising the exact same
+          # URL-construction logic a real unpinned install does.
+          release_dir="$RUNNER_TEMP/fake-releases/latest/download"
+          mkdir -p "$release_dir"
+          cp "$bin" "$release_dir/$asset"
+
+          # A minimal static file server (plain Node http/fs — no npm
+          # package fetch) standing in for GitHub's own release-asset
+          # CDN. Node, not e.g. Python: every entry in this matrix already
+          # has Node on PATH (set up above for the claude/opencode/codex
+          # CLIs under test), so this adds no new dependency/toolchain,
+          # unlike Python (present, but not guaranteed to be `python3` vs
+          # `python` the same way across all five of this matrix's OSes).
+          # A real HTTP round trip, not a file:// URL curl/Invoke-WebRequest
+          # would also happily accept but a real install never goes
+          # through.
+          cat > "$RUNNER_TEMP/serve-release.js" <<'EOF'
+          const http = require("http");
+          const fs = require("fs");
+          const path = require("path");
+          const root = process.argv[2];
+          const port = Number(process.argv[3]);
+          http.createServer((req, res) => {
+            const file = path.join(root, decodeURIComponent(req.url));
+            fs.readFile(file, (err, data) => {
+              if (err) { res.writeHead(404); res.end(); return; }
+              res.writeHead(200);
+              res.end(data);
+            });
+          }).listen(port, "127.0.0.1");
+          EOF
+          node "$RUNNER_TEMP/serve-release.js" "$RUNNER_TEMP/fake-releases" 8791 &
+          server_pid=$!
+          # This server only needs to live long enough for the install
+          # below — killed at the end of this step either way (`trap ...
+          # EXIT`, not a separate step) rather than left running for the
+          # rest of the job for nothing.
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+
+          for _ in $(seq 1 50); do
+            curl -fsS "http://127.0.0.1:8791/latest/download/$asset" -o /dev/null 2>/dev/null && break
+            sleep 0.2
+          done
+
+          export LLMMAN_BASE_URL="http://127.0.0.1:8791"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            pwsh -NoProfile -File install.ps1
+            # cygpath -w, not a bare "$LOCALAPPDATA/..." concatenation:
+            # this exact value is about to cross into $GITHUB_ENV for the
+            # *next* step's own child process (tests/launch_e2e.rs's
+            # `Command::new`) to spawn directly — a canonical
+            # backslash-separated Windows path there is one less thing to
+            # go wrong than relying on that consumer also tolerating
+            # forward slashes.
+            install_bin=$(cygpath -w "$LOCALAPPDATA/Microsoft/WindowsApps/llmman.exe")
+          else
+            sh install.sh
+            install_bin="$HOME/.local/bin/llmman"
+            # install.sh itself only prints instructions to add this to
+            # PATH for *future* shell sessions (see its own PATH-check
+            # branch) — added here too so any later step in this job that
+            # just runs `llmman` bare (matching what a real post-install
+            # shell would do) can.
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+
+          "$install_bin" --version
+          echo "LLMMAN_E2E_BIN=$install_bin" >> "$GITHUB_ENV"
+
       # LLAMA_ARG_N_GPU_LAYERS=0 on macOS only: llama-server reads this
       # itself (it's the env form of its own --gpu-layers flag), and this
       # process's environment reaches the llama-server subprocess
@@ -667,6 +779,17 @@ jobs:
       # this test binary must link against the same backend the one built
       # above did, or the two podman entries would silently test a docker-
       # backed binary instead.
+      #
+      # LLMMAN_E2E_BIN isn't set here — it doesn't need to be. The
+      # "Install llmman (via install script)" step above already exported
+      # it into $GITHUB_ENV, which every later step in this job (this one
+      # included) inherits automatically; see tests/launch_e2e.rs's own
+      # `llmman_bin` doc comment for what it's actually for: making this
+      # whole suite launch the *installed* binary the step above produced,
+      # not the one `cargo build`/this step's own compile drops in
+      # target/ (which still happens regardless — env!("CARGO_BIN_EXE_llmman")
+      # is a compile-time macro, and it's still that step's fallback for a
+      # plain local `cargo test` run).
       - name: cargo test --test launch_e2e
         run: cargo test --release --target ${{ matrix.target }} ${{ matrix.feature-flags }} --test launch_e2e -- --test-threads=1 --nocapture
         env:

--- a/install.ps1
+++ b/install.ps1
@@ -17,6 +17,16 @@
 # Env overrides:
 #   LLMMAN_VERSION   pin an exact release tag (e.g. "v0.2.0"); default: latest
 #   LLMMAN_REPO      "owner/repo" to fetch from; default: llmmanorg/llmman
+#   LLMMAN_BASE_URL  release base URL to fetch from, in place of GitHub's own
+#                    "https://github.com/$Repo/releases"; exists so CI
+#                    (.github/workflows/ci.yml's e2e job) can point this
+#                    script at a throwaway local HTTP server serving that
+#                    job's own just-built binary instead — a real GitHub
+#                    release for a commit/PR still under test wouldn't exist
+#                    yet — while every other part of the install (arch
+#                    detection, the download itself, the --version smoke
+#                    check, the final install-directory copy) still runs
+#                    completely unmodified against a real HTTP round trip.
 #   SKIP_INSTALL     download and verify only, don't install
 
 function Die {
@@ -36,12 +46,14 @@ function Main {
     }
 
     $Asset = "llmman-$Target.exe"
+    $BaseUrl = $env:LLMMAN_BASE_URL
+    if (!$BaseUrl) { $BaseUrl = "https://github.com/$Repo/releases" }
     $Version = $env:LLMMAN_VERSION
     if ($Version) {
-        $Url = "https://github.com/$Repo/releases/download/$Version/$Asset"
+        $Url = "$BaseUrl/download/$Version/$Asset"
         "Version: $Version"
     } else {
-        $Url = "https://github.com/$Repo/releases/latest/download/$Asset"
+        $Url = "$BaseUrl/latest/download/$Asset"
         "Version: latest"
     }
 

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,16 @@
 # Env overrides:
 #   LLMMAN_VERSION   pin an exact release tag (e.g. "v0.2.0"); default: latest
 #   LLMMAN_REPO      "owner/repo" to fetch from; default: llmmanorg/llmman
+#   LLMMAN_BASE_URL  release base URL to fetch from, in place of GitHub's own
+#                    "https://github.com/$LLMMAN_REPO/releases"; exists so
+#                    CI (.github/workflows/ci.yml's e2e job) can point this
+#                    script at a throwaway local HTTP server serving that
+#                    job's own just-built binary instead — a real GitHub
+#                    release for a commit/PR still under test wouldn't exist
+#                    yet — while every other part of the install (OS/arch
+#                    detection, the download itself, the --version smoke
+#                    check, the final install-directory copy) still runs
+#                    completely unmodified against a real HTTP round trip.
 #   SKIP_INSTALL     download and verify only, don't install to ~/.local/bin
 
 : "${LLMMAN_REPO:=llmmanorg/llmman}"
@@ -62,11 +72,12 @@ main() {
 	[ "$HOME" ] || die "No HOME, please check your OS"
 
 	ASSET="llmman-${TARGET}"
+	BASE_URL="${LLMMAN_BASE_URL:-https://github.com/$LLMMAN_REPO/releases}"
 	if [ "$LLMMAN_VERSION" ]; then
-		URL="https://github.com/$LLMMAN_REPO/releases/download/$LLMMAN_VERSION/$ASSET"
+		URL="$BASE_URL/download/$LLMMAN_VERSION/$ASSET"
 		printf "Version: %s\n" "$LLMMAN_VERSION"
 	else
-		URL="https://github.com/$LLMMAN_REPO/releases/latest/download/$ASSET"
+		URL="$BASE_URL/latest/download/$ASSET"
 		printf "Version: latest\n"
 	fi
 

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -37,8 +37,10 @@
 //! one shared daemon and to keep three real model launches from
 //! competing for the same GPU/CPU at once.
 //!
-//! Not run as part of `cargo build` or CI (`.github/workflows/ci.yml`
-//! never invokes `cargo test`) — run explicitly:
+//! Not run as part of `cargo build`, and not run by the `test` job in
+//! `.github/workflows/ci.yml` (that job only runs the in-crate
+//! `#[cfg(test)]` unit tests) — this file is its own separate `e2e` job
+//! there instead. To run it locally, invoke it explicitly:
 //!
 //!   cargo test --release --test launch_e2e -- --nocapture --test-threads=1
 //!
@@ -128,8 +130,28 @@ fn lock_serial() -> std::sync::MutexGuard<'static, ()> {
 /// actually reach it.
 static WARM: Once = Once::new();
 
+/// The `llmman` binary every test in this file launches.
+///
+/// CI (see `.github/workflows/ci.yml`'s e2e job) installs the exact
+/// binary `cargo build` just produced via the real `install.sh`/
+/// `install.ps1` scripts before running this suite, then points
+/// `LLMMAN_E2E_BIN` at the resulting installed copy (`~/.local/bin/llmman`
+/// on Unix, `%LOCALAPPDATA%\Microsoft\WindowsApps\llmman.exe` on Windows)
+/// — so what's actually under test is the same installed artifact a real
+/// user's `curl ... | sh`/`irm ... | iex` produces, not just whatever
+/// `cargo build` itself dropped in `target/`, closing the gap between
+/// this suite and how llmman is actually obtained in practice.
+///
+/// Falls back to Cargo's own `CARGO_BIN_EXE_llmman` (the pre-existing
+/// behavior) when that env var isn't set, so a plain local
+/// `cargo test --release --test launch_e2e` (see this file's own module
+/// doc comment) keeps working without requiring the installer to have
+/// been run first.
 fn llmman_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_llmman"))
+    match std::env::var_os("LLMMAN_E2E_BIN") {
+        Some(path) => PathBuf::from(path),
+        None => PathBuf::from(env!("CARGO_BIN_EXE_llmman")),
+    }
 }
 
 /// True if `bin` resolves on `PATH` — enough for test-skip purposes


### PR DESCRIPTION
## Summary

Before this change, the `e2e` CI job ran `tests/launch_e2e.rs` straight
against whatever `cargo build` had dropped in
`target/<triple>/release/` — `install.sh`/`install.ps1` themselves were
never actually exercised by CI at all.

This makes the e2e job install the freshly-built `llmman` binary via
the real install scripts first, so the suite tests the same artifact a
real user's `curl .../install.sh | sh` (or `irm .../install.ps1 | iex`)
actually produces, and so a regression in either install script now
gets real CI coverage on every OS/arch they support.

## How it works

- Added an `LLMMAN_BASE_URL` env override to both `install.sh` and
  `install.ps1` (defaults to GitHub's own releases URL — real end-user
  installs are unaffected). This lets CI point the *unmodified* install
  logic (OS/arch detection, download, `--version` smoke check, final
  install-directory copy) at a throwaway local HTTP server instead of a
  real GitHub release, since a release for a commit/PR still under test
  wouldn't exist yet.
- The e2e job's new "Install llmman (via install script)" step stages
  the just-built binary behind a minimal Node-based static file server
  (Node's already on PATH in that job for the claude/opencode/codex
  CLIs under test) and runs the real `install.sh`/`install.ps1` against
  it.
- `tests/launch_e2e.rs`'s `llmman_bin()` now prefers a new
  `LLMMAN_E2E_BIN` env var (set by that CI step to the installed
  binary's path) over the pre-existing `CARGO_BIN_EXE_llmman`, so a
  plain local `cargo test --test launch_e2e` still works without
  requiring the installer to have been run first.

## Testing

- `sh -n install.sh` and a local dry run of `install.sh` against a
  Python `http.server` with `LLMMAN_BASE_URL` set, confirming the
  override downloads/installs/verifies correctly.
- Manually reproduced the new CI step's exact shell logic locally
  (staging a real `cargo build --release --target aarch64-apple-darwin`
  binary, serving it via the same inline Node script, running
  `install.sh` against it) end-to-end.
- `LLMMAN_E2E_BIN=/usr/bin/true cargo test --release --test
  launch_e2e launch_claude_with_model` to confirm the new env override
  in `llmman_bin()` is actually picked up.
- `actionlint .github/workflows/ci.yml` — no new warnings (the two
  pre-existing shellcheck notices are unrelated, pre-dating this
  change).
- `cargo test --release --test launch_e2e --no-run` compiles cleanly.