### PR TITLE
Replace --store flag with LLMMAN_MODELS and LLMMAN_TMPDIR env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Daemon-wide `llama-server` tuning, set before `llmman serve` starts:
 | `LLMMAN_CONTEXT_LENGTH` | Context size (`--ctx-size`) for every model this daemon loads. Defaults to a VRAM-tiered value when unset. |
 | `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`, matching Ollama's `OLLAMA_FLASH_ATTENTION`. |
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0` — trades output quality for memory at long context lengths, matching Ollama's `OLLAMA_KV_CACHE_TYPE`. |
+| `LLMMAN_MODELS` | Local store directory, overriding the default below — matching Ollama's `OLLAMA_MODELS`. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
+| `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root — matching Ollama's `OLLAMA_TMPDIR`. |
 
 ### Benchmark
 
@@ -152,7 +154,8 @@ llmman resolve ghcr.io/org/model:tag
 
 `format` is `"safetensors"` (a directory) or `"gguf"` (a single file).
 `--no-pull` fails instead of pulling if the reference isn't already in the
-local store; `--store`/`--cache` override the default locations below.
+local store; `--cache` overrides the extracted-file cache location, and
+`LLMMAN_MODELS` overrides the store location below.
 
 ## Store location
 
@@ -163,7 +166,13 @@ Default locations:
 | Linux, macOS | `~/.local/share/llmman/store` |
 | Windows | `%LOCALAPPDATA%\llmman\store` |
 
-Commands that read or write the local store directly (`list`, `rm`, `tag`, `inspect`, `build`, `resolve`, `serve`) accept `--store <DIR>` to override it. Commands that go through the background daemon instead (`pull`, `push`, `run`, `launch`, `ps`) always use whichever store that daemon was started with — pass `--store` to `llmman serve` to change it for all of them. `transfer`, `login`, and `logout` never touch a local store at all.
+Set `LLMMAN_MODELS` to change this (matching Ollama's `OLLAMA_MODELS`).
+Commands that read or write the local store directly (`list`, `rm`, `tag`,
+`inspect`, `build`, `resolve`, `serve`) all honor it. Commands that go
+through the background daemon instead (`pull`, `push`, `run`, `launch`,
+`ps`) always use whichever store the daemon was started with — set
+`LLMMAN_MODELS` before `llmman serve` to change it for all of them.
+`transfer`, `login`, and `logout` never touch a local store at all.
 
 The store uses [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md), readable by `docker` and `podman`.
 

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -19,14 +19,10 @@ pub struct BuildArgs {
     /// Key=value labels to embed in the image config
     #[arg(short, long, value_name = "KEY=VALUE")]
     pub label: Vec<String>,
-
-    /// Local store directory (overrides default)
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
 }
 
 pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
-    let store_root = crate::default_store(args.store.as_deref())?;
+    let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
     let labels: HashMap<String, String> = args

--- a/src/cmd/inspect.rs
+++ b/src/cmd/inspect.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Args;
 
 use crate::ffi;
@@ -14,10 +12,6 @@ pub struct InspectArgs {
     /// Inspect a remote registry image instead of the local store
     #[arg(long)]
     pub remote: bool,
-
-    /// Local store directory (overrides default)
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
 }
 
 pub fn run(args: &InspectArgs) -> anyhow::Result<()> {
@@ -29,13 +23,13 @@ pub fn run(args: &InspectArgs) -> anyhow::Result<()> {
         let json = ffi::inspect_remote(&reference)?;
         println!("{}", json);
     } else {
-        inspect_local(args, &reference)?;
+        inspect_local(&reference)?;
     }
     Ok(())
 }
 
-fn inspect_local(args: &InspectArgs, reference: &str) -> anyhow::Result<()> {
-    let store_root = crate::default_store(args.store.as_deref())?;
+fn inspect_local(reference: &str) -> anyhow::Result<()> {
+    let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
     let desc = store.find(reference)?;
 

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Args;
 
 use crate::fmt::{human_size, relative_time, short_id};
@@ -11,9 +9,6 @@ pub struct ListArgs {
     /// Only show images whose repository (ignoring tag) matches this reference
     #[arg(value_name = "REFERENCE")]
     pub reference: Option<String>,
-    /// Local store directory (overrides default)
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
     /// Format output using a Go-template-style expression, e.g. --format="{{.ID}}".
     /// Available fields: .ID, .Digest, .Name, .Repository, .Tag, .Size, .Modified
     #[arg(long, value_name = "TEMPLATE")]
@@ -21,7 +16,7 @@ pub struct ListArgs {
 }
 
 pub fn run(args: &ListArgs) -> anyhow::Result<()> {
-    let store_root = crate::default_store(args.store.as_deref())?;
+    let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
     let mut images = store.list()?;
 

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -13,9 +13,8 @@ pub struct PullArgs {
 /// other Ollama-API client use, so bare-name resolution (shortnames::
 /// resolve_ollama_api) and the model store are always the daemon's.
 ///
-/// This intentionally has no `--store` override anymore: the daemon always
-/// uses its own default store (see `llmman serve --store` to change that
-/// store for the daemon itself, which then applies to every client).
+/// No store override of its own: set `LLMMAN_MODELS` before starting
+/// `llmman serve` to change the daemon's store for every client.
 pub fn run(args: &PullArgs) -> anyhow::Result<()> {
     crate::daemon::ensure_server("")?;
     crate::daemon::stream_progress("/api/pull", &args.reference)?;

--- a/src/cmd/push.rs
+++ b/src/cmd/push.rs
@@ -13,9 +13,8 @@ pub struct PushArgs {
 /// other Ollama-API client use, so bare-name resolution (shortnames::
 /// resolve_ollama_api) and the model store are always the daemon's.
 ///
-/// This intentionally has no `--store` override anymore: the daemon always
-/// uses its own default store (see `llmman serve --store` to change that
-/// store for the daemon itself, which then applies to every client).
+/// No store override of its own: set `LLMMAN_MODELS` before starting
+/// `llmman serve` to change the daemon's store for every client.
 pub fn run(args: &PushArgs) -> anyhow::Result<()> {
     crate::daemon::ensure_server("")?;
     crate::daemon::stream_progress("/api/push", &args.reference)?;

--- a/src/cmd/resolve.rs
+++ b/src/cmd/resolve.rs
@@ -42,11 +42,6 @@ pub struct ResolveArgs {
     #[arg(value_name = "REFERENCE")]
     pub reference: String,
 
-    /// Local OCI store directory (overrides the default; see
-    /// `llmman serve --store`'s doc comment for the platform default)
-    #[arg(long)]
-    pub store: Option<PathBuf>,
-
     /// Directory extracted model files are cached under (defaults to
     /// `<store>/cache`)
     #[arg(long)]
@@ -74,7 +69,7 @@ struct ResolveOutput<'a> {
 pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
     let reference = crate::shortnames::resolve_ollama_api(&args.reference);
 
-    let store_path = crate::default_store(args.store.as_deref())?;
+    let store_path = crate::default_store()?;
     let cache_path = args
         .cache
         .clone()

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Args;
 
 use crate::storage::OciStore;
@@ -9,14 +7,10 @@ pub struct RmArgs {
     /// Reference(s) to remove (e.g. registry.example.com/mymodel:latest)
     #[arg(value_name = "REFERENCE", required = true, num_args = 1..)]
     pub references: Vec<String>,
-
-    /// Local store directory (overrides default)
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
 }
 
 pub fn run(args: &RmArgs) -> anyhow::Result<()> {
-    let store_root = crate::default_store(args.store.as_deref())?;
+    let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
     let mut any_err = false;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -37,13 +37,6 @@ pub struct ServeArgs {
     #[arg(value_name = "MODEL")]
     pub model: Option<String>,
 
-    /// Local store directory (overrides the default). Every client of this
-    /// daemon — the CLI's `pull`/`push`/`run`/`list`/etc. and any Ollama-API
-    /// HTTP client — shares whichever store the daemon was started with;
-    /// there is no per-client override.
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
-
     /// Run llama-server in a container (docker or podman) instead of as a
     /// local process — Linux only. Auto-selects the matching
     /// ghcr.io/ggml-org/llama.cpp:server-<backend> image for whatever GPU
@@ -3617,7 +3610,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     } else {
         None
     };
-    let store_path = default_store(_args.store.as_deref())?;
+    let store_path = default_store()?;
     let cache_path = store_path.parent().unwrap_or(&store_path).join("cache");
     std::fs::create_dir_all(&cache_path)?;
     // See storage::repair's own doc comment — matches Ollama's own

--- a/src/cmd/tag.rs
+++ b/src/cmd/tag.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use clap::Args;
 
 use crate::storage::OciStore;
@@ -13,14 +11,10 @@ pub struct TagArgs {
     /// New reference to create
     #[arg(value_name = "TARGET")]
     pub target: String,
-
-    /// Local store directory (overrides default)
-    #[arg(long, value_name = "DIR")]
-    pub store: Option<PathBuf>,
 }
 
 pub fn run(args: &TagArgs) -> anyhow::Result<()> {
-    let store_root = crate::default_store(args.store.as_deref())?;
+    let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
     // resolve_ollama_api, not resolve: SOURCE must match how the model is

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -209,7 +209,7 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
     }
     let exe = std::env::current_exe().context("could not resolve own executable")?;
 
-    let log_path = crate::default_store(None)
+    let log_path = crate::default_store()
         .ok()
         .and_then(|store| store.parent().map(|p| p.join("serve.log")));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,15 +14,14 @@ pub mod shortnames;
 pub mod storage;
 pub mod webui;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-/// Return the path to the default local OCI store, or a caller-supplied override.
-///
-/// Linux and macOS both use `~/.local/share/llmman/store`.
-/// Windows uses `%LOCALAPPDATA%\llmman\store`.
-pub fn default_store(override_path: Option<&Path>) -> anyhow::Result<PathBuf> {
-    if let Some(p) = override_path {
-        return Ok(p.to_path_buf());
+/// Path to the local OCI store, from `LLMMAN_MODELS` (mirrors Ollama's
+/// `OLLAMA_MODELS`) or else `~/.local/share/llmman/store`
+/// (`%LOCALAPPDATA%\llmman\store` on Windows).
+pub fn default_store() -> anyhow::Result<PathBuf> {
+    if let Some(dir) = models_dir_from_env() {
+        return Ok(dir);
     }
     #[cfg(not(target_os = "windows"))]
     let base = dirs::home_dir()
@@ -33,4 +32,35 @@ pub fn default_store(override_path: Option<&Path>) -> anyhow::Result<PathBuf> {
     let base = dirs::data_local_dir()
         .ok_or_else(|| anyhow::anyhow!("could not determine local data directory"))?;
     Ok(base.join("llmman").join("store"))
+}
+
+fn models_dir_from_env() -> Option<PathBuf> {
+    parse_env_path(std::env::var("LLMMAN_MODELS").ok().as_deref())
+}
+
+/// Split out from [`models_dir_from_env`] for testing without touching
+/// the real environment. Blank values count as unset.
+fn parse_env_path(value: Option<&str>) -> Option<PathBuf> {
+    let trimmed = value?.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_env_path_returns_none_when_unset_or_blank() {
+        assert_eq!(parse_env_path(None), None);
+        assert_eq!(parse_env_path(Some("")), None);
+        assert_eq!(parse_env_path(Some("   ")), None);
+    }
+
+    #[test]
+    fn parse_env_path_trims_and_returns_the_given_path() {
+        assert_eq!(
+            parse_env_path(Some("  /custom/store  ")),
+            Some(PathBuf::from("/custom/store"))
+        );
+    }
 }

--- a/src/llama_release.rs
+++ b/src/llama_release.rs
@@ -247,10 +247,44 @@ fn install_dir(tag: &str, label: &str) -> Result<PathBuf> {
     Ok(install_root()?.join(tag).join(label))
 }
 
+/// Staging directory for a downloaded release archive, before it's
+/// extracted into [`install_dir`]. From `LLMMAN_TMPDIR` (mirrors Ollama's
+/// `OLLAMA_TMPDIR`) or else a `tmp` subdirectory of [`install_root`].
+fn tmp_dir() -> Result<PathBuf> {
+    if let Some(dir) = tmp_dir_from_env() {
+        return Ok(dir);
+    }
+    Ok(install_root()?.join("tmp"))
+}
+
+fn tmp_dir_from_env() -> Option<PathBuf> {
+    parse_tmp_dir(std::env::var("LLMMAN_TMPDIR").ok().as_deref())
+}
+
+/// Split out from [`tmp_dir_from_env`] for testing without touching the
+/// real environment. Blank values count as unset.
+fn parse_tmp_dir(value: Option<&str>) -> Option<PathBuf> {
+    let trimmed = value?.trim();
+    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
+}
+
+/// Includes our own pid in the filename so two `llmman` processes
+/// downloading the same asset at once (e.g. two concurrent `--pull-bin`
+/// runs) never share a staging path.
 fn tmp_path(name: &str) -> Result<PathBuf> {
-    let dir = install_root()?.join("tmp");
+    let dir = tmp_dir()?;
     std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
-    Ok(dir.join(name))
+    Ok(dir.join(format!("{name}.tmp-{}", std::process::id())))
+}
+
+/// Removes the staging file on drop, so a failed download or extraction
+/// (an early `?` return) doesn't leave the archive behind.
+struct RemoveOnDrop<'a>(&'a Path);
+
+impl Drop for RemoveOnDrop<'_> {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(self.0);
+    }
 }
 
 /// Recursively searches `dir` for a file literally named `name` — used to
@@ -286,6 +320,30 @@ fn progress_bar(total: u64, label: &str) -> Option<ProgressBar> {
     Some(pb)
 }
 
+/// Opens `dest` for writing without ever following an existing symlink
+/// there — `LLMMAN_TMPDIR` can point at a shared directory, and asset
+/// names are predictable, so a planted symlink must not redirect a
+/// download onto an arbitrary path. Retries once after unlinking a
+/// pre-existing entry (a stale file from an earlier run, or an attacker's
+/// symlink — either way, safe to remove and recreate).
+fn create_new_file(dest: &Path) -> Result<std::fs::File> {
+    let open = || {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(dest)
+    };
+    match open() {
+        Ok(f) => Ok(f),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(dest)
+                .with_context(|| format!("remove stale {}", dest.display()))?;
+            open().with_context(|| format!("create {}", dest.display()))
+        }
+        Err(e) => Err(e).with_context(|| format!("create {}", dest.display())),
+    }
+}
+
 fn download_to_file(
     client: &reqwest::blocking::Client,
     url: &str,
@@ -302,8 +360,7 @@ fn download_to_file(
     let total = resp.content_length().unwrap_or(0);
     let pb = progress_bar(total, label);
 
-    let mut file =
-        std::fs::File::create(dest).with_context(|| format!("create {}", dest.display()))?;
+    let mut file = create_new_file(dest)?;
     let mut buf = [0u8; 1 << 16];
     let mut downloaded = 0u64;
     loop {
@@ -452,10 +509,9 @@ fn try_ensure_from_network(
         query.label, asset.name
     );
     let tmp = tmp_path(&asset.name)?;
+    let _cleanup = RemoveOnDrop(&tmp);
     download_to_file(&client, &asset.browser_download_url, &tmp, &asset.name)?;
-    let extracted = extract(&tmp, &asset.name, &dest);
-    let _ = std::fs::remove_file(&tmp);
-    extracted?;
+    extract(&tmp, &asset.name, &dest)?;
 
     if let Some(companion_substr) = &query.companion_must_contain {
         match find_asset(&release, companion_substr) {
@@ -463,15 +519,14 @@ fn try_ensure_from_network(
                 let companion = companion.clone();
                 eprintln!("[llmman] downloading {}", companion.name);
                 let tmp2 = tmp_path(&companion.name)?;
+                let _cleanup = RemoveOnDrop(&tmp2);
                 download_to_file(
                     &client,
                     &companion.browser_download_url,
                     &tmp2,
                     &companion.name,
                 )?;
-                let extracted = extract(&tmp2, &companion.name, &dest);
-                let _ = std::fs::remove_file(&tmp2);
-                extracted?;
+                extract(&tmp2, &companion.name, &dest)?;
             }
             None => eprintln!(
                 "[llmman] warning: expected companion asset containing {companion_substr:?} \
@@ -546,6 +601,44 @@ fn newest_cached(label: &str, bin_name: &str) -> Result<Option<PathBuf>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_tmp_dir_returns_none_when_unset_or_blank() {
+        assert_eq!(parse_tmp_dir(None), None);
+        assert_eq!(parse_tmp_dir(Some("")), None);
+        assert_eq!(parse_tmp_dir(Some("   ")), None);
+    }
+
+    #[test]
+    fn parse_tmp_dir_trims_and_returns_the_given_path() {
+        assert_eq!(
+            parse_tmp_dir(Some("  /custom/tmp  ")),
+            Some(PathBuf::from("/custom/tmp"))
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn create_new_file_never_writes_through_a_planted_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-create-new-file-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let victim = dir.join("victim");
+        let dest = dir.join("dest");
+        std::fs::write(&victim, b"do not touch").unwrap();
+        symlink(&victim, &dest).unwrap();
+
+        create_new_file(&dest).unwrap();
+
+        assert_eq!(std::fs::read(&victim).unwrap(), b"do not touch");
+        assert!(dest.is_file() && !dest.is_symlink());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
     #[test]
     fn find_asset_matches_only_the_intended_substring() {


### PR DESCRIPTION
## Summary

- Removes the `--store <DIR>` flag from `list`, `rm`, `tag`, `inspect`, `build`, `resolve`, `serve`.
- Adds `LLMMAN_MODELS` (mirrors Ollama's `OLLAMA_MODELS`), read directly by `default_store()`. Same default as before when unset/blank.
- Adds `LLMMAN_TMPDIR` (mirrors `OLLAMA_TMPDIR`), overriding where a `llama-server` release archive is staged before extraction.
- Hardens the download to never write through a pre-existing symlink at the staging path (relevant now that `LLMMAN_TMPDIR` can point at a shared directory and asset names are predictable).
- Updates README accordingly.

## Why

Every store-touching subcommand carried its own `store: Option<PathBuf>` field just to forward an override into `default_store` — inconsistent with every other `LLMMAN_*` setting in this codebase (`LLMMAN_CONTEXT_LENGTH`, `LLMMAN_FLASH_ATTENTION`, ...) and with Ollama's own env-var-only model. `pull`/`push` never had `--store` for the same reason.

## Testing

- `cargo build`, `cargo test --lib` (146 passed), `cargo fmt --check`, `cargo clippy` (no new warnings)
- Manually confirmed `--store` is gone from `--help` output