### PR TITLE
fix(serve): default a missing tag before ensure_model's load lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,21 @@ env:
   LLAMA_CPP_RELEASE: b10293
 
 jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          components: rustfmt
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "llmman"
 version = "0.1.0"
 edition = "2021"
-description = "LLM model management tool using Docker or Podman transport libraries"
+description = "llmman manages OCI models"
 license = "Apache-2.0"
 
 [[bin]]

--- a/build.rs
+++ b/build.rs
@@ -139,9 +139,9 @@ fn main() {
     if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
         let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let msvc_triple = match arch.as_str() {
-            "x86_64"  => "x86_64-pc-windows-msvc",
+            "x86_64" => "x86_64-pc-windows-msvc",
             "aarch64" => "aarch64-pc-windows-msvc",
-            other     => panic!("unsupported Windows MSVC arch: {}", other),
+            other => panic!("unsupported Windows MSVC arch: {}", other),
         };
         // The wrapper calls clang with a fixed --target then forwards all other
         // args (%*).  Go treats this .cmd as the C compiler.
@@ -225,15 +225,12 @@ fn main() {
     for name in &["index.html", "bundle.js", "bundle.css", "loading.html"] {
         let src = webui_src.join(name);
         let dst = webui_out.join(format!("{name}.gz"));
-        let data = fs::read(&src)
-            .unwrap_or_else(|e| panic!("read webui/{name}: {e}"));
+        let data = fs::read(&src).unwrap_or_else(|e| panic!("read webui/{name}: {e}"));
         let mut enc = GzEncoder::new(Vec::new(), Compression::best());
         enc.write_all(&data).expect("gzip write");
         let compressed = enc.finish().expect("gzip finish");
-        fs::write(&dst, &compressed)
-            .unwrap_or_else(|e| panic!("write {name}.gz: {e}"));
+        fs::write(&dst, &compressed).unwrap_or_else(|e| panic!("write {name}.gz: {e}"));
     }
 
     println!("cargo:rerun-if-changed=webui/");
 }
-

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -135,7 +135,10 @@ fn print_integrations() {
         if find_on_path(i.binary).is_some() {
             println!("  {:<12} {}", i.name, i.description);
         } else {
-            println!("  {:<12} {} (not installed — {})", i.name, i.description, i.install_hint);
+            println!(
+                "  {:<12} {} (not installed — {})",
+                i.name, i.description, i.install_hint
+            );
         }
     }
     println!("\nUsage: llmman launch <integration> [--model <model>]");
@@ -203,8 +206,9 @@ fn launch(name: &str, model: &str, extra_args: &[String]) -> anyhow::Result<()> 
 /// claude: set ANTHROPIC_BASE_URL and a dummy ANTHROPIC_API_KEY so it talks to
 /// our server's Anthropic-compatible API.
 fn launch_claude(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
-    let bin = find_on_path("claude")
-        .ok_or_else(|| anyhow::anyhow!("claude is not installed — https://code.claude.com/docs/en/quickstart"))?;
+    let bin = find_on_path("claude").ok_or_else(|| {
+        anyhow::anyhow!("claude is not installed — https://code.claude.com/docs/en/quickstart")
+    })?;
 
     let mut args: Vec<String> = Vec::new();
     if !model.is_empty() {
@@ -231,18 +235,13 @@ fn launch_opencode(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
             p.exists().then_some(p)
         })
     });
-    let bin = bin.ok_or_else(|| {
-        anyhow::anyhow!("opencode is not installed — https://opencode.ai")
-    })?;
+    let bin =
+        bin.ok_or_else(|| anyhow::anyhow!("opencode is not installed — https://opencode.ai"))?;
 
     let effective_model = if model.is_empty() { "default" } else { model };
     let config = opencode_config(effective_model);
 
-    exec_with_env(
-        &bin,
-        extra_args,
-        &[("OPENCODE_CONFIG_CONTENT", &config)],
-    )
+    exec_with_env(&bin, extra_args, &[("OPENCODE_CONFIG_CONTENT", &config)])
 }
 
 fn opencode_config(model: &str) -> String {
@@ -294,11 +293,7 @@ fn launch_codex(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     args.extend(["--profile".to_string(), "llmman".to_string()]);
     args.extend_from_slice(extra_args);
 
-    exec_with_env(
-        &bin,
-        &args,
-        &[("OPENAI_API_KEY", "llmman")],
-    )
+    exec_with_env(&bin, &args, &[("OPENAI_API_KEY", "llmman")])
 }
 
 /// Writes codex's `llmman` profile.
@@ -383,8 +378,9 @@ fn launch_aider(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 
 /// copilot: passes COPILOT_PROVIDER_BASE_URL via env.
 fn launch_copilot(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
-    let bin = find_on_path("gh")
-        .ok_or_else(|| anyhow::anyhow!("gh (GitHub CLI) is not installed — https://cli.github.com"))?;
+    let bin = find_on_path("gh").ok_or_else(|| {
+        anyhow::anyhow!("gh (GitHub CLI) is not installed — https://cli.github.com")
+    })?;
 
     let base_url = format!("{SERVER}/v1");
     let mut args = vec!["copilot".to_string()];
@@ -393,17 +389,14 @@ fn launch_copilot(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     }
     args.extend_from_slice(extra_args);
 
-    exec_with_env(
-        &bin,
-        &args,
-        &[("COPILOT_PROVIDER_BASE_URL", &base_url)],
-    )
+    exec_with_env(&bin, &args, &[("COPILOT_PROVIDER_BASE_URL", &base_url)])
 }
 
 /// gemini: set GOOGLE_GENAI_BASE_URL pointing at our Anthropic-compatible endpoint.
 fn launch_gemini(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
-    let bin = find_on_path("gemini")
-        .ok_or_else(|| anyhow::anyhow!("gemini is not installed — npm install -g @google/gemini-cli"))?;
+    let bin = find_on_path("gemini").ok_or_else(|| {
+        anyhow::anyhow!("gemini is not installed — npm install -g @google/gemini-cli")
+    })?;
 
     let mut args: Vec<String> = Vec::new();
     if !model.is_empty() {
@@ -422,7 +415,12 @@ fn launch_gemini(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 }
 
 /// Generic launcher: just set OLLAMA_HOST and run the binary.
-fn launch_simple(binary: &str, install_hint: &str, _model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_simple(
+    binary: &str,
+    install_hint: &str,
+    _model: &str,
+    extra_args: &[String],
+) -> anyhow::Result<()> {
     let bin = find_on_path(binary)
         .ok_or_else(|| anyhow::anyhow!("{binary} is not installed — {install_hint}"))?;
     exec_with_env(&bin, extra_args, &[("OLLAMA_HOST", SERVER)])
@@ -432,11 +430,7 @@ fn launch_simple(binary: &str, install_hint: &str, _model: &str, extra_args: &[S
 // Process execution helper
 // ---------------------------------------------------------------------------
 
-fn exec_with_env(
-    bin: &PathBuf,
-    args: &[String],
-    extra_env: &[(&str, &str)],
-) -> anyhow::Result<()> {
+fn exec_with_env(bin: &PathBuf, args: &[String], extra_env: &[(&str, &str)]) -> anyhow::Result<()> {
     let mut cmd = Command::new(bin);
     cmd.args(args);
     cmd.stdin(std::process::Stdio::inherit());
@@ -451,7 +445,8 @@ fn exec_with_env(
     }
     cmd.envs(&env);
 
-    let status = cmd.status()
+    let status = cmd
+        .status()
         .with_context(|| format!("failed to run {}", bin.display()))?;
 
     std::process::exit(status.code().unwrap_or(1));

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -40,11 +40,19 @@ pub fn run(args: &ListArgs) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let name_w = images.iter().map(|i| i.reference.len()).max().unwrap_or(4).max(4);
+    let name_w = images
+        .iter()
+        .map(|i| i.reference.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
 
     println!(
         "{:<name_w$}    {:<16}    {:<10}    {}",
-        "NAME", "ID", "SIZE", "MODIFIED",
+        "NAME",
+        "ID",
+        "SIZE",
+        "MODIFIED",
         name_w = name_w,
     );
 
@@ -155,24 +163,39 @@ mod tests {
 
     #[test]
     fn split_repo_tag_splits_explicit_tag() {
-        assert_eq!(split_repo_tag("unsloth/Qwen3.5-0.8B:latest"), ("unsloth/Qwen3.5-0.8B", Some("latest")));
-        assert_eq!(split_repo_tag("unsloth/Qwen3.5-0.8B:q4"), ("unsloth/Qwen3.5-0.8B", Some("q4")));
+        assert_eq!(
+            split_repo_tag("unsloth/Qwen3.5-0.8B:latest"),
+            ("unsloth/Qwen3.5-0.8B", Some("latest"))
+        );
+        assert_eq!(
+            split_repo_tag("unsloth/Qwen3.5-0.8B:q4"),
+            ("unsloth/Qwen3.5-0.8B", Some("q4"))
+        );
     }
 
     #[test]
     fn split_repo_tag_returns_none_without_a_tag() {
-        assert_eq!(split_repo_tag("unsloth/Qwen3.5-0.8B"), ("unsloth/Qwen3.5-0.8B", None));
+        assert_eq!(
+            split_repo_tag("unsloth/Qwen3.5-0.8B"),
+            ("unsloth/Qwen3.5-0.8B", None)
+        );
     }
 
     #[test]
     fn matches_filter_matches_repo_without_tag() {
         // Both sides already fully-qualified: exact-match path.
-        assert!(matches_filter("hf.co/unsloth/Qwen3.5-0.8B:latest", "hf.co/unsloth/Qwen3.5-0.8B"));
+        assert!(matches_filter(
+            "hf.co/unsloth/Qwen3.5-0.8B:latest",
+            "hf.co/unsloth/Qwen3.5-0.8B"
+        ));
         assert!(matches_filter(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "hf.co/unsloth/Qwen3.5-0.8B:latest"
         ));
-        assert!(!matches_filter("hf.co/unsloth/Qwen3.5-0.8B:latest", "hf.co/other/model"));
+        assert!(!matches_filter(
+            "hf.co/unsloth/Qwen3.5-0.8B:latest",
+            "hf.co/other/model"
+        ));
     }
 
     #[test]
@@ -214,8 +237,14 @@ mod tests {
     fn render_format_substitutes_known_fields() {
         let img = sample();
         assert_eq!(render_format("{{.ID}}", &img).unwrap(), "0123456789ab");
-        assert_eq!(render_format("{{.Name}}", &img).unwrap(), "unsloth/Qwen3.5-0.8B:latest");
-        assert_eq!(render_format("{{.Repository}}", &img).unwrap(), "unsloth/Qwen3.5-0.8B");
+        assert_eq!(
+            render_format("{{.Name}}", &img).unwrap(),
+            "unsloth/Qwen3.5-0.8B:latest"
+        );
+        assert_eq!(
+            render_format("{{.Repository}}", &img).unwrap(),
+            "unsloth/Qwen3.5-0.8B"
+        );
         assert_eq!(render_format("{{.Tag}}", &img).unwrap(), "latest");
         assert_eq!(render_format("{{.Size}}", &img).unwrap(), "1.5 GB");
         assert_eq!(

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,7 +1,6 @@
 pub mod build;
-pub mod launch;
-pub mod run;
 pub mod inspect;
+pub mod launch;
 pub mod list;
 pub mod login;
 pub mod logout;
@@ -10,6 +9,7 @@ pub mod pull;
 pub mod push;
 pub mod resolve;
 pub mod rm;
+pub mod run;
 pub mod serve;
 pub mod tag;
 pub mod transfer;

--- a/src/cmd/ps.rs
+++ b/src/cmd/ps.rs
@@ -47,7 +47,9 @@ struct PsModel {
 /// precondition, since if there's no daemon there's nothing running to list.
 pub fn run(args: &PsArgs) -> anyhow::Result<()> {
     if !crate::daemon::server_alive() {
-        anyhow::bail!("llmman serve is not running (nothing is loaded) — start it with `llmman serve`");
+        anyhow::bail!(
+            "llmman serve is not running (nothing is loaded) — start it with `llmman serve`"
+        );
     }
 
     let resp: PsResponse = crate::daemon::get_json("/api/ps")?;
@@ -62,12 +64,26 @@ pub fn run(args: &PsArgs) -> anyhow::Result<()> {
     // which unconditionally renders its table (unlike `llmman list`, which
     // prints nothing at all for an empty store).
 
-    let name_w = models.iter().map(|m| m.name.len()).max().unwrap_or(4).max(4);
-    let proc_w = models.iter().map(|m| m.processor.len()).max().unwrap_or(9).max(9);
+    let name_w = models
+        .iter()
+        .map(|m| m.name.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    let proc_w = models
+        .iter()
+        .map(|m| m.processor.len())
+        .max()
+        .unwrap_or(9)
+        .max(9);
 
     println!(
         "{:<name_w$}    {:<12}    {:<10}    {:<proc_w$}    {:<9}    STARTED",
-        "NAME", "ID", "SIZE", "PROCESSOR", "CONTEXT",
+        "NAME",
+        "ID",
+        "SIZE",
+        "PROCESSOR",
+        "CONTEXT",
         name_w = name_w,
         proc_w = proc_w,
     );

--- a/src/cmd/resolve.rs
+++ b/src/cmd/resolve.rs
@@ -88,8 +88,7 @@ pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
         let layout_dir = store_path
             .to_str()
             .context("store path is not valid UTF-8")?;
-        crate::ffi::pull(&reference, layout_dir)
-            .with_context(|| format!("pulling {reference}"))?;
+        crate::ffi::pull(&reference, layout_dir).with_context(|| format!("pulling {reference}"))?;
     }
 
     let resolved = resolve_model(&store_path, &cache_path, &reference)

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -52,7 +52,11 @@ pub struct RunArgs {
     /// passed.
     #[arg(long)]
     pub num_predict: Option<u32>,
-    #[arg(value_name = "PROMPT", trailing_var_arg = true, allow_hyphen_values = true)]
+    #[arg(
+        value_name = "PROMPT",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
     pub prompt: Vec<String>,
 }
 
@@ -100,7 +104,13 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     let interactive = prompt.is_empty() && io::stdin().is_terminal();
 
     if interactive {
-        run_interactive_tty(&model, ChatOptions { think: args.think, num_predict: args.num_predict })
+        run_interactive_tty(
+            &model,
+            ChatOptions {
+                think: args.think,
+                num_predict: args.num_predict,
+            },
+        )
     } else {
         let p = if prompt.is_empty() {
             let mut s = String::new();
@@ -119,7 +129,16 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             // works identically against llmman or a real Ollama install
             // either way (both expose /api/chat).
             let client = chat_client()?;
-            chat_submit(&client, &model, &mut Vec::new(), p, ChatOptions { think: args.think, num_predict: args.num_predict })?;
+            chat_submit(
+                &client,
+                &model,
+                &mut Vec::new(),
+                p,
+                ChatOptions {
+                    think: args.think,
+                    num_predict: args.num_predict,
+                },
+            )?;
         }
         Ok(())
     }
@@ -148,7 +167,10 @@ struct Msg {
 /// actually finished loading. Mirrors daemon::stream_progress's own
 /// `.timeout(None)` for the same reason on the pull/push side.
 fn chat_client() -> anyhow::Result<Client> {
-    Client::builder().timeout(None).build().context("build http client")
+    Client::builder()
+        .timeout(None)
+        .build()
+        .context("build http client")
 }
 
 #[derive(Serialize)]
@@ -204,8 +226,8 @@ fn run_interactive_unix(model: &str, opts: ChatOptions) -> anyhow::Result<()> {
     let mut messages: Vec<Msg> = Vec::new();
     let mut rl = Readline::new()?;
     let mut multiline: Option<String> = None; // Some while inside """
-    // paste_sb accumulates lines while rl.pasting — mirrors ollama's `sb` +
-    // `case scanner.Pasting: fmt.Fprintln(&sb, line); continue`
+                                              // paste_sb accumulates lines while rl.pasting — mirrors ollama's `sb` +
+                                              // `case scanner.Pasting: fmt.Fprintln(&sb, line); continue`
     let mut paste_sb = String::new();
 
     loop {
@@ -313,7 +335,11 @@ fn chat_submit(
     content: String,
     opts: ChatOptions,
 ) -> anyhow::Result<()> {
-    messages.push(Msg { role: "user".into(), content, thinking: None });
+    messages.push(Msg {
+        role: "user".into(),
+        content,
+        thinking: None,
+    });
 
     let resp = client
         .post(&format!("{SERVER}/api/chat"))
@@ -322,7 +348,9 @@ fn chat_submit(
             messages,
             stream: true,
             think: opts.think,
-            options: opts.num_predict.map(|n| ChatReqOptions { num_predict: Some(n) }),
+            options: opts.num_predict.map(|n| ChatReqOptions {
+                num_predict: Some(n),
+            }),
         })
         .send()
         .context("connect to llmman serve")?;
@@ -340,8 +368,12 @@ fn chat_submit(
     let mut thinking_open = false;
     for line in std::io::BufReader::new(resp).lines() {
         let line = line?;
-        if line.is_empty() { continue; }
-        let Ok(chunk) = serde_json::from_str::<ChatChunk>(&line) else { continue };
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(chunk) = serde_json::from_str::<ChatChunk>(&line) else {
+            continue;
+        };
         if let Some(ref msg) = chunk.message {
             if let Some(ref t) = msg.thinking {
                 if !t.is_empty() {
@@ -362,10 +394,16 @@ fn chat_submit(
                 full.push_str(&msg.content);
             }
         }
-        if chunk.done { break; }
+        if chunk.done {
+            break;
+        }
     }
     println!("\n");
-    messages.push(Msg { role: "assistant".into(), content: full, thinking: None });
+    messages.push(Msg {
+        role: "assistant".into(),
+        content: full,
+        thinking: None,
+    });
     Ok(())
 }
 
@@ -379,10 +417,10 @@ mod unix_readline {
     use std::os::unix::io::AsRawFd;
 
     // Character codes — identical to ollama readline/types.go
-    const CHAR_INTERRUPT: u8 = 3;  // Ctrl-C
-    const CHAR_EOF: u8 = 4;        // Ctrl-D
-    const CHAR_CTRL_J: u8 = 10;    // \n  line feed / pasted newline
-    const CHAR_ENTER: u8 = 13;     // \r  keyboard Enter
+    const CHAR_INTERRUPT: u8 = 3; // Ctrl-C
+    const CHAR_EOF: u8 = 4; // Ctrl-D
+    const CHAR_CTRL_J: u8 = 10; // \n  line feed / pasted newline
+    const CHAR_ENTER: u8 = 13; // \r  keyboard Enter
     const CHAR_ESC: u8 = 27;
     const CHAR_ESCAPE_EX: u8 = 91; // '[' — second byte of ESC[
     const CHAR_BACKSPACE: u8 = 127;
@@ -394,9 +432,9 @@ mod unix_readline {
     // CharBracketedPaste = 50 ('2') — third byte of ESC[ sequence;
     // reading 3 more bytes gives "00~" (paste start) or "01~" (paste end).
     // Mirrors ollama readline/types.go: CharBracketedPaste/Start/End.
-    const CHAR_BRACKETED_PASTE: u8 = 50;   // '2'
+    const CHAR_BRACKETED_PASTE: u8 = 50; // '2'
     const PASTE_START: &[u8; 3] = b"00~";
-    const PASTE_END:   &[u8; 3] = b"01~";
+    const PASTE_END: &[u8; 3] = b"01~";
 
     pub struct Readline {
         reader: BufReader<Stdin>,
@@ -421,14 +459,19 @@ mod unix_readline {
 
             let mut raw = orig;
             unsafe {
-                raw.c_iflag &= !(libc::IGNBRK | libc::BRKINT | libc::PARMRK
-                    | libc::ISTRIP | libc::INLCR | libc::IGNCR
-                    | libc::ICRNL  | libc::IXON);
-                raw.c_lflag &= !(libc::ECHO | libc::ECHONL | libc::ICANON
-                    | libc::ISIG | libc::IEXTEN);
+                raw.c_iflag &= !(libc::IGNBRK
+                    | libc::BRKINT
+                    | libc::PARMRK
+                    | libc::ISTRIP
+                    | libc::INLCR
+                    | libc::IGNCR
+                    | libc::ICRNL
+                    | libc::IXON);
+                raw.c_lflag &=
+                    !(libc::ECHO | libc::ECHONL | libc::ICANON | libc::ISIG | libc::IEXTEN);
                 raw.c_cflag &= !(libc::CSIZE | libc::PARENB);
                 raw.c_cflag |= libc::CS8;
-                raw.c_cc[libc::VMIN as usize]  = 1;
+                raw.c_cc[libc::VMIN as usize] = 1;
                 raw.c_cc[libc::VTIME as usize] = 0;
                 if libc::tcsetattr(fd, libc::TCSANOW, &raw) < 0 {
                     anyhow::bail!("tcsetattr failed");
@@ -439,7 +482,12 @@ mod unix_readline {
             print!("\x1b[?2004h");
             std::io::stdout().flush().ok();
 
-            Ok(Self { reader: BufReader::new(stdin), orig, fd, pasting: false })
+            Ok(Self {
+                reader: BufReader::new(stdin),
+                orig,
+                fd,
+                pasting: false,
+            })
         }
 
         /// Read one logical line from the terminal.
@@ -514,7 +562,9 @@ mod unix_readline {
                     continue;
                 } else if esc {
                     esc = false;
-                    if r == CHAR_ESCAPE_EX { esc_ex = true; }
+                    if r == CHAR_ESCAPE_EX {
+                        esc_ex = true;
+                    }
                     continue;
                 }
 
@@ -531,7 +581,9 @@ mod unix_readline {
                             return Ok(None);
                         }
                     }
-                    CHAR_ESC => { esc = true; }
+                    CHAR_ESC => {
+                        esc = true;
+                    }
                     CHAR_BACKSPACE => {
                         if !buf.is_empty() {
                             // Remove last complete UTF-8 codepoint
@@ -601,7 +653,9 @@ mod unix_readline {
             // Disable bracketed paste, restore terminal — mirrors ollama's defer
             print!("\x1b[?2004l");
             std::io::stdout().flush().ok();
-            unsafe { libc::tcsetattr(self.fd, libc::TCSANOW, &self.orig); }
+            unsafe {
+                libc::tcsetattr(self.fd, libc::TCSANOW, &self.orig);
+            }
         }
     }
 }
@@ -622,12 +676,20 @@ fn run_interactive_cooked(model: &str, opts: ChatOptions) -> anyhow::Result<()> 
         print!("> ");
         io::stdout().flush().ok();
         let mut line = String::new();
-        if reader.read_line(&mut line)? == 0 { break; }
-        let line = line.trim_end_matches('\n').trim_end_matches('\r').to_string();
+        if reader.read_line(&mut line)? == 0 {
+            break;
+        }
+        let line = line
+            .trim_end_matches('\n')
+            .trim_end_matches('\r')
+            .to_string();
         match line.trim() {
             "" => continue,
             "/bye" | "/exit" => break,
-            "/clear" => { messages.clear(); continue; }
+            "/clear" => {
+                messages.clear();
+                continue;
+            }
             _ => {}
         }
         if !line.trim().is_empty() {

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -188,7 +188,9 @@ impl RunningModel {
         match &self.process {
             ModelProcess::Local(Engine::LlamaServer, _) => "llama-server (local)".into(),
             ModelProcess::Local(Engine::Vllm, _) => "vllm (local)".into(),
-            ModelProcess::Container(ociman, _) => format!("llama-server (container/{})", ociman.binary()),
+            ModelProcess::Container(ociman, _) => {
+                format!("llama-server (container/{})", ociman.binary())
+            }
         }
     }
 
@@ -590,7 +592,11 @@ const TAIL_LINES: usize = 20;
 /// fact (see `wait_for_ready`) can still report *why*, instead of just
 /// "the process exited" with the actual reason sitting only in a log file
 /// the caller (an HTTP client, ultimately a chat UI) never sees.
-fn spawn_tail_relay(reader: impl AsyncRead + Unpin + Send + 'static, tail: OutputTail, to_stderr: bool) {
+fn spawn_tail_relay(
+    reader: impl AsyncRead + Unpin + Send + 'static,
+    tail: OutputTail,
+    to_stderr: bool,
+) {
     tokio::spawn(async move {
         let mut lines = BufReader::new(reader).lines();
         while let Ok(Some(line)) = lines.next_line().await {
@@ -662,17 +668,24 @@ async fn spawn_llama_server(
     Ok((child, tail))
 }
 
-async fn spawn_vllm_server(model_dir: &Path, port: u16, model_name: &str) -> anyhow::Result<tokio::process::Child> {
+async fn spawn_vllm_server(
+    model_dir: &Path,
+    port: u16,
+    model_name: &str,
+) -> anyhow::Result<tokio::process::Child> {
     let vllm = which_binary("vllm")?;
     tokio::process::Command::new(&vllm)
         .args([
             "serve",
             model_dir.to_str().context("non-UTF-8 model path")?,
-            "--port", &port.to_string(),
-            "--host", "127.0.0.1",
+            "--port",
+            &port.to_string(),
+            "--host",
+            "127.0.0.1",
             // Register the model under the same name used in API requests so
             // {"model": "<ref>"} is accepted by vllm's OpenAI-compatible API.
-            "--served-model-name", model_name,
+            "--served-model-name",
+            model_name,
         ])
         .kill_on_drop(true)
         .spawn()
@@ -722,7 +735,9 @@ async fn wait_for_ready(
     let deadline = Instant::now() + Duration::from_secs(600);
     loop {
         if Instant::now() > deadline {
-            return Err(anyhow!("inference server on port {port} did not become ready within 600s"));
+            return Err(anyhow!(
+                "inference server on port {port} did not become ready within 600s"
+            ));
         }
         if !process.is_alive() {
             let detail = stderr_tail.and_then(|t| {
@@ -730,7 +745,9 @@ async fn wait_for_ready(
                 (!lines.is_empty()).then(|| lines.iter().cloned().collect::<Vec<_>>().join(" | "))
             });
             return Err(match detail {
-                Some(detail) => anyhow!("inference server on port {port} exited before becoming ready: {detail}"),
+                Some(detail) => anyhow!(
+                    "inference server on port {port} exited before becoming ready: {detail}"
+                ),
                 None => anyhow!("inference server on port {port} exited before becoming ready"),
             });
         }
@@ -789,7 +806,10 @@ fn keyed_lock(
 
 /// Removes `key` once nothing but `registry` itself still holds a clone —
 /// call after dropping your own clone.
-fn release_keyed_lock(registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>, key: &str) {
+fn release_keyed_lock(
+    registry: &StdMutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    key: &str,
+) {
     let mut locks = registry.lock().unwrap();
     if let Some(arc) = locks.get(key) {
         if Arc::strong_count(arc) <= 1 {
@@ -839,7 +859,10 @@ impl Drop for LoadLockGuard {
 
 async fn acquire_load_lock(model: &str) -> LoadLockGuard {
     let guard = load_lock(model).lock_owned().await;
-    LoadLockGuard { model: model.to_owned(), guard: Some(guard) }
+    LoadLockGuard {
+        model: model.to_owned(),
+        guard: Some(guard),
+    }
 }
 
 /// Pulls `model` into `layout_dir` if (still, after acquiring model's own
@@ -855,7 +878,10 @@ fn pull_serialized(store_path: &std::path::Path, model: &str) -> anyhow::Result<
     let lock = model_lock(model);
     let result = (|| {
         let _guard = lock.blocking_lock();
-        if OciStore::open(store_path).and_then(|s| s.find(model)).is_ok() {
+        if OciStore::open(store_path)
+            .and_then(|s| s.find(model))
+            .is_ok()
+        {
             return Ok(()); // someone else already pulled it while we waited
         }
         let layout_dir = store_path
@@ -868,13 +894,17 @@ fn pull_serialized(store_path: &std::path::Path, model: &str) -> anyhow::Result<
     result
 }
 
-/// Resolve a user-supplied model ref to the canonical reference stored in the
-/// OCI index (e.g. "hf.co/repo" → "hf.co/repo:latest").  Using the canonical
-/// form as the map key means "hf.co/repo" and "hf.co/repo:latest" both hit
-/// the same running process rather than spawning a second one.
+/// Resolve a user-supplied model ref to the canonical reference stored in
+/// the OCI index (e.g. "hf.co/repo" → "hf.co/repo:latest"). No-ops before
+/// the model is pulled — `ensure_model` also runs `default_tag` up front
+/// to cover that gap.
 fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
-    let Ok(store) = crate::storage::OciStore::open(store_path) else { return model_ref.to_owned() };
-    let Ok(desc)  = store.find(model_ref)                        else { return model_ref.to_owned() };
+    let Ok(store) = crate::storage::OciStore::open(store_path) else {
+        return model_ref.to_owned();
+    };
+    let Ok(desc) = store.find(model_ref) else {
+        return model_ref.to_owned();
+    };
     desc.annotations
         .as_ref()
         .and_then(|a| a.get("org.opencontainers.image.ref.name"))
@@ -900,6 +930,10 @@ async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
 
 async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError> {
     let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    // Default the tag before the lock below: otherwise two concurrent
+    // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
+    // locks and both spawn a process for the same model.
+    let model_ref = crate::storage::default_tag(&model_ref);
     let model_ref = canonical_ref(&state.0.store_path, &model_ref);
     let model_ref = model_ref.as_str();
 
@@ -929,12 +963,12 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
             .context("pull failed")?;
     }
 
-    // Re-canonicalise after the pull (tag may now be resolvable).
+    // Re-canonicalise after the pull: default_tag already fixed the lock
+    // key, so this only refines to a more specific stored form.
     let model_ref = canonical_ref(&state.0.store_path, model_ref);
     let model_ref = model_ref.as_str();
 
-    // Re-check under the post-pull name too: a different pre-pull alias
-    // of this same model may have raced us and started it already.
+    // Re-check in case that stored form differs from the key above.
     if let Some(port) = check_running(state, model_ref).await {
         return Ok(port);
     }
@@ -946,10 +980,12 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
     // failure here (e.g. a race with a concurrent `rm`) just means those
     // columns show as empty/zero rather than failing the whole request.
     let (digest, size) = OciStore::open(&state.0.store_path)
-        .and_then(|s| s.find(model_ref).map(|d| {
-            let size = s.total_size(&d);
-            (d.digest, size)
-        }))
+        .and_then(|s| {
+            s.find(model_ref).map(|d| {
+                let size = s.total_size(&d);
+                (d.digest, size)
+            })
+        })
         .unwrap_or_default();
     let port = find_free_port()?;
     eprintln!("[llmman] loading {model_ref} on port {port}");
@@ -960,18 +996,16 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<u16, AppError
     // serve.log, same as before).
     let mut stderr_tail: Option<OutputTail> = None;
     let mut process = match (&model_path, state.0.ociman) {
-        (ModelPath::Gguf(path), Some(ociman)) => {
-            ModelProcess::Container(
+        (ModelPath::Gguf(path), Some(ociman)) => ModelProcess::Container(
+            ociman,
+            crate::container::spawn(
                 ociman,
-                crate::container::spawn(
-                    ociman,
-                    path,
-                    port,
-                    state.0.llama_cpp_version.as_deref(),
-                    state.0.ctx_size,
-                )?,
-            )
-        }
+                path,
+                port,
+                state.0.llama_cpp_version.as_deref(),
+                state.0.ctx_size,
+            )?,
+        ),
         (ModelPath::Gguf(path), None) => {
             let bin = local_llama_server_bin(state).await?;
             let (child, tail) = spawn_llama_server(&bin, path, port, state.0.ctx_size).await?;
@@ -1088,7 +1122,9 @@ async fn collect_completion(
     let raw = resp.bytes().await.context("read llama-server response")?;
     eprintln!("[llmman] llama-server raw {} bytes", raw.len());
     if raw.is_empty() {
-        return Err(AppError(anyhow!("inference backend returned empty response body")));
+        return Err(AppError(anyhow!(
+            "inference backend returned empty response body"
+        )));
     }
 
     let text = String::from_utf8_lossy(&raw);
@@ -1098,7 +1134,10 @@ async fn collect_completion(
             continue;
         };
         match oai_chunk_to_content(payload) {
-            Some((tok, _thinking, true)) => { content.push_str(&tok); break; }
+            Some((tok, _thinking, true)) => {
+                content.push_str(&tok);
+                break;
+            }
             Some((tok, _thinking, false)) => content.push_str(&tok),
             None => {}
         }
@@ -1161,7 +1200,10 @@ fn oai_chunk_to_content(payload: &str) -> Option<(String, Option<String>, bool)>
     let choice = chunk.choices.first()?;
     let content = choice.delta.content.as_deref().unwrap_or("").to_string();
     // Accept both field names: "reasoning_content" (Homebrew llama-server) and "thinking" (git)
-    let thinking = choice.delta.reasoning_content.clone()
+    let thinking = choice
+        .delta
+        .reasoning_content
+        .clone()
         .or_else(|| choice.delta.thinking.clone())
         .filter(|s| !s.is_empty());
     let done = choice
@@ -1180,7 +1222,11 @@ fn oai_chunk_to_content(payload: &str) -> Option<(String, Option<String>, bool)>
 /// a non-2xx status into an AppError carrying the backend's error body.
 /// Shared by every route that streams llama-server's OpenAI-style SSE output
 /// back out in some other shape (stream_ollama, stream_anthropic below).
-async fn post_chat(client: &Client, url: &str, oai_req: &OAIChatRequest) -> Result<reqwest::Response, AppError> {
+async fn post_chat(
+    client: &Client,
+    url: &str,
+    oai_req: &OAIChatRequest,
+) -> Result<reqwest::Response, AppError> {
     let resp = client
         .post(url)
         .json(oai_req)
@@ -1213,7 +1259,8 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
     let resp = post_chat(&client, &url, &oai_req).await?;
 
     let stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
-        let out = line.strip_prefix("data: ")
+        let out = line
+            .strip_prefix("data: ")
             .and_then(|p| oai_chunk_to_content(p))
             .map(|(content, thinking, done)| {
                 let chunk = build_chunk(content, thinking, done);
@@ -1265,9 +1312,10 @@ async fn stream_anthropic(
         )
     };
 
-    let preamble_stream = futures::stream::once(futures::future::ready(
-        Ok::<_, std::convert::Infallible>(Bytes::from(preamble)),
-    ));
+    let preamble_stream =
+        futures::stream::once(futures::future::ready(Ok::<_, std::convert::Infallible>(
+            Bytes::from(preamble),
+        )));
 
     let sse_stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
         let out = if let Some(payload) = line.strip_prefix("data: ") {
@@ -1456,7 +1504,8 @@ async fn handle_tags(State(state): State<AppState>) -> Result<impl IntoResponse,
             model: img.reference,
             size: img.size,
             digest: img.digest,
-            modified_at: img.modified_at
+            modified_at: img
+                .modified_at
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                 .and_then(|d| chrono::DateTime::from_timestamp(d.as_secs() as i64, 0))
                 .map(|dt| dt.to_rfc3339())
@@ -1537,7 +1586,9 @@ async fn query_context_length(client: &Client, port: u16) -> Option<u64> {
         .await
         .ok()?;
     let body: serde_json::Value = resp.json().await.ok()?;
-    body.get("default_generation_settings")?.get("n_ctx")?.as_u64()
+    body.get("default_generation_settings")?
+        .get("n_ctx")?
+        .as_u64()
 }
 
 async fn handle_show(
@@ -1546,7 +1597,10 @@ async fn handle_show(
 ) -> Result<impl IntoResponse, AppError> {
     // ollama sends either {"name":"..."} or {"model":"..."} depending on call site;
     // filter out empty strings so we always fall back to whichever field is populated.
-    let model_ref = req.name.as_deref().filter(|s| !s.is_empty())
+    let model_ref = req
+        .name
+        .as_deref()
+        .filter(|s| !s.is_empty())
         .unwrap_or(&req.model);
     // Resolve the same way handle_pull stored it — otherwise a bare name
     // (e.g. "gemma4", pulled and stored as "docker.io/ai/gemma4") would
@@ -1648,7 +1702,10 @@ async fn handle_push(
 
     // Unlike pull, there's nothing sensible to do if the model isn't
     // already in the local store — push has no "fetch it first" fallback.
-    if OciStore::open(&store_path).and_then(|s| s.find(&model)).is_err() {
+    if OciStore::open(&store_path)
+        .and_then(|s| s.find(&model))
+        .is_err()
+    {
         let body = serde_json::json!({"error": format!("model not found: {model}")});
         return (StatusCode::NOT_FOUND, Json(body)).into_response();
     }
@@ -1744,7 +1801,10 @@ async fn handle_delete(
     State(state): State<AppState>,
     Json(req): Json<OllamaDeleteRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let model_ref = req.name.as_deref().filter(|s| !s.is_empty())
+    let model_ref = req
+        .name
+        .as_deref()
+        .filter(|s| !s.is_empty())
         .unwrap_or(&req.model);
     // See handle_show: resolve the same way handle_pull stored it.
     let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
@@ -1759,7 +1819,11 @@ async fn handle_ollama_chat(
     State(state): State<AppState>,
     Json(req): Json<OllamaChatRequest>,
 ) -> Result<Response, AppError> {
-    eprintln!("[llmman] /api/chat model={:?} messages={}", req.model, req.messages.len());
+    eprintln!(
+        "[llmman] /api/chat model={:?} messages={}",
+        req.model,
+        req.messages.len()
+    );
     let port = ensure_model(&state, &req.model).await?;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     let oai = OAIChatRequest {
@@ -1780,15 +1844,22 @@ async fn handle_ollama_chat(
         chat_template_kwargs: think_to_chat_template_kwargs(&req.think),
     };
     let model = req.model;
-    stream_ollama(state.0.client.clone(), url, oai, move |content, thinking, done| {
-        OllamaChatChunk {
+    stream_ollama(
+        state.0.client.clone(),
+        url,
+        oai,
+        move |content, thinking, done| OllamaChatChunk {
             model: model.clone(),
             created_at: now_rfc3339(),
-            message: OllamaMessage { role: "assistant".into(), content, thinking },
+            message: OllamaMessage {
+                role: "assistant".into(),
+                content,
+                thinking,
+            },
             done,
             done_reason: done.then_some("stop".into()),
-        }
-    })
+        },
+    )
     .await
 }
 
@@ -1798,11 +1869,20 @@ async fn handle_ollama_generate(
     State(state): State<AppState>,
     Json(req): Json<OllamaGenerateRequest>,
 ) -> Result<Response, AppError> {
-    eprintln!("[llmman] /api/generate model={:?} prompt_len={}", req.model, req.prompt.len());
+    eprintln!(
+        "[llmman] /api/generate model={:?} prompt_len={}",
+        req.model,
+        req.prompt.len()
+    );
 
     // Empty prompt + keep_alive:0 = unload request (ollama server/routes.go:354).
-    let is_unload = req.prompt.is_empty() && req.keep_alive.as_ref()
-        .and_then(|v| v.as_i64()).map(|n| n == 0).unwrap_or(false);
+    let is_unload = req.prompt.is_empty()
+        && req
+            .keep_alive
+            .as_ref()
+            .and_then(|v| v.as_i64())
+            .map(|n| n == 0)
+            .unwrap_or(false);
     if is_unload {
         let resolved = crate::shortnames::resolve_ollama_api(&req.model);
         let canonical = canonical_ref(&state.0.store_path, &resolved);
@@ -1850,16 +1930,19 @@ async fn handle_ollama_generate(
         chat_template_kwargs: think_to_chat_template_kwargs(&req.think),
     };
     let model = req.model;
-    stream_ollama(state.0.client.clone(), url, oai, move |response, thinking, done| {
-        OllamaGenerateChunk {
+    stream_ollama(
+        state.0.client.clone(),
+        url,
+        oai,
+        move |response, thinking, done| OllamaGenerateChunk {
             model: model.clone(),
             created_at: now_rfc3339(),
             response,
             thinking,
             done,
             done_reason: done.then_some("stop".into()),
-        }
-    })
+        },
+    )
     .await
 }
 
@@ -1887,8 +1970,6 @@ async fn handle_openai_models(
         .collect();
     Ok(Json(serde_json::json!({ "object": "list", "data": data })))
 }
-
-
 
 /// Shared body of every plain OpenAI-passthrough route: parse just enough of
 /// the request to find `model`, make sure it's loaded, then proxy the
@@ -2202,8 +2283,12 @@ fn opt_u32(opts: &Option<serde_json::Value>, key: &str) -> Option<u32> {
 /// env-inheritance behavior, and so the exact same list can be reused
 /// as-is by `crate::container::spawn`, whose `docker run`/`podman run`
 /// does *not* inherit the host environment into the container on its own.
-pub const GPU_VISIBLE_DEVICE_VARS: &[&str] =
-    &["CUDA_VISIBLE_DEVICES", "HIP_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES", "GGML_VK_VISIBLE_DEVICES"];
+pub const GPU_VISIBLE_DEVICE_VARS: &[&str] = &[
+    "CUDA_VISIBLE_DEVICES",
+    "HIP_VISIBLE_DEVICES",
+    "ROCR_VISIBLE_DEVICES",
+    "GGML_VK_VISIBLE_DEVICES",
+];
 
 /// Resolves the `llama-server` binary to run locally (no `--ociman`):
 /// prefers whatever is already on `PATH` untouched, unless
@@ -2286,10 +2371,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         None
     };
     let store_path = default_store(_args.store.as_deref())?;
-    let cache_path = store_path
-        .parent()
-        .unwrap_or(&store_path)
-        .join("cache");
+    let cache_path = store_path.parent().unwrap_or(&store_path).join("cache");
     std::fs::create_dir_all(&cache_path)?;
 
     let state = AppState(Arc::new(Inner {
@@ -2300,7 +2382,9 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         // Canonicalized now, while the file certainly still exists —
         // resolving later (in the handler) could fail once the install is
         // deleted, exactly the situation /api/version exists to expose.
-        exe: std::env::current_exe().ok().map(|p| p.canonicalize().unwrap_or(p)),
+        exe: std::env::current_exe()
+            .ok()
+            .map(|p| p.canonicalize().unwrap_or(p)),
         ociman: _args.ociman,
         llama_cpp_version: _args.llama_cpp_version.clone(),
         ctx_size: _args.ctx_size,
@@ -2439,9 +2523,18 @@ mod tests {
                     role: "system".into(),
                     content: "leading system prompt\n\na mid-conversation reminder".into(),
                 },
-                OAIMessage { role: "user".into(), content: "hi".into() },
-                OAIMessage { role: "assistant".into(), content: "hello".into() },
-                OAIMessage { role: "user".into(), content: "bye".into() },
+                OAIMessage {
+                    role: "user".into(),
+                    content: "hi".into()
+                },
+                OAIMessage {
+                    role: "assistant".into(),
+                    content: "hello".into()
+                },
+                OAIMessage {
+                    role: "user".into(),
+                    content: "bye".into()
+                },
             ]
         );
     }
@@ -2458,7 +2551,10 @@ mod tests {
 
         assert_eq!(
             messages,
-            vec![OAIMessage { role: "user".into(), content: "hi".into() }]
+            vec![OAIMessage {
+                role: "user".into(),
+                content: "hi".into()
+            }]
         );
     }
 
@@ -2583,16 +2679,23 @@ mod tests {
     fn oai_chunk_to_content_ported_ollama_stream_decoding_cases() {
         // Plain content token, stream not finished.
         assert_eq!(
-            oai_chunk_to_content(r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#),
+            oai_chunk_to_content(
+                r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#
+            ),
             Some(("hi".into(), None, false))
         );
         // finish_reason "stop" marks the stream done.
         assert_eq!(
-            oai_chunk_to_content(r#"{"choices":[{"delta":{"content":""},"finish_reason":"stop"}]}"#),
+            oai_chunk_to_content(
+                r#"{"choices":[{"delta":{"content":""},"finish_reason":"stop"}]}"#
+            ),
             Some((String::new(), None, true))
         );
         // The [DONE] sentinel also marks the stream done.
-        assert_eq!(oai_chunk_to_content("[DONE]"), Some((String::new(), None, true)));
+        assert_eq!(
+            oai_chunk_to_content("[DONE]"),
+            Some((String::new(), None, true))
+        );
         // llama-server's two reasoning field spellings both surface as
         // thinking: "reasoning_content" (Homebrew builds) and "thinking"
         // (git builds).
@@ -2603,7 +2706,9 @@ mod tests {
             Some((String::new(), Some("hmm".into()), false))
         );
         assert_eq!(
-            oai_chunk_to_content(r#"{"choices":[{"delta":{"thinking":"hmm"},"finish_reason":null}]}"#),
+            oai_chunk_to_content(
+                r#"{"choices":[{"delta":{"thinking":"hmm"},"finish_reason":null}]}"#
+            ),
             Some((String::new(), Some("hmm".into()), false))
         );
         // An empty reasoning string is filtered out rather than surfaced.
@@ -2663,8 +2768,14 @@ mod tests {
         assert_eq!(
             messages,
             vec![
-                OAIMessage { role: "system".into(), content: "you are a helpful assistant".into() },
-                OAIMessage { role: "user".into(), content: "hi".into() },
+                OAIMessage {
+                    role: "system".into(),
+                    content: "you are a helpful assistant".into()
+                },
+                OAIMessage {
+                    role: "user".into(),
+                    content: "hi".into()
+                },
             ]
         );
     }
@@ -2716,7 +2827,10 @@ mod tests {
             responses_input_item_text(&serde_json::json!({"type": "function_call", "name": "f"})),
             None
         );
-        assert_eq!(responses_input_item_text(&serde_json::json!({"content": 42})), None);
+        assert_eq!(
+            responses_input_item_text(&serde_json::json!({"content": 42})),
+            None
+        );
     }
 
     /// Ported from ollama's server/routes_options_test.go concept
@@ -2754,7 +2868,10 @@ mod tests {
         assert!(Arc::ptr_eq(&a1, &a2), "same key must return the same lock");
 
         let b = keyed_lock(&registry, "model-b");
-        assert!(!Arc::ptr_eq(&a1, &b), "different keys must not share a lock");
+        assert!(
+            !Arc::ptr_eq(&a1, &b),
+            "different keys must not share a lock"
+        );
 
         // Caller 1 finishes and releases its own clone — but caller 2's
         // clone (a2) is still outstanding, so the entry must survive.
@@ -2778,9 +2895,10 @@ mod tests {
 
         // A different model's load must acquire immediately.
         let other = load_lock("test-load-lock-other-model");
-        let _other_guard = tokio::time::timeout(std::time::Duration::from_millis(200), other.lock())
-            .await
-            .expect("a different model's load must not block on an unrelated one");
+        let _other_guard =
+            tokio::time::timeout(std::time::Duration::from_millis(200), other.lock())
+                .await
+                .expect("a different model's load must not block on an unrelated one");
 
         // The same model's load must not acquire until the first releases.
         let same = load_lock("test-load-lock-slow-model");
@@ -2803,6 +2921,33 @@ mod tests {
         drop(slow);
         release_load_lock("test-load-lock-slow-model");
         release_load_lock("test-load-lock-other-model");
+    }
+
+    /// Regression: aliases of an unpulled model must key into one lock
+    /// (see `ensure_model`'s `default_tag` call).
+    #[test]
+    fn ensure_model_key_pipeline_converges_aliases_before_the_lock() {
+        let tagless = crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(
+            "regression-test-model",
+        ));
+        let tagged = crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(
+            "regression-test-model:latest",
+        ));
+        assert_eq!(
+            tagless, tagged,
+            "tagless and :latest aliases must resolve to one key"
+        );
+
+        let a = load_lock(&tagless);
+        let b = load_lock(&tagged);
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "both aliases must take the same load lock"
+        );
+
+        drop(a);
+        drop(b);
+        release_load_lock(&tagless);
     }
 
     /// Regression: a call site that drops its guard but not its own `Arc`

--- a/src/container.rs
+++ b/src/container.rs
@@ -319,13 +319,19 @@ mod tests {
 
     #[test]
     fn cuda_major_12_picks_cuda12_image() {
-        assert_eq!(backend_from_hostgpu(HostGpu::Cuda { major: 12 }), GpuBackend::Cuda12);
+        assert_eq!(
+            backend_from_hostgpu(HostGpu::Cuda { major: 12 }),
+            GpuBackend::Cuda12
+        );
         assert_eq!(GpuBackend::Cuda12.image_tag(), "server-cuda");
     }
 
     #[test]
     fn cuda_major_13_picks_cuda13_image() {
-        assert_eq!(backend_from_hostgpu(HostGpu::Cuda { major: 13 }), GpuBackend::Cuda13);
+        assert_eq!(
+            backend_from_hostgpu(HostGpu::Cuda { major: 13 }),
+            GpuBackend::Cuda13
+        );
         assert_eq!(GpuBackend::Cuda13.image_tag(), "server-cuda13");
     }
 
@@ -334,7 +340,10 @@ mod tests {
         // No cuda14+ image exists yet -- a future driver reporting a
         // higher major version should still bucket into the newer of the
         // two published images rather than falling back to cuda12.
-        assert_eq!(backend_from_hostgpu(HostGpu::Cuda { major: 14 }), GpuBackend::Cuda13);
+        assert_eq!(
+            backend_from_hostgpu(HostGpu::Cuda { major: 14 }),
+            GpuBackend::Cuda13
+        );
     }
 
     #[test]
@@ -356,7 +365,10 @@ mod tests {
 
     #[test]
     fn image_ref_uses_floating_tag_when_no_version_given() {
-        assert_eq!(GpuBackend::Cpu.image_ref(None), "ghcr.io/ggml-org/llama.cpp:server");
+        assert_eq!(
+            GpuBackend::Cpu.image_ref(None),
+            "ghcr.io/ggml-org/llama.cpp:server"
+        );
         assert_eq!(
             GpuBackend::Cuda13.image_ref(None),
             "ghcr.io/ggml-org/llama.cpp:server-cuda13"
@@ -391,13 +403,23 @@ mod tests {
         let args = GpuBackend::Rocm.engine_args();
         assert_eq!(
             args,
-            vec!["--device", "/dev/kfd", "--device", "/dev/dri", "--group-add", "video"]
+            vec![
+                "--device",
+                "/dev/kfd",
+                "--device",
+                "/dev/dri",
+                "--group-add",
+                "video"
+            ]
         );
     }
 
     #[test]
     fn vulkan_backend_mounts_dri_only() {
-        assert_eq!(GpuBackend::Vulkan.engine_args(), vec!["--device", "/dev/dri"]);
+        assert_eq!(
+            GpuBackend::Vulkan.engine_args(),
+            vec!["--device", "/dev/dri"]
+        );
     }
 
     #[test]
@@ -416,6 +438,9 @@ mod tests {
     #[ignore = "result depends on this host's actual GPU/driver setup"]
     fn detect_backend_reports_this_hosts_real_hardware() {
         let backend = detect_backend();
-        println!("container::detect_backend() -> {backend:?} ({})", backend.image_ref(None));
+        println!(
+            "container::detect_backend() -> {backend:?} ({})",
+            backend.image_ref(None)
+        );
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -127,16 +127,22 @@ fn kill_daemon(identity: &DaemonIdentity, force: bool) {
         // Negative pid = the whole process group (the daemon is its own
         // group leader), falling back to just the pid if that fails.
         Some(pid) => {
-            let group = Command::new("kill").args([signal, &format!("-{pid}")]).status();
+            let group = Command::new("kill")
+                .args([signal, &format!("-{pid}")])
+                .status();
             if !group.map(|s| s.success()).unwrap_or(false) {
-                let _ = Command::new("kill").args([signal, &pid.to_string()]).status();
+                let _ = Command::new("kill")
+                    .args([signal, &pid.to_string()])
+                    .status();
             }
         }
         // A daemon too old to report its pid: match on the command line
         // ("<path>/llmman serve ..."), which no plain llmman CLI client
         // invocation shares.
         None => {
-            let _ = Command::new("pkill").args([signal, "-f", "llmman serve"]).status();
+            let _ = Command::new("pkill")
+                .args([signal, "-f", "llmman serve"])
+                .status();
         }
     }
 }
@@ -149,7 +155,9 @@ fn kill_daemon(identity: &DaemonIdentity, _force: bool) {
     match identity.pid {
         // /T takes the daemon's llama-server children down with it.
         Some(pid) => {
-            let _ = Command::new("taskkill").args(["/PID", &pid.to_string(), "/T", "/F"]).status();
+            let _ = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/T", "/F"])
+                .status();
         }
         None => {
             let _ = Command::new("powershell")
@@ -544,7 +552,10 @@ pub fn stream_progress(path: &str, reference: &str) -> anyhow::Result<()> {
             // clearly "nothing left worth animating" either way.
             if bar.is_none() && completed * 100 >= total * 99 {
                 if !printed_instant_complete {
-                    println!("Already have {reference} ({})", crate::fmt::human_size(total));
+                    println!(
+                        "Already have {reference} ({})",
+                        crate::fmt::human_size(total)
+                    );
                     printed_instant_complete = true;
                 }
                 last_status = "pulling".to_string(); // suppress a redundant plain "pulling" line below
@@ -626,5 +637,6 @@ pub fn get_json<T: serde::de::DeserializeOwned>(path: &str) -> anyhow::Result<T>
         let body = resp.text().unwrap_or_default();
         anyhow::bail!("{path}: server returned {status}: {body}");
     }
-    resp.json().with_context(|| format!("parse response from {path}"))
+    resp.json()
+        .with_context(|| format!("parse response from {path}"))
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -14,8 +14,11 @@ use serde::Deserialize;
 // ---------------------------------------------------------------------------
 extern "C" {
     fn llmman_free(s: *mut c_char);
-    fn llmman_login(server: *const c_char, username: *const c_char, password: *const c_char)
-        -> *mut c_char;
+    fn llmman_login(
+        server: *const c_char,
+        username: *const c_char,
+        password: *const c_char,
+    ) -> *mut c_char;
     fn llmman_logout(server: *const c_char) -> *mut c_char;
     fn llmman_push(layout_dir: *const c_char, reference: *const c_char) -> *mut c_char;
     fn llmman_pull(reference: *const c_char, layout_dir: *const c_char) -> *mut c_char;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -53,7 +53,10 @@ fn relative_time_secs(secs: u64) -> String {
 /// by `llmman list`'s MODIFIED column.
 pub fn relative_time(t: Option<SystemTime>) -> String {
     let secs = match t {
-        Some(t) => SystemTime::now().duration_since(t).unwrap_or_default().as_secs(),
+        Some(t) => SystemTime::now()
+            .duration_since(t)
+            .unwrap_or_default()
+            .as_secs(),
         None => return "unknown".into(),
     };
     relative_time_secs(secs)

--- a/src/hf.rs
+++ b/src/hf.rs
@@ -36,7 +36,10 @@ pub fn is_hf_host(server: &str) -> bool {
         .next()
         .unwrap_or(server)
         .to_ascii_lowercase();
-    matches!(host.as_str(), "hf.co" | "huggingface.co" | "www.huggingface.co")
+    matches!(
+        host.as_str(),
+        "hf.co" | "huggingface.co" | "www.huggingface.co"
+    )
 }
 
 /// The HuggingFace Hub API base URL, honoring `HF_ENDPOINT` — same
@@ -136,8 +139,7 @@ pub fn login(token: &str) -> anyhow::Result<String> {
     let username = whoami(token)?;
     let path = token_path();
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create {}", parent.display()))?;
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -37,7 +37,9 @@ pub enum HostGpu {
     /// `cuDriverGetVersion`) — used to decide between llama.cpp's
     /// separately published CUDA 12 vs. CUDA 13 Windows builds (see
     /// `llama_release::asset_query`).
-    Cuda { major: u32 },
+    Cuda {
+        major: u32,
+    },
     Rocm,
     Vulkan,
     /// macOS (Apple Silicon) only.
@@ -93,7 +95,10 @@ fn detect_gpu_api_isolated() -> HostGpu {
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 fn spawn_probe_subprocess() -> Option<HostGpu> {
     let exe = std::env::current_exe().ok()?;
-    let output = std::process::Command::new(exe).arg(PROBE_SUBPROCESS_ARG).output().ok()?;
+    let output = std::process::Command::new(exe)
+        .arg(PROBE_SUBPROCESS_ARG)
+        .output()
+        .ok()?;
     if !output.status.success() {
         return None;
     }
@@ -108,7 +113,9 @@ fn spawn_probe_subprocess() -> Option<HostGpu> {
 fn parse_probe_output(stdout: &str) -> Option<HostGpu> {
     let line = stdout.lines().next()?.trim();
     if let Some(major) = line.strip_prefix("cuda:") {
-        return Some(HostGpu::Cuda { major: major.parse().ok()? });
+        return Some(HostGpu::Cuda {
+            major: major.parse().ok()?,
+        });
     }
     match line {
         "rocm" => Some(HostGpu::Rocm),
@@ -205,12 +212,20 @@ fn open_cuda_lib() -> Option<Library> {
 
 #[cfg(target_os = "linux")]
 fn open_cuda_lib() -> Option<Library> {
-    unsafe { Library::new("libcuda.so.1").or_else(|_| Library::new("libcuda.so")).ok() }
+    unsafe {
+        Library::new("libcuda.so.1")
+            .or_else(|_| Library::new("libcuda.so"))
+            .ok()
+    }
 }
 
 #[cfg(target_os = "windows")]
 fn open_hip_lib() -> Option<Library> {
-    unsafe { Library::new("amdhip64_6.dll").or_else(|_| Library::new("amdhip64.dll")).ok() }
+    unsafe {
+        Library::new("amdhip64_6.dll")
+            .or_else(|_| Library::new("amdhip64.dll"))
+            .ok()
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -230,7 +245,11 @@ fn open_vulkan_lib() -> Option<Library> {
 
 #[cfg(target_os = "linux")]
 fn open_vulkan_lib() -> Option<Library> {
-    unsafe { Library::new("libvulkan.so.1").or_else(|_| Library::new("libvulkan.so")).ok() }
+    unsafe {
+        Library::new("libvulkan.so.1")
+            .or_else(|_| Library::new("libvulkan.so"))
+            .ok()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -287,13 +306,23 @@ fn detect_cuda() -> Option<HostGpu> {
             if cu_device_get(&mut device, 0) == CUDA_SUCCESS {
                 let mut major: i32 = 0;
                 let mut minor: i32 = 0;
-                cu_device_get_attribute(&mut major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
-                cu_device_get_attribute(&mut minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
+                cu_device_get_attribute(
+                    &mut major,
+                    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+                    device,
+                );
+                cu_device_get_attribute(
+                    &mut minor,
+                    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+                    device,
+                );
                 eprintln!("[llmman] CUDA device 0 compute capability: {major}.{minor}");
             }
         }
 
-        Some(HostGpu::Cuda { major: cuda_major_from_driver_version(driver_version) })
+        Some(HostGpu::Cuda {
+            major: cuda_major_from_driver_version(driver_version),
+        })
     }
 }
 
@@ -311,7 +340,9 @@ const HIP_SUCCESS: i32 = 0;
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 fn detect_rocm() -> bool {
-    let Some(lib) = open_hip_lib() else { return false };
+    let Some(lib) = open_hip_lib() else {
+        return false;
+    };
     unsafe {
         let Ok(hip_get_device_count) =
             lib.get::<unsafe extern "C" fn(*mut i32) -> i32>(b"hipGetDeviceCount\0")
@@ -387,7 +418,9 @@ struct RawPhysicalDeviceProperties([u8; 1024]);
 
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 fn detect_vulkan() -> bool {
-    let Some(lib) = open_vulkan_lib() else { return false };
+    let Some(lib) = open_vulkan_lib() else {
+        return false;
+    };
     unsafe { detect_vulkan_inner(&lib).unwrap_or(false) }
 }
 
@@ -405,7 +438,9 @@ unsafe fn detect_vulkan_inner(lib: &Library) -> Option<bool> {
         lib.get(b"vkGetPhysicalDeviceProperties\0").ok()?;
     let vk_get_physical_device_queue_family_properties: Symbol<
         unsafe extern "C" fn(VkPhysicalDevice, *mut u32, *mut VkQueueFamilyProperties),
-    > = lib.get(b"vkGetPhysicalDeviceQueueFamilyProperties\0").ok()?;
+    > = lib
+        .get(b"vkGetPhysicalDeviceQueueFamilyProperties\0")
+        .ok()?;
 
     let create_info = VkInstanceCreateInfo {
         s_type: VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
@@ -423,7 +458,8 @@ unsafe fn detect_vulkan_inner(lib: &Library) -> Option<bool> {
     }
 
     let mut count: u32 = 0;
-    let capable = if vk_enumerate_physical_devices(instance, &mut count, std::ptr::null_mut()) != VK_SUCCESS
+    let capable = if vk_enumerate_physical_devices(instance, &mut count, std::ptr::null_mut())
+        != VK_SUCCESS
         || count == 0
     {
         false
@@ -447,16 +483,25 @@ unsafe fn detect_vulkan_inner(lib: &Library) -> Option<bool> {
                 }
 
                 let mut qcount: u32 = 0;
-                vk_get_physical_device_queue_family_properties(device, &mut qcount, std::ptr::null_mut());
+                vk_get_physical_device_queue_family_properties(
+                    device,
+                    &mut qcount,
+                    std::ptr::null_mut(),
+                );
                 if qcount == 0 {
                     continue;
                 }
                 let mut queues = vec![VkQueueFamilyProperties::default(); qcount as usize];
-                vk_get_physical_device_queue_family_properties(device, &mut qcount, queues.as_mut_ptr());
+                vk_get_physical_device_queue_family_properties(
+                    device,
+                    &mut qcount,
+                    queues.as_mut_ptr(),
+                );
 
-                let has_compute = queues
-                    .iter()
-                    .any(|q| q.queue_flags & VK_QUEUE_COMPUTE_BIT != 0 && q.queue_flags & VK_QUEUE_TRANSFER_BIT != 0);
+                let has_compute = queues.iter().any(|q| {
+                    q.queue_flags & VK_QUEUE_COMPUTE_BIT != 0
+                        && q.queue_flags & VK_QUEUE_TRANSFER_BIT != 0
+                });
                 if has_compute {
                     capable_count += 1;
                 }
@@ -493,8 +538,14 @@ mod tests {
         assert_eq!(parse_probe_output("none\n"), Some(HostGpu::None));
         assert_eq!(parse_probe_output("rocm\n"), Some(HostGpu::Rocm));
         assert_eq!(parse_probe_output("vulkan\n"), Some(HostGpu::Vulkan));
-        assert_eq!(parse_probe_output("cuda:12\n"), Some(HostGpu::Cuda { major: 12 }));
-        assert_eq!(parse_probe_output("cuda:13\n"), Some(HostGpu::Cuda { major: 13 }));
+        assert_eq!(
+            parse_probe_output("cuda:12\n"),
+            Some(HostGpu::Cuda { major: 12 })
+        );
+        assert_eq!(
+            parse_probe_output("cuda:13\n"),
+            Some(HostGpu::Cuda { major: 13 })
+        );
         assert_eq!(parse_probe_output(""), None);
         assert_eq!(parse_probe_output("garbage\n"), None);
         assert_eq!(parse_probe_output("cuda:not-a-number\n"), None);
@@ -513,7 +564,9 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn a_failing_subprocess_status_is_not_mistaken_for_a_real_result() {
-        let output = std::process::Command::new("false").output().expect("run `false`");
+        let output = std::process::Command::new("false")
+            .output()
+            .expect("run `false`");
         assert!(!output.status.success());
         // spawn_probe_subprocess's own early `if !output.status.success()
         // { return None; }` is exactly what a real crash (or, here, this

--- a/src/llama_release.rs
+++ b/src/llama_release.rs
@@ -82,7 +82,10 @@ fn fetch_release(client: &reqwest::blocking::Client, version: Option<&str>) -> R
 }
 
 fn find_asset<'a>(release: &'a Release, must_contain: &str) -> Option<&'a Asset> {
-    release.assets.iter().find(|a| a.name.contains(must_contain))
+    release
+        .assets
+        .iter()
+        .find(|a| a.name.contains(must_contain))
 }
 
 // ---------------------------------------------------------------------------
@@ -283,15 +286,24 @@ fn progress_bar(total: u64, label: &str) -> Option<ProgressBar> {
     Some(pb)
 }
 
-fn download_to_file(client: &reqwest::blocking::Client, url: &str, dest: &Path, label: &str) -> Result<()> {
-    let mut resp = client.get(url).send().with_context(|| format!("download {url}"))?;
+fn download_to_file(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    dest: &Path,
+    label: &str,
+) -> Result<()> {
+    let mut resp = client
+        .get(url)
+        .send()
+        .with_context(|| format!("download {url}"))?;
     if !resp.status().is_success() {
         anyhow::bail!("download {url} returned {}", resp.status());
     }
     let total = resp.content_length().unwrap_or(0);
     let pb = progress_bar(total, label);
 
-    let mut file = std::fs::File::create(dest).with_context(|| format!("create {}", dest.display()))?;
+    let mut file =
+        std::fs::File::create(dest).with_context(|| format!("create {}", dest.display()))?;
     let mut buf = [0u8; 1 << 16];
     let mut downloaded = 0u64;
     loop {
@@ -365,7 +377,11 @@ pub struct Resolved {
 /// `resolve_llama_server`).
 pub fn ensure_llama_server(pinned_version: Option<&str>) -> Result<Resolved> {
     let query = asset_query();
-    let bin_name = if cfg!(target_os = "windows") { "llama-server.exe" } else { "llama-server" };
+    let bin_name = if cfg!(target_os = "windows") {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
 
     // If we already fetched this exact (tag, backend) combination before,
     // reuse it without touching the network at all — pinned or not, a
@@ -373,7 +389,10 @@ pub fn ensure_llama_server(pinned_version: Option<&str>) -> Result<Resolved> {
     if let Some(tag) = pinned_version {
         let dest = install_dir(tag, &query.label)?;
         if let Some(bin) = find_binary(&dest, bin_name) {
-            return Ok(Resolved { bin, backend_label: query.label });
+            return Ok(Resolved {
+                bin,
+                backend_label: query.label,
+            });
         }
     } else {
         // Unpinned: still worth a cheap local check for *some* cached tag
@@ -390,7 +409,10 @@ pub fn ensure_llama_server(pinned_version: Option<&str>) -> Result<Resolved> {
                         "[llmman] could not check for a newer llama-server release ({e:#}); \
                          using previously downloaded build"
                     );
-                    return Ok(Resolved { bin, backend_label: query.label });
+                    return Ok(Resolved {
+                        bin,
+                        backend_label: query.label,
+                    });
                 }
             }
         }
@@ -410,7 +432,10 @@ fn try_ensure_from_network(
     let dest = install_dir(&tag, &query.label)?;
 
     if let Some(bin) = find_binary(&dest, bin_name) {
-        return Ok(Resolved { bin, backend_label: query.label.clone() });
+        return Ok(Resolved {
+            bin,
+            backend_label: query.label.clone(),
+        });
     }
 
     let asset = find_asset(&release, &query.must_contain)
@@ -422,7 +447,10 @@ fn try_ensure_from_network(
         })?
         .clone();
 
-    eprintln!("[llmman] downloading llama-server ({}) {tag}: {}", query.label, asset.name);
+    eprintln!(
+        "[llmman] downloading llama-server ({}) {tag}: {}",
+        query.label, asset.name
+    );
     let tmp = tmp_path(&asset.name)?;
     download_to_file(&client, &asset.browser_download_url, &tmp, &asset.name)?;
     let extracted = extract(&tmp, &asset.name, &dest);
@@ -435,7 +463,12 @@ fn try_ensure_from_network(
                 let companion = companion.clone();
                 eprintln!("[llmman] downloading {}", companion.name);
                 let tmp2 = tmp_path(&companion.name)?;
-                download_to_file(&client, &companion.browser_download_url, &tmp2, &companion.name)?;
+                download_to_file(
+                    &client,
+                    &companion.browser_download_url,
+                    &tmp2,
+                    &companion.name,
+                )?;
                 let extracted = extract(&tmp2, &companion.name, &dest);
                 let _ = std::fs::remove_file(&tmp2);
                 extracted?;
@@ -448,10 +481,17 @@ fn try_ensure_from_network(
         }
     }
 
-    let bin = find_binary(&dest, bin_name)
-        .with_context(|| format!("llama-server binary not found after extracting {}", asset.name))?;
+    let bin = find_binary(&dest, bin_name).with_context(|| {
+        format!(
+            "llama-server binary not found after extracting {}",
+            asset.name
+        )
+    })?;
     mark_executable(&bin)?;
-    Ok(Resolved { bin, backend_label: query.label.clone() })
+    Ok(Resolved {
+        bin,
+        backend_label: query.label.clone(),
+    })
 }
 
 #[cfg(unix)]
@@ -489,9 +529,13 @@ fn newest_cached(label: &str, bin_name: &str) -> Result<Option<PathBuf>> {
             continue;
         }
         let tag = entry.file_name().to_string_lossy().into_owned();
-        let Some(build) = build_number(&tag) else { continue };
+        let Some(build) = build_number(&tag) else {
+            continue;
+        };
         let dest = entry.path().join(label);
-        let Some(bin) = find_binary(&dest, bin_name) else { continue };
+        let Some(bin) = find_binary(&dest, bin_name) else {
+            continue;
+        };
         if best.as_ref().map(|(b, _)| build > *b).unwrap_or(true) {
             best = Some((build, bin));
         }
@@ -508,9 +552,18 @@ mod tests {
         let release = Release {
             tag_name: "b10360".into(),
             assets: vec![
-                Asset { name: "llama-b10360-bin-ubuntu-x64.tar.gz".into(), browser_download_url: String::new() },
-                Asset { name: "llama-b10360-bin-ubuntu-vulkan-x64.tar.gz".into(), browser_download_url: String::new() },
-                Asset { name: "llama-b10360-bin-ubuntu-rocm-7.14-x64.tar.gz".into(), browser_download_url: String::new() },
+                Asset {
+                    name: "llama-b10360-bin-ubuntu-x64.tar.gz".into(),
+                    browser_download_url: String::new(),
+                },
+                Asset {
+                    name: "llama-b10360-bin-ubuntu-vulkan-x64.tar.gz".into(),
+                    browser_download_url: String::new(),
+                },
+                Asset {
+                    name: "llama-b10360-bin-ubuntu-rocm-7.14-x64.tar.gz".into(),
+                    browser_download_url: String::new(),
+                },
             ],
         };
         assert_eq!(
@@ -518,7 +571,9 @@ mod tests {
             "llama-b10360-bin-ubuntu-x64.tar.gz"
         );
         assert_eq!(
-            find_asset(&release, "-bin-ubuntu-vulkan-x64.tar.gz").unwrap().name,
+            find_asset(&release, "-bin-ubuntu-vulkan-x64.tar.gz")
+                .unwrap()
+                .name,
             "llama-b10360-bin-ubuntu-vulkan-x64.tar.gz"
         );
         assert_eq!(
@@ -557,11 +612,18 @@ mod tests {
     #[ignore = "hits the network and downloads a real llama.cpp release"]
     fn ensure_llama_server_downloads_a_runnable_binary() {
         let resolved = ensure_llama_server(None).expect("ensure_llama_server");
-        assert!(resolved.bin.is_file(), "{} is not a file", resolved.bin.display());
+        assert!(
+            resolved.bin.is_file(),
+            "{} is not a file",
+            resolved.bin.display()
+        );
         let output = std::process::Command::new(&resolved.bin)
             .arg("--version")
             .output()
             .expect("run downloaded llama-server --version");
-        assert!(output.status.success(), "llama-server --version failed: {output:?}");
+        assert!(
+            output.status.success(),
+            "llama-server --version failed: {output:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,9 @@ fn main() {
     // `ffi::ensure_runtime_init`/`daemon::disable_std_handle_inheritance`
     // below: this child is meant to do nothing but the one raw probe and
     // exit, as fast and dependency-free as possible.
-    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new(hostgpu::PROBE_SUBPROCESS_ARG)) {
+    if std::env::args_os().nth(1).as_deref()
+        == Some(std::ffi::OsStr::new(hostgpu::PROBE_SUBPROCESS_ARG))
+    {
         hostgpu::probe_subprocess_main();
     }
 
@@ -106,21 +108,21 @@ fn main() {
 
     let cli = Cli::parse();
     let result = match &cli.command {
-        Commands::Launch(a)   => cmd::launch::run(a),
-        Commands::Run(a)      => cmd::run::run(a),
-        Commands::Build(a)    => cmd::build::run(a),
-        Commands::Login(a)    => cmd::login::run(a),
-        Commands::Logout(a)   => cmd::logout::run(a),
-        Commands::Push(a)     => cmd::push::run(a),
-        Commands::Pull(a)     => cmd::pull::run(a),
-        Commands::Resolve(a)  => cmd::resolve::run(a),
+        Commands::Launch(a) => cmd::launch::run(a),
+        Commands::Run(a) => cmd::run::run(a),
+        Commands::Build(a) => cmd::build::run(a),
+        Commands::Login(a) => cmd::login::run(a),
+        Commands::Logout(a) => cmd::logout::run(a),
+        Commands::Push(a) => cmd::push::run(a),
+        Commands::Pull(a) => cmd::pull::run(a),
+        Commands::Resolve(a) => cmd::resolve::run(a),
         Commands::Transfer(a) => cmd::transfer::run(a),
-        Commands::List(a)     => cmd::list::run(a),
-        Commands::Ps(a)       => cmd::ps::run(a),
-        Commands::Rm(a)       => cmd::rm::run(a),
-        Commands::Inspect(a)  => cmd::inspect::run(a),
-        Commands::Serve(a)    => cmd::serve::run(a),
-        Commands::Tag(a)      => cmd::tag::run(a),
+        Commands::List(a) => cmd::list::run(a),
+        Commands::Ps(a) => cmd::ps::run(a),
+        Commands::Rm(a) => cmd::rm::run(a),
+        Commands::Inspect(a) => cmd::inspect::run(a),
+        Commands::Serve(a) => cmd::serve::run(a),
+        Commands::Tag(a) => cmd::tag::run(a),
     };
     if let Err(e) = result {
         eprintln!("Error: {:#}", e);

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -70,12 +70,18 @@ fn layer_filepath(l: &crate::storage::oci::Descriptor) -> Option<&str> {
 }
 
 fn is_gguf_layer(l: &crate::storage::oci::Descriptor) -> bool {
-    if l.media_type == HF_GGUF_MEDIA_TYPE { return true; }
-    layer_filepath(l).map(|p| p.to_lowercase().ends_with(".gguf")).unwrap_or(false)
+    if l.media_type == HF_GGUF_MEDIA_TYPE {
+        return true;
+    }
+    layer_filepath(l)
+        .map(|p| p.to_lowercase().ends_with(".gguf"))
+        .unwrap_or(false)
 }
 
 fn is_safetensors_layer(l: &crate::storage::oci::Descriptor) -> bool {
-    layer_filepath(l).map(|p| p.to_lowercase().ends_with(".safetensors")).unwrap_or(false)
+    layer_filepath(l)
+        .map(|p| p.to_lowercase().ends_with(".safetensors"))
+        .unwrap_or(false)
 }
 
 // gguf_architecture/gguf_context_length_override (a GGUF metadata reader
@@ -97,7 +103,11 @@ fn is_safetensors_layer(l: &crate::storage::oci::Descriptor) -> bool {
 /// Resolve `model_ref` (already present in the `OciStore` at `store_path`)
 /// to either a `.gguf` file or an extracted safetensors directory, caching
 /// any extraction under `cache_path`.
-pub fn resolve_model(store_path: &Path, cache_path: &Path, model_ref: &str) -> anyhow::Result<ModelPath> {
+pub fn resolve_model(
+    store_path: &Path,
+    cache_path: &Path,
+    model_ref: &str,
+) -> anyhow::Result<ModelPath> {
     let store = OciStore::open(store_path)?;
     let desc = store
         .find(model_ref)
@@ -106,7 +116,9 @@ pub fn resolve_model(store_path: &Path, cache_path: &Path, model_ref: &str) -> a
 
     // ── GGUF → llama-server ────────────────────────────────────────────────
     if let Some(gguf_layer) = manifest.layers.iter().find(|l| is_gguf_layer(l)) {
-        let title = layer_filepath(gguf_layer).unwrap_or("model.gguf").to_owned();
+        let title = layer_filepath(gguf_layer)
+            .unwrap_or("model.gguf")
+            .to_owned();
         let layer_hex = digest_hex(&gguf_layer.digest)?;
 
         // HF blobs are stored as raw GGUF — use directly.
@@ -129,10 +141,12 @@ pub fn resolve_model(store_path: &Path, cache_path: &Path, model_ref: &str) -> a
             }
         }
         std::fs::create_dir_all(&cached_dir)?;
-        let blob = store.read_blob(&gguf_layer.digest)
+        let blob = store
+            .read_blob(&gguf_layer.digest)
             .with_context(|| format!("read blob {}", gguf_layer.digest))?;
         let dest = if blob.len() >= 4 && &blob[..4] == b"GGUF" {
-            let name = Path::new(&title).file_name()
+            let name = Path::new(&title)
+                .file_name()
                 .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
             let p = cached_dir.join(name);
             std::fs::write(&p, &blob)?;
@@ -144,7 +158,8 @@ pub fn resolve_model(store_path: &Path, cache_path: &Path, model_ref: &str) -> a
                 let mut entry = entry?;
                 let ep = entry.path()?.to_path_buf();
                 if ep.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    let name = ep.file_name()
+                    let name = ep
+                        .file_name()
                         .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
                     let d = cached_dir.join(name);
                     entry.unpack(&d)?;
@@ -159,12 +174,15 @@ pub fn resolve_model(store_path: &Path, cache_path: &Path, model_ref: &str) -> a
 
     // ── safetensors → vllm ────────────────────────────────────────────────
     if manifest.layers.iter().any(|l| is_safetensors_layer(l)) {
-        let model_dir = extract_safetensors_dir(&store, store_path, cache_path, &desc.digest, &manifest)?;
+        let model_dir =
+            extract_safetensors_dir(&store, store_path, cache_path, &desc.digest, &manifest)?;
         return Ok(ModelPath::SafeTensors(model_dir));
     }
 
     // Nothing usable found — report what was present.
-    let exts: std::collections::HashSet<String> = manifest.layers.iter()
+    let exts: std::collections::HashSet<String> = manifest
+        .layers
+        .iter()
         .filter_map(|l| layer_filepath(l))
         .filter_map(|p| Path::new(p).extension()?.to_str().map(|e| e.to_lowercase()))
         .collect();
@@ -195,28 +213,41 @@ fn extract_safetensors_dir(
         let include = matches!(
             layer.media_type.as_str(),
             "application/vnd.cncf.model.weight.config.v1.raw"
-            | "application/vnd.cncf.model.weight.v1.raw"
+                | "application/vnd.cncf.model.weight.v1.raw"
         );
-        if !include { continue; }
+        if !include {
+            continue;
+        }
 
-        let Some(rel_path) = layer_filepath(layer) else { continue };
+        let Some(rel_path) = layer_filepath(layer) else {
+            continue;
+        };
         let dest = cache_dir.join(rel_path);
-        if dest.exists() { continue; }
+        if dest.exists() {
+            continue;
+        }
 
         std::fs::create_dir_all(dest.parent().context("no parent")?)?;
         let layer_hex = digest_hex(&layer.digest)?;
         let blob = store_path.join("blobs").join("sha256").join(layer_hex);
-        std::fs::copy(&blob, &dest)
-            .with_context(|| format!("copy {rel_path} from blob store"))?;
+        std::fs::copy(&blob, &dest).with_context(|| format!("copy {rel_path} from blob store"))?;
         eprintln!("[llmman] extracted {rel_path}");
     }
 
     // Model dir = parent of config.json
     for layer in &manifest.layers {
-        let Some(rel_path) = layer_filepath(layer) else { continue };
-        if Path::new(rel_path).file_name().map(|n| n == "config.json").unwrap_or(false) {
+        let Some(rel_path) = layer_filepath(layer) else {
+            continue;
+        };
+        if Path::new(rel_path)
+            .file_name()
+            .map(|n| n == "config.json")
+            .unwrap_or(false)
+        {
             let config = cache_dir.join(rel_path);
-            return config.parent().map(|p| p.to_path_buf())
+            return config
+                .parent()
+                .map(|p| p.to_path_buf())
                 .ok_or_else(|| anyhow!("config.json has no parent directory"));
         }
     }
@@ -230,7 +261,10 @@ mod tests {
     #[test]
     fn format_matches_variant() {
         assert_eq!(ModelPath::Gguf(PathBuf::from("/x/m.gguf")).format(), "gguf");
-        assert_eq!(ModelPath::SafeTensors(PathBuf::from("/x")).format(), "safetensors");
+        assert_eq!(
+            ModelPath::SafeTensors(PathBuf::from("/x")).format(),
+            "safetensors"
+        );
     }
 
     #[test]

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -118,9 +118,7 @@ pub fn login_device() -> anyhow::Result<Option<DeviceLoginResult>> {
         .split('?')
         .next()
         .unwrap_or(&state.verification_uri_complete);
-    println!(
-        "Press ENTER to open your browser or submit your device code here: {display_url}"
-    );
+    println!("Press ENTER to open your browser or submit your device code here: {display_url}");
     println!();
     println!("Waiting for authentication in the browser\u{2026}");
 
@@ -195,10 +193,7 @@ fn wait_for_device_token(
             .post(format!("{}/oauth/token", tenant_url()))
             .form(&[
                 ("client_id", CLIENT_ID),
-                (
-                    "grant_type",
-                    "urn:ietf:params:oauth:grant-type:device_code",
-                ),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
                 ("device_code", state.device_code.as_str()),
             ])
             .timeout(Duration::from_secs(60))
@@ -210,7 +205,10 @@ fn wait_for_device_token(
         match token.error.as_deref() {
             Some("authorization_pending") => continue,
             Some(_) => {
-                anyhow::bail!("failed waiting for authentication: {}", token.error_description);
+                anyhow::bail!(
+                    "failed waiting for authentication: {}",
+                    token.error_description
+                );
             }
             None => return Ok(token),
         }

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -214,22 +214,37 @@ mod tests {
         // and dead-ended in the Go shim's HF-only parser with a misleading
         // "invalid HuggingFace reference" error instead.
         assert_eq!(resolve_ollama_api("qwen3.5"), "docker.io/ai/qwen3.5");
-        assert_eq!(resolve_ollama_api("qwen3.5:0.8B"), "docker.io/ai/qwen3.5:0.8B");
+        assert_eq!(
+            resolve_ollama_api("qwen3.5:0.8B"),
+            "docker.io/ai/qwen3.5:0.8B"
+        );
     }
 
     #[test]
     fn resolve_ollama_api_leaves_structured_references_to_resolve() {
         // Owner/repo (has a "/") falls back to resolve()'s hf.co default.
-        assert_eq!(resolve_ollama_api("unsloth/Qwen3.5-0.8B-GGUF"), resolve("unsloth/Qwen3.5-0.8B-GGUF"));
+        assert_eq!(
+            resolve_ollama_api("unsloth/Qwen3.5-0.8B-GGUF"),
+            resolve("unsloth/Qwen3.5-0.8B-GGUF")
+        );
         // Already has an explicit host.
         assert_eq!(resolve_ollama_api("hf.co/foo/bar"), "hf.co/foo/bar");
-        assert_eq!(resolve_ollama_api("docker.io/ai/gemma4"), "docker.io/ai/gemma4");
+        assert_eq!(
+            resolve_ollama_api("docker.io/ai/gemma4"),
+            "docker.io/ai/gemma4"
+        );
     }
 
     #[test]
     fn resolve_ollama_api_matches_resolve_for_uri_schemes_and_paths() {
-        assert_eq!(resolve_ollama_api("hf://unsloth/Qwen3.5-0.8B-GGUF"), resolve("hf://unsloth/Qwen3.5-0.8B-GGUF"));
-        assert_eq!(resolve_ollama_api("/abs/path/model.gguf"), "/abs/path/model.gguf");
+        assert_eq!(
+            resolve_ollama_api("hf://unsloth/Qwen3.5-0.8B-GGUF"),
+            resolve("hf://unsloth/Qwen3.5-0.8B-GGUF")
+        );
+        assert_eq!(
+            resolve_ollama_api("/abs/path/model.gguf"),
+            "/abs/path/model.gguf"
+        );
     }
 
     #[test]
@@ -258,10 +273,16 @@ mod tests {
         // namespace/model (ollama: -> registry.ollama.ai/namespace/model).
         assert_eq!(resolve("namespace/model"), "hf.co/namespace/model");
         // Fully-qualified references pass through untouched...
-        assert_eq!(resolve("example.com/ns/model:tag"), "example.com/ns/model:tag");
+        assert_eq!(
+            resolve("example.com/ns/model:tag"),
+            "example.com/ns/model:tag"
+        );
         // ...including a host:port first component (ollama's
         // "host:port/namespace/model:tag" case) and localhost.
-        assert_eq!(resolve("example.com:5000/ns/model:tag"), "example.com:5000/ns/model:tag");
+        assert_eq!(
+            resolve("example.com:5000/ns/model:tag"),
+            "example.com:5000/ns/model:tag"
+        );
         assert_eq!(resolve("localhost/ns/model"), "localhost/ns/model");
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,2 +1,2 @@
 pub mod oci;
-pub use oci::OciStore;
+pub use oci::{default_tag, OciStore};

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -151,8 +151,7 @@ impl OciStore {
     // ------------------------------------------------------------------
 
     pub fn read_index(&self) -> anyhow::Result<Index> {
-        let data = fs::read(self.root.join("index.json"))
-            .context("read index.json")?;
+        let data = fs::read(self.root.join("index.json")).context("read index.json")?;
         serde_json::from_slice(&data).context("parse index.json")
     }
 
@@ -206,8 +205,8 @@ impl OciStore {
             .join("sha256")
             .join(format!("tmp-{}", std::process::id()));
         {
-            let mut src = fs::File::open(path)
-                .with_context(|| format!("open {}", path.display()))?;
+            let mut src =
+                fs::File::open(path).with_context(|| format!("open {}", path.display()))?;
             let mut dst = fs::File::create(&tmp)?;
             let mut buf = vec![0u8; 1 << 20]; // 1 MiB chunks
             loop {
@@ -429,10 +428,8 @@ impl OciStore {
             },
         };
         let config_data = serde_json::to_vec(&cncf_config)?;
-        let config_desc = self.write_blob(
-            "application/vnd.cncf.model.config.v1+json",
-            &config_data,
-        )?;
+        let config_desc =
+            self.write_blob("application/vnd.cncf.model.config.v1+json", &config_data)?;
 
         // `--label key=value` pairs have no dedicated slot in the model
         // config schema, so they're carried as manifest annotations instead.
@@ -477,7 +474,10 @@ fn classify_model_layer(rel_path: &str) -> &'static str {
         .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or(lower.as_str());
-    let ext = Path::new(base).extension().and_then(|e| e.to_str()).unwrap_or("");
+    let ext = Path::new(base)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
 
     match ext {
         "safetensors" | "bin" | "pt" | "pth" | "gguf" | "ggml" | "ot" | "engine" | "trt"
@@ -549,19 +549,39 @@ fn ref_matches(desc: &Descriptor, reference: &str) -> bool {
         return true;
     }
 
-    // If reference carries no tag (no ':' after the last '/'), try `:latest`.
-    let after_slash = &reference[reference.rfind('/').unwrap_or(0)..];
-    if !after_slash.contains(':') && stored.as_str() == format!("{reference}:latest") {
+    if stored.as_str() == default_tag(reference) {
         return true;
     }
 
     false
 }
 
+/// Appends `:latest` to `reference` if it has no tag, so a tag-less
+/// reference and its `:latest` spelling are one string wherever a
+/// reference is used as a map/lock key. A no-op on anything that isn't a
+/// taggable registry reference — a URI-scheme source (`s3://`, `ngc://`,
+/// `ms://`, ...) or an absolute local path — since those never carry a
+/// tag and appending one would corrupt them.
+pub fn default_tag(reference: &str) -> String {
+    if reference.starts_with('/') || reference.contains("://") {
+        return reference.to_owned();
+    }
+    let after_slash = &reference[reference.rfind('/').unwrap_or(0)..];
+    if after_slash.contains(':') {
+        reference.to_owned()
+    } else {
+        format!("{reference}:latest")
+    }
+}
+
 fn split_digest(digest: &str) -> anyhow::Result<(&str, &str)> {
     let mut parts = digest.splitn(2, ':');
-    let algo = parts.next().ok_or_else(|| anyhow!("invalid digest: {}", digest))?;
-    let hex = parts.next().ok_or_else(|| anyhow!("invalid digest: {}", digest))?;
+    let algo = parts
+        .next()
+        .ok_or_else(|| anyhow!("invalid digest: {}", digest))?;
+    let hex = parts
+        .next()
+        .ok_or_else(|| anyhow!("invalid digest: {}", digest))?;
     Ok((algo, hex))
 }
 
@@ -597,7 +617,10 @@ mod tests {
 
     fn desc_with_ref(ref_name: &str) -> Descriptor {
         let mut ann = std::collections::HashMap::new();
-        ann.insert("org.opencontainers.image.ref.name".to_string(), ref_name.to_string());
+        ann.insert(
+            "org.opencontainers.image.ref.name".to_string(),
+            ref_name.to_string(),
+        );
         Descriptor {
             media_type: "application/vnd.oci.image.manifest.v1+json".into(),
             digest: "sha256:deadbeef".into(),
@@ -634,6 +657,38 @@ mod tests {
     fn ref_matches_defaults_a_tagless_reference_to_latest() {
         let d = desc_with_ref("docker.io/ai/qwen3.5:latest");
         assert!(ref_matches(&d, "docker.io/ai/qwen3.5"));
+    }
+
+    #[test]
+    fn default_tag_appends_latest_only_when_no_tag_is_present() {
+        assert_eq!(
+            default_tag("docker.io/ai/gemma4"),
+            "docker.io/ai/gemma4:latest"
+        );
+        assert_eq!(
+            default_tag("docker.io/ai/gemma4:latest"),
+            "docker.io/ai/gemma4:latest"
+        );
+        assert_eq!(
+            default_tag("docker.io/ai/gemma4:e4b"),
+            "docker.io/ai/gemma4:e4b"
+        );
+        // A colon before the last '/' (a port in a registry host) must not
+        // be mistaken for a tag separator.
+        assert_eq!(
+            default_tag("localhost:5000/gemma4"),
+            "localhost:5000/gemma4:latest"
+        );
+    }
+
+    #[test]
+    fn default_tag_leaves_non_registry_sources_untouched() {
+        // These never carry a tag; appending one would corrupt them.
+        assert_eq!(default_tag("ngc://org/model"), "ngc://org/model");
+        assert_eq!(default_tag("s3://bucket/key"), "s3://bucket/key");
+        assert_eq!(default_tag("gs://bucket/key"), "gs://bucket/key");
+        assert_eq!(default_tag("ms://owner/repo"), "ms://owner/repo");
+        assert_eq!(default_tag("/abs/path/model.gguf"), "/abs/path/model.gguf");
     }
 
     #[test]

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -4,14 +4,11 @@
 /// file from the `webui/` directory.  Serve them with the headers
 /// `Content-Encoding: gzip` and the appropriate `Content-Type`.
 
-pub static INDEX_HTML: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/index.html.gz"));
+pub static INDEX_HTML: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/index.html.gz"));
 
-pub static BUNDLE_JS: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/bundle.js.gz"));
+pub static BUNDLE_JS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/bundle.js.gz"));
 
-pub static BUNDLE_CSS: &[u8] =
-    include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/bundle.css.gz"));
+pub static BUNDLE_CSS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/bundle.css.gz"));
 
 pub static LOADING_HTML: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/loading.html.gz"));

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -122,7 +122,9 @@ static SERIAL: Mutex<()> = Mutex::new(());
 /// and `launch_opencode_with_model` too, hiding whether either of *those*
 /// would have actually passed on their own.
 fn lock_serial() -> std::sync::MutexGuard<'static, ()> {
-    SERIAL.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 /// Guards `warm_model` so its real (slow, first-time) work happens only
@@ -171,8 +173,10 @@ fn on_path(bin: &str) -> bool {
     };
     if cfg!(windows) {
         const EXTS: &[&str] = &["exe", "cmd", "bat"];
-        std::env::split_paths(&path)
-            .any(|dir| EXTS.iter().any(|ext| dir.join(format!("{bin}.{ext}")).is_file()))
+        std::env::split_paths(&path).any(|dir| {
+            EXTS.iter()
+                .any(|ext| dir.join(format!("{bin}.{ext}")).is_file())
+        })
     } else {
         std::env::split_paths(&path).any(|dir| dir.join(bin).is_file())
     }
@@ -199,9 +203,17 @@ fn fresh_home(label: &str) -> PathBuf {
 /// (The "bytes total" in that marker is really "bytes retained": the
 /// buffer itself is capped — see [`READER_BUF_CAP`].)
 fn tail_str(buf: &VecDeque<u8>, n: usize) -> String {
-    let tail: Vec<u8> = buf.iter().skip(buf.len().saturating_sub(n)).copied().collect();
+    let tail: Vec<u8> = buf
+        .iter()
+        .skip(buf.len().saturating_sub(n))
+        .copied()
+        .collect();
     if buf.len() > n {
-        format!("...<{} bytes total>...{}", buf.len(), String::from_utf8_lossy(&tail))
+        format!(
+            "...<{} bytes total>...{}",
+            buf.len(),
+            String::from_utf8_lossy(&tail)
+        )
     } else {
         String::from_utf8_lossy(&tail).into_owned()
     }
@@ -401,7 +413,9 @@ fn try_spawn_with_timeout(
         cmd.process_group(0);
     }
 
-    let mut child = cmd.spawn().unwrap_or_else(|e| panic!("spawn {description}: {e}"));
+    let mut child = cmd
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn {description}: {e}"));
     // Kept permanently (not removed once the investigation that added it
     // concluded — see this repo's own git history): a real Windows/macOS
     // hang in this file once showed only a bare "still running" heartbeat
@@ -416,7 +430,10 @@ fn try_spawn_with_timeout(
     // up to the very last heartbeat before that happens stays visible
     // even if everything after it is lost — useful for whatever the next
     // one of these turns out to be, not just the one this was built for.
-    eprintln!("[spawn_with_timeout] pid={} spawned: {description}", child.id());
+    eprintln!(
+        "[spawn_with_timeout] pid={} spawned: {description}",
+        child.id()
+    );
     let stdout_pipe = child.stdout.take().expect("child stdout");
     let stderr_pipe = child.stderr.take().expect("child stderr");
     let stdout_buf = Arc::new(Mutex::new(VecDeque::new()));
@@ -459,10 +476,18 @@ fn try_spawn_with_timeout(
             // (which is precisely what the old unconditional join did —
             // see kill_process_tree).
             kill_process_tree(&mut child);
-            let stdout =
-                String::from_utf8_lossy(&collect_reader(stdout_thread, &stdout_buf, Duration::from_secs(5))).into_owned();
-            let stderr =
-                String::from_utf8_lossy(&collect_reader(stderr_thread, &stderr_buf, Duration::from_secs(5))).into_owned();
+            let stdout = String::from_utf8_lossy(&collect_reader(
+                stdout_thread,
+                &stdout_buf,
+                Duration::from_secs(5),
+            ))
+            .into_owned();
+            let stderr = String::from_utf8_lossy(&collect_reader(
+                stderr_thread,
+                &stderr_buf,
+                Duration::from_secs(5),
+            ))
+            .into_owned();
             return Err(TimedOut {
                 message: format!(
                     "{description} did not finish within {timeout:?} — likely a hang\n\
@@ -479,7 +504,11 @@ fn try_spawn_with_timeout(
     // grandchild must not be able to wedge a *successful* run either.
     let stdout = collect_reader(stdout_thread, &stdout_buf, Duration::from_secs(30));
     let stderr = collect_reader(stderr_thread, &stderr_buf, Duration::from_secs(30));
-    Ok(std::process::Output { status, stdout, stderr })
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 /// Forces `MODEL` to be pulled and fully loaded — via `llmman run`, our
@@ -522,7 +551,13 @@ fn warm_model() {
     WARM.call_once(|| {
         eprintln!("[warm_model] starting");
         let mut cmd = Command::new(llmman_bin());
-        cmd.arg("run").arg(MODEL).arg("--think").arg("false").arg("--num-predict").arg("64").arg(PROMPT);
+        cmd.arg("run")
+            .arg(MODEL)
+            .arg("--think")
+            .arg("false")
+            .arg("--num-predict")
+            .arg("64")
+            .arg(PROMPT);
         let output = spawn_with_timeout(cmd, TIMEOUT, "llmman run (model warm-up)");
         eprintln!("[warm_model] done, status={:?}", output.status);
         assert!(
@@ -653,7 +688,11 @@ fn launch_and_assert(integration: &str, extra_args: &[&str]) {
                     "[test] {integration}: attempt {attempt}/{MAX_ATTEMPTS} timed out \
                      (small-model sampling variance can degenerate into an endless agent \
                      loop — see launch_and_assert's own doc comment); {}\n{}",
-                    if attempt < MAX_ATTEMPTS { "retrying with a fresh HOME" } else { "giving up" },
+                    if attempt < MAX_ATTEMPTS {
+                        "retrying with a fresh HOME"
+                    } else {
+                        "giving up"
+                    },
                     timed_out.message
                 );
                 last_failure = Some(timed_out.message);
@@ -675,7 +714,11 @@ fn launch_and_assert(integration: &str, extra_args: &[&str]) {
             "[test] {integration}: attempt {attempt}/{MAX_ATTEMPTS} succeeded but the reply \
              didn't contain \"pong\" (small-model sampling variance — see launch_and_assert's \
              own doc comment); {}",
-            if attempt < MAX_ATTEMPTS { "retrying with a fresh HOME" } else { "giving up" }
+            if attempt < MAX_ATTEMPTS {
+                "retrying with a fresh HOME"
+            } else {
+                "giving up"
+            }
         );
         last_failure = Some(format!(
             "expected {integration}'s reply to contain \"pong\"\n\
@@ -735,7 +778,10 @@ fn launch_opencode_with_model() {
     // step in one environment during development; keep this on so a CI
     // failure's logs show exactly what opencode was doing right up to a
     // timeout, instead of just the banner and silence.
-    launch_and_assert("opencode", &["run", PROMPT, "--print-logs", "--log-level", "DEBUG"]);
+    launch_and_assert(
+        "opencode",
+        &["run", PROMPT, "--print-logs", "--log-level", "DEBUG"],
+    );
 }
 
 #[test]
@@ -755,4 +801,3 @@ fn launch_codex_with_model() {
     // `exec <prompt>`: codex's non-interactive one-shot mode.
     launch_and_assert("codex", &["exec", PROMPT]);
 }
-


### PR DESCRIPTION
Fixes a race where concurrent requests for aliases of an unpulled
model (`gemma4` vs `gemma4:latest`) could take different load locks
and each spawn its own process.

`default_tag` appends `:latest` when missing, purely from the string
(mirrors ollama's `ParseName`). `ensure_model` now applies it before
acquiring the load lock, so both aliases key into the same lock.

Also: `cargo fmt` across the crate (it had drifted) plus a new
`cargo fmt --check` CI job so that doesn't happen again.

### release-note
```release-note
NONE
```
