### PR TITLE
test(vllm-plugin): add real e2e coverage, incl. a live vllm serve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ env:
   # than each duplicating the full "llama-<release>-bin-..." filename
   # independently.
   LLAMA_CPP_RELEASE: b10293
+  # vLLM version the e2e job's "Install vLLM (CPU, e2e)" step installs,
+  # for vllm-plugin/tests/test_e2e.py's real `vllm serve` test.
+  VLLM_VERSION: "0.27.1"
 
 jobs:
   build:
@@ -293,9 +296,13 @@ jobs:
   # (same runners, same msvc-arch/rustflags choices), so the launch/env/
   # config plumbing this actually exercises gets checked on every
   # platform/architecture llmman ships a binary for, not just a subset.
+  #
+  # Also runs vllm-plugin/tests/test_e2e.py (Linux x86_64/aarch64 and
+  # macOS aarch64, both `matrix.backend` entries) against this job's own
+  # installed `llmman` binary and a real (CPU-only) `vllm serve`.
   # --------------------------------------------------------------------------
   e2e:
-    name: E2E (launch claude/opencode/codex/hermes/openclaw) — ${{ matrix.target }} (${{ matrix.backend }})
+    name: E2E (launch claude/opencode/codex/hermes/openclaw, vllm-plugin) — ${{ matrix.target }} (${{ matrix.backend }})
     runs-on: ${{ matrix.runner }}
     # These take a long time (see the timeout-minutes comment below), so
     # they're skipped on pull_request entirely and only run on the two
@@ -316,7 +323,12 @@ jobs:
     # Windows). Exhausting every attempt doesn't fail this job either way
     # (see launch_and_assert's own doc comment) — a run can still
     # legitimately take this long in wall-clock time before giving up.
-    timeout-minutes: 180
+    #
+    # +90 on top of that 180 (270 total) for the vllm-plugin steps'
+    # own per-step budgets below: up to 60 min for "Install vLLM (CPU,
+    # e2e)" (a from-source build on macOS) plus up to 30 min for
+    # "pytest -m e2e (vllm-plugin)".
+    timeout-minutes: 270
     strategy:
       fail-fast: false
       matrix:
@@ -367,6 +379,17 @@ jobs:
             llama-asset: macos-arm64.tar.gz
             backend: docker
             feature-flags: ""
+
+          # ── macOS aarch64 (Apple Silicon, podman backend) ────────────────
+          # Same reasoning as the Linux podman entries above; `build`
+          # already compiles this backend for macOS, but nothing
+          # previously ran it against a real registry there.
+          - target: aarch64-apple-darwin
+            runner: macos-15
+            go-os: darwin
+            llama-asset: macos-arm64.tar.gz
+            backend: podman
+            feature-flags: "--no-default-features --features podman"
 
           # ── Windows x86_64 (docker backend) ──────────────────────────────
           # lld-link, not MSVC link.exe — see the `build` job's own comment
@@ -815,6 +838,78 @@ jobs:
         run: cargo test --release --target ${{ matrix.target }} ${{ matrix.feature-flags }} --test launch_e2e -- --test-threads=1 --nocapture
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+      # ── vllm-plugin e2e (Linux + macOS) ──────────────────────────────────
+      # `vllm-plugin/tests/test_e2e.py` against this job's own installed
+      # `llmman` binary and a real CPU-only `vllm serve`. Excludes
+      # Windows: no vLLM CPU wheel/backend exists for it.
+      #
+      # Uses a venv, not the bare system python3 (Ubuntu 24.04's is PEP
+      # 668-locked). Both vllm-plugin and vllm (next step) install into
+      # this same venv so the plugin's entry point (see pyproject.toml)
+      # is actually discoverable by the vllm process.
+      - name: Set up Python (vllm-plugin e2e)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install vllm-plugin (e2e)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m venv "$RUNNER_TEMP/vllm-plugin-venv"
+          "$RUNNER_TEMP/vllm-plugin-venv/bin/pip" install -e ./vllm-plugin pytest
+          echo "$RUNNER_TEMP/vllm-plugin-venv/bin" >> "$GITHUB_PATH"
+
+      # No GPU assumed, so this installs vLLM's CPU platform, not the
+      # default CUDA wheel. Linux has prebuilt CPU wheels; macOS Apple
+      # Silicon doesn't, so that leg builds from source instead
+      # (cmake/ninja/Xcode assumed present on the macos-15 runner image).
+      # LD_PRELOAD (x86_64 only): vLLM's CPU wheel needs Intel OpenMP
+      # preloaded; located via a glob scoped to this venv.
+      - name: Install vLLM (CPU, e2e)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        timeout-minutes: 60
+        shell: bash
+        run: |
+          set -euo pipefail
+          venv="$RUNNER_TEMP/vllm-plugin-venv"
+
+          if [ "${{ runner.os }}" = "macOS" ]; then
+            src="$RUNNER_TEMP/vllm-source"
+            git clone --branch "v${VLLM_VERSION}" --depth 1 https://github.com/vllm-project/vllm.git "$src"
+            "$venv/bin/pip" install -r "$src/requirements/cpu.txt"
+            "$venv/bin/pip" install -e "$src"
+          else
+            case "${{ matrix.target }}" in
+              x86_64-*) arch=x86_64 ;;
+              aarch64-*) arch=aarch64 ;;
+              *) echo "unhandled target for vLLM CPU wheel: ${{ matrix.target }}" >&2; exit 1 ;;
+            esac
+            wheel="vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_34_${arch}.whl"
+            "$venv/bin/pip" install \
+              "https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/$wheel" \
+              --extra-index-url https://download.pytorch.org/whl/cpu
+
+            if [ "$arch" = "x86_64" ]; then
+              iomp=$("$venv/bin/python3" -c "import glob, sysconfig; m = glob.glob(sysconfig.get_paths()['purelib'] + '/**/libiomp5.so', recursive=True); print(m[0] if m else '')")
+              if [ -n "$iomp" ]; then
+                echo "LD_PRELOAD=$iomp" >> "$GITHUB_ENV"
+              else
+                echo "::warning::libiomp5.so not found under $venv; LD_PRELOAD not set for vLLM CPU (x86_64)"
+              fi
+            fi
+          fi
+
+      # LLMMAN_BIN isn't needed: `llmman` is already on PATH (added to
+      # $GITHUB_PATH by "Install llmman (via install script)" above).
+      - name: pytest -m e2e (vllm-plugin)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        timeout-minutes: 30
+        run: pytest -m e2e -v
+        working-directory: vllm-plugin
 
       # `llmman serve`'s own stdout/stderr never reach the test's own logs
       # above at all — see daemon::ensure_server's doc comment on why it's

--- a/vllm-plugin/README.md
+++ b/vllm-plugin/README.md
@@ -65,3 +65,10 @@ pytest
 `tests/test_install_integration.py` additionally exercises the real
 `vllm.config.model.ModelConfig` hook, and is skipped automatically if
 vLLM isn't installed in the current environment.
+
+`tests/test_e2e.py` goes further: a real `llmman` binary resolving a
+real `oci://` reference, no mocks — plus, when `vllm` is installed, a
+real `vllm serve oci://qwen3.5:0.8b-safetensors` process, never
+pre-resolved by the test itself, proving this plugin's entry point is
+actually discovered by a real vLLM startup. Excluded from a plain
+`pytest` run; run with `pytest -m e2e`.

--- a/vllm-plugin/pyproject.toml
+++ b/vllm-plugin/pyproject.toml
@@ -27,3 +27,10 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "e2e: exercises a real llmman binary/registry pull (see tests/test_e2e.py). Excluded by default; run with `pytest -m e2e`.",
+]
+# A plain `pytest` must not pull ~740MB or need llmman installed by
+# default. CI passes its own `-m e2e` on the command line, which
+# overrides this.
+addopts = "-m 'not e2e'"

--- a/vllm-plugin/tests/test_e2e.py
+++ b/vllm-plugin/tests/test_e2e.py
@@ -1,0 +1,305 @@
+"""End-to-end tests against a real `llmman` binary.
+
+Unlike the rest of this directory (which stubs `llmman`, monkeypatches
+`_patch.resolve`, or never constructs a real `ModelConfig`), these tests
+call this plugin's real public surface (`_llmman_cli.resolve()`,
+`_patch._make_patched()`) against a real `llmman` binary and a real
+registry pull — same "no mocks" reasoning as `tests/launch_e2e.rs`.
+
+Gated behind the `e2e` pytest marker (excluded by default via
+`pyproject.toml`'s `addopts`); run explicitly with:
+
+    pytest -m e2e -v
+
+CI runs this in `.github/workflows/ci.yml`'s `e2e` job, right after
+`cargo test --test launch_e2e`, on Linux x86_64/aarch64 and macOS
+aarch64. That ordering matters for the two lightweight tests below:
+`launch_e2e.rs`'s `warm_model()` has already pulled `MODEL` into the
+default store, so `resolve()` here hits a warm cache instead of a
+second ~740MB download. The `vllm serve` test pays its own separate
+pull instead (see its own docstring).
+
+Every test here skips (not fails) when its own prerequisite (`llmman`,
+`vllm`) isn't available, same as `tests/launch_e2e.rs`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_llmman import _patch
+from vllm_llmman._llmman_cli import LlmmanNotFoundError, llmman_binary, resolve
+
+pytestmark = pytest.mark.e2e
+
+# Same short name as tests/launch_e2e.rs::MODEL, resolving to the same
+# ~740MB docker.io/ai/qwen3.5:0.8b already warmed into the store there.
+# GGUF vs. safetensors doesn't matter to resolve()/`_patch`'s hook (both
+# only ever consume the JSON's `path`), so reusing that warm cache here
+# is strictly cheaper than a second pull.
+MODEL = "qwen3.5:0.8b"
+
+# The real safetensors counterpart of MODEL (same Docker Hub repo,
+# `ai/qwen3.5:0.8b-safetensors`, ~1.7GB CNCF ModelPack manifest) — this
+# plugin's actual reason to exist is loading safetensors via vLLM, which
+# can't load a bare .gguf file, so the vllm serve test below needs its
+# own separate pull rather than reusing MODEL's cache.
+MODEL_SAFETENSORS = "qwen3.5:0.8b-safetensors"
+
+# Same convention as launch_e2e.rs's own PROMPT: reply quality isn't
+# under test, the resolve/serve plumbing is.
+PROMPT = "Reply with exactly the single word: pong"
+
+# Explicit --served-model-name for the vllm serve test, rather than
+# relying on whatever vLLM would default it to from a raw --model
+# oci://... argument.
+SERVED_MODEL_NAME = "vllm-llmman-e2e"
+
+# Generous: a cold ~1.7GB pull plus real CPU weight loading, no GPU
+# assumed anywhere. 1.5x launch_e2e.rs's own TIMEOUT (600s) for CPU-only
+# inference and a larger checkout.
+VLLM_STARTUP_TIMEOUT = 900
+
+
+def _require_llmman() -> str:
+    """The real `llmman` binary path, or a skip."""
+    try:
+        return llmman_binary()
+    except LlmmanNotFoundError as e:
+        pytest.skip(str(e))
+
+
+@pytest.fixture(scope="module")
+def resolved_model() -> dict:
+    """Resolves `MODEL` via the real `llmman` binary once per module."""
+    _require_llmman()
+    return resolve(MODEL)
+
+
+def test_resolve_pulls_and_returns_a_real_existing_path(resolved_model):
+    """Checks `llmman resolve`'s JSON contract (see `src/cmd/resolve.rs`)
+    against a real subprocess call.
+    """
+    assert resolved_model["reference"] == "docker.io/ai/qwen3.5:0.8b"
+    assert resolved_model["format"] in ("gguf", "safetensors")
+
+    path = Path(resolved_model["path"])
+    assert path.exists(), f"resolved path does not exist: {path}"
+    if resolved_model["format"] == "gguf":
+        assert path.is_file()
+        assert path.stat().st_size > 0
+    else:
+        assert path.is_dir()
+        assert (path / "config.json").exists()
+
+
+def test_resolve_is_idempotent_against_an_already_pulled_reference(resolved_model):
+    """A second `resolve()` for an already-pulled reference returns the
+    same path without erroring — the path every vLLM process (API
+    server, engine core, each worker) after the first takes.
+    """
+    again = resolve(MODEL)
+    assert again == resolved_model
+
+
+def test_patched_hook_resolves_a_real_oci_reference_end_to_end():
+    """`_patch._make_patched`'s hook, against the real (never
+    monkeypatched here) `_llmman_cli.resolve()`: recognizes `oci://`,
+    strips it, and rewrites `self.model` to the resolved local path.
+    `original` fails the test if called — an `oci://` reference must
+    never fall through to vLLM's own runai path.
+    """
+    _require_llmman()
+
+    def original(self, model, tokenizer):
+        pytest.fail("must not delegate to the original runai hook for an oci:// reference")
+
+    patched = _patch._make_patched(original)
+
+    ref = f"oci://{MODEL}"
+    cfg = SimpleNamespace(model=ref, tokenizer=ref, model_weights=None)
+    patched(cfg, cfg.model, cfg.tokenizer)
+
+    assert cfg.model_weights == ref  # original oci:// reference preserved
+    assert cfg.tokenizer == cfg.model  # shared tokenizer, resolved once
+
+    path = Path(cfg.model)
+    assert path.exists(), f"patched hook rewrote model to a nonexistent path: {path}"
+    assert path != Path(ref)  # actually rewritten, not left as-is
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _tail(path: Path, n: int = 8000) -> str:
+    """The last `n` bytes of `path` — `vllm serve`'s log, attached to
+    failure messages since its output goes to a file, not pytest's
+    captured output.
+    """
+    try:
+        data = path.read_bytes()
+    except FileNotFoundError:
+        return "<no log file>"
+    return data[-n:].decode(errors="replace")
+
+
+def _wait_for_health(port: int, timeout: float, proc: subprocess.Popen, log_path: Path) -> None:
+    """Polls `/health` until it answers 200, the process exits early, or
+    `timeout` is exhausted.
+    """
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/health"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            pytest.fail(
+                f"vllm serve exited early (code {proc.returncode}) before becoming healthy\n"
+                f"--- {log_path} tail ---\n{_tail(log_path)}"
+            )
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, ConnectionError, TimeoutError, OSError):
+            pass
+        time.sleep(2)
+    pytest.fail(
+        f"vllm serve did not become healthy within {timeout}s\n"
+        f"--- {log_path} tail ---\n{_tail(log_path)}"
+    )
+
+
+def _chat(port: int, prompt: str) -> str:
+    """One real `/v1/chat/completions` request, stdlib only."""
+    body = json.dumps(
+        {
+            "model": SERVED_MODEL_NAME,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": 16,
+            "temperature": 0,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        payload = json.loads(resp.read())
+    return payload["choices"][0]["message"]["content"]
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Kills `proc`'s entire process group (it was spawned with
+    `start_new_session=True`), escalating SIGTERM -> SIGKILL.
+
+    Always sends both signals rather than returning as soon as `proc`
+    itself exits: vLLM spawns its own worker subprocess(es) in the same
+    group, which can outlive the direct `vllm` process, so checking only
+    `proc`'s own exit status would miss them. `os.killpg` raising
+    `ProcessLookupError` is the actual signal the whole group is gone
+    (a process group only disappears once empty) — the reliable stop
+    condition here, unlike `proc.poll()`.
+    """
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(proc.pid, sig)
+        except ProcessLookupError:
+            break
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
+    """A real `vllm serve oci://qwen3.5:0.8b-safetensors` subprocess,
+    launched as a real user would, with nothing here pre-resolving or
+    pre-pulling the reference first.
+
+    Deliberately never calls `_llmman_cli.resolve()`/`llmman resolve`
+    directly: the point is proving vLLM's own plugin loading discovers
+    and installs this package's hook on its own, and that constructing a
+    real `ModelConfig` for an `oci://` reference during vLLM's own
+    startup is what triggers the pull.
+
+    `--dtype float16`: the one dtype vLLM's CPU platform supports on
+    every OS in ci.yml's matrix (bf16 isn't supported on macOS CPU).
+    `--enforce-eager`: skips CUDA-graph startup work that doesn't apply
+    on CPU. `--max-model-len 1024`: bounds the CPU KV-cache for this
+    test's tiny prompt/reply.
+    """
+    pytest.importorskip("vllm")
+    binary = shutil.which("vllm")
+    if not binary:
+        pytest.skip("`vllm` console script not found on PATH")
+    _require_llmman()
+
+    port = _free_port()
+    log_path = tmp_path / "vllm-serve.log"
+    cmd = [
+        binary,
+        "serve",
+        f"oci://{MODEL_SAFETENSORS}",
+        "--served-model-name",
+        SERVED_MODEL_NAME,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--dtype",
+        "float16",
+        "--enforce-eager",
+        "--max-model-len",
+        "1024",
+    ]
+    env = dict(os.environ)
+    # Bounds vLLM CPU's own KV-cache arena, well under its default
+    # sizing heuristic, to avoid OOM on a shared/constrained CI runner.
+    env.setdefault("VLLM_CPU_KVCACHE_SPACE", "4")
+
+    log_file = open(log_path, "wb")
+    try:
+        # start_new_session=True: see _terminate. Output goes to a file,
+        # not a pipe: a long-running server's log can otherwise deadlock
+        # subprocess.PIPE once its OS buffer fills with nothing draining
+        # it (see launch_e2e.rs's spawn_reader for the Rust-side fix).
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            env=env,
+            start_new_session=True,
+        )
+    finally:
+        log_file.close()
+
+    try:
+        _wait_for_health(port, VLLM_STARTUP_TIMEOUT, proc, log_path)
+        reply = _chat(port, PROMPT)
+        assert "pong" in reply.lower(), (
+            f'expected the served model\'s reply to contain "pong", got: {reply!r}\n'
+            f"--- {log_path} tail ---\n{_tail(log_path)}"
+        )
+    finally:
+        _terminate(proc)


### PR DESCRIPTION
## Summary

Adds real e2e coverage for `vllm-plugin`, which previously only had tests stubbing `llmman` or monkeypatching this plugin's own hook — nothing exercised a real `llmman` binary or a real vLLM process.

`vllm-plugin/tests/test_e2e.py` (gated behind a new `e2e` pytest marker, run with `pytest -m e2e`):
- Two lightweight tests hit real `llmman resolve`, reusing the warm cache `tests/launch_e2e.rs` already produces.
- A third exercises `_patch`'s hook against a stub `ModelConfig`, still via the real `resolve()`.
- A fourth launches a real `vllm serve oci://qwen3.5:0.8b-safetensors` (a real CNCF ModelPack tag on Docker Hub) and sends it a real chat request — it never calls `resolve()` itself, proving vLLM's own plugin loading is what triggers the pull.

CI wiring (`.github/workflows/ci.yml`, in the existing `e2e` job):
- Broadened the vllm-plugin steps to Linux + macOS, added a CPU-only vLLM install step (prebuilt wheel on Linux, built from source on macOS).
- Added a macOS aarch64 podman matrix entry (previously only docker was e2e-tested there).
- Pinned `VLLM_VERSION` and bumped `timeout-minutes` 180 → 270.

## Caveat

macOS builds vLLM from source every run (no caching yet) — could be slow/flaky; caching the built wheel is the natural follow-up if so.

## Testing

`py_compile`, `actionlint`/PyYAML on the workflow, `bash -n` on the extracted new step, and confirmed the `qwen3.5:0.8b-safetensors` tag and pinned vLLM wheel URLs actually exist. Couldn't run the suite live here (no GPU-less vLLM/llmman toolchain), so this PR's own CI is the first real run.