### PR TITLE
Add cp/stop/show/gpu-discover commands, harmony + thinking parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,15 @@ Models are packaged as standard OCI artifacts and stored in any compatible regis
 | `resolve` | Pull (if needed) and print the local path of a model, as JSON — for other tools to consume |
 | `list`    | List locally stored models |
 | `ps`      | List models currently loaded |
+| `stop`    | Stop (unload) a running model |
 | `build`   | Package model files into a local OCI image |
 | `push`    | Push a local image to a registry |
 | `transfer` | Transfer an image directly from one location to another (e.g. HuggingFace to an OCI registry) |
+| `cp`      | Copy a local image to a new reference |
 | `rm`      | Remove a local image |
 | `tag`     | Create a new local tag pointing to an existing image |
 | `inspect` | Show the manifest of a local or remote image |
+| `show`    | Show a local model's architecture, parameters, license, and template |
 | `login`   | Log in to a container registry |
 | `logout`  | Log out from a container registry |
 

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -1,0 +1,34 @@
+use clap::Args;
+
+use crate::storage::OciStore;
+
+#[derive(Args, Debug)]
+pub struct CpArgs {
+    /// Existing local reference to copy
+    #[arg(value_name = "SOURCE")]
+    pub source: String,
+
+    /// New reference to create, pointing at the same image
+    #[arg(value_name = "DESTINATION")]
+    pub destination: String,
+}
+
+/// `llmman cp SOURCE DESTINATION` — copy a model under a new name,
+/// mirroring `ollama cp` (`cmd/cmd.go`'s `CopyHandler`, `server/
+/// images.go`'s `CopyModel`): both are really just "point a second
+/// reference at the same content", exactly what `llmman tag` already does
+/// (see `storage::OciStore::tag`) — `cp` exists as its own command purely
+/// to match ollama's naming for anyone coming from there, not because the
+/// underlying operation differs at all.
+pub fn run(args: &CpArgs) -> anyhow::Result<()> {
+    let store_root = crate::default_store()?;
+    let store = OciStore::open(&store_root)?;
+
+    // resolve_ollama_api, not resolve: SOURCE must match how the model is
+    // actually stored — same reasoning as tag.rs/rm.rs.
+    let source = crate::shortnames::resolve_ollama_api(&args.source);
+    let desc = store.find(&source)?;
+    store.tag(desc, &args.destination)?;
+    println!("copied '{}' to '{}'", args.source, args.destination);
+    Ok(())
+}

--- a/src/cmd/gpu_discover.rs
+++ b/src/cmd/gpu_discover.rs
@@ -1,0 +1,39 @@
+//! `llmman gpu-discover` — a hidden (undocumented, absent from `--help`)
+//! standalone entry point for the same accelerator probe `llmman serve`
+//! and `llama_release`/`container` already run internally (see
+//! `crate::hostgpu`), so a user or an issue report can run the probe on
+//! its own and see exactly what it found, without needing to start a
+//! whole server first. Mirrors `ollama gpu-discover`
+//! (`cmd/cmd.go`'s hidden `gpu-discover` command) in spirit — llmman's own
+//! probe has no `--lib-dir` equivalent to take (dynamic-loaded vendor
+//! libraries are found by the OS's normal search path, not a directory
+//! llmman itself searches), so this takes no flags at all.
+
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct GpuDiscoverArgs {}
+
+pub fn run(_args: &GpuDiscoverArgs) -> anyhow::Result<()> {
+    let (gpu, vram) = crate::hostgpu::detect_with_vram();
+    let kind = match gpu {
+        crate::hostgpu::HostGpu::None => "none".to_string(),
+        crate::hostgpu::HostGpu::Cuda { major } => format!("cuda (driver major version {major})"),
+        crate::hostgpu::HostGpu::Rocm => "rocm".to_string(),
+        crate::hostgpu::HostGpu::Vulkan => "vulkan".to_string(),
+        crate::hostgpu::HostGpu::Metal => "metal".to_string(),
+    };
+    println!("accelerator: {kind}");
+    if vram > 0 {
+        println!("vram: {}", crate::fmt::human_size(vram));
+    } else {
+        println!("vram: unknown");
+    }
+    match crate::hostgpu::default_ctx_size_for(vram) {
+        Some(n) => println!("default context length override: {n}"),
+        None => println!(
+            "default context length override: none (uses each model's own trained context)"
+        ),
+    }
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,6 @@
 pub mod build;
+pub mod cp;
+pub mod gpu_discover;
 pub mod inspect;
 pub mod launch;
 pub mod list;
@@ -11,5 +13,7 @@ pub mod resolve;
 pub mod rm;
 pub mod run;
 pub mod serve;
+pub mod show;
+pub mod stop;
 pub mod tag;
 pub mod transfer;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2338,6 +2338,154 @@ async fn post_chat(
 // generic driver; build_chunk supplies just that piece.
 // ---------------------------------------------------------------------------
 
+/// Fallback content/thinking separation for a backend that hands back raw
+/// `<think>...</think>` or gpt-oss-style harmony channel tokens as plain
+/// `content` text, instead of already splitting them into a structured
+/// `reasoning_content`/`thinking` delta field the way `oai_chunk_to_content`
+/// prefers. One instance is created per streamed response (see
+/// `stream_ollama`) and fed every chunk's `content` in order, so it can
+/// buffer across a token boundary that splits a tag mid-way exactly like
+/// `thinking::Parser`/`harmony::HarmonyMessageHandler` themselves already
+/// do internally.
+enum RawContentExtractor {
+    /// No backend-structured thinking has been seen yet, and not enough
+    /// raw content has arrived yet to decide a mode from — the `String`
+    /// buffers everything seen so far. Kept buffered (rather than decided
+    /// per-chunk) because a real streamed response can hand this the
+    /// first token of a tag one byte at a time, and e.g. a lone `"<"` is
+    /// a prefix of every candidate tag below, not evidence of any one of
+    /// them in particular.
+    Undetermined(String),
+    /// A backend already supplied structured thinking on some earlier
+    /// chunk of this stream — never scan raw content again, even if a
+    /// later chunk's `content` happens to contain literal tag-like text
+    /// as part of genuine output.
+    Passthrough,
+    Harmony(Box<crate::harmony::HarmonyMessageHandler>),
+    PlainThink(Box<crate::thinking::Parser>),
+}
+
+/// Every raw-token prefix `RawContentExtractor::Undetermined` can still be
+/// waiting to disambiguate between — gpt-oss harmony's two possible
+/// stream-start spellings (see the `<|channel|>` case below) and a plain
+/// `<think>` tag.
+const CANDIDATE_TAGS: [&str; 3] = ["<|start|>", "<|channel|>", "<think>"];
+
+impl RawContentExtractor {
+    fn new() -> Self {
+        RawContentExtractor::Undetermined(String::new())
+    }
+
+    /// Returns the (content, thinking) to actually emit for this chunk,
+    /// given what the backend itself already reported.
+    fn process(
+        &mut self,
+        content: String,
+        backend_thinking: Option<String>,
+    ) -> (String, Option<String>) {
+        if backend_thinking.is_some() {
+            // `flush` first: if this transition happens straight out of
+            // `Undetermined` (an earlier chunk was still a strict prefix
+            // of a candidate tag — e.g. a lone `"<"` — when this chunk
+            // turned out to carry backend-structured thinking instead),
+            // whatever was buffered for disambiguation must still reach
+            // the client; it otherwise has no other path out once `self`
+            // is overwritten below. A no-op on every other variant (see
+            // `flush`'s own doc comment).
+            let buffered = self.flush();
+            *self = RawContentExtractor::Passthrough;
+            return (buffered + &content, backend_thinking);
+        }
+        match self {
+            RawContentExtractor::Passthrough => (content, None),
+            RawContentExtractor::Harmony(h) => {
+                let (c, t, tool) = h.add_content(&content);
+                (c, non_empty_thinking(t, tool))
+            }
+            RawContentExtractor::PlainThink(p) => {
+                let (t, c) = p.add_content(&content);
+                (c, (!t.is_empty()).then_some(t))
+            }
+            RawContentExtractor::Undetermined(buf) => {
+                buf.push_str(&content);
+                let trimmed = buf.trim_start();
+                if trimmed.is_empty()
+                    || CANDIDATE_TAGS
+                        .iter()
+                        .any(|tag| tag.starts_with(trimmed) && trimmed.len() < tag.len())
+                {
+                    // Still ambiguous (whitespace only so far, or a
+                    // strict prefix of a candidate tag that could still
+                    // go either way) — keep buffering, nothing to emit
+                    // yet.
+                    return (String::new(), None);
+                }
+                let buffered = std::mem::take(buf);
+                let trimmed_starts_with = |tag: &str| buffered.trim_start().starts_with(tag);
+                if trimmed_starts_with("<|start|>") || trimmed_starts_with("<|channel|>") {
+                    let mut h = crate::harmony::HarmonyMessageHandler::new();
+                    // A raw completion stream from a chat-templated
+                    // request typically never re-emits the assistant's
+                    // own `<|start|>assistant` preamble (the template
+                    // already sent it as part of the *prompt*, before
+                    // generation started) — only what follows it, i.e.
+                    // `<|channel|>...`. HarmonyParser's own state machine
+                    // requires having seen a `<|start|>` before it will
+                    // recognize anything after it as a header (see
+                    // `harmony::HarmonyParser`'s `LookingForMessageStart`
+                    // state) — priming it here is exactly what
+                    // `add_implicit_start`'s own doc comment describes.
+                    // Not primed for a stream that already starts with a
+                    // literal `<|start|>` itself, which needs no help
+                    // finding its own message boundary.
+                    if trimmed_starts_with("<|channel|>") {
+                        h.parser.add_implicit_start();
+                    }
+                    let (c, t, tool) = h.add_content(&buffered);
+                    let thinking = non_empty_thinking(t, tool);
+                    *self = RawContentExtractor::Harmony(Box::new(h));
+                    (c, thinking)
+                } else {
+                    let mut p = crate::thinking::Parser::new("<think>", "</think>");
+                    let (t, c) = p.add_content(&buffered);
+                    *self = RawContentExtractor::PlainThink(Box::new(p));
+                    (c, (!t.is_empty()).then_some(t))
+                }
+            }
+        }
+    }
+
+    /// Drains whatever `Undetermined` is still holding back for
+    /// disambiguation — called once the stream is `done` (see
+    /// `stream_ollama`), so a reply that ends while still a strict prefix
+    /// of a candidate tag (e.g. the very last byte generated is a lone
+    /// `"<"`) still reaches the client instead of being silently dropped.
+    /// A no-op for every other variant: `Harmony`/`PlainThink` only ever
+    /// hold back a *candidate closing/end tag* this same way internally,
+    /// which real Ollama's own `thinking.Parser` (this module's `PlainThink`
+    /// is a direct port of it) has the identical characteristic for and
+    /// never flushes either — not a new gap this fallback introduces.
+    fn flush(&mut self) -> String {
+        match self {
+            RawContentExtractor::Undetermined(buf) => std::mem::take(buf),
+            _ => String::new(),
+        }
+    }
+}
+
+/// Folds a harmony tool-call channel's raw argument text (`tool`) into
+/// the same "thinking" bucket as real reasoning text (`thinking`) — there
+/// being no structured-tool-call plumbing wired to this raw-token fallback
+/// path (see `RawContentExtractor`'s own doc comment: this only ever
+/// engages when a backend hands back literal, unparsed harmony tokens in
+/// the first place), hiding a stray tool call's raw JSON in "thinking"
+/// rather than ever showing it in the user-visible `content` field is the
+/// safer failure mode of the two.
+fn non_empty_thinking(thinking: String, tool: String) -> Option<String> {
+    let combined = thinking + &tool;
+    (!combined.is_empty()).then_some(combined)
+}
+
 /// `build_chunk`'s `tool_calls` parameter is only ever `Some` on the final
 /// (`done`) chunk of an `/api/chat` response that made one or more tool
 /// calls — `/api/generate` (no tool-calling support in real Ollama
@@ -2354,6 +2502,7 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
     let resp = post_chat(&client, &url, &oai_req).await?;
 
     let tool_calls_acc = std::cell::RefCell::new(std::collections::BTreeMap::new());
+    let content_extractor = std::cell::RefCell::new(RawContentExtractor::new());
     let stream = bytes_to_lines(resp.bytes_stream()).map(move |line| {
         // Moved into this closure purely to keep it alive — see
         // ActivityGuard's doc comment — until the stream itself is
@@ -2364,6 +2513,15 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
             .and_then(|payload| {
                 accumulate_tool_call_deltas(payload, &tool_calls_acc);
                 let (content, thinking, done) = oai_chunk_to_content(payload)?;
+                let (mut content, thinking) =
+                    content_extractor.borrow_mut().process(content, thinking);
+                if done {
+                    // Idempotent even across the two `done` chunks
+                    // real Ollama's stream can produce (see below):
+                    // `flush` drains via `mem::take`, so the second call
+                    // just returns an already-empty string.
+                    content.push_str(&content_extractor.borrow_mut().flush());
+                }
                 // llama-server's SSE stream signals "done" twice — once on
                 // the chunk carrying a real finish_reason, then again on
                 // the trailing literal "[DONE]" line — so `done` here can
@@ -4871,6 +5029,169 @@ mod tests {
         // Malformed JSON and an empty choices array are skipped, not fatal.
         assert_eq!(oai_chunk_to_content("not json"), None);
         assert_eq!(oai_chunk_to_content(r#"{"choices":[]}"#), None);
+    }
+
+    #[test]
+    fn raw_content_extractor_passes_plain_content_through_untouched() {
+        let mut ext = RawContentExtractor::new();
+        assert_eq!(
+            ext.process("hello there".into(), None),
+            ("hello there".into(), None)
+        );
+        assert_eq!(
+            ext.process(" friend".into(), None),
+            (" friend".into(), None)
+        );
+    }
+
+    /// Once a backend has ever supplied structured `thinking` on a
+    /// stream, raw content must never be scanned again — even if it
+    /// later happens to contain literal `<think>` text as part of a
+    /// genuine reply (e.g. the model discussing the tag itself).
+    #[test]
+    fn raw_content_extractor_locks_into_passthrough_once_backend_thinking_seen() {
+        let mut ext = RawContentExtractor::new();
+        assert_eq!(
+            ext.process(String::new(), Some("reasoning".into())),
+            (String::new(), Some("reasoning".into()))
+        );
+        assert_eq!(
+            ext.process("<think>literal text</think>".into(), None),
+            ("<think>literal text</think>".into(), None)
+        );
+    }
+
+    /// Regression test: a chunk still buffered in `Undetermined` (a
+    /// strict prefix of a candidate tag, e.g. a lone `"<"`) must not be
+    /// silently dropped when a *later* chunk turns out to carry
+    /// backend-structured thinking instead — that transition previously
+    /// overwrote `self` with `Passthrough` without ever draining it.
+    #[test]
+    fn raw_content_extractor_recovers_a_buffered_prefix_when_backend_thinking_appears_later() {
+        let mut ext = RawContentExtractor::new();
+        // "<" alone is a strict prefix of every candidate tag, so it's
+        // held back rather than emitted.
+        assert_eq!(ext.process("<".into(), None), (String::new(), None));
+        // The backend now reports structured thinking on this chunk —
+        // the buffered "<" must be prepended to this chunk's own content,
+        // not lost.
+        assert_eq!(
+            ext.process("hello".into(), Some("reasoning".into())),
+            ("<hello".into(), Some("reasoning".into()))
+        );
+        // Now locked into Passthrough: a later flush has nothing left to
+        // recover.
+        assert_eq!(ext.flush(), "");
+    }
+
+    #[test]
+    fn raw_content_extractor_falls_back_to_plain_think_tags() {
+        let mut ext = RawContentExtractor::new();
+        let (c1, t1) = ext.process("<think>".into(), None);
+        assert_eq!((c1, t1), (String::new(), None));
+        let (c2, t2) = ext.process("hmm".into(), None);
+        assert_eq!((c2, t2), (String::new(), Some("hmm".into())));
+        let (c3, t3) = ext.process("</think>answer".into(), None);
+        assert_eq!((c3, t3), ("answer".into(), None));
+    }
+
+    #[test]
+    fn raw_content_extractor_falls_back_to_harmony_channels() {
+        let mut ext = RawContentExtractor::new();
+        let (content, thinking) = ext.process(
+            "<|start|>assistant<|channel|>analysis<|message|>thinking...<|end|>\
+             <|start|>assistant<|channel|>final<|message|>the answer<|end|>"
+                .into(),
+            None,
+        );
+        assert_eq!(content, "the answer");
+        assert_eq!(thinking, Some("thinking...".into()));
+    }
+
+    #[test]
+    fn raw_content_extractor_leaves_content_without_any_tag_untouched() {
+        let mut ext = RawContentExtractor::new();
+        let (content, thinking) = ext.process("just a normal reply".into(), None);
+        assert_eq!(content, "just a normal reply");
+        assert_eq!(thinking, None);
+    }
+
+    /// Regression test: a real streamed response hands this one token (or
+    /// even one byte) at a time — the very first chunk of a harmony
+    /// stream is never the whole `"<|channel|>..."` string at once, just
+    /// its first byte, which is also a valid prefix of `<|start|>` and
+    /// `<think>`. `Undetermined` must buffer across calls instead of
+    /// deciding (wrongly, into `PlainThink`) from that first ambiguous
+    /// byte alone.
+    #[test]
+    fn raw_content_extractor_buffers_across_calls_to_classify_a_token_split_harmony_stream() {
+        let mut ext = RawContentExtractor::new();
+        let whole = "<|start|>assistant<|channel|>analysis<|message|>thinking...<|end|>\
+             <|start|>assistant<|channel|>final<|message|>the answer<|end|>";
+        let mut content = String::new();
+        let mut thinking = String::new();
+        for ch in whole.chars() {
+            let mut buf = [0u8; 4];
+            let (c, t) = ext.process(ch.encode_utf8(&mut buf).to_string(), None);
+            content.push_str(&c);
+            if let Some(t) = t {
+                thinking.push_str(&t);
+            }
+        }
+        assert_eq!(content, "the answer");
+        assert_eq!(thinking, "thinking...");
+    }
+
+    /// Regression test: llama-server's own chat template already emits
+    /// the assistant's `<|start|>assistant` preamble as part of the
+    /// *prompt*, so a real raw completion stream for a gpt-oss-style
+    /// model routinely starts directly at `<|channel|>`, never repeating
+    /// `<|start|>` itself. Without priming the harmony parser via
+    /// `add_implicit_start` for exactly this case, `HarmonyParser` would
+    /// sit in `LookingForMessageStart` forever and never emit anything.
+    #[test]
+    fn raw_content_extractor_primes_harmony_when_a_stream_starts_mid_message() {
+        let mut ext = RawContentExtractor::new();
+        let (content, thinking) = ext.process(
+            "<|channel|>analysis<|message|>thinking...<|end|>\
+             <|start|>assistant<|channel|>final<|message|>the answer<|end|>"
+                .into(),
+            None,
+        );
+        assert_eq!(content, "the answer");
+        assert_eq!(thinking, Some("thinking...".into()));
+    }
+
+    /// Regression test: a reply that ends while `Undetermined` is still
+    /// holding back a strict prefix of a candidate tag (here, the whole
+    /// reply is just a lone `"<"`) must not silently lose that text —
+    /// `flush` (called by `stream_ollama` on its `done` chunk) drains it.
+    #[test]
+    fn raw_content_extractor_flush_recovers_a_buffered_prefix_at_stream_end() {
+        let mut ext = RawContentExtractor::new();
+        let (content, thinking) = ext.process("<".into(), None);
+        assert_eq!(content, "");
+        assert_eq!(thinking, None);
+        assert_eq!(ext.flush(), "<");
+        // Idempotent: a second flush (mirroring the two `done` chunks a
+        // real stream can produce) must not resurrect it.
+        assert_eq!(ext.flush(), "");
+    }
+
+    /// `flush` is a no-op once a mode has been decided — that buffering
+    /// is `thinking::Parser`/`harmony::HarmonyMessageHandler`'s own
+    /// internal concern (see `RawContentExtractor::flush`'s own doc
+    /// comment on why this mirrors real Ollama's own, identical
+    /// limitation rather than a new gap).
+    #[test]
+    fn raw_content_extractor_flush_is_a_no_op_once_a_mode_is_decided() {
+        let mut ext = RawContentExtractor::new();
+        ext.process("just a normal reply".into(), None);
+        assert_eq!(ext.flush(), "");
+
+        let mut ext = RawContentExtractor::new();
+        ext.process(String::new(), Some("reasoning".into()));
+        assert_eq!(ext.flush(), "");
     }
 
     /// Ported from ollama's api/client_test.go (TestClientStream): SSE

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -1,0 +1,334 @@
+//! `llmman show MODEL` — display a locally stored model's metadata:
+//! architecture, parameter count, context length, quantization, license,
+//! and chat template — the llmman equivalent of `ollama show`.
+//!
+//! Unlike `ollama show` (which always goes through a running server),
+//! this runs entirely against the local `OciStore`, same as `inspect`/
+//! `tag`/`rm` — no daemon required. Real GGUF/safetensors metadata is
+//! read directly (see `crate::gguf`) rather than relying on a stored
+//! Modelfile — llmman has no such document, model config lives in the
+//! model file itself (GGUF metadata) or its `config.json`/
+//! `tokenizer_config.json` (safetensors).
+
+use std::io::Read;
+use std::path::Path;
+
+use clap::Args;
+
+use crate::modelpack::{resolve_model, ModelPath};
+use crate::storage::oci::Descriptor;
+use crate::storage::OciStore;
+
+#[derive(Args, Debug)]
+pub struct ShowArgs {
+    /// Model to show
+    #[arg(value_name = "MODEL")]
+    pub model: String,
+
+    /// Show only the model's license text
+    #[arg(long)]
+    pub license: bool,
+
+    /// Show only the model's chat template
+    #[arg(long)]
+    pub template: bool,
+
+    /// Show only the model's architecture/parameters/quantization block
+    #[arg(long)]
+    pub parameters: bool,
+
+    /// Show every parsed GGUF metadata key/value pair
+    #[arg(short, long)]
+    pub verbose: bool,
+}
+
+pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
+    let store_path = crate::default_store()?;
+    let store = OciStore::open(&store_path)?;
+    let reference = crate::shortnames::resolve_ollama_api(&args.model);
+    let desc = store.find(&reference)?;
+    let manifest = store.read_manifest(&desc.digest)?;
+
+    let cache_path = store_path.join("cache");
+    std::fs::create_dir_all(&cache_path).ok();
+    let resolved = resolve_model(&store_path, &cache_path, &reference)?;
+
+    // A read failure here (a corrupt/truncated GGUF header) downgrades to
+    // `None` rather than aborting the whole command with `?`: the
+    // digest/size lines, `--license` (manifest-layer case), and any
+    // Labels section below don't depend on GGUF metadata at all, and
+    // still deserve to print even when it can't be read.
+    let gguf_info = match &resolved {
+        ModelPath::Gguf(path, _) => match crate::gguf::read_info(path) {
+            Ok(info) => Some(info),
+            Err(e) => {
+                eprintln!("[llmman] reading GGUF metadata for {reference}: {e:#}");
+                None
+            }
+        },
+        ModelPath::SafeTensors(_) => None,
+    };
+    let safetensors_config = match &resolved {
+        ModelPath::SafeTensors(dir) => read_json_file(&dir.join("config.json")),
+        ModelPath::Gguf(..) => None,
+    };
+    let tokenizer_config = match &resolved {
+        ModelPath::SafeTensors(dir) => read_json_file(&dir.join("tokenizer_config.json")),
+        ModelPath::Gguf(..) => None,
+    };
+
+    // Any single-focus flag suppresses the full summary and prints just
+    // that one thing, matching `ollama show --license`/`--template`/
+    // `--parameters`'s own behavior.
+    if args.license {
+        match find_license(&store, &manifest, gguf_info.as_ref()) {
+            Some(text) => println!("{}", text.trim_end()),
+            None => println!("(no license found)"),
+        }
+        return Ok(());
+    }
+    if args.template {
+        match chat_template(gguf_info.as_ref(), tokenizer_config.as_ref()) {
+            Some(text) => println!("{}", text.trim_end()),
+            None => println!("(no chat template found)"),
+        }
+        return Ok(());
+    }
+    if args.parameters {
+        print_parameters_block(
+            gguf_info.as_ref(),
+            safetensors_config.as_ref(),
+            resolved.format(),
+        );
+        return Ok(());
+    }
+    if args.verbose {
+        if let Some(info) = &gguf_info {
+            let mut keys: Vec<_> = info.metadata.keys().collect();
+            keys.sort();
+            for key in keys {
+                println!("{key} = {}", format_value(&info.metadata[key]));
+            }
+        } else if let Some(cfg) = &safetensors_config {
+            println!("{}", serde_json::to_string_pretty(cfg)?);
+        } else {
+            println!("(no metadata found)");
+        }
+        return Ok(());
+    }
+
+    // Full summary.
+    println!("  {}", reference);
+    println!();
+    println!("  Digest       {}", desc.digest);
+    println!(
+        "  Size         {}",
+        crate::fmt::human_size(store.total_size(&desc))
+    );
+    println!();
+    println!("Model");
+    print_parameters_block(
+        gguf_info.as_ref(),
+        safetensors_config.as_ref(),
+        resolved.format(),
+    );
+
+    if let Some(text) = find_license(&store, &manifest, gguf_info.as_ref()) {
+        println!();
+        println!("License");
+        for line in text.lines().take(3) {
+            println!("    {line}");
+        }
+        if text.lines().count() > 3 {
+            println!("    ...");
+        }
+    }
+
+    if chat_template(gguf_info.as_ref(), tokenizer_config.as_ref()).is_some() {
+        println!();
+        println!("Template");
+        println!(
+            "    (present — use `llmman show --template {}` to view it)",
+            args.model
+        );
+    }
+
+    if let Some(annotations) = &manifest.annotations {
+        if !annotations.is_empty() {
+            println!();
+            println!("Labels");
+            let mut keys: Vec<_> = annotations.keys().collect();
+            keys.sort();
+            for key in keys {
+                println!("    {key} = {}", annotations[key]);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_parameters_block(
+    gguf_info: Option<&crate::gguf::Info>,
+    safetensors_config: Option<&serde_json::Value>,
+    format: &str,
+) {
+    println!("    format               {format}");
+    if let Some(info) = gguf_info {
+        if let Some(arch) = info.architecture() {
+            println!("    architecture         {arch}");
+        }
+        if info.parameter_count > 0 {
+            println!(
+                "    parameters           {}",
+                crate::fmt::human_count(info.parameter_count)
+            );
+        }
+        if let Some(ctx) = info.context_length() {
+            println!("    context length       {ctx}");
+        }
+        if let Some(emb) = info.embedding_length() {
+            println!("    embedding length     {emb}");
+        }
+        if let Some(blocks) = info.block_count() {
+            println!("    block count          {blocks}");
+        }
+        if let Some(q) = &info.quantization {
+            println!("    quantization         {q}");
+        }
+    } else if let Some(cfg) = safetensors_config {
+        if let Some(arch) = cfg
+            .get("model_type")
+            .or_else(|| cfg.get("architectures").and_then(|a| a.get(0)))
+            .and_then(|v| v.as_str())
+        {
+            println!("    architecture         {arch}");
+        }
+        for (label, key) in [
+            ("hidden size", "hidden_size"),
+            ("layers", "num_hidden_layers"),
+            ("attention heads", "num_attention_heads"),
+            ("context length", "max_position_embeddings"),
+            ("vocab size", "vocab_size"),
+        ] {
+            if let Some(v) = cfg.get(key).and_then(|v| v.as_u64()) {
+                println!("    {label:<20} {v}");
+            }
+        }
+        if let Some(dtype) = cfg.get("torch_dtype").and_then(|v| v.as_str()) {
+            println!("    quantization         {dtype}");
+        }
+    }
+}
+
+fn format_value(v: &crate::gguf::Value) -> String {
+    use crate::gguf::Value;
+    match v {
+        // `&s[..200]` truncates on a *byte* offset — GGUF metadata
+        // strings (a chat template, `general.description`, ...) are
+        // routinely non-ASCII, and slicing mid-character panics with
+        // "byte index 200 is not a char boundary". Walking char_indices
+        // to the last boundary at or before 200 keeps the same
+        // ~200-byte-ish truncation length without ever landing inside a
+        // multi-byte character.
+        Value::String(s) if s.len() > 200 => {
+            let end = s
+                .char_indices()
+                .map(|(i, _)| i)
+                .take_while(|&i| i <= 200)
+                .last()
+                .unwrap_or(0);
+            format!("{}... ({} bytes)", &s[..end], s.len())
+        }
+        Value::String(s) => s.clone(),
+        Value::Array(items) => format!("[{} items]", items.len()),
+        Value::Bool(b) => b.to_string(),
+        Value::F32(f) => f.to_string(),
+        Value::F64(f) => f.to_string(),
+        other => other
+            .as_u64()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| format!("{other:?}")),
+    }
+}
+
+/// The model's chat template, if one can be found — GGUF's
+/// `tokenizer.chat_template` key, or (for safetensors) a
+/// `tokenizer_config.json`'s own `chat_template` field.
+fn chat_template(
+    gguf_info: Option<&crate::gguf::Info>,
+    tokenizer_config: Option<&serde_json::Value>,
+) -> Option<String> {
+    if let Some(info) = gguf_info {
+        if let Some(t) = info.str("tokenizer.chat_template") {
+            return Some(t.to_string());
+        }
+    }
+    tokenizer_config?
+        .get("chat_template")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Finds and reads a manifest layer that looks like a license file
+/// (`LICENSE`, `LICENSE.txt`, `LICENSE.md`, case-insensitive) — or, for a
+/// GGUF file, falls back to any `general.license*` metadata string.
+fn find_license(
+    store: &OciStore,
+    manifest: &crate::storage::oci::Manifest,
+    gguf_info: Option<&crate::gguf::Info>,
+) -> Option<String> {
+    for layer in &manifest.layers {
+        let Some(filepath) = layer.annotations.as_ref().and_then(|a| {
+            a.get("org.cncf.model.filepath")
+                .or_else(|| a.get("org.opencontainers.image.title"))
+        }) else {
+            continue;
+        };
+        let base = Path::new(filepath)
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or(filepath)
+            .to_lowercase();
+        if base == "license" || base.starts_with("license.") {
+            if let Ok(text) = read_layer_text(store, layer) {
+                return Some(text);
+            }
+        }
+    }
+    // No LICENSE-ish layer found — fall back to whichever
+    // `general.license*` metadata key (if any) the GGUF file itself
+    // carries, matching this function's own doc comment.
+    let info = gguf_info?;
+    info.str("general.license")
+        .or_else(|| info.str("general.license.name"))
+        .map(str::to_string)
+}
+
+/// Reads a manifest layer's text content — transparently un-tarring it if
+/// it's a single-file tar (as every layer `llmman build` produces is —
+/// see `storage::oci::classify_model_layer`'s own doc comment), or else
+/// treating the whole blob as raw text (as HuggingFace/cloud-source pulls
+/// store un-archived doc/config blobs — see `go-shim/uri_sources.go`'s
+/// `classifyFile`).
+fn read_layer_text(store: &OciStore, layer: &Descriptor) -> anyhow::Result<String> {
+    let blob = store.read_blob(&layer.digest)?;
+    if blob.len() >= 512 {
+        let mut archive = tar::Archive::new(std::io::Cursor::new(&blob));
+        if let Ok(entries) = archive.entries() {
+            for entry in entries.flatten() {
+                let mut entry = entry;
+                let mut s = String::new();
+                if entry.read_to_string(&mut s).is_ok() && !s.is_empty() {
+                    return Ok(s);
+                }
+            }
+        }
+    }
+    Ok(String::from_utf8_lossy(&blob).into_owned())
+}
+
+fn read_json_file(path: &Path) -> Option<serde_json::Value> {
+    let data = std::fs::read(path).ok()?;
+    serde_json::from_slice(&data).ok()
+}

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -1,0 +1,51 @@
+use clap::Args;
+use serde::Deserialize;
+
+#[derive(Args, Debug)]
+pub struct StopArgs {
+    /// Model to unload
+    #[arg(value_name = "MODEL")]
+    pub model: String,
+}
+
+/// Wire shape of GET /api/ps's response — see `ps.rs`'s own copy of this
+/// same shape and its doc comment on why each CLI command that needs it
+/// keeps its own minimal copy instead of sharing one type with the
+/// daemon.
+#[derive(Debug, Deserialize)]
+struct PsResponse {
+    models: Vec<PsModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PsModel {
+    name: String,
+}
+
+/// `llmman stop MODEL` — unload a running model immediately, mirroring
+/// `ollama stop` (`cmd/cmd.go`'s `StopHandler`/`loadOrUnloadModel`), which
+/// posts `{"model": ..., "keep_alive": 0}` (empty prompt) to
+/// `/api/generate` — the exact sentinel `cmd::serve::handle_ollama_generate`
+/// already reads as an immediate-unload request. See `daemon::unload`.
+pub fn run(args: &StopArgs) -> anyhow::Result<()> {
+    if !crate::daemon::server_alive() {
+        anyhow::bail!("llmman serve is not running (nothing is loaded) — nothing to stop");
+    }
+
+    let reference = crate::shortnames::resolve_ollama_api(&args.model);
+
+    // The unload endpoint itself always reports success even when
+    // nothing by that name was running (canonical_ref falls back
+    // gracefully — see cmd::serve's own doc comment on it), so "was this
+    // model actually loaded" is checked here, against a `ps` snapshot,
+    // purely to give the same "couldn't find model to stop" error
+    // `ollama stop` gives instead of a silent, meaningless success.
+    let running: PsResponse = crate::daemon::get_json("/api/ps")?;
+    if !running.models.iter().any(|m| m.name == reference) {
+        anyhow::bail!("couldn't find model \"{}\" to stop", args.model);
+    }
+
+    crate::daemon::unload(&reference)?;
+    println!("Stopped {}", reference);
+    Ok(())
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -626,6 +626,26 @@ pub fn ensure_model_pulled(reference: &str) -> anyhow::Result<()> {
     stream_progress("/api/pull", reference)
 }
 
+/// POSTs the Ollama unload sentinel (`{"model": reference, "keep_alive":
+/// 0}`, no `prompt` field — i.e. an empty prompt) to `/api/generate` —
+/// see `cmd::serve`'s `handle_ollama_generate` for the server side that
+/// reads this exact shape as an immediate-unload request, mirroring real
+/// Ollama's own `ollama stop` (`cmd/cmd.go`'s `loadOrUnloadModel`). Used
+/// by `llmman stop`.
+pub fn unload(reference: &str) -> anyhow::Result<()> {
+    let resp = reqwest::blocking::Client::new()
+        .post(format!("{SERVER}/api/generate"))
+        .json(&serde_json::json!({"model": reference, "keep_alive": 0}))
+        .send()
+        .with_context(|| format!("request /api/generate (unload) for {reference}"))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_default();
+        anyhow::bail!("stop {reference}: server returned {status}: {body}");
+    }
+    Ok(())
+}
+
 /// A plain `GET {SERVER}{path}` returning the parsed JSON body — for
 /// callers (currently just `ps`) that don't need `stream_progress`'s
 /// newline-delimited-JSON streaming, just a single request/response.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -30,6 +30,25 @@ pub fn human_size(bytes: u64) -> String {
     }
 }
 
+/// Human-scaled parameter/element count (e.g. "7.2B", "600.0M",
+/// "125.0K") — used by `llmman show` to render a GGUF/safetensors model's
+/// total parameter count, mirroring `ollama show`'s own
+/// `format.HumanNumber`.
+pub fn human_count(n: u64) -> String {
+    const B: u64 = 1_000_000_000;
+    const M: u64 = 1_000_000;
+    const K: u64 = 1_000;
+    if n >= B {
+        format!("{:.1}B", n as f64 / B as f64)
+    } else if n >= M {
+        format!("{:.1}M", n as f64 / M as f64)
+    } else if n >= K {
+        format!("{:.1}K", n as f64 / K as f64)
+    } else {
+        n.to_string()
+    }
+}
+
 /// Relative-time string ("5 minutes ago", "yesterday", ...) for a duration
 /// expressed in seconds-in-the-past. Shared core of [`relative_time`] and
 /// [`relative_time_rfc3339`], which just compute `secs` differently.
@@ -124,6 +143,17 @@ mod tests {
         assert_eq!(human_size(1_500), "1.5 kB");
         assert_eq!(human_size(1_500_000), "1.5 MB");
         assert_eq!(human_size(1_500_000_000), "1.5 GB");
+    }
+
+    #[test]
+    fn human_count_picks_the_right_unit() {
+        assert_eq!(human_count(512), "512");
+        assert_eq!(human_count(999), "999");
+        assert_eq!(human_count(1_000), "1.0K");
+        assert_eq!(human_count(1_500), "1.5K");
+        assert_eq!(human_count(7_200_000_000), "7.2B");
+        assert_eq!(human_count(600_000_000), "600.0M");
+        assert_eq!(human_count(999_999_999), "1000.0M");
     }
 
     #[test]

--- a/src/gguf.rs
+++ b/src/gguf.rs
@@ -1,0 +1,568 @@
+//! Minimal GGUF (<https://github.com/ggml-org/ggml/blob/master/docs/gguf.md>)
+//! header reader — reads just the metadata key/value section and the
+//! tensor-info array (name/shape/type — never the tensor *data* itself),
+//! which is all `cmd::show` needs to report a GGUF model's architecture,
+//! parameter count, quantization, context length, and chat template
+//! without extracting/loading the whole file.
+//!
+//! Deliberately narrower than a full GGUF library: no writing, no
+//! alignment/padding handling past the tensor-info array, no support for
+//! the ancient, tensor-count-as-u32 GGUF v1 format (real models in the
+//! wild are v2/v3).
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::Path;
+
+use anyhow::{bail, Context};
+
+/// One parsed GGUF metadata value. See
+/// <https://github.com/ggml-org/ggml/blob/master/docs/gguf.md#file-structure>
+/// for the underlying `gguf_metadata_value_type` this mirrors.
+#[derive(Debug, Clone)]
+pub enum Value {
+    U8(u8),
+    I8(i8),
+    U16(u16),
+    I16(i16),
+    U32(u32),
+    I32(i32),
+    F32(f32),
+    Bool(bool),
+    String(String),
+    Array(Vec<Value>),
+    U64(u64),
+    I64(i64),
+    F64(f64),
+}
+
+impl Value {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::String(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Any non-negative integer variant, widened to `u64`.
+    pub fn as_u64(&self) -> Option<u64> {
+        match *self {
+            Value::U8(v) => Some(v as u64),
+            Value::U16(v) => Some(v as u64),
+            Value::U32(v) => Some(v as u64),
+            Value::U64(v) => Some(v),
+            Value::I8(v) if v >= 0 => Some(v as u64),
+            Value::I16(v) if v >= 0 => Some(v as u64),
+            Value::I32(v) if v >= 0 => Some(v as u64),
+            Value::I64(v) if v >= 0 => Some(v as u64),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            Value::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+}
+
+/// One entry of the tensor-info array — everything but the tensor's own
+/// data, which this reader never touches.
+#[derive(Debug, Clone)]
+struct TensorInfo {
+    #[allow(dead_code)]
+    name: String,
+    dims: Vec<u64>,
+    ggml_type: u32,
+}
+
+/// Parsed GGUF header, ready for `cmd::show` to render.
+#[derive(Debug, Clone, Default)]
+pub struct Info {
+    pub metadata: HashMap<String, Value>,
+    pub tensor_count: u64,
+    /// Total element count across every tensor (i.e. the model's
+    /// parameter count) — independent of quantization, matching how
+    /// `ollama show`'s own "Parameters" figure counts elements, not
+    /// bytes.
+    pub parameter_count: u64,
+    /// The most common quantization type name among 2-D-or-higher
+    /// tensors (the actual weight matrices — 1-D bias/norm tensors are
+    /// excluded since they're almost always kept at F32/F16 regardless of
+    /// the model's overall quantization and would otherwise skew a
+    /// per-tensor-count vote toward "unquantized").
+    pub quantization: Option<String>,
+}
+
+impl Info {
+    /// Convenience accessor for a string-valued key.
+    pub fn str(&self, key: &str) -> Option<&str> {
+        self.metadata.get(key).and_then(Value::as_str)
+    }
+
+    /// Convenience accessor for an integer-valued key.
+    pub fn u64(&self, key: &str) -> Option<u64> {
+        self.metadata.get(key).and_then(Value::as_u64)
+    }
+
+    /// `general.architecture` — e.g. "llama", "qwen3", "gemma3" — used to
+    /// look up architecture-prefixed keys like `{arch}.context_length`.
+    pub fn architecture(&self) -> Option<&str> {
+        self.str("general.architecture")
+    }
+
+    /// `{architecture}.context_length`, if both are present.
+    pub fn context_length(&self) -> Option<u64> {
+        let arch = self.architecture()?;
+        self.u64(&format!("{arch}.context_length"))
+    }
+
+    /// `{architecture}.embedding_length`, if both are present.
+    pub fn embedding_length(&self) -> Option<u64> {
+        let arch = self.architecture()?;
+        self.u64(&format!("{arch}.embedding_length"))
+    }
+
+    /// `{architecture}.block_count` (i.e. number of transformer layers).
+    pub fn block_count(&self) -> Option<u64> {
+        let arch = self.architecture()?;
+        self.u64(&format!("{arch}.block_count"))
+    }
+}
+
+struct Reader<R> {
+    inner: R,
+}
+
+impl<R: Read> Reader<R> {
+    fn u8(&mut self) -> anyhow::Result<u8> {
+        let mut b = [0u8; 1];
+        self.inner.read_exact(&mut b)?;
+        Ok(b[0])
+    }
+    fn i8(&mut self) -> anyhow::Result<i8> {
+        Ok(self.u8()? as i8)
+    }
+    fn bool_(&mut self) -> anyhow::Result<bool> {
+        Ok(self.u8()? != 0)
+    }
+    fn u16(&mut self) -> anyhow::Result<u16> {
+        let mut b = [0u8; 2];
+        self.inner.read_exact(&mut b)?;
+        Ok(u16::from_le_bytes(b))
+    }
+    fn i16(&mut self) -> anyhow::Result<i16> {
+        let mut b = [0u8; 2];
+        self.inner.read_exact(&mut b)?;
+        Ok(i16::from_le_bytes(b))
+    }
+    fn u32(&mut self) -> anyhow::Result<u32> {
+        let mut b = [0u8; 4];
+        self.inner.read_exact(&mut b)?;
+        Ok(u32::from_le_bytes(b))
+    }
+    fn i32(&mut self) -> anyhow::Result<i32> {
+        let mut b = [0u8; 4];
+        self.inner.read_exact(&mut b)?;
+        Ok(i32::from_le_bytes(b))
+    }
+    fn f32(&mut self) -> anyhow::Result<f32> {
+        let mut b = [0u8; 4];
+        self.inner.read_exact(&mut b)?;
+        Ok(f32::from_le_bytes(b))
+    }
+    fn u64(&mut self) -> anyhow::Result<u64> {
+        let mut b = [0u8; 8];
+        self.inner.read_exact(&mut b)?;
+        Ok(u64::from_le_bytes(b))
+    }
+    fn i64(&mut self) -> anyhow::Result<i64> {
+        let mut b = [0u8; 8];
+        self.inner.read_exact(&mut b)?;
+        Ok(i64::from_le_bytes(b))
+    }
+    fn f64(&mut self) -> anyhow::Result<f64> {
+        let mut b = [0u8; 8];
+        self.inner.read_exact(&mut b)?;
+        Ok(f64::from_le_bytes(b))
+    }
+
+    /// A GGUF string: a `u64` byte length followed by (not
+    /// NUL-terminated) UTF-8 bytes — decoded lossily, since a stray
+    /// invalid byte in, say, a license string must never fail the whole
+    /// read.
+    fn string(&mut self) -> anyhow::Result<String> {
+        let len = self.u64()? as usize;
+        // A malformed/corrupt length must not attempt a multi-GiB
+        // allocation on `show`'s behalf — real GGUF strings (names,
+        // templates, license text) are never anywhere close to this.
+        if len > 64 * 1024 * 1024 {
+            bail!("implausible GGUF string length: {len}");
+        }
+        let mut buf = vec![0u8; len];
+        self.inner.read_exact(&mut buf)?;
+        Ok(String::from_utf8_lossy(&buf).into_owned())
+    }
+
+    fn value(&mut self, ty: u32) -> anyhow::Result<Value> {
+        self.value_at(ty, 0)
+    }
+
+    /// `value`'s real implementation, tracking array-nesting `depth` —
+    /// an array's own element type (read from the file, not validated
+    /// against anything) can itself be `9` (array), so a hostile or
+    /// merely corrupt GGUF file that repeats a nested-array header can
+    /// otherwise recurse once per ~12 input bytes. A real stack overflow
+    /// aborts the whole process below any `anyhow::Result` this reader
+    /// could otherwise report, taking `llmman show` down with it instead
+    /// of just failing to read one untrusted (e.g. pulled-from-a-registry)
+    /// file — bounding the depth turns that into an ordinary error.
+    fn value_at(&mut self, ty: u32, depth: u32) -> anyhow::Result<Value> {
+        if depth > 8 {
+            bail!("GGUF value nesting too deep (> 8 levels)");
+        }
+        Ok(match ty {
+            0 => Value::U8(self.u8()?),
+            1 => Value::I8(self.i8()?),
+            2 => Value::U16(self.u16()?),
+            3 => Value::I16(self.i16()?),
+            4 => Value::U32(self.u32()?),
+            5 => Value::I32(self.i32()?),
+            6 => Value::F32(self.f32()?),
+            7 => Value::Bool(self.bool_()?),
+            8 => Value::String(self.string()?),
+            9 => {
+                let elem_ty = self.u32()?;
+                let len = self.u64()?;
+                if len > 10_000_000 {
+                    bail!("implausible GGUF array length: {len}");
+                }
+                let mut items = Vec::with_capacity(len.min(1024) as usize);
+                for _ in 0..len {
+                    items.push(self.value_at(elem_ty, depth + 1)?);
+                }
+                Value::Array(items)
+            }
+            10 => Value::U64(self.u64()?),
+            11 => Value::I64(self.i64()?),
+            12 => Value::F64(self.f64()?),
+            other => bail!("unknown GGUF value type: {other}"),
+        })
+    }
+}
+
+/// Reads `path`'s GGUF header: the magic/version, every metadata
+/// key/value pair, and the tensor-info array (name/shape/type only, never
+/// tensor data) — enough to derive parameter count and dominant
+/// quantization without loading the model itself.
+pub fn read_info(path: &Path) -> anyhow::Result<Info> {
+    let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+    let mut r = Reader {
+        inner: BufReader::new(file),
+    };
+
+    let mut magic = [0u8; 4];
+    r.inner.read_exact(&mut magic).context("read GGUF magic")?;
+    if &magic != b"GGUF" {
+        bail!("not a GGUF file: {}", path.display());
+    }
+    let version = r.u32().context("read GGUF version")?;
+    if version < 2 {
+        bail!("unsupported GGUF version {version} (only v2+ is supported)");
+    }
+
+    let tensor_count = r.u64().context("read tensor_count")?;
+    let metadata_kv_count = r.u64().context("read metadata_kv_count")?;
+
+    let mut metadata = HashMap::with_capacity(metadata_kv_count.min(4096) as usize);
+    for _ in 0..metadata_kv_count {
+        let key = r.string().context("read metadata key")?;
+        let value_type = r.u32().context("read metadata value type")?;
+        let value = r
+            .value(value_type)
+            .with_context(|| format!("read metadata value for {key:?}"))?;
+        metadata.insert(key, value);
+    }
+
+    let mut tensors = Vec::with_capacity(tensor_count.min(65536) as usize);
+    for _ in 0..tensor_count {
+        let name = r.string().context("read tensor name")?;
+        let n_dims = r.u32().context("read tensor n_dims")?;
+        if n_dims > 8 {
+            bail!("implausible tensor rank: {n_dims}");
+        }
+        let mut dims = Vec::with_capacity(n_dims as usize);
+        for _ in 0..n_dims {
+            dims.push(r.u64().context("read tensor dim")?);
+        }
+        let ggml_type = r.u32().context("read tensor type")?;
+        let _offset = r.u64().context("read tensor offset")?;
+        tensors.push(TensorInfo {
+            name,
+            dims,
+            ggml_type,
+        });
+    }
+
+    let parameter_count = tensors
+        .iter()
+        .map(|t| {
+            t.dims
+                .iter()
+                .fold(1u128, |acc, &d| acc.saturating_mul(d as u128))
+        })
+        .fold(0u128, |acc, n| acc.saturating_add(n))
+        .min(u64::MAX as u128) as u64;
+
+    let quantization = dominant_quantization(&tensors);
+
+    Ok(Info {
+        metadata,
+        tensor_count,
+        parameter_count,
+        quantization,
+    })
+}
+
+/// The `ggml_type` name most representative of a model's actual
+/// quantization — the modal type (by total element count, not tensor
+/// count, so a handful of huge matrices outweigh many tiny ones) among
+/// tensors with rank ≥ 2 (real weight matrices; 1-D bias/norm tensors are
+/// excluded — see [`Info::quantization`]'s own doc comment).
+fn dominant_quantization(tensors: &[TensorInfo]) -> Option<String> {
+    let mut totals: HashMap<u32, u128> = HashMap::new();
+    for t in tensors {
+        if t.dims.len() < 2 {
+            continue;
+        }
+        let elems = t
+            .dims
+            .iter()
+            .fold(1u128, |acc, &d| acc.saturating_mul(d as u128));
+        // Saturating, not `+=`: a corrupt tensor's `dims` can already
+        // saturate `elems` to `u128::MAX` (see the fold above); a second
+        // tensor sharing the same `ggml_type` would then overflow a plain
+        // `+=` and panic in a debug build, aborting `llmman show` instead
+        // of just reporting the file's real (if implausible) contents.
+        let entry = totals.entry(t.ggml_type).or_insert(0);
+        *entry = entry.saturating_add(elems);
+    }
+    let (ty, _) = totals.into_iter().max_by_key(|(_, n)| *n)?;
+    Some(ggml_type_name(ty).to_string())
+}
+
+/// `ggml_type` id → name, mirroring `ggml.c`'s own `type_traits[].type_name`
+/// table. Deprecated/removed ids (4, 5, 31-33) map to a placeholder rather
+/// than panicking or erroring — an old file naming one is still a file we
+/// should be able to at least partially describe.
+fn ggml_type_name(ty: u32) -> &'static str {
+    match ty {
+        0 => "F32",
+        1 => "F16",
+        2 => "Q4_0",
+        3 => "Q4_1",
+        6 => "Q5_0",
+        7 => "Q5_1",
+        8 => "Q8_0",
+        9 => "Q8_1",
+        10 => "Q2_K",
+        11 => "Q3_K",
+        12 => "Q4_K",
+        13 => "Q5_K",
+        14 => "Q6_K",
+        15 => "Q8_K",
+        16 => "IQ2_XXS",
+        17 => "IQ2_XS",
+        18 => "IQ3_XXS",
+        19 => "IQ1_S",
+        20 => "IQ4_NL",
+        21 => "IQ3_S",
+        22 => "IQ2_S",
+        23 => "IQ4_XS",
+        24 => "I8",
+        25 => "I16",
+        26 => "I32",
+        27 => "I64",
+        28 => "F64",
+        29 => "IQ1_M",
+        30 => "BF16",
+        34 => "TQ1_0",
+        35 => "TQ2_0",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Builds a minimal-but-valid GGUF file in memory: one string
+    /// metadata key, one u32 metadata key, and one 2-D tensor, then
+    /// writes it to a temp file and reads it back through [`read_info`].
+    fn write_test_gguf() -> std::path::PathBuf {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&1u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&2u64.to_le_bytes()); // metadata_kv_count
+
+        // general.architecture = "llama"
+        write_string(&mut buf, "general.architecture");
+        buf.extend_from_slice(&8u32.to_le_bytes()); // STRING
+        write_string(&mut buf, "llama");
+
+        // llama.context_length = 4096 (u32)
+        write_string(&mut buf, "llama.context_length");
+        buf.extend_from_slice(&4u32.to_le_bytes()); // UINT32
+        buf.extend_from_slice(&4096u32.to_le_bytes());
+
+        // one tensor: "blk.0.weight", 2 dims [4, 8], type Q4_K (12)
+        write_string(&mut buf, "blk.0.weight");
+        buf.extend_from_slice(&2u32.to_le_bytes()); // n_dims
+        buf.extend_from_slice(&4u64.to_le_bytes());
+        buf.extend_from_slice(&8u64.to_le_bytes());
+        buf.extend_from_slice(&12u32.to_le_bytes()); // ggml_type = Q4_K
+        buf.extend_from_slice(&0u64.to_le_bytes()); // offset
+
+        let path = std::env::temp_dir().join(format!(
+            "llmman-gguf-test-{}-{}.gguf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&buf).unwrap();
+        path
+    }
+
+    fn write_string(buf: &mut Vec<u8>, s: &str) {
+        buf.extend_from_slice(&(s.len() as u64).to_le_bytes());
+        buf.extend_from_slice(s.as_bytes());
+    }
+
+    #[test]
+    fn reads_metadata_and_computes_parameter_count_and_quantization() {
+        let path = write_test_gguf();
+        let info = read_info(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(info.architecture(), Some("llama"));
+        assert_eq!(info.context_length(), Some(4096));
+        assert_eq!(info.tensor_count, 1);
+        assert_eq!(info.parameter_count, 32); // 4 * 8
+        assert_eq!(info.quantization, Some("Q4_K".to_string()));
+    }
+
+    /// Regression test: two tensors whose declared dimensions each
+    /// individually saturate `elems` to `u128::MAX` (a corrupt/hostile
+    /// file, not a real one) must not overflow-panic when
+    /// `dominant_quantization` sums their per-type totals — see that
+    /// function's own comment on why `saturating_add` replaced a plain
+    /// `+=` there.
+    #[test]
+    fn read_info_does_not_overflow_when_summing_saturated_element_counts() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&2u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&0u64.to_le_bytes()); // metadata_kv_count
+
+        for name in ["blk.0.weight", "blk.1.weight"] {
+            write_string(&mut buf, name);
+            buf.extend_from_slice(&3u32.to_le_bytes()); // n_dims
+                                                        // Three u64::MAX dims: their product vastly exceeds
+                                                        // u128::MAX, so `elems` saturates to u128::MAX for this
+                                                        // tensor alone.
+            for _ in 0..3 {
+                buf.extend_from_slice(&u64::MAX.to_le_bytes());
+            }
+            buf.extend_from_slice(&0u32.to_le_bytes()); // ggml_type = F32, same for both
+            buf.extend_from_slice(&0u64.to_le_bytes()); // offset
+        }
+
+        let path = std::env::temp_dir().join(format!(
+            "llmman-gguf-saturate-{}-{}.gguf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&buf).unwrap();
+
+        // Must not panic (a debug-build overflow would abort the whole
+        // process, not just this call) and must report a sane result.
+        let info = read_info(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        assert_eq!(info.parameter_count, u64::MAX);
+        assert_eq!(info.quantization, Some("F32".to_string()));
+    }
+
+    #[test]
+    fn read_info_rejects_a_non_gguf_file() {
+        let path =
+            std::env::temp_dir().join(format!("llmman-gguf-nonmagic-{}.bin", std::process::id()));
+        std::fs::write(&path, b"not a gguf file at all").unwrap();
+        let err = read_info(&path).unwrap_err();
+        std::fs::remove_file(&path).ok();
+        assert!(err.to_string().contains("not a GGUF file"));
+    }
+
+    #[test]
+    fn ggml_type_name_covers_common_quantizations() {
+        assert_eq!(ggml_type_name(0), "F32");
+        assert_eq!(ggml_type_name(12), "Q4_K");
+        assert_eq!(ggml_type_name(14), "Q6_K");
+        assert_eq!(ggml_type_name(9999), "unknown");
+    }
+
+    /// Regression test: a GGUF file whose metadata contains a
+    /// deeply-nested array-of-array-of-... chain must be rejected with an
+    /// ordinary error, not recurse until the process's stack overflows —
+    /// see `Reader::value_at`'s own doc comment. Built with 12 levels of
+    /// nesting (past the 8-level bound) around a single UINT8 leaf.
+    #[test]
+    fn read_info_rejects_metadata_nested_past_the_depth_limit_instead_of_overflowing_the_stack() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"GGUF");
+        buf.extend_from_slice(&3u32.to_le_bytes()); // version
+        buf.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+        buf.extend_from_slice(&1u64.to_le_bytes()); // metadata_kv_count
+
+        write_string(&mut buf, "test.nested");
+        buf.extend_from_slice(&9u32.to_le_bytes()); // top-level value type: ARRAY
+        for _ in 0..12 {
+            buf.extend_from_slice(&9u32.to_le_bytes()); // element type: ARRAY (nested)
+            buf.extend_from_slice(&1u64.to_le_bytes()); // length: 1
+        }
+        // Innermost leaf: one UINT8 array of length 1.
+        buf.extend_from_slice(&0u32.to_le_bytes()); // element type: UINT8
+        buf.extend_from_slice(&1u64.to_le_bytes()); // length: 1
+        buf.push(0u8);
+
+        let path = std::env::temp_dir().join(format!(
+            "llmman-gguf-nested-{}-{}.gguf",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut f = File::create(&path).unwrap();
+        f.write_all(&buf).unwrap();
+
+        let err = read_info(&path).unwrap_err();
+        std::fs::remove_file(&path).ok();
+        assert!(
+            err.chain()
+                .any(|c| c.to_string().contains("nesting too deep")),
+            "got: {err:#}"
+        );
+    }
+}

--- a/src/harmony.rs
+++ b/src/harmony.rs
@@ -1,0 +1,524 @@
+//! Parser for OpenAI's "Harmony" response format — the
+//! `<|start|>...<|channel|>...<|message|>...<|end|>` channel-based format
+//! used by gpt-oss-style models to interleave a `final` (user-visible),
+//! `analysis` (reasoning/thinking), and `commentary` (tool-call) channel
+//! in one raw token stream.
+//!
+//! Ported from ollama's `harmony/harmonyparser.go`. Used as a fallback in
+//! `cmd::serve` for backends that hand back these literal special tokens
+//! in `content` unparsed (llama-server's own gpt-oss chat template
+//! integration normally separates these itself via structured
+//! `reasoning_content`/`tool_calls` fields — see `oai_chunk_to_content` —
+//! so this only ever engages when raw harmony tokens show up in plain
+//! `content` text instead).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParserState {
+    LookingForMessageStart,
+    ParsingHeader,
+    ParsingContent,
+}
+
+/// One header field parsed out of a harmony message's
+/// `<|start|>...<|message|>` preamble.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HarmonyHeader {
+    pub role: String,
+    pub channel: String,
+    pub recipient: String,
+}
+
+/// A single event emitted by [`HarmonyParser::add_content`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HarmonyEvent {
+    MessageStart,
+    HeaderComplete(HarmonyHeader),
+    ContentEmitted(String),
+    MessageEnd,
+}
+
+/// Low-level state machine that turns a raw harmony token stream into a
+/// sequence of [`HarmonyEvent`]s. See the module doc comment.
+#[derive(Debug, Clone)]
+pub struct HarmonyParser {
+    state: ParserState,
+    pub message_start_tag: String,
+    pub message_end_tag: String,
+    pub header_end_tag: String,
+    acc: String,
+}
+
+impl HarmonyParser {
+    pub fn new(
+        message_start_tag: impl Into<String>,
+        message_end_tag: impl Into<String>,
+        header_end_tag: impl Into<String>,
+    ) -> Self {
+        Self {
+            state: ParserState::LookingForMessageStart,
+            message_start_tag: message_start_tag.into(),
+            message_end_tag: message_end_tag.into(),
+            header_end_tag: header_end_tag.into(),
+            acc: String::new(),
+        }
+    }
+
+    /// The standard gpt-oss tag set (`<|start|>`/`<|end|>`/`<|message|>`).
+    pub fn gpt_oss() -> Self {
+        Self::new("<|start|>", "<|end|>", "<|message|>")
+    }
+
+    /// Prime the parser as though `<|start|>assistant` had already been
+    /// consumed — for a chat turn where the assistant's own message start
+    /// isn't part of the raw stream being fed in (llama-server's own
+    /// template already emitted it before generation started).
+    ///
+    /// Required before the first [`Self::add_content`] call whenever a raw
+    /// stream is known to start mid-message (e.g. directly at
+    /// `<|channel|>`, with no leading `<|start|>` of its own) — this
+    /// parser's own state machine only recognizes a header once it's seen
+    /// a `<|start|>` to anchor it. `cmd::serve`'s `RawContentExtractor` is
+    /// the one caller that actually needs this today: it inspects a raw
+    /// stream's very first non-whitespace bytes to tell `<|start|>...`
+    /// and `<|channel|>...` starts apart, and only calls this for the
+    /// latter.
+    pub fn add_implicit_start(&mut self) {
+        self.acc
+            .push_str(&format!("{}assistant", self.message_start_tag));
+    }
+
+    pub fn add_content(&mut self, content: &str) -> Vec<HarmonyEvent> {
+        self.acc.push_str(content);
+
+        let mut events = Vec::new();
+        loop {
+            let (mut new_events, keep_looping) = self.eat();
+            events.append(&mut new_events);
+            if !keep_looping {
+                break;
+            }
+        }
+        events
+    }
+
+    fn eat(&mut self) -> (Vec<HarmonyEvent>, bool) {
+        match self.state {
+            ParserState::LookingForMessageStart => {
+                if let Some(pos) = self.acc.find(&self.message_start_tag) {
+                    let after = self.acc[pos + self.message_start_tag.len()..].to_string();
+                    self.acc.clear();
+                    self.acc.push_str(&after);
+                    self.state = ParserState::ParsingHeader;
+                    (vec![HarmonyEvent::MessageStart], true)
+                } else {
+                    (Vec::new(), false)
+                }
+            }
+            ParserState::ParsingHeader => {
+                if let Some(pos) = self.acc.find(&self.header_end_tag) {
+                    let header = self.acc[..pos].to_string();
+                    let after = self.acc[pos + self.header_end_tag.len()..].to_string();
+                    self.acc.clear();
+                    self.acc.push_str(&after);
+                    self.state = ParserState::ParsingContent;
+                    (
+                        vec![HarmonyEvent::HeaderComplete(parse_header(&header))],
+                        true,
+                    )
+                } else {
+                    (Vec::new(), false)
+                }
+            }
+            ParserState::ParsingContent => {
+                if let Some(pos) = self.acc.find(&self.message_end_tag) {
+                    let content = self.acc[..pos].to_string();
+                    let after = self.acc[pos + self.message_end_tag.len()..].to_string();
+                    self.acc.clear();
+                    self.acc.push_str(&after);
+                    self.state = ParserState::LookingForMessageStart;
+                    let mut events = Vec::new();
+                    if !content.is_empty() {
+                        events.push(HarmonyEvent::ContentEmitted(content));
+                    }
+                    events.push(HarmonyEvent::MessageEnd);
+                    (events, true)
+                } else {
+                    let overlap_len = overlap(&self.acc, &self.message_end_tag);
+                    if overlap_len > 0 {
+                        let split = self.acc.len() - overlap_len;
+                        let content = self.acc[..split].to_string();
+                        let remaining = self.acc[split..].to_string();
+                        self.acc.clear();
+                        self.acc.push_str(&remaining);
+                        if content.is_empty() {
+                            (Vec::new(), false)
+                        } else {
+                            (vec![HarmonyEvent::ContentEmitted(content)], false)
+                        }
+                    } else if self.acc.is_empty() {
+                        (Vec::new(), false)
+                    } else {
+                        let content = std::mem::take(&mut self.acc);
+                        (vec![HarmonyEvent::ContentEmitted(content)], false)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Parses a harmony message header (everything between `<|start|>` and
+/// `<|message|>`) into role/channel/recipient — ported from
+/// `HarmonyParser.parseHeader` in ollama's harmony/harmonyparser.go.
+fn parse_header(raw: &str) -> HarmonyHeader {
+    let mut raw = raw.to_string();
+    let mut header = HarmonyHeader::default();
+
+    // Ensure `<|constrain|>` is parsed as its own token even if the model
+    // didn't put a space before it.
+    if raw.contains("<|constrain|>") {
+        raw = raw.replacen("<|constrain|>", " <|constrain|>", 1);
+        raw = raw.trim().to_string();
+    }
+
+    // The optional channel tag: `<|channel|>` followed by the channel
+    // name, up to the first whitespace character (if any).
+    if let Some(idx) = raw.find("<|channel|>") {
+        let before = raw[..idx].to_string();
+        let mut after = raw[idx + "<|channel|>".len()..].to_string();
+        let split_at = after.find(char::is_whitespace).unwrap_or(after.len());
+        header.channel = after[..split_at].to_string();
+        after = after[split_at..].to_string();
+        raw = format!("{before}{after}");
+        raw = raw.trim().to_string();
+    }
+
+    let mut tokens = raw.split_whitespace();
+    let Some(role) = tokens.next() else {
+        return header;
+    };
+    let mut rest: Vec<&str> = tokens.collect();
+
+    if let Some(recipient) = role.strip_prefix("to=") {
+        header.recipient = recipient.to_string();
+        header.role = "tool".to_string();
+    } else {
+        header.role = role.to_string();
+    }
+
+    if header.recipient.is_empty() {
+        if let Some(first) = rest.first() {
+            if let Some(recipient) = first.strip_prefix("to=") {
+                header.recipient = recipient.to_string();
+                rest.remove(0);
+            }
+        }
+    }
+
+    header
+}
+
+/// Longest overlap between a suffix of `s` and a prefix of `delim`.
+fn overlap(s: &str, delim: &str) -> usize {
+    let max = delim.len().min(s.len());
+    for i in (1..=max).rev() {
+        if s.ends_with(&delim[..i]) {
+            return i;
+        }
+    }
+    0
+}
+
+// ---------------------------------------------------------------------------
+// HarmonyMessageHandler — maps low-level events onto (content, thinking,
+// tool_content), plus a simple per-turn tool-call text accumulator.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MessageState {
+    Normal,
+    Thinking,
+    ToolCalling,
+}
+
+/// Accumulates the raw text of a single tool call's arguments while
+/// `HarmonyMessageHandler` is in the `ToolCalling` state — see
+/// [`HarmonyMessageHandler::drain_tool_call`].
+#[derive(Debug, Default)]
+pub struct ToolCallAccumulator {
+    acc: String,
+    tool_name: Option<String>,
+}
+
+impl ToolCallAccumulator {
+    pub fn set_tool_name(&mut self, name: impl Into<String>) {
+        self.tool_name = Some(name.into());
+    }
+
+    pub fn add(&mut self, content: &str) {
+        self.acc.push_str(content);
+    }
+
+    /// Drains the accumulated raw argument text and the tool name it was
+    /// for, resetting both — `None` for the name if no tool call header
+    /// was ever seen this turn.
+    pub fn drain(&mut self) -> (Option<String>, String) {
+        let name = self.tool_name.take();
+        (name, std::mem::take(&mut self.acc))
+    }
+}
+
+/// Higher-level harmony handler: maps `analysis`/`commentary`/`final`
+/// channel events onto ollama-style (content, thinking, tool_content)
+/// buckets. See ollama's `HarmonyMessageHandler.AddContent`.
+pub struct HarmonyMessageHandler {
+    state: MessageState,
+    pub parser: HarmonyParser,
+    pub tool_calls: ToolCallAccumulator,
+}
+
+impl Default for HarmonyMessageHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HarmonyMessageHandler {
+    pub fn new() -> Self {
+        Self {
+            state: MessageState::Normal,
+            parser: HarmonyParser::gpt_oss(),
+            tool_calls: ToolCallAccumulator::default(),
+        }
+    }
+
+    /// Feeds raw content through the parser and sorts each emitted event
+    /// into (content, thinking, tool_content) — tool-call argument text is
+    /// also appended to `self.tool_calls` as it arrives, ready for
+    /// [`ToolCallAccumulator::drain`] once the turn is `done`.
+    pub fn add_content(&mut self, content: &str) -> (String, String, String) {
+        let mut out_content = String::new();
+        let mut out_thinking = String::new();
+        let mut out_tool = String::new();
+
+        for event in self.parser.add_content(content) {
+            match event {
+                HarmonyEvent::HeaderComplete(header) => match header.channel.as_str() {
+                    "analysis" => {
+                        if !header.recipient.is_empty() {
+                            self.state = MessageState::ToolCalling;
+                            self.tool_calls.set_tool_name(header.recipient);
+                        } else {
+                            self.state = MessageState::Thinking;
+                        }
+                    }
+                    "commentary" => {
+                        if !header.recipient.is_empty() {
+                            self.state = MessageState::ToolCalling;
+                            self.tool_calls.set_tool_name(header.recipient);
+                        } else {
+                            self.state = MessageState::Normal;
+                        }
+                    }
+                    "final" => self.state = MessageState::Normal,
+                    _ => {}
+                },
+                HarmonyEvent::ContentEmitted(text) => match self.state {
+                    MessageState::Normal => out_content.push_str(&text),
+                    MessageState::Thinking => out_thinking.push_str(&text),
+                    MessageState::ToolCalling => out_tool.push_str(&text),
+                },
+                HarmonyEvent::MessageEnd => self.state = MessageState::Normal,
+                HarmonyEvent::MessageStart => {}
+            }
+        }
+
+        if !out_tool.is_empty() {
+            self.tool_calls.add(&out_tool);
+        }
+
+        (out_content, out_thinking, out_tool)
+    }
+
+    /// Strips a `functions.` recipient prefix (as harmony spells a
+    /// user-defined tool's recipient, e.g. `functions.get_weather`) down
+    /// to the bare tool name — the rest of a recipient (a built-in like
+    /// `browser.search`) is left as-is.
+    pub fn drain_tool_call(&mut self) -> Option<(String, String)> {
+        let (name, raw) = self.tool_calls.drain();
+        let name = name?;
+        let name = name.strip_prefix("functions.").unwrap_or(&name).to_string();
+        Some((name, raw))
+    }
+}
+
+/// True if `s` looks like it opens with (or otherwise contains) a harmony
+/// structural token — used by `cmd::serve` to decide whether a stream of
+/// raw model output should be run through this module at all, versus the
+/// plain `thinking::Parser` fallback (or no extraction at all).
+pub fn looks_like_harmony(s: &str) -> bool {
+    let s = s.trim_start();
+    s.starts_with("<|start|>") || s.starts_with("<|channel|>") || s.contains("<|channel|>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ported from ollama's harmony/harmonyparser_test.go TestHeaderParsing.
+    #[test]
+    fn header_parsing() {
+        let cases = [
+            ("assistant<|channel|>analysis", "assistant", "analysis", ""),
+            (
+                "assistant<|channel|>analysis to=functions.get_weather",
+                "assistant",
+                "analysis",
+                "functions.get_weather",
+            ),
+            (
+                "assistant to=functions.get_weather<|channel|>analysis",
+                "assistant",
+                "analysis",
+                "functions.get_weather",
+            ),
+            (
+                "to=functions.get_weather<|channel|>analysis",
+                "tool",
+                "analysis",
+                "functions.get_weather",
+            ),
+            (
+                "assistant to=functions.get_weather abc<|channel|>analysis",
+                "assistant",
+                "analysis",
+                "functions.get_weather",
+            ),
+            (
+                "assistant<|channel|>commentary to=functions.get_weather <|constrain|>json",
+                "assistant",
+                "commentary",
+                "functions.get_weather",
+            ),
+            (
+                "assistant to=functions.get_weather<|channel|>commentary <|constrain|>json",
+                "assistant",
+                "commentary",
+                "functions.get_weather",
+            ),
+        ];
+        for (input, want_role, want_channel, want_recipient) in cases {
+            let header = parse_header(input);
+            assert_eq!(header.role, want_role, "role for {input:?}");
+            assert_eq!(header.channel, want_channel, "channel for {input:?}");
+            assert_eq!(header.recipient, want_recipient, "recipient for {input:?}");
+        }
+    }
+
+    /// Ported (non-streaming subset) from ollama's harmony/harmonyparser_test.go
+    /// TestHarmonyParserNonStreaming.
+    #[test]
+    fn non_streaming_events() {
+        let mut p = HarmonyParser::gpt_oss();
+        let events = p.add_content("<|start|>user<|message|>What is 2 + 2?<|end|>");
+        assert_eq!(
+            events,
+            vec![
+                HarmonyEvent::MessageStart,
+                HarmonyEvent::HeaderComplete(HarmonyHeader {
+                    role: "user".into(),
+                    channel: "".into(),
+                    recipient: "".into(),
+                }),
+                HarmonyEvent::ContentEmitted("What is 2 + 2?".into()),
+                HarmonyEvent::MessageEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_streaming_tool_call_header() {
+        let mut p = HarmonyParser::gpt_oss();
+        let events = p.add_content(
+            "<|start|>assistant<|channel|>commentary to=functions.calc<|message|>Computing...<|end|>",
+        );
+        assert_eq!(
+            events,
+            vec![
+                HarmonyEvent::MessageStart,
+                HarmonyEvent::HeaderComplete(HarmonyHeader {
+                    role: "assistant".into(),
+                    channel: "commentary".into(),
+                    recipient: "functions.calc".into(),
+                }),
+                HarmonyEvent::ContentEmitted("Computing...".into()),
+                HarmonyEvent::MessageEnd,
+            ]
+        );
+    }
+
+    #[test]
+    fn message_handler_splits_analysis_channel_into_thinking() {
+        let mut h = HarmonyMessageHandler::new();
+        let (content, thinking, _tool) = h.add_content(
+            "<|start|>assistant<|channel|>analysis<|message|>hmm, let me think<|end|>",
+        );
+        assert_eq!(thinking, "hmm, let me think");
+        assert_eq!(content, "");
+    }
+
+    #[test]
+    fn message_handler_splits_final_channel_into_content() {
+        let mut h = HarmonyMessageHandler::new();
+        let (content, thinking, _tool) =
+            h.add_content("<|start|>assistant<|channel|>final<|message|>hello there<|end|>");
+        assert_eq!(content, "hello there");
+        assert_eq!(thinking, "");
+    }
+
+    #[test]
+    fn message_handler_routes_tool_call_channel_and_drains_it() {
+        let mut h = HarmonyMessageHandler::new();
+        let (content, thinking, tool) = h.add_content(
+            "<|start|>assistant<|channel|>commentary to=functions.get_weather<|message|>{\"city\":\"SF\"}<|end|>",
+        );
+        assert_eq!(content, "");
+        assert_eq!(thinking, "");
+        assert_eq!(tool, "{\"city\":\"SF\"}");
+
+        let (name, raw) = h.drain_tool_call().expect("a tool call was accumulated");
+        assert_eq!(name, "get_weather");
+        assert_eq!(raw, "{\"city\":\"SF\"}");
+    }
+
+    #[test]
+    fn streaming_across_many_small_chunks_matches_one_big_call() {
+        let whole = "<|start|>assistant<|channel|>analysis<|message|>thinking here<|end|><|start|>assistant<|channel|>final<|message|>the answer<|end|>";
+
+        let mut one_shot = HarmonyMessageHandler::new();
+        let (c1, t1, _) = one_shot.add_content(whole);
+
+        let mut streamed = HarmonyMessageHandler::new();
+        let mut c2 = String::new();
+        let mut t2 = String::new();
+        for ch in whole.chars() {
+            let mut buf = [0u8; 4];
+            let s = ch.encode_utf8(&mut buf);
+            let (c, t, _) = streamed.add_content(s);
+            c2.push_str(&c);
+            t2.push_str(&t);
+        }
+
+        assert_eq!(c1, c2);
+        assert_eq!(t1, t2);
+        assert_eq!(c1, "the answer");
+        assert_eq!(t1, "thinking here");
+    }
+
+    #[test]
+    fn looks_like_harmony_detects_leading_tokens() {
+        assert!(looks_like_harmony("<|start|>assistant<|channel|>final"));
+        assert!(looks_like_harmony("<|channel|>analysis<|message|>hi"));
+        assert!(!looks_like_harmony("hello, how can I help?"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@ pub mod container;
 pub mod daemon;
 pub mod ffi;
 pub mod fmt;
+pub mod gguf;
+pub mod harmony;
 pub mod hf;
 pub mod hostgpu;
 pub mod llama_release;
@@ -12,6 +14,7 @@ pub mod modelpack;
 pub mod oauth;
 pub mod shortnames;
 pub mod storage;
+pub mod thinking;
 pub mod webui;
 
 use std::path::PathBuf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,14 +44,23 @@ enum Commands {
     List(cmd::list::ListArgs),
     /// List models currently loaded by a running `llmman serve`
     Ps(cmd::ps::PsArgs),
+    /// Copy a local image to a new reference
+    Cp(cmd::cp::CpArgs),
     /// Remove a local image
     Rm(cmd::rm::RmArgs),
+    /// Stop (unload) a running model
+    Stop(cmd::stop::StopArgs),
     /// Show the manifest of a local (or remote with --remote) image
     Inspect(cmd::inspect::InspectArgs),
+    /// Show a local model's architecture, parameters, license, and template
+    Show(cmd::show::ShowArgs),
     /// Start an inference server (Ollama, OpenAI, Anthropic compatible APIs)
     Serve(cmd::serve::ServeArgs),
     /// Create a new local tag pointing to an existing image
     Tag(cmd::tag::TagArgs),
+    /// Probe the local host's GPU/accelerator support (internal diagnostic)
+    #[command(hide = true)]
+    GpuDiscover(cmd::gpu_discover::GpuDiscoverArgs),
 }
 
 // ---------------------------------------------------------------------------
@@ -102,10 +111,14 @@ fn main() {
         Commands::Transfer(a) => cmd::transfer::run(a),
         Commands::List(a) => cmd::list::run(a),
         Commands::Ps(a) => cmd::ps::run(a),
+        Commands::Cp(a) => cmd::cp::run(a),
         Commands::Rm(a) => cmd::rm::run(a),
+        Commands::Stop(a) => cmd::stop::run(a),
         Commands::Inspect(a) => cmd::inspect::run(a),
+        Commands::Show(a) => cmd::show::run(a),
         Commands::Serve(a) => cmd::serve::run(a),
         Commands::Tag(a) => cmd::tag::run(a),
+        Commands::GpuDiscover(a) => cmd::gpu_discover::run(a),
     };
     if let Err(e) = result {
         eprintln!("Error: {:#}", e);

--- a/src/thinking.rs
+++ b/src/thinking.rs
@@ -1,0 +1,312 @@
+//! Native `<think>...</think>` extraction — a direct port of ollama's
+//! `thinking/parser.go`, used as a fallback when the inference backend
+//! doesn't already separate reasoning from content itself (see
+//! `cmd::serve`'s own `oai_chunk_to_content`, which prefers a backend's
+//! structured `reasoning_content`/`thinking` delta field whenever one is
+//! present and only ever falls back to this parser scanning raw `content`
+//! text for literal tag characters).
+//!
+//! Streaming-safe: [`Parser::add_content`] can be called repeatedly with
+//! small, arbitrarily-split chunks of a model's raw output (as llama-server
+//! delivers token-by-token over SSE) and always returns exactly the
+//! (thinking, content) text that's already unambiguous, buffering
+//! internally only what's still needed to disambiguate a tag that might be
+//! split across calls (e.g. one call ending in `<thi` and the next starting
+//! with `nk>`).
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    /// Looking for the opening tag; haven't seen any non-whitespace yet.
+    LookingForOpening,
+    /// Saw the opening tag; eating whitespace before the thinking content.
+    ThinkingStartedEatingWhitespace,
+    /// Inside the thinking block, haven't seen the closing tag yet.
+    Thinking,
+    /// Saw the closing tag; eating whitespace before the real content.
+    ThinkingDoneEatingWhitespace,
+    /// Closing tag seen, and at least one non-whitespace content byte too.
+    ThinkingDone,
+}
+
+/// Incremental `<think>...</think>`-style tag extractor. See the module
+/// doc comment.
+#[derive(Debug, Clone)]
+pub struct Parser {
+    state: State,
+    pub opening_tag: String,
+    pub closing_tag: String,
+    acc: String,
+}
+
+impl Parser {
+    pub fn new(opening_tag: impl Into<String>, closing_tag: impl Into<String>) -> Self {
+        Self {
+            state: State::LookingForOpening,
+            opening_tag: opening_tag.into(),
+            closing_tag: closing_tag.into(),
+            acc: String::new(),
+        }
+    }
+
+    /// Returns `(thinking, content)` — the thinking text and the
+    /// non-thinking text that should be immediately emitted to the user.
+    /// Internally buffers whatever's still needed to disambiguate a
+    /// partially-seen tag.
+    pub fn add_content(&mut self, content: &str) -> (String, String) {
+        self.acc.push_str(content);
+
+        let mut thinking_out = String::new();
+        let mut remaining_out = String::new();
+
+        loop {
+            let (thinking, remaining, keep_looping) = self.eat();
+            thinking_out.push_str(&thinking);
+            remaining_out.push_str(&remaining);
+            if !keep_looping {
+                break;
+            }
+        }
+
+        (thinking_out, remaining_out)
+    }
+
+    /// One parsing step. The returned bool is true iff the caller should
+    /// keep looping (more unambiguous progress can be made immediately
+    /// without additional input).
+    fn eat(&mut self) -> (String, String, bool) {
+        match self.state {
+            State::LookingForOpening => {
+                let trimmed = self.acc.trim_start();
+                if let Some(after_tag) = strip_all_leading_occurrences(trimmed, &self.opening_tag) {
+                    let after = after_tag.trim_start().to_string();
+                    self.acc.clear();
+                    self.acc.push_str(&after);
+                    self.state = if after.is_empty() {
+                        State::ThinkingStartedEatingWhitespace
+                    } else {
+                        State::Thinking
+                    };
+                    (String::new(), String::new(), true)
+                } else if !self.opening_tag.is_empty() && self.opening_tag.starts_with(trimmed) {
+                    // Partial opening tag seen so far — keep accumulating.
+                    (String::new(), String::new(), false)
+                } else if trimmed.is_empty() {
+                    // Whitespace only so far — keep accumulating.
+                    (String::new(), String::new(), false)
+                } else {
+                    // No opening tag: thinking was skipped entirely. Use
+                    // the *untrimmed* content — real content's own
+                    // leading whitespace must be preserved.
+                    self.state = State::ThinkingDone;
+                    let untrimmed = std::mem::take(&mut self.acc);
+                    (String::new(), untrimmed, false)
+                }
+            }
+            State::ThinkingStartedEatingWhitespace => {
+                let trimmed = self.acc.trim_start().to_string();
+                self.acc.clear();
+                if trimmed.is_empty() {
+                    (String::new(), String::new(), false)
+                } else {
+                    self.state = State::Thinking;
+                    self.acc.push_str(&trimmed);
+                    (String::new(), String::new(), true)
+                }
+            }
+            State::Thinking => {
+                let acc = self.acc.clone();
+                if let Some(pos) = acc.find(&self.closing_tag) {
+                    let thinking = acc[..pos].to_string();
+                    let remaining = acc[pos + self.closing_tag.len()..].to_string();
+                    let remaining = remaining.trim_start().to_string();
+                    self.acc.clear();
+                    self.state = if remaining.is_empty() {
+                        State::ThinkingDoneEatingWhitespace
+                    } else {
+                        State::ThinkingDone
+                    };
+                    (thinking, remaining, false)
+                } else {
+                    let overlap_len = overlap(&acc, &self.closing_tag);
+                    if overlap_len > 0 {
+                        let split = acc.len() - overlap_len;
+                        let thinking = acc[..split].to_string();
+                        let remaining = acc[split..].to_string();
+                        self.acc.clear();
+                        self.acc.push_str(&remaining);
+                        (thinking, String::new(), false)
+                    } else {
+                        self.acc.clear();
+                        (acc, String::new(), false)
+                    }
+                }
+            }
+            State::ThinkingDoneEatingWhitespace => {
+                let trimmed = self.acc.trim_start().to_string();
+                self.acc.clear();
+                if !trimmed.is_empty() {
+                    self.state = State::ThinkingDone;
+                }
+                (String::new(), trimmed, false)
+            }
+            State::ThinkingDone => {
+                let acc = std::mem::take(&mut self.acc);
+                (String::new(), acc, false)
+            }
+        }
+    }
+}
+
+/// Mirrors Go's `strings.Join(strings.Split(trimmed, tag)[1:], tag)`:
+/// if `trimmed` starts with `tag`, returns everything after the *first*
+/// occurrence (any further occurrences of `tag` inside are left intact,
+/// unlike a plain `strip_prefix`, which behaves identically for a single
+/// occurrence but this makes the equivalence to the Go split/join
+/// explicit). `None` if `trimmed` doesn't start with `tag`.
+fn strip_all_leading_occurrences<'a>(trimmed: &'a str, tag: &str) -> Option<&'a str> {
+    if tag.is_empty() {
+        return None;
+    }
+    trimmed.strip_prefix(tag)
+}
+
+/// Longest overlap between a suffix of `s` and a prefix of `delim`.
+fn overlap(s: &str, delim: &str) -> usize {
+    let max = delim.len().min(s.len());
+    for i in (1..=max).rev() {
+        if s.ends_with(&delim[..i]) {
+            return i;
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parser() -> Parser {
+        Parser::new("<think>", "</think>")
+    }
+
+    /// Ported from ollama's thinking/parser_test.go TestExtractThinking.
+    #[test]
+    fn extract_thinking_whole_string_at_once() {
+        let cases = [
+            ("<think> internal </think> world", "internal ", "world"),
+            (
+                "<think>a</think><think>b</think>c",
+                "a",
+                "<think>b</think>c",
+            ),
+            ("no think", "", "no think"),
+        ];
+        for (input, want_think, want_content) in cases {
+            let mut p = parser();
+            let (thinking, content) = p.add_content(input);
+            assert_eq!(thinking, want_think, "thinking for {input:?}");
+            assert_eq!(content, want_content, "content for {input:?}");
+        }
+    }
+
+    /// Ported from ollama's thinking/parser_test.go TestThinkingStreaming.
+    #[test]
+    fn thinking_streaming_token_by_token() {
+        let mut p = parser();
+        let steps: &[(&str, &str, &str, State)] = &[
+            ("<think>", "", "", State::ThinkingStartedEatingWhitespace),
+            ("\n", "", "", State::ThinkingStartedEatingWhitespace),
+            ("</think>", "", "", State::ThinkingDoneEatingWhitespace),
+            ("\n\n", "", "", State::ThinkingDoneEatingWhitespace),
+            ("Hi", "", "Hi", State::ThinkingDone),
+            (" there", "", " there", State::ThinkingDone),
+        ];
+        for (input, want_thinking, want_content, want_state) in steps {
+            let (thinking, content) = p.add_content(input);
+            assert_eq!(&thinking, want_thinking, "thinking for {input:?}");
+            assert_eq!(&content, want_content, "content for {input:?}");
+            assert_eq!(p.state, *want_state, "state after {input:?}");
+        }
+    }
+
+    #[test]
+    fn content_without_a_thinking_tag_passes_through_untouched() {
+        let mut p = parser();
+        let (thinking, content) = p.add_content("  abc");
+        assert_eq!(thinking, "");
+        assert_eq!(content, "  abc");
+        assert_eq!(p.state, State::ThinkingDone);
+
+        // Regression: must not re-emit the first chunk.
+        let (thinking, content) = p.add_content("def");
+        assert_eq!(thinking, "");
+        assert_eq!(content, "def");
+    }
+
+    #[test]
+    fn content_before_a_thinking_tag_nerfs_it() {
+        let mut p = parser();
+        let (thinking, content) = p.add_content("  abc <think>def</think> ghi");
+        assert_eq!(thinking, "");
+        assert_eq!(content, "  abc <think>def</think> ghi");
+    }
+
+    #[test]
+    fn partial_opening_tag_builds_up_across_calls() {
+        let mut p = parser();
+        assert_eq!(p.add_content("  <th"), ("".into(), "".into()));
+        assert_eq!(p.state, State::LookingForOpening);
+        assert_eq!(p.add_content("in"), ("".into(), "".into()));
+        assert_eq!(p.state, State::LookingForOpening);
+        assert_eq!(p.add_content("k>a"), ("a".into(), "".into()));
+        assert_eq!(p.state, State::Thinking);
+    }
+
+    #[test]
+    fn partial_closing_tag_fakeout_recovers() {
+        let mut p = parser();
+        assert_eq!(p.add_content("<think>abc</th"), ("abc".into(), "".into()));
+        assert_eq!(p.state, State::Thinking);
+        // "</thing>" looked like a closing tag was starting but wasn't.
+        assert_eq!(p.add_content("ing>def"), ("</thing>def".into(), "".into()));
+        assert_eq!(p.state, State::Thinking);
+        assert_eq!(p.add_content("ghi</thi"), ("ghi".into(), "".into()));
+        assert_eq!(p.add_content("nk>jkl"), ("".into(), "jkl".into()));
+        assert_eq!(p.state, State::ThinkingDone);
+    }
+
+    #[test]
+    fn whitespace_after_closing_tag_is_eaten() {
+        let mut p = parser();
+        let (thinking, content) = p.add_content("  <think>abc</think>\n\ndef");
+        assert_eq!(thinking, "abc");
+        assert_eq!(content, "def");
+    }
+
+    #[test]
+    fn leading_thinking_whitespace_is_eaten_but_inner_preserved() {
+        let mut p = parser();
+        assert_eq!(p.add_content("  <think>   \t "), ("".into(), "".into()));
+        assert_eq!(p.state, State::ThinkingStartedEatingWhitespace);
+        assert_eq!(
+            p.add_content("  these are some "),
+            ("these are some ".into(), "".into())
+        );
+        assert_eq!(
+            p.add_content("thoughts </think>  "),
+            ("thoughts ".into(), "".into())
+        );
+        assert_eq!(p.state, State::ThinkingDoneEatingWhitespace);
+        assert_eq!(
+            p.add_content("  more content"),
+            ("".into(), "more content".into())
+        );
+    }
+
+    #[test]
+    fn overlap_finds_longest_suffix_prefix_match() {
+        assert_eq!(overlap("abc</thi", "</think>"), 5);
+        assert_eq!(overlap("abcdef", "</think>"), 0);
+        assert_eq!(overlap("", "</think>"), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Ports several ollama-parity features that llmman was missing:

- **`llmman cp SOURCE DESTINATION`** — copies a local image under a new reference (same underlying operation as `tag`, just named/shaped like `ollama cp`).
- **`llmman stop MODEL`** — unloads a running model on demand, using the existing Ollama `keep_alive: 0` unload sentinel `handle_ollama_generate` already understands. Errors like `ollama stop` when the model isn't currently loaded.
- **`llmman show MODEL`** — architecture, parameter count, context length, quantization, license, and chat template for a locally stored model. Backed by a new minimal GGUF header reader (`src/gguf.rs`, metadata + tensor-info only, never tensor data) plus `config.json`/`tokenizer_config.json` reading for safetensors models. Supports `--license`/`--template`/`--parameters`/`--verbose`.
- **`llmman gpu-discover`** (hidden from `--help`, like ollama's own) — standalone entry point for the accelerator probe `llmman serve` already runs internally.
- **`src/thinking.rs`** — faithful port of ollama's `thinking/parser.go`: incremental, streaming-safe `<think>...</think>` extraction.
- **`src/harmony.rs`** — port of ollama's `harmony/harmonyparser.go`: the gpt-oss-style `<|start|>...<|channel|>...<|message|>...<|end|>` channel parser, plus a higher-level message handler splitting analysis/commentary/final channels into content/thinking/tool buckets.

The two parsers are wired into `cmd::serve`'s `/api/chat`/`/api/generate` streaming pipeline as a `RawContentExtractor` fallback: only engaged when a backend hands back raw, unparsed special tokens in `content` instead of already splitting them into a structured `reasoning_content`/`thinking` delta field (the existing, preferred path) — and once a backend has ever supplied structured thinking on a stream, the fallback is permanently disabled for the rest of it.

llmman already has `login`/`logout` (registry/HuggingFace credentials, same shape as `docker login`/`docker logout`), so no separate identity-keypair command is added here.

Also adds `fmt::human_count` and updates the README's command table.

## Review feedback addressed

- `RawContentExtractor` now buffers raw content until its mode is unambiguous (rather than guessing from a single, possibly one-byte chunk), correctly primes the harmony parser for a stream that starts mid-message at `<|channel|>`, and flushes any still-buffered prefix once the stream ends.
- `gguf.rs` bounds array-nesting recursion depth (avoids a stack overflow on a malformed file) and sums per-type element counts with saturating arithmetic (avoids an overflow panic).
- `show.rs` truncates long metadata on a UTF-8 char boundary (fixes a panic on non-ASCII metadata), no longer aborts the whole command when GGUF metadata is unreadable, and implements the `general.license*` GGUF fallback its own doc comment described.

## Testing

- `cargo build` / `cargo build --release` — clean, no new warnings.
- `cargo test --lib` — all green, including new regression tests for every fix above.
- `cargo fmt --check` — clean.
- Manual smoke tests: `gpu-discover`, `stop`/`cp`/`show` error paths, and a non-ASCII GGUF metadata file confirming the truncation fix no longer panics.