### PR TITLE
fix(build): name the CGO shim archive libNAME.a on windows-gnu, not NAME.lib

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -111,6 +111,7 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let shim_dir = manifest_dir.join("go-shim");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
 
     // Determine backend build tags from Cargo features.
     // For the podman backend we add two extra tags to avoid pulling in C library
@@ -127,7 +128,14 @@ fn main() {
 
     // Always build natively — each platform's CI runner builds its own binary.
     // CGO requires the host C toolchain, which is always present on native runners.
-    let lib_name = if target_os == "windows" {
+    //
+    // Only *-pc-windows-msvc uses the MSVC "NAME.lib" naming; *-pc-windows-gnu
+    // is a GNU-ABI target like Linux/macOS and needs "libNAME.a". The final
+    // link step (mingw's ld) tolerates either name on a GNU target, but the
+    // `llmman` lib crate's own compilation checks a `#[link(kind =
+    // "static")]` dependency's presence itself first, by each target's
+    // canonical name, with no such leniency.
+    let lib_name = if target_os == "windows" && target_env == "msvc" {
         "llmman_shim.lib"
     } else {
         "libllmman_shim.a"


### PR DESCRIPTION
## Summary

`x86_64-pc-windows-gnu` (mingw) cross-compiles have been broken since #272
added a `[lib]` target to `Cargo.toml`:

```
error: could not find native static library `llmman_shim`, perhaps an -L flag is missing?
```

## Why

`build.rs` names the CGO shim archive `llmman_shim.lib` (MSVC convention)
for every `target_os == "windows"`, `libllmman_shim.a` (GNU convention)
otherwise. That was tolerated on `windows-gnu` because the final link step
(mingw's `ld`) accepts either name — verified directly, `-lfoo` finds a
plain `foo.lib` file just fine there.

`#272`'s `[lib]` target changes that: cargo now also compiles `llmman` as
its own rlib, and *that* compilation checks a `#[link(kind = "static")]`
dependency's presence itself, using each target's canonical static-lib
name, before the final binary link ever runs. That check has none of the
final linker's leniency, so it fails to find `llmman_shim.lib` under the
name it expects (`libllmman_shim.a`) on a GNU-ABI target — even though the
file exists right there in the `-L` search path.

Fix: only use the MSVC name when `target_env == "msvc"`; `windows-gnu`
gets `libllmman_shim.a` like every other GNU-ABI target (Linux, macOS).
`windows-msvc` (including the ARM64 `lib.exe` repack path right below) is
untouched.

## Testing

- `cargo build --lib --bin llmman`, `cargo test --lib` (161 passed),
  `cargo fmt --check`, `cargo clippy --lib --bin llmman --all-features`
  (no new warnings).
- Reproduced the failure and verified the fix in a `debian:bookworm` +
  `gcc-mingw-w64-x86-64` + `rustup stable` container matching
  docker/sandboxes' own Dockerfile: fails cross-compiling
  `x86_64-pc-windows-gnu` at the current pin (`5a266b6`), succeeds with
  this fix on top.
- Bisected against the old pin (`5047ea3`, pre-`[lib]` target) to confirm
  it built fine there, isolating the regression to `#272`'s `[lib]`
  target rather than this naming logic itself (present, unexercised,
  since the crate's very first commit).

Fixes docker/sandboxes#5317's `build-binaries (release, windows/amd64)`
CI job.

```release-note
NONE
```
