### PR TITLE
fix: make vllm-backed safetensors launches (opencode/codex/claude) actually work

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -77,7 +77,32 @@ fn emit_version() {
         None => pkg,
     };
     println!("cargo:rustc-env=LLMMAN_VERSION={version}");
-    println!("cargo:rerun-if-changed=.git/HEAD");
+    // `HEAD` only changes on a checkout/branch switch; an ordinary `git
+    // commit` on the current branch instead updates `logs/HEAD` (the
+    // reflog) — without watching that too, `--dirty`'s output (and so
+    // LLMMAN_VERSION) can go stale across a commit, defeating
+    // stale_daemon's version comparison in daemon.rs. Resolved via
+    // `git rev-parse --git-path` rather than a hardcoded `.git/...` path
+    // so this also reruns correctly from a linked worktree, where the
+    // real HEAD/logs live under `.git/worktrees/<name>/` instead.
+    for path in ["HEAD", "logs/HEAD"] {
+        if let Some(resolved) = git_path(path) {
+            println!("cargo:rerun-if-changed={}", resolved.display());
+        }
+    }
+}
+
+/// Resolves a path relative to the repo's git dir (e.g. `"HEAD"` or
+/// `"logs/HEAD"`) via `git rev-parse --git-path`, so it's correct both for
+/// a plain `.git` directory and a linked worktree's own `.git` file.
+fn git_path(path: &str) -> Option<PathBuf> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", path])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| PathBuf::from(s.trim()))
 }
 
 fn main() {

--- a/go-shim/hf.go
+++ b/go-shim/hf.go
@@ -827,11 +827,16 @@ func pullHF(ctx context.Context, ref, layoutDir, progressKey string) error {
 }
 
 // safetensorsMediaType maps a file extension to the appropriate CNCF layer media type.
+//
+// ".jinja" is config, not doc: many HF repos ship a standalone
+// chat_template.jinja file, and the Rust-side extractor drops "doc"
+// layers, so a chat template classified that way never reaches the
+// served model directory and vllm refuses every chat request.
 func safetensorsMediaType(path string) string {
 	switch strings.ToLower(filepath.Ext(path)) {
 	case ".safetensors", ".bin", ".pt", ".pth":
 		return modelspec.MediaTypeModelWeightRaw
-	case ".json", ".model", ".txt", ".tiktoken":
+	case ".json", ".model", ".txt", ".tiktoken", ".jinja":
 		return modelspec.MediaTypeModelWeightConfigRaw
 	default:
 		return modelspec.MediaTypeModelDocRaw
@@ -849,7 +854,9 @@ func shouldDownloadSafetensors(path string) bool {
 	switch ext {
 	case ".safetensors", ".bin", ".pt", ".pth": // weights
 		return true
-	case ".json", ".model", ".txt", ".tiktoken": // config / tokeniser
+	// config / tokenizer — ".jinja" is a standalone chat template file,
+	// see safetensorsMediaType.
+	case ".json", ".model", ".txt", ".tiktoken", ".jinja":
 		return true
 	}
 	// README and licence are useful but optional.

--- a/go-shim/hf_test.go
+++ b/go-shim/hf_test.go
@@ -254,3 +254,20 @@ func TestBuildCNCFManifestPopulatesMetadata(t *testing.T) {
 		t.Errorf("modelfs.diffIds has %d entries, want 2 (one per layer)", len(model.ModelFS.DiffIDs))
 	}
 }
+
+// Regression: a standalone chat_template.jinja file used to be silently
+// excluded from a safetensors pull, causing vllm/transformers to refuse
+// every chat request with "you must provide a chat template".
+func TestShouldDownloadSafetensorsIncludesChatTemplateJinja(t *testing.T) {
+	if !shouldDownloadSafetensors("chat_template.jinja") {
+		t.Error("chat_template.jinja must be downloaded as part of a safetensors pull")
+	}
+}
+
+func TestSafetensorsMediaTypeClassifiesChatTemplateJinjaAsConfig(t *testing.T) {
+	got := safetensorsMediaType("chat_template.jinja")
+	want := modelspec.MediaTypeModelWeightConfigRaw
+	if got != want {
+		t.Errorf("safetensorsMediaType(chat_template.jinja) = %q, want %q", got, want)
+	}
+}

--- a/go-shim/uri_sources.go
+++ b/go-shim/uri_sources.go
@@ -92,8 +92,9 @@ func classifyFile(name string) string {
 	case ".safetensors", ".bin", ".pt", ".pth", ".gguf", ".ggml",
 		".gguf_v2", ".ot", ".engine", ".trt", ".onnx":
 		return "application/vnd.cncf.model.weight.v1.raw"
+	// ".jinja": a standalone chat_template.jinja file, see hf.go.
 	case ".json", ".yaml", ".yml", ".toml", ".ini", ".cfg", ".conf",
-		".model", ".tiktoken", ".vocab", ".merges", ".spm":
+		".model", ".tiktoken", ".vocab", ".merges", ".spm", ".jinja":
 		return "application/vnd.cncf.model.weight.config.v1.raw"
 	case ".txt":
 		// tokenizer vocab / merges files are config; README is doc

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -186,8 +186,8 @@ struct RunningModel {
 impl RunningModel {
     fn processor(&self) -> String {
         match &self.process {
-            ModelProcess::Local(Engine::LlamaServer, _) => "llama-server (local)".into(),
-            ModelProcess::Local(Engine::Vllm, _) => "vllm (local)".into(),
+            ModelProcess::Local(Engine::LlamaServer, _, _) => "llama-server (local)".into(),
+            ModelProcess::Local(Engine::Vllm, _, _) => "vllm (local)".into(),
             ModelProcess::Container(ociman, _) => {
                 format!("llama-server (container/{})", ociman.binary())
             }
@@ -196,7 +196,7 @@ impl RunningModel {
 
     fn pid(&self) -> Option<u32> {
         match &self.process {
-            ModelProcess::Local(_, child) => child.id(),
+            ModelProcess::Local(_, child, _) => child.id(),
             ModelProcess::Container(_, child) => child.id(),
         }
     }
@@ -211,22 +211,48 @@ enum Engine {
 }
 
 /// A running inference backend: either a local `llama-server`/`vllm`
-/// process (killed via `Child::kill_on_drop`, as before, set at spawn
-/// time) or an attached `docker run --rm --init -t`/`podman run` process
-/// (see crate::container::spawn's doc comment) — gracefully stopped via
-/// SIGTERM on drop, since the default forceful kill `kill_on_drop` would
-/// use cannot be forwarded to (and so does not stop) the container.
+/// process (killed via `Child::kill_on_drop`, except `Engine::Vllm` —
+/// see this Drop impl) or an attached `docker run`/`podman run` process,
+/// gracefully stopped via SIGTERM on drop since `kill_on_drop`'s SIGKILL
+/// can't be forwarded to (and so doesn't stop) the container.
 enum ModelProcess {
-    Local(Engine, #[allow(dead_code)] tokio::process::Child),
+    // `Option<u32>` is the pid captured right after spawn, not
+    // `child.id()` at drop time: `is_alive`'s `try_wait` reaps the child
+    // once it exits, after which `child.id()` returns `None` — losing the
+    // only pid needed to SIGKILL an `Engine::Vllm` group in Drop below.
+    Local(Engine, tokio::process::Child, Option<u32>),
     Container(crate::container::ContainerManager, tokio::process::Child),
 }
 
 impl Drop for ModelProcess {
     fn drop(&mut self) {
-        if let ModelProcess::Container(_, child) = self {
-            if let Some(pid) = child.id() {
-                crate::container::stop(pid);
+        match self {
+            ModelProcess::Container(_, child) => {
+                if let Some(pid) = child.id() {
+                    crate::container::stop(pid);
+                }
             }
+            // vllm forks its own API-server/engine-core workers, which
+            // don't share a process tree `kill_on_drop`'s single-pid kill
+            // can reach — SIGKILLing just the top pid (e.g. on a
+            // cancelled load) orphans them, still holding GPU memory
+            // indefinitely. spawn_vllm_server puts this child in its own
+            // process group so the whole group can be killed here.
+            #[cfg(unix)]
+            ModelProcess::Local(Engine::Vllm, _, pid) => {
+                if let Some(pid) = pid {
+                    let result = unsafe { libc::kill(-(*pid as libc::pid_t), libc::SIGKILL) };
+                    if result != 0 {
+                        let err = std::io::Error::last_os_error();
+                        eprintln!(
+                            "[llmman] warning: SIGKILL to vllm process group {pid} failed: {err}"
+                        );
+                    }
+                }
+            }
+            #[cfg(not(unix))]
+            ModelProcess::Local(Engine::Vllm, _, _) => {}
+            ModelProcess::Local(Engine::LlamaServer, _, _) => {}
         }
     }
 }
@@ -245,7 +271,7 @@ impl ModelProcess {
     /// cheap for.
     fn is_alive(&mut self) -> bool {
         let child = match self {
-            ModelProcess::Local(_, child) => child,
+            ModelProcess::Local(_, child, _) => child,
             ModelProcess::Container(_, child) => child,
         };
         matches!(child.try_wait(), Ok(None))
@@ -674,20 +700,31 @@ async fn spawn_vllm_server(
     model_name: &str,
 ) -> anyhow::Result<tokio::process::Child> {
     let vllm = which_binary("vllm")?;
-    tokio::process::Command::new(&vllm)
-        .args([
-            "serve",
-            model_dir.to_str().context("non-UTF-8 model path")?,
-            "--port",
-            &port.to_string(),
-            "--host",
-            "127.0.0.1",
-            // Register the model under the same name used in API requests so
-            // {"model": "<ref>"} is accepted by vllm's OpenAI-compatible API.
-            "--served-model-name",
-            model_name,
-        ])
-        .kill_on_drop(true)
+    let mut cmd = tokio::process::Command::new(&vllm);
+    cmd.args([
+        "serve",
+        model_dir.to_str().context("non-UTF-8 model path")?,
+        "--port",
+        &port.to_string(),
+        "--host",
+        "127.0.0.1",
+        // Register the model under the same name used in API requests so
+        // {"model": "<ref>"} is accepted by vllm's OpenAI-compatible API.
+        "--served-model-name",
+        model_name,
+    ]);
+    // vllm's default --gpu-memory-utilization (0.9 of the *device's
+    // total* memory) routinely exceeds what's actually free on a
+    // unified-memory host or any box already running other GPU
+    // workloads, so it refuses to start. Let a user work around it.
+    if let Ok(extra) = std::env::var("LLMMAN_VLLM_ARGS") {
+        cmd.args(extra.split_whitespace());
+    }
+    // Own process group so ModelProcess's Drop impl can kill vllm's whole
+    // worker tree, not just this one pid, without also killing ourselves.
+    #[cfg(unix)]
+    cmd.process_group(0);
+    cmd.kill_on_drop(true)
         .spawn()
         .with_context(|| format!("spawn vllm from {}", vllm.display()))
 }
@@ -928,7 +965,14 @@ async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
     None
 }
 
-async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError> {
+/// Ensures `model_ref` is loaded and returns `(canonical_ref, port)`. The
+/// canonical name is what it's actually registered under with its backend
+/// (`--served-model-name`), which can differ from a tagless `model_ref`
+/// (e.g. `hf.co/owner/repo` canonicalizes to `...:latest`). Callers must
+/// forward this canonical name, not their own input, as the "model" field
+/// sent to the backend — vllm validates it strictly and 404s otherwise
+/// (llama-server doesn't, so this went unnoticed for GGUF models).
+async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16), AppError> {
     let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
     // Default the tag before the lock below: otherwise two concurrent
     // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
@@ -938,7 +982,7 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
     let model_ref = model_ref.as_str();
 
     if let Some(port) = check_running(state, model_ref).await {
-        return Ok(port);
+        return Ok((model_ref.to_string(), port));
     }
 
     let _guard = acquire_load_lock(model_ref).await;
@@ -946,7 +990,7 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
     // Someone else may have finished loading this model while we
     // waited for the lock above.
     if let Some(port) = check_running(state, model_ref).await {
-        return Ok(port);
+        return Ok((model_ref.to_string(), port));
     }
 
     // If the model is not in the local store, pull it now.
@@ -970,7 +1014,7 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
 
     // Re-check in case that stored form differs from the key above.
     if let Some(port) = check_running(state, model_ref).await {
-        return Ok(port);
+        return Ok((model_ref.to_string(), port));
     }
 
     let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
@@ -1010,10 +1054,12 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
             let bin = local_llama_server_bin(state).await?;
             let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
             stderr_tail = Some(tail);
-            ModelProcess::Local(Engine::LlamaServer, child)
+            ModelProcess::Local(Engine::LlamaServer, child, None)
         }
         (ModelPath::SafeTensors(dir), _) => {
-            ModelProcess::Local(Engine::Vllm, spawn_vllm_server(dir, port, model_ref).await?)
+            let child = spawn_vllm_server(dir, port, model_ref).await?;
+            let pid = child.id();
+            ModelProcess::Local(Engine::Vllm, child, pid)
         }
     };
     wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
@@ -1029,7 +1075,7 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
             started_at: now_rfc3339(),
         },
     );
-    Ok(port)
+    Ok((model_ref.to_string(), port))
 }
 
 /// Returns the local llama-server binary to spawn: the one resolved at
@@ -1635,16 +1681,31 @@ async fn handle_show(
 
 #[derive(Debug, Deserialize)]
 struct OllamaPullRequest {
+    #[serde(default)]
     model: String,
-    #[serde(alias = "name", default)]
-    _name: String,
+    // Real Ollama keeps `Name` as a deprecated fallback for `Model`
+    // (server/routes.go's `cmp.Or(req.Model, req.Name)`) — some clients
+    // only ever send `name`, which used to 422 outright since `model`
+    // was required. Falls back below like handle_show/handle_delete
+    // already do.
+    #[serde(default)]
+    name: String,
 }
 
 async fn handle_pull(
     State(state): State<AppState>,
     Json(req): Json<OllamaPullRequest>,
 ) -> impl IntoResponse {
-    let model = crate::shortnames::resolve_ollama_api(&req.model);
+    let model_ref = if req.model.is_empty() {
+        req.name.as_str()
+    } else {
+        req.model.as_str()
+    };
+    if model_ref.is_empty() {
+        let body = serde_json::json!({"error": "model is required"});
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
+    let model = crate::shortnames::resolve_ollama_api(model_ref);
     eprintln!("[llmman] /api/pull model={model:?}");
     let store_path = state.0.store_path.clone();
 
@@ -1687,16 +1748,28 @@ async fn handle_pull(
 
 #[derive(Debug, Deserialize)]
 struct OllamaPushRequest {
+    #[serde(default)]
     model: String,
-    #[serde(alias = "name", default)]
-    _name: String,
+    // See OllamaPullRequest's `name` field doc comment: same deprecated
+    // `Name`-falls-back-to-`Model` shape as real Ollama's PushRequest.
+    #[serde(default)]
+    name: String,
 }
 
 async fn handle_push(
     State(state): State<AppState>,
     Json(req): Json<OllamaPushRequest>,
 ) -> impl IntoResponse {
-    let model = crate::shortnames::resolve_ollama_api(&req.model);
+    let model_ref = if req.model.is_empty() {
+        req.name.as_str()
+    } else {
+        req.model.as_str()
+    };
+    if model_ref.is_empty() {
+        let body = serde_json::json!({"error": "model is required"});
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
+    let model = crate::shortnames::resolve_ollama_api(model_ref);
     eprintln!("[llmman] /api/push model={model:?}");
     let store_path = state.0.store_path.clone();
 
@@ -1824,10 +1897,10 @@ async fn handle_ollama_chat(
         req.model,
         req.messages.len()
     );
-    let port = ensure_model(&state, &req.model).await?;
+    let (model, port) = ensure_model(&state, &req.model).await?;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     let oai = OAIChatRequest {
-        model: req.model.clone(),
+        model: model.clone(),
         messages: req
             .messages
             .iter()
@@ -1843,7 +1916,6 @@ async fn handle_ollama_chat(
         repeat_penalty: opt_f64(&req.options, "repeat_penalty").or(Some(DEFAULT_REPEAT_PENALTY)),
         chat_template_kwargs: think_to_chat_template_kwargs(&req.think),
     };
-    let model = req.model;
     stream_ollama(
         state.0.client.clone(),
         url,
@@ -1901,7 +1973,7 @@ async fn handle_ollama_generate(
         .into_response());
     }
 
-    let port = ensure_model(&state, &req.model).await?;
+    let (model, port) = ensure_model(&state, &req.model).await?;
     // Empty prompt = load-only request (mirrors ollama server/routes.go:429).
     if req.prompt.is_empty() {
         return Ok(Json(OllamaGenerateChunk {
@@ -1917,7 +1989,7 @@ async fn handle_ollama_generate(
 
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     let oai = OAIChatRequest {
-        model: req.model.clone(),
+        model: model.clone(),
         messages: vec![OAIMessage {
             role: "user".into(),
             content: req.prompt.clone(),
@@ -1929,7 +2001,6 @@ async fn handle_ollama_generate(
         repeat_penalty: opt_f64(&req.options, "repeat_penalty").or(Some(DEFAULT_REPEAT_PENALTY)),
         chat_template_kwargs: think_to_chat_template_kwargs(&req.think),
     };
-    let model = req.model;
     stream_ollama(
         state.0.client.clone(),
         url,
@@ -1971,21 +2042,23 @@ async fn handle_openai_models(
     Ok(Json(serde_json::json!({ "object": "list", "data": data })))
 }
 
-/// Shared body of every plain OpenAI-passthrough route: parse just enough of
-/// the request to find `model`, make sure it's loaded, then proxy the
-/// untouched request body straight through to llama-server's equivalent
-/// endpoint. `llama_path` is the only thing that differs between
-/// handle_openai_chat/completions/embeddings below.
+/// Shared body of every plain OpenAI-passthrough route: parse just enough
+/// of the request to find `model`, make sure it's loaded, rewrite `model`
+/// to its canonical name (see `ensure_model`), then proxy through to the
+/// backend's equivalent endpoint. `llama_path` is the only thing that
+/// differs between handle_openai_chat/completions/embeddings below.
 async fn proxy_openai(
     state: &AppState,
     headers: &HeaderMap,
     body: Bytes,
     llama_path: &str,
 ) -> Result<Response, AppError> {
-    let req: serde_json::Value =
+    let mut req: serde_json::Value =
         serde_json::from_slice(&body).context("parse OpenAI request body")?;
     let model = req["model"].as_str().unwrap_or("").to_string();
-    let port = ensure_model(state, &model).await?;
+    let (model, port) = ensure_model(state, &model).await?;
+    req["model"] = serde_json::Value::String(model);
+    let body = Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);
     let url = format!("http://127.0.0.1:{port}{llama_path}");
     proxy(&state.0.client, &url, headers, body).await
 }
@@ -2208,13 +2281,15 @@ async fn handle_anthropic_messages(
     State(state): State<AppState>,
     Json(req): Json<AnthropicRequest>,
 ) -> Result<Response, AppError> {
-    let port = ensure_model(&state, &req.model).await?;
+    // Backend needs its canonical name (see ensure_model); the response
+    // below still echoes req.model back, unchanged from before.
+    let (canonical_model, port) = ensure_model(&state, &req.model).await?;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
 
     let messages = build_anthropic_messages(&req);
 
     let oai = OAIChatRequest {
-        model: req.model.clone(),
+        model: canonical_model,
         messages,
         stream: req.stream,
         temperature: req.temperature,
@@ -2989,5 +3064,36 @@ mod tests {
             !LOAD_LOCKS.lock().unwrap().contains_key(key),
             "aborting a task holding LoadLockGuard must still release the registry entry"
         );
+    }
+
+    /// Regression test for `OllamaPullRequest`'s `name` field: a body
+    /// carrying only `{"name": "..."}` used to fail Axum's `Json`
+    /// extraction outright — `model` was a required, non-default field —
+    /// before this handler's own name-falls-back-to-model logic ever ran.
+    #[test]
+    fn ollama_pull_request_accepts_a_name_only_body() {
+        let req: OllamaPullRequest =
+            serde_json::from_value(serde_json::json!({"name": "docker.io/ai/gemma4:E2B"}))
+                .expect("a name-only body must still deserialize");
+        assert_eq!(req.model, "");
+        assert_eq!(req.name, "docker.io/ai/gemma4:E2B");
+    }
+
+    #[test]
+    fn ollama_pull_request_accepts_a_model_only_body() {
+        let req: OllamaPullRequest =
+            serde_json::from_value(serde_json::json!({"model": "docker.io/ai/gemma4:E2B"}))
+                .expect("a model-only body must still deserialize");
+        assert_eq!(req.model, "docker.io/ai/gemma4:E2B");
+        assert_eq!(req.name, "");
+    }
+
+    #[test]
+    fn ollama_push_request_accepts_a_name_only_body() {
+        let req: OllamaPushRequest =
+            serde_json::from_value(serde_json::json!({"name": "docker.io/ai/gemma4:E2B"}))
+                .expect("a name-only body must still deserialize");
+        assert_eq!(req.model, "");
+        assert_eq!(req.name, "docker.io/ai/gemma4:E2B");
     }
 }

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -269,27 +269,18 @@ impl OciStore {
         desc.annotations = Some(ann);
 
         let mut idx = self.read_index()?;
-        let mut replaced = false;
-        for entry in &mut idx.manifests {
-            if ref_matches(entry, reference) {
-                *entry = desc.clone();
-                replaced = true;
-                break;
-            }
-        }
-        if !replaced {
-            idx.manifests.push(desc);
+        match matching_index(&idx.manifests, reference) {
+            Some(i) => idx.manifests[i] = desc,
+            None => idx.manifests.push(desc),
         }
         self.write_index(&idx)
     }
 
-    /// Find the descriptor for `reference` in the index.
-    /// Matches either the full stored reference or (as fallback) just its tag component.
+    /// Find the descriptor for `reference` in the index — see `matching_index`.
     pub fn find(&self, reference: &str) -> anyhow::Result<Descriptor> {
         let idx = self.read_index()?;
-        idx.manifests
-            .into_iter()
-            .find(|m| ref_matches(m, reference))
+        matching_index(&idx.manifests, reference)
+            .map(|i| idx.manifests[i].clone())
             .ok_or_else(|| anyhow!("image not found: {}", reference))
     }
 
@@ -338,14 +329,14 @@ impl OciStore {
             .collect())
     }
 
-    /// Remove a manifest from the index by reference.  Does not GC blobs.
+    /// Remove the same single entry `find` would return for `reference`
+    /// (see `matching_index`). Does not GC blobs.
     pub fn remove(&self, reference: &str) -> anyhow::Result<()> {
         let mut idx = self.read_index()?;
-        let before = idx.manifests.len();
-        idx.manifests.retain(|m| !ref_matches(m, reference));
-        if idx.manifests.len() == before {
+        let Some(i) = matching_index(&idx.manifests, reference) else {
             return Err(anyhow!("image not found: {}", reference));
-        }
+        };
+        idx.manifests.remove(i);
         self.write_index(&idx)
     }
 
@@ -482,8 +473,9 @@ fn classify_model_layer(rel_path: &str) -> &'static str {
     match ext {
         "safetensors" | "bin" | "pt" | "pth" | "gguf" | "ggml" | "ot" | "engine" | "trt"
         | "onnx" => WEIGHT_TAR_MEDIA_TYPE,
+        // "jinja": a standalone chat_template.jinja file, see go-shim/hf.go.
         "json" | "yaml" | "yml" | "toml" | "ini" | "cfg" | "conf" | "model" | "tiktoken"
-        | "vocab" | "merges" | "spm" => WEIGHT_CONFIG_TAR_MEDIA_TYPE,
+        | "vocab" | "merges" | "spm" | "jinja" => WEIGHT_CONFIG_TAR_MEDIA_TYPE,
         "txt" => {
             if base.contains("vocab") || base.contains("merges") {
                 WEIGHT_CONFIG_TAR_MEDIA_TYPE
@@ -505,55 +497,74 @@ fn classify_model_layer(rel_path: &str) -> &'static str {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Returns true if the descriptor's ref annotation matches `reference`.
-///
-/// Three strategies are tried in order:
-/// 1. Exact match (`"reg/repo:tag"` == `"reg/repo:tag"`)
-/// 2. Tag-only match (`"latest"` matches `"reg/repo:latest"`)
-/// 3. Tagless match: if `reference` has no tag, implicitly append `:latest`
-///    so `"reg/repo"` matches `"reg/repo:latest"`
-fn ref_matches(desc: &Descriptor, reference: &str) -> bool {
-    let stored = match desc
-        .annotations
-        .as_ref()
-        .and_then(|a| a.get("org.opencontainers.image.ref.name"))
-    {
-        Some(s) => s,
-        None => return false,
+/// True if the descriptor's ref annotation matches `reference` precisely
+/// — exact match, tag-only match (a bare `reference` against a stored
+/// `"reg/repo:tag"`), or tagless match (`reference` with an implicit
+/// `:latest` appended). The tag-only branch is unambiguous only when
+/// `reference` is a bare tag that's unique across stored tags — two
+/// different repos sharing the same tag (e.g. both `:0.8b`) can still
+/// both match here, same as `ref_matches_bare_tag_heuristic` below.
+fn ref_matches_precise(desc: &Descriptor, reference: &str) -> bool {
+    let Some(stored) = stored_ref_name(desc) else {
+        return false;
     };
 
     if stored == reference || tag_from_ref(stored) == reference {
         return true;
     }
-
-    // The podman backend's own OCI-layout writer can only ever record a
-    // bare tag here, never a full reference: go-shim/backend_podman.go's
-    // pullToLayout builds the destination as `oci:<layoutDir>:<tag>`
-    // (via tagFromRef), and go.podman.io/image's oci transport uses that
-    // trailing component verbatim as the stored annotation
-    // (oci/layout/oci_dest.go's PutManifest) — there's no repository
-    // component in that reference shape at all to also record. This is
-    // architecturally different from the docker/containerd backend's own
-    // writer (shared_oci.go's updateIndex), which always stores the
-    // *full* reference it was called with, matched by the first check
-    // above. A `stored` value with no '/' is that shape: match it
-    // against the incoming reference's own tag instead of requiring an
-    // (impossible, for this backend) full-reference match.
-    //
-    // Known limitation, not fixed here: two different repositories
-    // pulled with the podman backend that happen to share the same bare
-    // tag are indistinguishable once stored this way — podman's
-    // OCI-layout writer has no way to record more than a tag per entry
-    // to begin with, regardless of what this lookup does.
-    if !stored.contains('/') && stored.as_str() == tag_from_ref(reference) {
+    // `default_tag` also guards non-taggable sources (URI schemes, absolute
+    // paths), so this can't accidentally match one of those against some
+    // unrelated stored `"...:latest"`.
+    if stored == default_tag(reference) {
         return true;
     }
-
-    if stored.as_str() == default_tag(reference) {
-        return true;
-    }
-
     false
+}
+
+/// The podman backend can only ever store a bare tag here, never a full
+/// reference (see backend_podman.go's pullToLayout) — match it against
+/// `reference`'s own tag component instead. Deliberately weaker/lower
+/// priority than `ref_matches_precise`: comparing only a tag substring,
+/// with no repository info, can false-positive against an unrelated
+/// entry (e.g. every tagless reference defaults to "latest"), so `find`
+/// only consults this once nothing in the index matches precisely.
+///
+/// Known limitation: two different repos pulled via podman that happen
+/// to share the same bare tag are indistinguishable once stored this way.
+fn ref_matches_bare_tag_heuristic(desc: &Descriptor, reference: &str) -> bool {
+    let Some(stored) = stored_ref_name(desc) else {
+        return false;
+    };
+    !stored.contains('/') && stored == tag_from_ref(reference)
+}
+
+/// The index of the entry in `manifests` that `find`/`tag`/`remove` should
+/// treat as matching `reference`, or `None`.
+///
+/// Two full passes, not one pass with per-entry fallbacks: two different
+/// entries can each satisfy a different strategy for the same
+/// `reference`, and only iteration order would decide the winner
+/// otherwise. Regression this fixes: an unrelated model stored under a
+/// bare "latest" tag could hijack an unrelated tagless reference (which
+/// also defaults to "latest"), including on a second lookup of a
+/// reference already canonicalized to `...:latest` by a first call. A
+/// precise match anywhere in the index now always wins.
+fn matching_index(manifests: &[Descriptor], reference: &str) -> Option<usize> {
+    manifests
+        .iter()
+        .position(|m| ref_matches_precise(m, reference))
+        .or_else(|| {
+            manifests
+                .iter()
+                .position(|m| ref_matches_bare_tag_heuristic(m, reference))
+        })
+}
+
+fn stored_ref_name(desc: &Descriptor) -> Option<&str> {
+    desc.annotations
+        .as_ref()
+        .and_then(|a| a.get("org.opencontainers.image.ref.name"))
+        .map(|s| s.as_str())
 }
 
 /// Appends `:latest` to `reference` if it has no tag, so a tag-less
@@ -632,31 +643,17 @@ mod tests {
     /// The docker/containerd backend's own writer (shared_oci.go's
     /// updateIndex) always stores the full reference it was called with.
     #[test]
-    fn ref_matches_a_full_reference_stored_verbatim() {
+    fn ref_matches_precise_a_full_reference_stored_verbatim() {
         let d = desc_with_ref("docker.io/ai/qwen3.5:0.8b");
-        assert!(ref_matches(&d, "docker.io/ai/qwen3.5:0.8b"));
-        assert!(!ref_matches(&d, "docker.io/ai/qwen3.5:1.5b"));
-        assert!(!ref_matches(&d, "docker.io/ai/other:0.8b"));
-    }
-
-    /// Regression test: the podman backend's OCI-layout writer
-    /// (go.podman.io/image, via the `oci:<dir>:<tag>` reference shape —
-    /// see backend_podman.go's pullToLayout) can only ever store a bare
-    /// tag here, never a full reference — a real pull otherwise
-    /// succeeded but the model could never be found again afterward
-    /// (`resolve model ...: image not found`) until this matched.
-    #[test]
-    fn ref_matches_a_bare_tag_stored_by_the_podman_backend() {
-        let d = desc_with_ref("0.8b");
-        assert!(ref_matches(&d, "docker.io/ai/qwen3.5:0.8b"));
-        assert!(ref_matches(&d, "0.8b"));
-        assert!(!ref_matches(&d, "docker.io/ai/qwen3.5:1.5b"));
+        assert!(ref_matches_precise(&d, "docker.io/ai/qwen3.5:0.8b"));
+        assert!(!ref_matches_precise(&d, "docker.io/ai/qwen3.5:1.5b"));
+        assert!(!ref_matches_precise(&d, "docker.io/ai/other:0.8b"));
     }
 
     #[test]
-    fn ref_matches_defaults_a_tagless_reference_to_latest() {
+    fn ref_matches_precise_defaults_a_tagless_reference_to_latest() {
         let d = desc_with_ref("docker.io/ai/qwen3.5:latest");
-        assert!(ref_matches(&d, "docker.io/ai/qwen3.5"));
+        assert!(ref_matches_precise(&d, "docker.io/ai/qwen3.5"));
     }
 
     #[test]
@@ -692,14 +689,65 @@ mod tests {
     }
 
     #[test]
-    fn ref_matches_returns_false_without_a_ref_name_annotation() {
+    fn ref_matches_precise_returns_false_without_a_ref_name_annotation() {
         let d = Descriptor {
             media_type: "application/vnd.oci.image.manifest.v1+json".into(),
             digest: "sha256:deadbeef".into(),
             size: 123,
             annotations: None,
         };
-        assert!(!ref_matches(&d, "docker.io/ai/qwen3.5:0.8b"));
+        assert!(!ref_matches_precise(&d, "docker.io/ai/qwen3.5:0.8b"));
+    }
+
+    /// Regression test: the podman backend's OCI-layout writer
+    /// (go.podman.io/image, via the `oci:<dir>:<tag>` reference shape —
+    /// see backend_podman.go's pullToLayout) can only ever store a bare
+    /// tag here, never a full reference — a real pull otherwise
+    /// succeeded but the model could never be found again afterward
+    /// (`resolve model ...: image not found`) until this matched.
+    #[test]
+    fn ref_matches_bare_tag_heuristic_matches_a_bare_tag_stored_by_the_podman_backend() {
+        let d = desc_with_ref("0.8b");
+        assert!(ref_matches_bare_tag_heuristic(
+            &d,
+            "docker.io/ai/qwen3.5:0.8b"
+        ));
+        assert!(!ref_matches_bare_tag_heuristic(
+            &d,
+            "docker.io/ai/qwen3.5:1.5b"
+        ));
+        // An exact bare-tag match is ref_matches_precise's job instead,
+        // via matching_index's two-tier priority.
+        assert_eq!(matching_index(&[d], "0.8b"), Some(0));
+    }
+
+    /// Regression: an unrelated model stored under a bare "latest" tag
+    /// must not hijack a precisely-matching tagless reference (which also
+    /// defaults to "latest"), whether that reference is still tagless or
+    /// already canonicalized to `...:latest` by a prior lookup — earlier
+    /// index position must not decide the winner either way.
+    #[test]
+    fn matching_index_prefers_a_precise_match_over_an_unrelated_bare_latest_regardless_of_order() {
+        let unrelated_bare_latest = desc_with_ref("latest");
+        let inferact = desc_with_ref("hf.co/Inferact/Qwen3.8-27B-NVFP4:latest");
+        let manifests = vec![unrelated_bare_latest.clone(), inferact.clone()];
+
+        let i = matching_index(&manifests, "hf.co/Inferact/Qwen3.8-27B-NVFP4")
+            .expect("must find a match");
+        assert_eq!(manifests[i].digest, inferact.digest);
+
+        let i = matching_index(&manifests, "hf.co/Inferact/Qwen3.8-27B-NVFP4:latest")
+            .expect("must find a match");
+        assert_eq!(manifests[i].digest, inferact.digest);
+
+        // No more specific match anywhere: the bare-tag heuristic still
+        // applies as a last resort.
+        let only_bare_latest = vec![unrelated_bare_latest.clone()];
+        assert_eq!(
+            matching_index(&only_bare_latest, "docker.io/ai/qwen3.5:latest"),
+            Some(0)
+        );
+        assert_eq!(matching_index(&only_bare_latest, "latest"), Some(0));
     }
 
     #[test]
@@ -708,8 +756,9 @@ mod tests {
         assert_eq!(tag_from_ref("docker.io/ai/qwen3.5"), "latest");
         // A bare tag with no slash and no colon (podman's own stored
         // shape) has nothing to extract from — falls back to "latest",
-        // which is why ref_matches needs its own dedicated bare-tag
-        // check above rather than reusing this for both directions.
+        // which is why ref_matches_bare_tag_heuristic exists as its own
+        // dedicated check above rather than reusing this for both
+        // directions.
         assert_eq!(tag_from_ref("0.8b"), "latest");
     }
 


### PR DESCRIPTION
## Summary

Verifying `llmman launch --model <safetensors-model> <opencode|codex|claude>` end-to-end on real hardware (vllm 0.27.1, GB10/DGX Spark) turned up five bugs blocking it entirely. All fixed here, squashed into one commit.

- **hf-pull**: standalone `chat_template.jinja` files were dropped from safetensors pulls, so vllm refused every chat request with "you must provide a chat template".
- **oci**: a cached bare `"latest"` tag (podman backend) could hijack an unrelated tagless reference, silently serving the wrong model. Reference matching is now a precise pass + a lower-priority bare-tag heuristic, so a precise match always wins regardless of index order.
- **serve**: vllm forks worker processes that outlive a single-pid kill, orphaning them (holding GPU memory) if a load gets cancelled. Fixed via a dedicated process group, SIGKILLed as a group on drop (Unix only — Windows keeps the old single-pid `kill_on_drop`).
- **serve**: `/api/pull`/`/api/push` 422'd on a body with only `{"name": ...}` instead of falling back to it like `handle_show`/`handle_delete` already do.
- **serve**: `ensure_model` registers the backend under a canonicalized name, but callers proxied requests using the client's original name — vllm validates this strictly and 404'd. `ensure_model` now returns the canonical name and every caller forwards it.

Also: `LLMMAN_VLLM_ARGS` to pass extra flags to vllm (its default `--gpu-memory-utilization` routinely exceeds what's free on unified-memory hosts), and `build.rs` now watches `.git/logs/HEAD` too (via `git rev-parse --git-path`, so it works from a linked worktree) so `LLMMAN_VERSION` doesn't go stale across a same-branch commit.

Note: an earlier revision of this PR also added an `openclaw` launch integration — split out to a separate PR.

## Testing

- `cargo test --release`: 75 unit + 3 e2e tests passing.
- `go test ./...` (go-shim), including 2 new regression tests for the chat-template fix.
- `cargo clippy`, `cargo fmt --check`.
- Manual end-to-end verification on real hardware for `docker.io/ai/qwen3.8:27b-safetensors`, `docker.io/ai/qwen3.8:27b-nvfp4`, and `hf.co/Inferact/Qwen3.8-27B-NVFP4`.

### release-note
```release-note
Fix vllm-backed safetensors launches (opencode/codex/claude)
```
