### PR TITLE
serve: reasoning effort, context-shift, OOM retry, multi-GPU, audio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,6 +1019,7 @@ dependencies = [
  "indicatif",
  "libc",
  "libloading",
+ "multer",
  "reqwest",
  "serde",
  "serde_json",
@@ -1089,6 +1090,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1594,6 +1612,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ indicatif  = "0.18"
 flate2     = "1"
 zip        = { version = "2", default-features = false, features = ["deflate"] }
 libloading = "0.8"
+multer     = "3"
 
 [features]
 default = ["docker"]

--- a/src/cmd/resolve.rs
+++ b/src/cmd/resolve.rs
@@ -16,9 +16,12 @@
 //! {"reference":"ghcr.io/org/model:tag","path":"/abs/path","format":"safetensors"}
 //! ```
 //! `format` is either `"safetensors"` (a directory containing
-//! `config.json`) or `"gguf"` (a single `.gguf` file). Any diagnostic
-//! output (pull progress, extraction notes) goes to stderr, same as every
-//! other `llmman` subcommand, so stdout stays parseable.
+//! `config.json`) or `"gguf"` (a single `.gguf` file); a `"gguf"` result
+//! additionally carries `"mmproj":"/abs/path"` when a companion
+//! multimodal projector file (see `modelpack::ModelPath::mmproj`'s doc
+//! comment) was found alongside it, omitted entirely otherwise. Any
+//! diagnostic output (pull progress, extraction notes) goes to stderr,
+//! same as every other `llmman` subcommand, so stdout stays parseable.
 //!
 //! On failure, nothing is printed to stdout, an error is printed to
 //! stderr, and the process exits non-zero — the same convention `main`
@@ -60,6 +63,12 @@ struct ResolveOutput<'a> {
     reference: &'a str,
     path: String,
     format: &'static str,
+    /// A companion `--mmproj` multimodal projector file resolved
+    /// alongside a GGUF model (see
+    /// `modelpack::ModelPath::mmproj`'s doc comment), if any. Always
+    /// absent for `format: "safetensors"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mmproj: Option<String>,
 }
 
 pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
@@ -98,6 +107,7 @@ pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
         reference: &reference,
         path: resolved.path().to_string_lossy().into_owned(),
         format: resolved.format(),
+        mmproj: resolved.mmproj().map(|p| p.to_string_lossy().into_owned()),
     };
     println!("{}", serde_json::to_string(&out)?);
     Ok(())

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 
 use anyhow::{anyhow, Context};
 use axum::body::{Body, Bytes};
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
@@ -175,6 +175,128 @@ fn parse_kv_cache_type(value: Option<&str>) -> Option<String> {
     (!v.is_empty()).then(|| v.to_string())
 }
 
+/// `--split-mode` value requested for every `llama-server` spawn — read
+/// from `LLMMAN_SCHED_SPREAD`, llmman's equivalent of Ollama's
+/// `OLLAMA_SCHED_SPREAD`. Truthy forwards `--split-mode layer` (spread
+/// across every GPU — already llama-server's own default, now explicit);
+/// falsey forwards `--split-mode none` (restrict to one GPU). Unset
+/// leaves llama-server's own default untouched.
+fn sched_spread_from_env() -> Option<&'static str> {
+    parse_sched_spread(std::env::var("LLMMAN_SCHED_SPREAD").ok().as_deref())
+}
+
+/// [`sched_spread_from_env`]'s parsing, split out so it's testable
+/// without mutating the real process environment.
+fn parse_sched_spread(value: Option<&str>) -> Option<&'static str> {
+    let v = value?.trim();
+    if v.is_empty() {
+        return None;
+    }
+    match v.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" | "layer" => Some("layer"),
+        "0" | "false" | "no" | "off" | "none" => Some("none"),
+        _ => None,
+    }
+}
+
+/// Explicit `--context-shift`/`--no-context-shift` override from
+/// `LLMMAN_CONTEXT_SHIFT`, or `None` if unset/empty/unparseable — in
+/// which case [`supports_context_shift`]'s per-model default applies
+/// instead, same as leaving Ollama's own `--think`-style env vars unset
+/// defers to its per-model `supportsContextShift`.
+fn context_shift_override_from_env() -> Option<bool> {
+    parse_context_shift(std::env::var("LLMMAN_CONTEXT_SHIFT").ok().as_deref())
+}
+
+/// [`context_shift_override_from_env`]'s parsing, split out so it's
+/// testable without mutating the real process environment.
+fn parse_context_shift(value: Option<&str>) -> Option<bool> {
+    let v = value?.trim();
+    if v.is_empty() {
+        return None;
+    }
+    Some(!matches!(
+        v.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    ))
+}
+
+/// Whether `model_ref` gets `--context-shift` by default, absent an
+/// explicit `LLMMAN_CONTEXT_SHIFT` override. Enabled except for
+/// DeepSeek-family ("deepseek2" architecture) models, mirroring Ollama's
+/// own `supportsContextShift` (`server/sched.go`) — their MLA-compressed
+/// KV cache can't be shifted the way llama-server expects. Ollama
+/// detects that from parsed GGUF metadata; llmman deliberately doesn't
+/// parse GGUF metadata at all (see modelpack.rs's removed
+/// gguf_architecture note), so this is a coarser name-based heuristic
+/// instead.
+fn supports_context_shift(model_ref: &str) -> bool {
+    !model_ref.to_ascii_lowercase().contains("deepseek")
+}
+
+/// Resolves the `--context-shift`/`--no-context-shift` value to spawn
+/// `model_ref` with: `env_override` (see
+/// [`context_shift_override_from_env`]) when set, else
+/// [`supports_context_shift`]'s per-model default.
+fn resolve_context_shift(model_ref: &str, env_override: Option<bool>) -> bool {
+    env_override.unwrap_or_else(|| supports_context_shift(model_ref))
+}
+
+// ---------------------------------------------------------------------------
+// Out-of-memory auto-shrink retry (ensure_model) — mirrors Ollama's
+// reduceAutoNumCtxForLoadOOM: a chosen --ctx-size can still be too big
+// for actual free VRAM, so retry with it halved a few times instead of
+// failing the load outright.
+// ---------------------------------------------------------------------------
+
+/// Max halving retries for an OOM-looking local llama-server load.
+const MAX_CTX_SHRINK_ATTEMPTS: u32 = 4;
+
+/// Floor below which a still-failing load is a hard failure, not
+/// something to keep shrinking.
+const MIN_CTX_SIZE_FOR_RETRY: u32 = 16384;
+
+/// First retry value when `ctx_size` started as `None` (no number to
+/// halve). Matches the top VRAM tier's own default (see
+/// `hostgpu::default_ctx_size_for`) rather than starting below
+/// `MIN_CTX_SIZE_FOR_RETRY`.
+const STARTING_CTX_SIZE_FOR_UNBOUNDED_RETRY: u32 = 32768;
+
+/// Next `--ctx-size` to retry an OOM'd load with, or `None` if shrinking
+/// further wouldn't help (at/under the floor already).
+fn next_ctx_size_after_oom(current: Option<u32>) -> Option<u32> {
+    match current {
+        None => Some(STARTING_CTX_SIZE_FOR_UNBOUNDED_RETRY),
+        Some(n) => {
+            let next = (n / 2).max(MIN_CTX_SIZE_FOR_RETRY);
+            // `next < n`, not just `!=`: below the floor, halving+max
+            // would otherwise suggest a *larger* ctx-size, backwards
+            // after an OOM.
+            (next < n).then_some(next)
+        }
+    }
+}
+
+/// True if `detail` (a failed load's stderr tail, or an error message)
+/// looks like a memory-allocation failure rather than some other startup
+/// error. Matched against known ggml/llama.cpp allocator log phrasings —
+/// deliberately specific rather than one broad substring, since
+/// misclassifying an unrelated failure as OOM would burn several slow
+/// retries before surfacing the real error.
+fn looks_like_oom(detail: &str) -> bool {
+    let d = detail.to_ascii_lowercase();
+    [
+        "failed to allocate",
+        "out of memory",
+        "not enough memory",
+        "insufficient memory",
+        "cudamalloc failed",
+        "std::bad_alloc",
+    ]
+    .iter()
+    .any(|needle| d.contains(needle))
+}
+
 // ---------------------------------------------------------------------------
 // Shared state
 // ---------------------------------------------------------------------------
@@ -203,6 +325,12 @@ struct Inner {
     // every spawn_llama_server/container::spawn call, local or
     // containerized.
     ctx_size: Option<u32>,
+    // True if `ctx_size` came from an explicit LLMMAN_CONTEXT_LENGTH
+    // rather than hostgpu's VRAM-tiered auto default — see
+    // ensure_model's OOM retry loop, which only auto-shrinks the latter
+    // (mirrors Ollama's own numCtxAuto gate on reduceAutoNumCtxForLoadOOM:
+    // a user's explicit choice shouldn't be silently overridden).
+    ctx_size_explicit: bool,
     // See flash_attention_from_env's doc comment — forwarded verbatim to
     // every spawn_llama_server/container::spawn call, local or
     // containerized.
@@ -211,6 +339,16 @@ struct Inner {
     // every spawn_llama_server/container::spawn call, local or
     // containerized.
     kv_cache_type: Option<String>,
+    // See context_shift_override_from_env's doc comment — resolved
+    // per-model (see resolve_context_shift) rather than forwarded
+    // verbatim, unlike this struct's other passthrough fields.
+    context_shift_override: Option<bool>,
+    // See sched_spread_from_env's doc comment — this is only the
+    // *initial* value passed to spawn_llama_server/container::spawn;
+    // ensure_model's OOM retry loop may relax an explicit `"none"` to
+    // `"layer"` for that one load if the restriction itself looks like
+    // the cause.
+    split_mode: Option<&'static str>,
     store_path: PathBuf,
     cache_path: PathBuf,
     client: Client,
@@ -356,6 +494,38 @@ impl ModelProcess {
         };
         matches!(child.try_wait(), Ok(None))
     }
+
+    /// Stops this process and waits for it to actually exit, unlike this
+    /// same cleanup on `Drop` above: `kill_on_drop`/a bare SIGTERM signal
+    /// is fire-and-forget and doesn't wait for the OS to reap the
+    /// process. Used by `ensure_model`'s OOM retry loop before spawning a
+    /// replacement, so a still-exiting old server can't linger and race
+    /// the new one (each retry also gets its own fresh port as a second
+    /// safety net — see that loop's own comment).
+    async fn stop_and_wait(&mut self) {
+        match self {
+            ModelProcess::Container(_, child) => {
+                if let Some(pid) = child.id() {
+                    crate::container::stop(pid);
+                }
+            }
+            #[cfg(unix)]
+            ModelProcess::Local(Engine::Vllm, _, pid) => {
+                if let Some(pid) = pid {
+                    unsafe { libc::kill(-(*pid as libc::pid_t), libc::SIGKILL) };
+                }
+            }
+            ModelProcess::Local(_, _, _) => {}
+        }
+        // `Child::kill` sends SIGKILL and awaits the exit itself — after
+        // an already-successful graceful stop above, this is a no-op
+        // beyond confirming the process is actually gone.
+        let child = match self {
+            ModelProcess::Local(_, child, _) => child,
+            ModelProcess::Container(_, child) => child,
+        };
+        let _ = child.kill().await;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -478,23 +648,28 @@ fn format_to_response_format(format: &Option<serde_json::Value>) -> Option<serde
     }
 }
 
-/// Translates Ollama's own `think` request field into the
-/// `chat_template_kwargs` llama-server's `/v1/chat/completions` expects to
-/// actually toggle a Qwen3-style template's thinking block (verified
-/// directly against a running llama-server: a request-level
-/// `"reasoning_budget"` field, despite mirroring the CLI flag of the same
-/// name, is *not* respected — only `chat_template_kwargs.enable_thinking`
-/// is).
-///
-/// Only handles the plain-boolean case of `think` (`true`/`false`) —
-/// Ollama's documented string thinking levels (`"low"`/`"medium"`/
-/// `"high"`/`"max"`) have no equivalent in `enable_thinking`'s plain
-/// on/off, so those (along with `think` being absent entirely) are left
-/// as a no-op: the template's own default applies, exactly as if this
-/// field didn't exist.
+/// Translates Ollama's `think` request field into the
+/// `chat_template_kwargs` llama-server actually reads. `true`/`false` →
+/// `{"enable_thinking": <bool>}`. A string level (`"low"`/`"medium"`/
+/// `"high"`/`"max"`) → `{"enable_thinking": true, "reasoning_effort":
+/// <level>}`, the jinja variable gpt-oss's and DeepSeek-V4's own
+/// templates read for reasoning depth. Anything else is a no-op.
 fn think_to_chat_template_kwargs(think: &Option<serde_json::Value>) -> Option<serde_json::Value> {
     match think {
         Some(serde_json::Value::Bool(b)) => Some(serde_json::json!({ "enable_thinking": b })),
+        // Only forward the four levels llama-server's own templates
+        // actually understand — an unrecognized level (a typo, a future
+        // Ollama addition, ...) is left a no-op rather than forwarded
+        // verbatim, so the template's own default applies instead of
+        // silently misbehaving on an unsupported reasoning_effort value.
+        Some(serde_json::Value::String(level))
+            if matches!(level.trim(), "low" | "medium" | "high" | "max") =>
+        {
+            Some(serde_json::json!({
+                "enable_thinking": true,
+                "reasoning_effort": level.trim(),
+            }))
+        }
         _ => None,
     }
 }
@@ -1340,10 +1515,13 @@ fn spawn_tail_relay(
 async fn spawn_llama_server(
     bin: &Path,
     model: &Path,
+    mmproj: Option<&Path>,
     port: u16,
     ctx_size: Option<u32>,
     flash_attention: Option<&str>,
     kv_cache_type: Option<&str>,
+    context_shift: bool,
+    split_mode: Option<&str>,
 ) -> anyhow::Result<(tokio::process::Child, OutputTail)> {
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args([
@@ -1354,6 +1532,16 @@ async fn spawn_llama_server(
         "--host",
         "127.0.0.1",
     ]);
+    // See ModelPath::mmproj's doc comment — enables llama-server to
+    // actually act on `images` (vision) and serve
+    // `/v1/audio/transcriptions` (audio) instead of silently ignoring
+    // both.
+    if let Some(mmproj) = mmproj {
+        cmd.args([
+            "--mmproj",
+            mmproj.to_str().context("non-UTF-8 mmproj path")?,
+        ]);
+    }
     // `ctx_size` is already the effective value (see
     // context_length_from_env); `None` leaves --ctx-size unset, falling
     // back to n_ctx_train.
@@ -1369,6 +1557,17 @@ async fn spawn_llama_server(
     // --cache-type-k/-v unset, falling back to llama-server's own `f16`.
     if let Some(t) = kv_cache_type {
         cmd.args(["--cache-type-k", t, "--cache-type-v", t]);
+    }
+    // See context_shift_from_env's doc comment.
+    cmd.arg(if context_shift {
+        "--context-shift"
+    } else {
+        "--no-context-shift"
+    });
+    // See sched_spread_from_env's doc comment; `None` leaves
+    // --split-mode unset, falling back to llama-server's own `layer`.
+    if let Some(mode) = split_mode {
+        cmd.args(["--split-mode", mode]);
     }
     // See GPU_VISIBLE_DEVICE_VARS's own doc comment — already inherited
     // by default, forwarded explicitly here for clarity.
@@ -1671,6 +1870,39 @@ async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
     None
 }
 
+/// Evicts every currently-running model other than `model_ref` that
+/// isn't actively serving a request, waiting for each to fully exit (see
+/// `ModelProcess::stop_and_wait`'s own doc comment) so its VRAM is
+/// actually freed before returning — mirrors Ollama's own OOM fallback of
+/// evicting every other loaded model and retrying once
+/// (`server/sched.go`). Skips any model with `in_flight > 0`, same as
+/// `reap_idle_models_once`'s own safety check — freeing memory for a new
+/// load should never mean killing a request that had already begun.
+/// Returns `true` if anything was evicted, so a caller only gained by
+/// this knows whether retrying is actually worth it.
+async fn evict_other_models(state: &AppState, model_ref: &str) -> bool {
+    let mut mgr = state.0.manager.lock().await;
+    let other_keys: Vec<String> = mgr
+        .running
+        .iter()
+        .filter(|(k, m)| k.as_str() != model_ref && m.in_flight == 0)
+        .map(|(k, _)| k.clone())
+        .collect();
+    let mut evicted: Vec<(String, RunningModel)> = Vec::with_capacity(other_keys.len());
+    for key in other_keys {
+        if let Some(running) = mgr.running.remove(&key) {
+            evicted.push((key, running));
+        }
+    }
+    drop(mgr); // release the lock before the (possibly slow) stops below
+    let any = !evicted.is_empty();
+    for (name, mut running) in evicted {
+        eprintln!("[llmman] evicting {name} to free memory before retrying {model_ref}");
+        running.process.stop_and_wait().await;
+    }
+    any
+}
+
 /// Ensures `model_ref` is loaded and returns `(canonical_ref, port)`. The
 /// canonical name is what it's actually registered under with its backend
 /// (`--served-model-name`), which can differ from a tagless `model_ref`
@@ -1737,48 +1969,136 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
             })
         })
         .unwrap_or_default();
-    let port = find_free_port()?;
-    eprintln!("[llmman] loading {model_ref} on port {port}");
-    // Only a local llama-server child gets a captured stderr tail today
-    // (see spawn_llama_server) — container/vllm startup failures still
-    // fail fast via ModelProcess::is_alive below, just without an inline
-    // "here's why" (their own stdio is still inherited straight into
-    // serve.log, same as before).
-    let mut stderr_tail: Option<OutputTail> = None;
-    let mut process = match (&model_path, state.0.ociman) {
-        (ModelPath::Gguf(path), Some(ociman)) => ModelProcess::Container(
-            ociman,
-            crate::container::spawn(
+    let context_shift = resolve_context_shift(model_ref, state.0.context_shift_override);
+    // OOM retry loop — on a local llama-server load that fails with a
+    // memory-allocation-looking error, tries progressively more invasive
+    // fallbacks before giving up (see each branch's own comment for which
+    // Ollama behavior it mirrors). Never mutates state.0.ctx_size, so a
+    // later reload starts fresh. A fresh `port` is picked for every
+    // attempt, not just the first — otherwise a retry's replacement
+    // process could try to bind the same port the previous (failed,
+    // possibly not-yet-fully-exited) one was still holding.
+    let mut ctx_size = state.0.ctx_size;
+    let mut split_mode = state.0.split_mode;
+    let mut shrink_attempts = 0u32;
+    let mut evicted_others = false;
+    let mut split_mode_relaxed = false;
+    let mut process;
+    let mut port = find_free_port()?;
+    loop {
+        eprintln!("[llmman] loading {model_ref} on port {port}");
+        // Only a local llama-server child captures a stderr tail (see
+        // spawn_llama_server) — every retry below only fires for that case.
+        let mut stderr_tail: Option<OutputTail> = None;
+        process = match (&model_path, state.0.ociman) {
+            (ModelPath::Gguf(path, mmproj), Some(ociman)) => ModelProcess::Container(
                 ociman,
-                path,
-                port,
-                state.0.llama_cpp_version.as_deref(),
-                state.0.ctx_size,
-                state.0.flash_attention.as_deref(),
-                state.0.kv_cache_type.as_deref(),
-            )?,
-        ),
-        (ModelPath::Gguf(path), None) => {
-            let bin = local_llama_server_bin(state).await?;
-            let (child, tail) = spawn_llama_server(
-                &bin,
-                path,
-                port,
-                state.0.ctx_size,
-                state.0.flash_attention.as_deref(),
-                state.0.kv_cache_type.as_deref(),
-            )
-            .await?;
-            stderr_tail = Some(tail);
-            ModelProcess::Local(Engine::LlamaServer, child, None)
+                crate::container::spawn(
+                    ociman,
+                    path,
+                    mmproj.as_deref(),
+                    port,
+                    state.0.llama_cpp_version.as_deref(),
+                    ctx_size,
+                    state.0.flash_attention.as_deref(),
+                    state.0.kv_cache_type.as_deref(),
+                    context_shift,
+                    split_mode,
+                )?,
+            ),
+            (ModelPath::Gguf(path, mmproj), None) => {
+                let bin = local_llama_server_bin(state).await?;
+                let (child, tail) = spawn_llama_server(
+                    &bin,
+                    path,
+                    mmproj.as_deref(),
+                    port,
+                    ctx_size,
+                    state.0.flash_attention.as_deref(),
+                    state.0.kv_cache_type.as_deref(),
+                    context_shift,
+                    split_mode,
+                )
+                .await?;
+                stderr_tail = Some(tail);
+                ModelProcess::Local(Engine::LlamaServer, child, None)
+            }
+            (ModelPath::SafeTensors(dir), _) => {
+                let child = spawn_vllm_server(dir, port, model_ref).await?;
+                let pid = child.id();
+                ModelProcess::Local(Engine::Vllm, child, pid)
+            }
+        };
+
+        match wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await {
+            Ok(()) => break,
+            Err(e) => {
+                let looks_oom = stderr_tail.is_some() // local llama-server only
+                    && looks_like_oom(&e.to_string());
+                if !looks_oom {
+                    return Err(e.into());
+                }
+                // See ModelProcess::stop_and_wait's own doc comment.
+                process.stop_and_wait().await;
+
+                // Cheapest fallback first: free memory without changing
+                // anything about how this model itself gets loaded, by
+                // evicting every other idle-but-loaded model (mirrors
+                // Ollama's own "evict all other models and retry once").
+                if !evicted_others {
+                    evicted_others = true;
+                    if evict_other_models(state, model_ref).await {
+                        eprintln!(
+                            "[llmman] {model_ref} failed to load on port {port}, which looks like an out-of-memory error — evicted other loaded models and retrying: {:#}",
+                            e
+                        );
+                        port = find_free_port()?;
+                        continue;
+                    }
+                }
+
+                // A hard LLMMAN_SCHED_SPREAD=0 (--split-mode none)
+                // restriction can itself be why this looks OOM — the
+                // model simply doesn't fit on one GPU at all, which no
+                // amount of ctx-size shrinking below would fix. Lift it
+                // before falling back to shrinking.
+                if !split_mode_relaxed && split_mode == Some("none") {
+                    split_mode_relaxed = true;
+                    split_mode = Some("layer");
+                    eprintln!(
+                        "[llmman] {model_ref} failed to load on port {port} with --split-mode none, which looks like an out-of-memory error — retrying with --split-mode layer (spread across every GPU) instead of failing outright: {:#}",
+                        e
+                    );
+                    port = find_free_port()?;
+                    continue;
+                }
+
+                // Only auto-shrink a ctx-size this daemon picked itself —
+                // silently overriding an explicit LLMMAN_CONTEXT_LENGTH
+                // would ignore the user's own stated choice (mirrors
+                // Ollama's own numCtxAuto gate on
+                // reduceAutoNumCtxForLoadOOM).
+                let can_shrink =
+                    !state.0.ctx_size_explicit && shrink_attempts < MAX_CTX_SHRINK_ATTEMPTS;
+                let Some(next) = can_shrink
+                    .then(|| next_ctx_size_after_oom(ctx_size))
+                    .flatten()
+                else {
+                    return Err(e.into());
+                };
+                eprintln!(
+                    "[llmman] {model_ref} failed to load on port {port}, which looks like an out-of-memory error — retrying with --ctx-size {next} (was {}): {:#}",
+                    ctx_size
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|| "model default".to_string()),
+                    e
+                );
+                ctx_size = Some(next);
+                shrink_attempts += 1;
+                port = find_free_port()?;
+            }
         }
-        (ModelPath::SafeTensors(dir), _) => {
-            let child = spawn_vllm_server(dir, port, model_ref).await?;
-            let pid = child.id();
-            ModelProcess::Local(Engine::Vllm, child, pid)
-        }
-    };
-    wait_for_ready(&state.0.client, port, &mut process, stderr_tail.as_ref()).await?;
+    }
     eprintln!("[llmman] {model_ref} ready on port {port}");
 
     state.0.manager.lock().await.running.insert(
@@ -1845,7 +2165,11 @@ async fn proxy(
     body: Bytes,
     activity: ActivityGuard,
 ) -> Result<Response, AppError> {
-    let mut req = client.post(url).body(body.to_vec());
+    // `Bytes` clones are refcounted, not copies — passing `body` straight
+    // through (reqwest::Body: From<Bytes>) avoids an extra full-size
+    // allocation that `body.to_vec()` would add on top of it, which
+    // matters most for large multipart audio uploads.
+    let mut req = client.post(url).body(body);
     if let Some(ct) = headers.get("content-type") {
         req = req.header("content-type", ct);
     }
@@ -2876,6 +3200,68 @@ async fn handle_openai_embeddings(
     proxy_openai(&state, &headers, body, "/v1/embeddings").await
 }
 
+// -- OpenAI Audio Transcriptions API (/v1/audio/transcriptions) -------------
+//
+// llama-server has its own native implementation (requires the model to
+// be loaded with mtmd audio support via a companion --mmproj — see
+// ModelPath::mmproj), so this is a plain pass-through like
+// handle_openai_responses. The request body is multipart/form-data, not
+// JSON, so proxy_openai's "parse as JSON to find model" doesn't apply —
+// multipart_text_field below extracts just the model field instead.
+
+/// Axum's own default `DefaultBodyLimit` (2 MiB) is well under a typical
+/// audio file's size — real recordings routinely run tens of MiB — so
+/// both transcription routes below opt out of it in favor of this
+/// higher cap instead of disabling it outright.
+const TRANSCRIPTION_BODY_LIMIT_BYTES: usize = 200 * 1024 * 1024;
+
+/// Extracts a top-level form field's text value from a
+/// `multipart/form-data` body, or `None` if not multipart / no boundary /
+/// field not found.
+async fn multipart_text_field(
+    body: &Bytes,
+    headers: &HeaderMap,
+    field_name: &str,
+) -> Option<String> {
+    let content_type = headers.get("content-type")?.to_str().ok()?;
+    let boundary = multer::parse_boundary(content_type).ok()?;
+    // Single-chunk stream over a cheap Bytes clone — the body is already
+    // fully buffered, so there's nothing to actually stream.
+    let stream = futures::stream::once(async { Ok::<_, std::io::Error>(body.clone()) });
+    let mut multipart = multer::Multipart::new(stream, boundary);
+    while let Ok(Some(field)) = multipart.next_field().await {
+        if field.name() == Some(field_name) {
+            return field.text().await.ok();
+        }
+    }
+    None
+}
+
+async fn handle_openai_transcriptions(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let Some(model) = multipart_text_field(&body, &headers, "model")
+        .await
+        .filter(|m| !m.is_empty())
+    else {
+        // A malformed request, not a server-side failure — matches
+        // handle_pull's own "missing required field" convention instead
+        // of AppError's blanket 500.
+        let body = serde_json::json!({
+            "error": "transcription request is missing a required \"model\" form field"
+        });
+        return Ok((StatusCode::BAD_REQUEST, Json(body)).into_response());
+    };
+    let (model, port) = ensure_model(&state, &model).await?;
+    // No `keep_alive` field on this API surface either — see
+    // proxy_openai's own comment on the same choice.
+    let activity = begin_activity(&state, &model, None).await;
+    let url = format!("http://127.0.0.1:{port}/v1/audio/transcriptions");
+    proxy(&state.0.client, &url, &headers, body, activity).await
+}
+
 // -- OpenAI Responses API (/v1/responses) ------------------------------------
 //
 // llama-server (llama.cpp) has its own native /v1/responses implementation
@@ -3234,11 +3620,16 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     let store_path = default_store(_args.store.as_deref())?;
     let cache_path = store_path.parent().unwrap_or(&store_path).join("cache");
     std::fs::create_dir_all(&cache_path)?;
+    // See storage::repair's own doc comment — matches Ollama's own
+    // unconditional `fixBlobs(blobsDir)` at the top of `server.Serve`,
+    // before it starts listening.
+    crate::storage::repair::repair_store(&store_path)?;
 
     // See context_length_from_env's doc comment. spawn_blocking: like
     // resolve_llama_server above, the VRAM probe fallback spawns a
     // subprocess and must not block this async fn's executor thread.
-    let ctx_size = match context_length_from_env() {
+    let ctx_size_explicit = context_length_from_env();
+    let ctx_size = match ctx_size_explicit {
         Some(n) => Some(n),
         None => tokio::task::spawn_blocking(crate::hostgpu::default_ctx_size)
             .await
@@ -3259,8 +3650,11 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         ociman: _args.ociman,
         llama_cpp_version: _args.llama_cpp_version.clone(),
         ctx_size,
+        ctx_size_explicit: ctx_size_explicit.is_some(),
         flash_attention: flash_attention_from_env(),
         kv_cache_type: kv_cache_type_from_env(),
+        context_shift_override: context_shift_override_from_env(),
+        split_mode: sched_spread_from_env(),
         store_path,
         cache_path,
         client: Client::new(),
@@ -3290,6 +3684,16 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         .route("/v1/chat/completions", post(handle_openai_chat))
         .route("/v1/completions", post(handle_openai_completions))
         .route("/v1/embeddings", post(handle_openai_embeddings))
+        .route(
+            "/v1/audio/transcriptions",
+            post(handle_openai_transcriptions)
+                .layer(DefaultBodyLimit::max(TRANSCRIPTION_BODY_LIMIT_BYTES)),
+        )
+        .route(
+            "/audio/transcriptions",
+            post(handle_openai_transcriptions)
+                .layer(DefaultBodyLimit::max(TRANSCRIPTION_BODY_LIMIT_BYTES)),
+        )
         .route("/v1/responses", post(handle_openai_responses))
         .route(
             "/v1/responses/input_tokens",
@@ -3781,8 +4185,11 @@ mod tests {
             ociman: None,
             llama_cpp_version: None,
             ctx_size: None,
+            ctx_size_explicit: false,
             flash_attention: None,
             kv_cache_type: None,
+            context_shift_override: None,
+            split_mode: None,
             store_path: std::env::temp_dir(),
             cache_path: std::env::temp_dir(),
             client: Client::new(),
@@ -3873,6 +4280,57 @@ mod tests {
             mgr.running.contains_key("not-yet-expired"),
             "a model whose keep_alive deadline hasn't passed yet must survive"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evict_other_models_evicts_everything_except_the_target_and_in_flight_models() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "the-model-being-loaded".into(),
+                running_model_fixture(None, Duration::from_secs(0), 0),
+            );
+            mgr.running.insert(
+                "idle-other-model".into(),
+                running_model_fixture(None, Duration::from_secs(0), 0),
+            );
+            mgr.running.insert(
+                "busy-other-model".into(),
+                running_model_fixture(None, Duration::from_secs(0), 1),
+            );
+        }
+
+        let evicted_anything = evict_other_models(&state, "the-model-being-loaded").await;
+        assert!(evicted_anything);
+
+        let mgr = state.0.manager.lock().await;
+        assert!(
+            mgr.running.contains_key("the-model-being-loaded"),
+            "the model ensure_model is trying to load isn't itself an eviction target"
+        );
+        assert!(
+            !mgr.running.contains_key("idle-other-model"),
+            "an idle other model should be evicted to free memory"
+        );
+        assert!(
+            mgr.running.contains_key("busy-other-model"),
+            "a model with an in-flight request must survive eviction, same as reap_idle_models"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evict_other_models_reports_nothing_evicted_when_nothing_is_evictable() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "the-model-being-loaded".into(),
+                running_model_fixture(None, Duration::from_secs(0), 0),
+            );
+        }
+
+        assert!(!evict_other_models(&state, "the-model-being-loaded").await);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -4026,6 +4484,125 @@ mod tests {
         assert_eq!(parse_kv_cache_type(Some("   ")), None);
     }
 
+    #[test]
+    fn parse_sched_spread_maps_truthy_and_falsey_spellings_to_split_mode() {
+        for truthy in ["1", "true", "yes", "on", "layer", " ON \n"] {
+            assert_eq!(
+                parse_sched_spread(Some(truthy)),
+                Some("layer"),
+                "input {truthy:?}"
+            );
+        }
+        for falsey in ["0", "false", "no", "off", "none", " OFF \n"] {
+            assert_eq!(
+                parse_sched_spread(Some(falsey)),
+                Some("none"),
+                "input {falsey:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sched_spread_leaves_llama_servers_own_default_untouched_when_unset_or_unparseable() {
+        assert_eq!(parse_sched_spread(None), None);
+        assert_eq!(parse_sched_spread(Some("")), None);
+        assert_eq!(parse_sched_spread(Some("   ")), None);
+        assert_eq!(parse_sched_spread(Some("garbage")), None);
+    }
+
+    #[test]
+    fn parse_context_shift_is_unset_when_absent_or_empty() {
+        // No explicit override — resolve_context_shift's per-model
+        // default applies instead. See context_shift_override_from_env's
+        // doc comment.
+        assert_eq!(parse_context_shift(None), None);
+        assert_eq!(parse_context_shift(Some("")), None);
+        assert_eq!(parse_context_shift(Some("   ")), None);
+        // An unrecognized-but-non-empty value is still an explicit
+        // override, same as the old bool-returning parser — it just
+        // isn't one of the recognized falsey spellings below.
+        assert_eq!(parse_context_shift(Some("garbage")), Some(true));
+    }
+
+    #[test]
+    fn parse_context_shift_recognizes_every_falsey_spelling() {
+        assert_eq!(parse_context_shift(Some("0")), Some(false));
+        assert_eq!(parse_context_shift(Some("false")), Some(false));
+        assert_eq!(parse_context_shift(Some("no")), Some(false));
+        assert_eq!(parse_context_shift(Some("off")), Some(false));
+        // Case-insensitive, whitespace-tolerant.
+        assert_eq!(parse_context_shift(Some(" FALSE \n")), Some(false));
+    }
+
+    #[test]
+    fn parse_context_shift_recognizes_explicit_truthy_spellings_too() {
+        assert_eq!(parse_context_shift(Some("1")), Some(true));
+        assert_eq!(parse_context_shift(Some("true")), Some(true));
+        assert_eq!(parse_context_shift(Some("on")), Some(true));
+        assert_eq!(parse_context_shift(Some("yes")), Some(true));
+    }
+
+    #[test]
+    fn supports_context_shift_disables_only_for_deepseek_family_models() {
+        assert!(!supports_context_shift("deepseek-v3:latest"));
+        assert!(!supports_context_shift("deepseek-r1:70b"));
+        assert!(!supports_context_shift("DeepSeek-V2.5:latest")); // case-insensitive
+        assert!(supports_context_shift("qwen3.5:latest"));
+        assert!(supports_context_shift("gpt-oss:20b"));
+    }
+
+    #[test]
+    fn resolve_context_shift_lets_an_explicit_override_win_over_the_model_default() {
+        // An explicit LLMMAN_CONTEXT_SHIFT always wins, even against a
+        // deepseek model that would otherwise default to disabled.
+        assert!(resolve_context_shift("deepseek-v3:latest", Some(true)));
+        assert!(!resolve_context_shift("qwen3.5:latest", Some(false)));
+        // No override — falls back to the per-model default.
+        assert!(!resolve_context_shift("deepseek-v3:latest", None));
+        assert!(resolve_context_shift("qwen3.5:latest", None));
+    }
+
+    #[test]
+    fn next_ctx_size_after_oom_halves_from_the_vram_tiered_default_down_to_the_floor() {
+        // The default_ctx_size_for(<=46GiB) tier — see hostgpu.rs.
+        assert_eq!(next_ctx_size_after_oom(Some(32768)), Some(16384));
+        // At (or below) the floor, no further shrink is offered.
+        assert_eq!(next_ctx_size_after_oom(Some(16384)), None);
+        assert_eq!(next_ctx_size_after_oom(Some(8192)), None);
+    }
+
+    #[test]
+    fn next_ctx_size_after_oom_starts_an_unbounded_ctx_size_at_an_explicit_ceiling() {
+        // ctx_size: None means "defer to the model's own trained
+        // context" (see hostgpu::default_ctx_size) — nothing to halve,
+        // so the first retry pins an explicit starting point instead.
+        assert_eq!(next_ctx_size_after_oom(None), Some(32768));
+    }
+
+    #[test]
+    fn looks_like_oom_matches_known_allocation_failure_phrasings() {
+        for msg in [
+            "ggml_backend_alloc_ctx_tensors_from_buft: failed to allocate CUDA0 buffer of size 123",
+            "llama_kv_cache: failed to allocate buffer for kv cache",
+            "CUDA error: out of memory",
+            "terminate called after throwing an instance of 'std::bad_alloc'",
+            "cudaMalloc failed: out of memory",
+        ] {
+            assert!(looks_like_oom(msg), "expected OOM match for {msg:?}");
+        }
+    }
+
+    #[test]
+    fn looks_like_oom_does_not_flag_unrelated_startup_failures() {
+        for msg in [
+            "error while loading shared libraries: libcuda.so.1: cannot open shared object file",
+            "error loading model: unknown architecture 'not-a-real-arch'",
+            "error: unknown argument: --not-a-real-flag",
+        ] {
+            assert!(!looks_like_oom(msg), "unexpected OOM match for {msg:?}");
+        }
+    }
+
     /// Regression test for the Claude Code bug described on
     /// `build_anthropic_messages`'s own doc comment: a `system`-role
     /// message anywhere in `messages` (not just the top-level `system`
@@ -4161,14 +4738,13 @@ mod tests {
     // differ; each test's doc comment calls out any such adaptation.
 
     /// Ported from ollama's openai/openai_test.go
-    /// (TestFromChatRequest_ReasoningEffort), adapted to llmman's narrower
-    /// mapping: only the plain-boolean `think` forms have an equivalent in
-    /// llama-server's `chat_template_kwargs.enable_thinking`; ollama's
-    /// string thinking levels ("low"/"medium"/"high"/"max") have no
-    /// counterpart there and are deliberately a no-op (None), as is an
-    /// absent `think` — the template's own default then applies.
+    /// (TestFromChatRequest_ReasoningEffort): a boolean `think` maps to
+    /// `enable_thinking`, and a string thinking level
+    /// ("low"/"medium"/"high"/"max") additionally maps to
+    /// `reasoning_effort` — the jinja variable gpt-oss's and
+    /// DeepSeek-V4's own chat templates read.
     #[test]
-    fn think_to_chat_template_kwargs_maps_booleans_and_ignores_levels() {
+    fn think_to_chat_template_kwargs_maps_booleans_and_reasoning_levels() {
         assert_eq!(
             think_to_chat_template_kwargs(&Some(serde_json::json!(true))),
             Some(serde_json::json!({ "enable_thinking": true }))
@@ -4177,14 +4753,31 @@ mod tests {
             think_to_chat_template_kwargs(&Some(serde_json::json!(false))),
             Some(serde_json::json!({ "enable_thinking": false }))
         );
-        for level in ["low", "medium", "high", "max", "minimal", "none"] {
+        for level in ["low", "medium", "high", "max"] {
             assert_eq!(
                 think_to_chat_template_kwargs(&Some(serde_json::json!(level))),
+                Some(serde_json::json!({
+                    "enable_thinking": true,
+                    "reasoning_effort": level,
+                })),
+                "string level {level:?}"
+            );
+        }
+        // Anything other than the four known levels is a no-op — an
+        // unrecognized value shouldn't be forwarded to the template
+        // verbatim (see think_to_chat_template_kwargs's own comment).
+        for not_a_level in ["", "  ", "verbose", "LOW"] {
+            assert_eq!(
+                think_to_chat_template_kwargs(&Some(serde_json::json!(not_a_level))),
                 None,
-                "string level {level:?} must be a no-op"
+                "string {not_a_level:?}"
             );
         }
         assert_eq!(think_to_chat_template_kwargs(&None), None);
+        assert_eq!(
+            think_to_chat_template_kwargs(&Some(serde_json::Value::Null)),
+            None
+        );
     }
 
     /// Ported from ollama's api/client_test.go (TestClientStream /
@@ -4531,5 +5124,82 @@ mod tests {
                 .expect("a name-only body must still deserialize");
         assert_eq!(req.model, "");
         assert_eq!(req.name, "docker.io/ai/gemma4:E2B");
+    }
+
+    // -- multipart_text_field (/v1/audio/transcriptions) ----------------------
+
+    /// Builds a `multipart/form-data` body + matching `content-type`
+    /// header out of `fields` (name, value) pairs — a hand-rolled encoder
+    /// rather than a dependency, just enough to exercise
+    /// `multipart_text_field` against real (if minimal) multipart wire
+    /// format.
+    fn multipart_body(fields: &[(&str, &str)]) -> (Bytes, HeaderMap) {
+        let boundary = "llmman-test-boundary";
+        let mut body = String::new();
+        for (name, value) in fields {
+            body.push_str(&format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"{name}\"\r\n\r\n{value}\r\n"
+            ));
+        }
+        body.push_str(&format!("--{boundary}--\r\n"));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}")
+                .parse()
+                .unwrap(),
+        );
+        (Bytes::from(body), headers)
+    }
+
+    #[tokio::test]
+    async fn multipart_text_field_finds_a_named_field_among_several() {
+        let (body, headers) = multipart_body(&[
+            ("language", "en"),
+            ("model", "docker.io/ai/whisper:latest"),
+            ("response_format", "json"),
+        ]);
+        assert_eq!(
+            multipart_text_field(&body, &headers, "model").await,
+            Some("docker.io/ai/whisper:latest".to_string())
+        );
+        assert_eq!(
+            multipart_text_field(&body, &headers, "language").await,
+            Some("en".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn multipart_text_field_leaves_the_original_body_untouched() {
+        // Regression: multipart_text_field parses a *clone* of the body
+        // for the field it wants — the original `Bytes` handed to
+        // `proxy` afterward must still be the exact, complete multipart
+        // payload (file bytes included), not something already partially
+        // consumed by this lookup.
+        let (body, headers) = multipart_body(&[("model", "m"), ("prompt", "hello")]);
+        let before = body.clone();
+        let _ = multipart_text_field(&body, &headers, "model").await;
+        assert_eq!(body, before);
+    }
+
+    #[tokio::test]
+    async fn multipart_text_field_is_none_for_a_missing_field_or_non_multipart_body() {
+        let (body, headers) = multipart_body(&[("language", "en")]);
+        assert_eq!(multipart_text_field(&body, &headers, "model").await, None);
+
+        let plain_body = Bytes::from_static(b"{\"model\":\"m\"}");
+        let mut json_headers = HeaderMap::new();
+        json_headers.insert("content-type", "application/json".parse().unwrap());
+        assert_eq!(
+            multipart_text_field(&plain_body, &json_headers, "model").await,
+            None
+        );
+
+        // No content-type header at all.
+        assert_eq!(
+            multipart_text_field(&plain_body, &HeaderMap::new(), "model").await,
+            None
+        );
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -218,14 +218,25 @@ pub fn pull_image(ociman: ContainerManager, llama_cpp_version: Option<&str>) -> 
 /// same way as `--flash-attn <mode>` and `--cache-type-k`/`--cache-type-v
 /// <type>` respectively — see `cmd::serve::flash_attention_from_env` and
 /// `cmd::serve::kv_cache_type_from_env`'s doc comments.
+///
+/// `context_shift` forwards `--context-shift`/`--no-context-shift`.
+///
+/// `split_mode`, when given, forwards `--split-mode <mode>`.
+///
+/// `mmproj_path`, when given, forwards `--mmproj <path>`, mounted as its
+/// own `/mmproj` read-only volume (it's extracted into a different cache
+/// directory than `model_path`, so it can't share that mount).
 pub fn spawn(
     ociman: ContainerManager,
     model_path: &Path,
+    mmproj_path: Option<&Path>,
     port: u16,
     llama_cpp_version: Option<&str>,
     ctx_size: Option<u32>,
     flash_attention: Option<&str>,
     kv_cache_type: Option<&str>,
+    context_shift: bool,
+    split_mode: Option<&str>,
 ) -> Result<tokio::process::Child> {
     let backend = detect_backend();
     let image = backend.image_ref(llama_cpp_version);
@@ -257,6 +268,19 @@ pub fn spawn(
         "-v".into(),
         format!("{model_dir_str}:/models:ro"),
     ];
+    let mmproj_file = mmproj_path
+        .map(|p| -> Result<&str> {
+            let dir = p.parent().context("mmproj path has no parent directory")?;
+            let dir_str = dir
+                .to_str()
+                .context("mmproj directory is not valid UTF-8")?;
+            args.push("-v".into());
+            args.push(format!("{dir_str}:/mmproj:ro"));
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .context("mmproj path has no valid UTF-8 filename")
+        })
+        .transpose()?;
     args.extend(backend.engine_args());
     // Unlike a local llama-server child process, `docker run`/`podman run`
     // does not inherit the host's environment into the container on its
@@ -279,6 +303,10 @@ pub fn spawn(
         "--host".into(),
         "0.0.0.0".into(),
     ]);
+    if let Some(mmproj_file) = mmproj_file {
+        args.push("--mmproj".into());
+        args.push(format!("/mmproj/{mmproj_file}"));
+    }
     if let Some(n) = ctx_size {
         args.push("--ctx-size".into());
         args.push(n.to_string());
@@ -292,6 +320,18 @@ pub fn spawn(
         args.push(t.to_string());
         args.push("--cache-type-v".into());
         args.push(t.to_string());
+    }
+    args.push(
+        if context_shift {
+            "--context-shift"
+        } else {
+            "--no-context-shift"
+        }
+        .into(),
+    );
+    if let Some(mode) = split_mode {
+        args.push("--split-mode".into());
+        args.push(mode.to_string());
     }
 
     tokio::process::Command::new(ociman.binary())

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -356,6 +356,12 @@ fn cuda_major_from_driver_version(driver_version: i32) -> u32 {
     (driver_version / 1000).max(0) as u32
 }
 
+/// `Some((kind, total_vram_bytes))` if at least one CUDA device is
+/// present. Sums every visible device's memory (via
+/// `cuDeviceTotalMem_v2`), not just device 0's, so a multi-GPU host's
+/// combined VRAM sizes `--ctx-size` correctly (see
+/// `default_ctx_size_for`) — matching `detect_vulkan_inner`'s existing
+/// multi-device summation below.
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 fn detect_cuda() -> Option<(HostGpu, u64)> {
     let lib = open_cuda_lib()?;
@@ -383,8 +389,14 @@ fn detect_cuda() -> Option<(HostGpu, u64)> {
             lib.get::<unsafe extern "C" fn(*mut i32, i32) -> i32>(b"cuDeviceGet\0"),
             lib.get::<unsafe extern "C" fn(*mut i32, i32, i32) -> i32>(b"cuDeviceGetAttribute\0"),
         ) {
-            let mut device: i32 = 0;
-            if cu_device_get(&mut device, 0) == CUDA_SUCCESS {
+            let cu_device_total_mem = lib
+                .get::<unsafe extern "C" fn(*mut u64, i32) -> i32>(b"cuDeviceTotalMem_v2\0")
+                .ok();
+            for index in 0..count {
+                let mut device: i32 = 0;
+                if cu_device_get(&mut device, index) != CUDA_SUCCESS {
+                    continue;
+                }
                 let mut major: i32 = 0;
                 let mut minor: i32 = 0;
                 cu_device_get_attribute(
@@ -397,14 +409,12 @@ fn detect_cuda() -> Option<(HostGpu, u64)> {
                     CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
                     device,
                 );
-                eprintln!("[llmman] CUDA device 0 compute capability: {major}.{minor}");
+                eprintln!("[llmman] CUDA device {index} compute capability: {major}.{minor}");
 
-                if let Ok(cu_device_total_mem) =
-                    lib.get::<unsafe extern "C" fn(*mut u64, i32) -> i32>(b"cuDeviceTotalMem_v2\0")
-                {
+                if let Some(cu_device_total_mem) = &cu_device_total_mem {
                     let mut bytes: u64 = 0;
                     if cu_device_total_mem(&mut bytes, device) == CUDA_SUCCESS {
-                        vram = bytes;
+                        vram += bytes;
                     }
                 }
             }
@@ -431,8 +441,9 @@ fn detect_cuda() -> Option<(HostGpu, u64)> {
 
 const HIP_SUCCESS: i32 = 0;
 
-/// `Some(total_vram_bytes)` if a HIP device is present (0 if its memory
-/// couldn't be read), `None` if not.
+/// `Some(total_vram_bytes)` if at least one HIP device is present, `None`
+/// if not. Sums every device's memory rather than just device 0's — see
+/// `detect_cuda`'s doc comment.
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 fn detect_rocm() -> Option<u64> {
     let lib = open_hip_lib()?;
@@ -450,10 +461,14 @@ fn detect_rocm() -> Option<u64> {
             lib.get::<unsafe extern "C" fn(i32) -> i32>(b"hipSetDevice\0"),
             lib.get::<unsafe extern "C" fn(*mut u64, *mut u64) -> i32>(b"hipMemGetInfo\0"),
         ) {
-            hip_set_device(0);
-            let (mut free, mut total): (u64, u64) = (0, 0);
-            if hip_mem_get_info(&mut free, &mut total) == HIP_SUCCESS {
-                vram = total;
+            for index in 0..count {
+                if hip_set_device(index) != HIP_SUCCESS {
+                    continue;
+                }
+                let (mut free, mut total): (u64, u64) = (0, 0);
+                if hip_mem_get_info(&mut free, &mut total) == HIP_SUCCESS {
+                    vram += total;
+                }
             }
         }
         Some(vram)

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -24,8 +24,10 @@ const HF_GGUF_MEDIA_TYPE: &str = "application/vnd.docker.ai.gguf.v3";
 
 /// What kind of model did we find in the OCI store?
 pub enum ModelPath {
-    /// A GGUF file — serve with llama-server.
-    Gguf(PathBuf),
+    /// A GGUF file — serve with llama-server. The second field, when
+    /// present, is a companion `--mmproj` projector GGUF (see
+    /// [`is_mmproj_layer`]) needed for vision/audio support.
+    Gguf(PathBuf, Option<PathBuf>),
     /// A safetensors directory — serve with vllm.
     SafeTensors(PathBuf),
 }
@@ -36,8 +38,18 @@ impl ModelPath {
     /// `config.json`) for a safetensors checkout.
     pub fn path(&self) -> &Path {
         match self {
-            ModelPath::Gguf(p) => p,
+            ModelPath::Gguf(p, _) => p,
             ModelPath::SafeTensors(p) => p,
+        }
+    }
+
+    /// The companion `--mmproj` projector file resolved alongside a
+    /// `Gguf` model, if any — always `None` for `SafeTensors` (vllm has
+    /// no equivalent separate-projector-file convention).
+    pub fn mmproj(&self) -> Option<&Path> {
+        match self {
+            ModelPath::Gguf(_, mmproj) => mmproj.as_deref(),
+            ModelPath::SafeTensors(_) => None,
         }
     }
 
@@ -46,7 +58,7 @@ impl ModelPath {
     /// branch on format without matching the enum directly.
     pub fn format(&self) -> &'static str {
         match self {
-            ModelPath::Gguf(_) => "gguf",
+            ModelPath::Gguf(..) => "gguf",
             ModelPath::SafeTensors(_) => "safetensors",
         }
     }
@@ -84,6 +96,16 @@ fn is_safetensors_layer(l: &crate::storage::oci::Descriptor) -> bool {
         .unwrap_or(false)
 }
 
+/// True if a (already-confirmed-GGUF) layer looks like a multimodal
+/// projector rather than the main model — matched by filename containing
+/// "mmproj", the de facto convention GGUF repos use, since there's no
+/// media-type or metadata distinction to key off instead.
+fn is_mmproj_layer(l: &crate::storage::oci::Descriptor) -> bool {
+    layer_filepath(l)
+        .map(|p| p.to_lowercase().contains("mmproj"))
+        .unwrap_or(false)
+}
+
 // gguf_architecture/gguf_context_length_override (a GGUF metadata reader
 // + --override-kv builder that let --ctx-size force a context above a
 // model's own trained length) were tried and removed: llama-server's own
@@ -96,6 +118,66 @@ fn is_safetensors_layer(l: &crate::storage::oci::Descriptor) -> bool {
 // whose trained context is that tight was never going to serve well
 // regardless — see docker/sandboxes' own llmmanCtxSize doc comment for the
 // model-selection fix that replaced this instead.
+
+/// Extracts a single GGUF layer to a local path, caching under
+/// `cache_path` — shared by [`resolve_model`] for both the primary model
+/// GGUF and, when present, a companion `--mmproj` GGUF (see
+/// [`is_mmproj_layer`]), since both are extracted exactly the same way.
+fn extract_gguf_layer(
+    store: &OciStore,
+    store_path: &Path,
+    cache_path: &Path,
+    layer: &crate::storage::oci::Descriptor,
+) -> anyhow::Result<PathBuf> {
+    let title = layer_filepath(layer).unwrap_or("model.gguf").to_owned();
+    let layer_hex = digest_hex(&layer.digest)?;
+
+    // HF blobs are stored as raw GGUF — use directly.
+    if layer.media_type == HF_GGUF_MEDIA_TYPE {
+        let blob_path = store_path.join("blobs").join("sha256").join(layer_hex);
+        if blob_path.exists() {
+            eprintln!("[llmman] using blob directly: {}", blob_path.display());
+            return Ok(blob_path);
+        }
+    }
+
+    // Otherwise extract from tar layer.
+    let cached_dir = cache_path.join(layer_hex);
+    if cached_dir.exists() {
+        for e in std::fs::read_dir(&cached_dir)?.flatten() {
+            let p = e.path();
+            if p.extension().and_then(|e| e.to_str()) == Some("gguf") {
+                return Ok(p);
+            }
+        }
+    }
+    std::fs::create_dir_all(&cached_dir)?;
+    let blob = store
+        .read_blob(&layer.digest)
+        .with_context(|| format!("read blob {}", layer.digest))?;
+    if blob.len() >= 4 && &blob[..4] == b"GGUF" {
+        let name = Path::new(&title)
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
+        let p = cached_dir.join(name);
+        std::fs::write(&p, &blob)?;
+        return Ok(p);
+    }
+    let mut archive = tar::Archive::new(std::io::Cursor::new(&blob));
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let ep = entry.path()?.to_path_buf();
+        if ep.extension().and_then(|e| e.to_str()) == Some("gguf") {
+            let name = ep
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
+            let d = cached_dir.join(name);
+            entry.unpack(&d)?;
+            return Ok(d);
+        }
+    }
+    Err(anyhow!("no .gguf in tar layer {}", layer.digest))
+}
 
 /// Resolve `model_ref` (already present in the `OciStore` at `store_path`)
 /// to either a `.gguf` file or an extracted safetensors directory, caching
@@ -112,61 +194,34 @@ pub fn resolve_model(
     let manifest = store.read_manifest(&desc.digest)?;
 
     // ── GGUF → llama-server ────────────────────────────────────────────────
-    if let Some(gguf_layer) = manifest.layers.iter().find(|l| is_gguf_layer(l)) {
-        let title = layer_filepath(gguf_layer)
-            .unwrap_or("model.gguf")
-            .to_owned();
-        let layer_hex = digest_hex(&gguf_layer.digest)?;
+    let gguf_layers: Vec<&crate::storage::oci::Descriptor> = manifest
+        .layers
+        .iter()
+        .filter(|l| is_gguf_layer(l))
+        .collect();
+    if !gguf_layers.is_empty() {
+        // Prefer a non-mmproj-named layer as the primary model, so an
+        // mmproj file that happens to sort first (e.g. "mmproj-F16.gguf"
+        // before "model-Q4_K_M.gguf") isn't picked as the model itself.
+        // Falls back to the first layer if every one looks like mmproj.
+        let primary = *gguf_layers
+            .iter()
+            .find(|l| !is_mmproj_layer(l))
+            .unwrap_or(&gguf_layers[0]);
+        let mmproj = gguf_layers
+            .iter()
+            .copied()
+            .find(|l| is_mmproj_layer(l) && l.digest != primary.digest);
 
-        // HF blobs are stored as raw GGUF — use directly.
-        if gguf_layer.media_type == HF_GGUF_MEDIA_TYPE {
-            let blob_path = store_path.join("blobs").join("sha256").join(layer_hex);
-            if blob_path.exists() {
-                eprintln!("[llmman] using blob directly: {}", blob_path.display());
-                return Ok(ModelPath::Gguf(blob_path));
-            }
+        let primary_path = extract_gguf_layer(&store, store_path, cache_path, primary)?;
+        let mmproj_path = mmproj
+            .map(|l| extract_gguf_layer(&store, store_path, cache_path, l))
+            .transpose()
+            .context("extracting companion mmproj file")?;
+        if mmproj_path.is_some() {
+            eprintln!("[llmman] {model_ref}: found companion mmproj file");
         }
-
-        // Otherwise extract from tar layer.
-        let cached_dir = cache_path.join(layer_hex);
-        if cached_dir.exists() {
-            for e in std::fs::read_dir(&cached_dir)?.flatten() {
-                let p = e.path();
-                if p.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    return Ok(ModelPath::Gguf(p));
-                }
-            }
-        }
-        std::fs::create_dir_all(&cached_dir)?;
-        let blob = store
-            .read_blob(&gguf_layer.digest)
-            .with_context(|| format!("read blob {}", gguf_layer.digest))?;
-        let dest = if blob.len() >= 4 && &blob[..4] == b"GGUF" {
-            let name = Path::new(&title)
-                .file_name()
-                .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
-            let p = cached_dir.join(name);
-            std::fs::write(&p, &blob)?;
-            p
-        } else {
-            let mut archive = tar::Archive::new(std::io::Cursor::new(&blob));
-            let mut extracted = None;
-            for entry in archive.entries()? {
-                let mut entry = entry?;
-                let ep = entry.path()?.to_path_buf();
-                if ep.extension().and_then(|e| e.to_str()) == Some("gguf") {
-                    let name = ep
-                        .file_name()
-                        .unwrap_or_else(|| std::ffi::OsStr::new("model.gguf"));
-                    let d = cached_dir.join(name);
-                    entry.unpack(&d)?;
-                    extracted = Some(d);
-                    break;
-                }
-            }
-            extracted.ok_or_else(|| anyhow!("no .gguf in tar layer of {model_ref}"))?
-        };
-        return Ok(ModelPath::Gguf(dest));
+        return Ok(ModelPath::Gguf(primary_path, mmproj_path));
     }
 
     // ── safetensors → vllm ────────────────────────────────────────────────
@@ -257,7 +312,10 @@ mod tests {
 
     #[test]
     fn format_matches_variant() {
-        assert_eq!(ModelPath::Gguf(PathBuf::from("/x/m.gguf")).format(), "gguf");
+        assert_eq!(
+            ModelPath::Gguf(PathBuf::from("/x/m.gguf"), None).format(),
+            "gguf"
+        );
         assert_eq!(
             ModelPath::SafeTensors(PathBuf::from("/x")).format(),
             "safetensors"
@@ -268,5 +326,56 @@ mod tests {
     fn path_returns_inner_pathbuf() {
         let p = ModelPath::SafeTensors(PathBuf::from("/models/foo"));
         assert_eq!(p.path(), Path::new("/models/foo"));
+    }
+
+    #[test]
+    fn mmproj_is_none_unless_explicitly_set() {
+        let no_mmproj = ModelPath::Gguf(PathBuf::from("/x/m.gguf"), None);
+        assert_eq!(no_mmproj.mmproj(), None);
+
+        let with_mmproj = ModelPath::Gguf(
+            PathBuf::from("/x/m.gguf"),
+            Some(PathBuf::from("/x/mmproj-f16.gguf")),
+        );
+        assert_eq!(with_mmproj.mmproj(), Some(Path::new("/x/mmproj-f16.gguf")));
+
+        // SafeTensors (vllm) has no equivalent separate-projector-file
+        // convention.
+        assert_eq!(ModelPath::SafeTensors(PathBuf::from("/x")).mmproj(), None);
+    }
+
+    fn descriptor(digest: &str, filepath: &str) -> crate::storage::oci::Descriptor {
+        let mut ann = std::collections::HashMap::new();
+        ann.insert("org.cncf.model.filepath".to_string(), filepath.to_string());
+        crate::storage::oci::Descriptor {
+            media_type: "application/vnd.cncf.model.weight.v1.tar".into(),
+            digest: digest.to_string(),
+            size: 123,
+            annotations: Some(ann),
+        }
+    }
+
+    #[test]
+    fn is_mmproj_layer_matches_filename_regardless_of_case_or_position() {
+        assert!(is_mmproj_layer(&descriptor("sha256:a", "mmproj-F16.gguf")));
+        assert!(is_mmproj_layer(&descriptor(
+            "sha256:b",
+            "Qwen3-VL-mmproj.gguf"
+        )));
+        assert!(!is_mmproj_layer(&descriptor(
+            "sha256:c",
+            "model.Q4_K_M.gguf"
+        )));
+    }
+
+    #[test]
+    fn is_gguf_layer_matches_both_mmproj_and_primary_model_files() {
+        // is_mmproj_layer only narrows *within* the GGUF files a manifest
+        // has — is_gguf_layer itself must still say "yes" for an mmproj
+        // file, or resolve_model's gguf_layers filter would silently
+        // drop it instead of finding a companion.
+        assert!(is_gguf_layer(&descriptor("sha256:a", "mmproj-F16.gguf")));
+        assert!(is_gguf_layer(&descriptor("sha256:b", "model.Q4_K_M.gguf")));
+        assert!(!is_gguf_layer(&descriptor("sha256:c", "model.safetensors")));
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,2 +1,3 @@
 pub mod oci;
+pub mod repair;
 pub use oci::{default_tag, OciStore};

--- a/src/storage/repair.rs
+++ b/src/storage/repair.rs
@@ -1,0 +1,206 @@
+//! Blob-store startup repair — llmman's equivalent of Ollama's
+//! `server/fixblobs.go`, run unconditionally at the start of every
+//! `llmman serve`, before it starts listening (matching `server.Serve`'s
+//! own unconditional `fixBlobs(blobsDir)` call).
+//!
+//! Deliberately cheap, matching Ollama's own approach: removes stray temp
+//! files left behind by an interrupted blob write (`OciStore`'s
+//! `tmp-<pid>`/`<hex>.tmp` naming), and reports any locally tagged image
+//! whose manifest references a blob that isn't actually present. Neither
+//! needs reading a blob's contents, so this stays fast even on a large
+//! store — unlike a full sha256 re-verification of every blob, which is
+//! expensive enough to be left out of every-startup checking entirely.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Context;
+
+use super::OciStore;
+
+/// Minimum age a stray temp file must have before it's treated as
+/// abandoned rather than a write still in progress — matches Ollama's own
+/// `layerPruneGracePeriod` (`server/images.go`).
+const STALE_TMP_FILE_AGE: Duration = Duration::from_secs(60 * 60);
+
+/// Runs the startup repair pass described in the module doc comment.
+/// Mirrors `fixBlobs`'s own error handling: a hard failure reading the
+/// blobs directory propagates (failing `llmman serve` startup, like
+/// Ollama's `Serve` does on `fixBlobs`'s error), but a single bad entry
+/// is only logged and skipped.
+pub fn repair_store(store_root: &Path) -> anyhow::Result<()> {
+    let blobs_dir = store_root.join("blobs").join("sha256");
+    if blobs_dir.is_dir() {
+        remove_stale_temp_files(&blobs_dir)
+            .with_context(|| format!("read {}", blobs_dir.display()))?;
+    }
+    report_incomplete_images(store_root);
+    Ok(())
+}
+
+fn remove_stale_temp_files(blobs_dir: &Path) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(blobs_dir)? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("[llmman] couldn't read blob store entry: {e:#}");
+                continue;
+            }
+        };
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !(name.starts_with("tmp-") || name.ends_with(".tmp")) {
+            continue;
+        }
+        if !is_stale(&path) {
+            continue;
+        }
+        if let Err(e) = std::fs::remove_file(&path) {
+            eprintln!(
+                "[llmman] couldn't remove stale temp file {}: {e:#}",
+                path.display()
+            );
+            continue;
+        }
+        eprintln!("[llmman] removed stale temp file {name}");
+    }
+    Ok(())
+}
+
+/// True if `path`'s last modification is older than `STALE_TMP_FILE_AGE`.
+/// A file whose metadata can't be read (removed out from under us,
+/// unsupported mtime, ...) is treated as not-yet-stale rather than
+/// erroring the whole pass.
+fn is_stale(path: &Path) -> bool {
+    let Ok(modified) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return false;
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age >= STALE_TMP_FILE_AGE)
+}
+
+/// Logs every locally tagged image whose manifest or layers reference a
+/// blob that isn't actually present in `store_root`, so a user notices
+/// (in `llmman serve`'s own log) which images need re-pulling rather than
+/// only discovering it later when loading one of them fails. Errors
+/// opening the store or listing images are swallowed rather than failing
+/// startup — this is a best-effort diagnostic, not a precondition for
+/// serving.
+fn report_incomplete_images(store_root: &Path) {
+    let Ok(store) = OciStore::open(store_root) else {
+        return;
+    };
+    let Ok(images) = store.list() else {
+        return;
+    };
+    for img in images {
+        let complete = store
+            .find(&img.reference)
+            .and_then(|desc| store.read_manifest(&desc.digest))
+            .map(|manifest| {
+                std::iter::once(&manifest.config)
+                    .chain(manifest.layers.iter())
+                    .all(|l| blob_exists(store_root, &l.digest))
+            })
+            .unwrap_or(false);
+        if !complete {
+            eprintln!(
+                "[llmman] {} is missing one or more blobs and should be re-pulled",
+                img.reference
+            );
+        }
+    }
+}
+
+/// True if `digest` ("sha256:<hex>") names a blob file that's actually
+/// present under `store_root`. Malformed digests (no `sha256:` prefix —
+/// shouldn't happen for anything llmman itself ever wrote, but a
+/// hand-edited or foreign-tool-written manifest could) count as "not
+/// present" rather than panicking.
+fn blob_exists(store_root: &Path, digest: &str) -> bool {
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        return false;
+    };
+    store_root.join("blobs").join("sha256").join(hex).is_file()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_exists_requires_the_sha256_prefix_and_a_real_file() {
+        let dir = std::env::temp_dir().join(format!("llmman-repair-test-{}", std::process::id()));
+        let blobs = dir.join("blobs").join("sha256");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("abc123"), b"hi").unwrap();
+
+        assert!(blob_exists(&dir, "sha256:abc123"));
+        assert!(!blob_exists(&dir, "sha256:does-not-exist"));
+        assert!(!blob_exists(&dir, "abc123")); // missing "sha256:" prefix
+        assert!(!blob_exists(&dir, "md5:abc123")); // wrong algorithm prefix
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    // filetime_set (and its libc_timeval/set_file_times helpers) are
+    // Unix-only — gate the whole test rather than porting them, since
+    // this repo has no other Windows-specific mtime-backdating need.
+    #[test]
+    #[cfg(unix)]
+    fn remove_stale_temp_files_only_removes_files_past_the_grace_period() {
+        let dir =
+            std::env::temp_dir().join(format!("llmman-repair-test-stale-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let fresh = dir.join("tmp-12345");
+        let stale = dir.join("tmp-99999");
+        std::fs::write(&fresh, b"in progress").unwrap();
+        std::fs::write(&stale, b"abandoned").unwrap();
+        // Back-date the "stale" file's mtime past the grace period.
+        let old = SystemTime::now() - STALE_TMP_FILE_AGE - Duration::from_secs(60);
+        filetime_set(&stale, old);
+
+        remove_stale_temp_files(&dir).unwrap();
+
+        assert!(fresh.exists(), "fresh temp file should be left alone");
+        assert!(!stale.exists(), "stale temp file should be removed");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Minimal mtime-backdating helper — avoids pulling in a `filetime`
+    /// dependency just for this one test.
+    #[cfg(unix)]
+    fn filetime_set(path: &Path, when: SystemTime) {
+        let file = std::fs::File::open(path).unwrap();
+        let duration = when.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let ts = libc_timeval(duration);
+        set_file_times(&file, ts);
+    }
+
+    #[cfg(unix)]
+    fn libc_timeval(d: Duration) -> (i64, i64) {
+        (d.as_secs() as i64, d.subsec_micros() as i64)
+    }
+
+    #[cfg(unix)]
+    fn set_file_times(file: &std::fs::File, (secs, micros): (i64, i64)) {
+        use std::os::unix::io::AsRawFd;
+        let times = [
+            libc::timeval {
+                tv_sec: secs as _,
+                tv_usec: micros as _,
+            },
+            libc::timeval {
+                tv_sec: secs as _,
+                tv_usec: micros as _,
+            },
+        ];
+        unsafe {
+            libc::futimes(file.as_raw_fd(), times.as_ptr());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Six Ollama-parity improvements to `llmman serve`'s inference backend:

1. **Reasoning-effort thinking levels** — `think: "low"/"medium"/"high"/"max"`
   (previously silently ignored, boolean-only) now maps to
   `chat_template_kwargs.reasoning_effort`, the jinja variable gpt-oss's
   and DeepSeek-V4's own chat templates read to pick reasoning depth.
   Only the four known levels are forwarded; anything else is a no-op.
2. **Context-shift, per-model** — every spawned `llama-server` gets
   `--context-shift` by default (matching Ollama's always-shift-instead-
   of-fail behavior), except DeepSeek-family models, mirroring Ollama's
   own per-model `supportsContextShift` (their MLA KV cache can't be
   shifted safely). `LLMMAN_CONTEXT_SHIFT` overrides either default.
3. **OOM retry, layered fallbacks** — a local `llama-server` load that
   fails with a memory-allocation error now falls back, in order: evict
   every other idle loaded model and retry (mirrors Ollama's own OOM
   eviction fallback); lift a hard `LLMMAN_SCHED_SPREAD=0` single-GPU
   restriction if that's the actual cause; then retry up to 4 times with
   `--ctx-size` halved down to a 16384 floor (skipped for an explicit
   `LLMMAN_CONTEXT_LENGTH`, mirroring Ollama's `numCtxAuto` gate on
   `reduceAutoNumCtxForLoadOOM`). Each retry explicitly stops the failed
   process (waiting for it to exit) and picks a fresh port, rather than
   racing a replacement server against one still shutting down.
4. **Multi-GPU fixes** — `hostgpu`'s CUDA/ROCm VRAM probes previously only
   queried device 0; they now sum every visible device, so multi-GPU
   hosts get the right VRAM-tiered `--ctx-size` default. Also adds
   `LLMMAN_SCHED_SPREAD` (Ollama's `OLLAMA_SCHED_SPREAD` equivalent),
   forwarding `--split-mode layer`/`none`.
5. **Audio transcription** — `/v1/audio/transcriptions` (+ the bare
   `/audio/transcriptions` alias) now proxy through to llama-server's own
   native implementation, returning 400 (not 500) for a missing `model`
   field, with a raised body-size limit so real audio uploads don't hit
   axum's 2 MiB default. This required teaching `resolve_model` to find
   and extract a companion `--mmproj` projector file alongside a model's
   main GGUF — `ModelPath::Gguf` now carries an optional resolved mmproj
   path, threaded through `spawn_llama_server` and `container::spawn`.
6. **Automatic blob-store repair** — a cheap pass (stray temp-file
   cleanup + missing-blob reporting, no full blob re-hashing) now runs
   at the start of every `llmman serve`, matching Ollama's own
   `fixBlobs` behavior, instead of being a separate manual command.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --release --bin llmman`
- `cargo build --release` and `cargo build --release --no-default-features --features podman`
- `cargo test --release --bin llmman` — 150 passed, 0 failed (2 ignored, real-hardware-only)


