### PR TITLE
fix(go-shim): make index.json writes atomic, reads lock-consistent

### DIFF
--- a/go-shim/backend_docker.go
+++ b/go-shim/backend_docker.go
@@ -428,7 +428,7 @@ func llmman_push(cLayoutDir, cRef *C.char) *C.char {
 // the last one).
 func pushToRegistry(ctx context.Context, layoutDir, ref string) (changed bool, err error) {
 	// Locate the manifest in the local index
-	idx, err := readIndex(layoutDir)
+	idx, err := readIndexLocked(layoutDir)
 	if err != nil {
 		return false, fmt.Errorf("read OCI index: %w", err)
 	}

--- a/go-shim/hf.go
+++ b/go-shim/hf.go
@@ -681,7 +681,7 @@ func parseHFRef(ref string) (host, owner, repo, tag string, err error) {
 // cachedLayerName returns the GGUF filename for ref if it is fully cached in
 // the local OCI store (manifest blob + all layer blobs present), or "" if not.
 func cachedLayerName(layoutDir, ref string) string {
-	idx, err := readIndex(layoutDir)
+	idx, err := readIndexLocked(layoutDir)
 	if err != nil {
 		return ""
 	}

--- a/go-shim/shared_oci.go
+++ b/go-shim/shared_oci.go
@@ -157,13 +157,31 @@ func readIndex(layoutDir string) (ocispec.Index, error) {
 	return idx, json.Unmarshal(data, &idx)
 }
 
+func readIndexLocked(layoutDir string) (ocispec.Index, error) {
+	lock, err := lockIndex(layoutDir)
+	if err != nil {
+		return ocispec.Index{}, err
+	}
+	defer lock.release()
+	return readIndex(layoutDir)
+}
+
 // writeIndex writes index.json to an OCI layout directory.
 func writeIndex(layoutDir string, idx ocispec.Index) error {
 	data, err := json.MarshalIndent(idx, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(layoutDir, "index.json"), data, 0o644)
+	path := filepath.Join(layoutDir, "index.json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
 }
 
 // ensureLayout initialises the OCI layout marker files if not present.

--- a/go-shim/shared_oci_test.go
+++ b/go-shim/shared_oci_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// TestWriteIndexIsAtomic is a regression test: writeIndex used to
+// os.WriteFile straight over index.json, so a reader racing a write (or a
+// process killed mid-write) could observe a truncated/partial file. It now
+// writes to a temp file and renames it into place — this checks that
+// behaviour directly (content round-trips, no leftover .tmp) rather than
+// relying on the previous version's absence of it.
+func TestWriteIndexIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{
+			{MediaType: ocispec.MediaTypeImageManifest, Digest: digest.FromString("one"), Size: 1},
+		},
+	}
+	if err := writeIndex(dir, idx); err != nil {
+		t.Fatalf("writeIndex: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "index.json.tmp")); !os.IsNotExist(err) {
+		t.Fatalf("expected index.json.tmp to be gone after a successful write, stat error: %v", err)
+	}
+
+	got, err := readIndex(dir)
+	if err != nil {
+		t.Fatalf("readIndex: %v", err)
+	}
+	if len(got.Manifests) != 1 || got.Manifests[0].Digest != idx.Manifests[0].Digest {
+		t.Fatalf("readIndex returned %+v, want the single manifest just written", got)
+	}
+}
+
+// TestUpdateIndexIsSafeForConcurrentWriters is a regression test for the
+// race updateIndex's lockIndex call exists to prevent: without it, two
+// concurrent read-modify-write cycles on index.json can each read the same
+// starting state and one's write clobbers the other's, silently losing a
+// manifest entry. Runs many concurrent updateIndex calls, each adding a
+// distinct ref, and checks every one of them survived.
+func TestUpdateIndexIsSafeForConcurrentWriters(t *testing.T) {
+	dir := t.TempDir()
+	const n = 25
+
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ref := fmt.Sprintf("ref-%d", i)
+			desc := ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageManifest,
+				Digest:    digest.FromString(ref),
+				Size:      int64(i),
+			}
+			if err := updateIndex(dir, ref, desc); err != nil {
+				errs <- fmt.Errorf("updateIndex(%s): %w", ref, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	idx, err := readIndex(dir)
+	if err != nil {
+		t.Fatalf("readIndex: %v", err)
+	}
+	if len(idx.Manifests) != n {
+		t.Fatalf("got %d manifests after %d concurrent updateIndex calls, want %d (lost a concurrent write)",
+			len(idx.Manifests), n, n)
+	}
+	seen := make(map[string]bool, n)
+	for _, m := range idx.Manifests {
+		seen[m.Annotations[ocispec.AnnotationRefName]] = true
+	}
+	for i := 0; i < n; i++ {
+		ref := fmt.Sprintf("ref-%d", i)
+		if !seen[ref] {
+			t.Errorf("manifest for %s missing from final index", ref)
+		}
+	}
+}


### PR DESCRIPTION
writeIndex overwrote index.json in place via a plain os.WriteFile. A process killed mid-write (or an unlucky page-cache flush ordering) left a truncated, permanently-corrupt index.json — breaking `llmman list`/`ps`/every future pull against that store until someone deleted or hand-repaired the file. Fixed by writing to a temp file and renaming it into place, the same atomic pattern writeBlob/ writeBlobStream already use for blob content in this same file — a reader can now only ever see the fully-old or fully-new content, never a partial mix.

Separately, updateIndex already took an exclusive advisory lock (lockIndex) around its own read-modify-write cycle, but pushToRegistry and cachedLayerName called readIndex directly, unlocked — so a concurrent updateIndex write could still be raced by a plain read that now (post atomic-write fix) can't observe corruption, but can still observe a stale-but-valid snapshot exactly as a write commits. Added readIndexLocked, taking the same lock briefly around a read-only readIndex call, and switched both call sites to it.

Checked ollama's own equivalent (manifest.WriteManifest in ../ollama/manifest/manifest.go): it has the identical gap — a plain os.Create with no rename, no locking — but its blast radius is smaller, since it writes one file per model rather than a single shared index every command depends on, so a torn write there only ever corrupts that one model's manifest. llmman's index.json is a single point of failure for the whole store, which is why this is worth the extra locking rigor here specifically. Ollama's own blob writer (manifest.NewLayer) already uses the same temp+rename pattern this fix applies to writeIndex, for the same reason.

Added shared_oci_test.go: a roundtrip/atomicity check for writeIndex, and a concurrent-updateIndex test (25 goroutines each adding a distinct manifest entry) verifying none of them get lost to the race this locking exists to prevent. Both pass under -race.