### PR TITLE
fix(go-shim): always send a Range header on HF file GETs

### DIFF
--- a/go-shim/hf.go
+++ b/go-shim/hf.go
@@ -1028,9 +1028,12 @@ func downloadAttempt(ctx context.Context, client *http.Client, url, token, layou
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	if startOffset > 0 {
-		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", startOffset))
-	}
+	// Always send a Range header, even for a fresh download at byte 0 —
+	// some HF CDNs (seen on a CloudFront/S3-fronted Xet-CAS bridge) 400 a
+	// full-object GET with no Range at all past a few tens of GB, which
+	// isHTTP4xx treats as permanent, so every retry just repeats the same
+	// failure. The same origin serves "bytes=0-" fine as a 206.
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-", startOffset))
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/go-shim/hf_range_get_test.go
+++ b/go-shim/hf_range_get_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// cloudFrontLikeServer mimics the real CloudFront/S3-fronted HF Xet-CAS
+// bridge behavior for a large file: a GET with no Range header 400s;
+// "Range: bytes=0-" (the whole file, phrased as a range) gets a 206.
+func cloudFrontLikeServer(t *testing.T, body []byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") != "bytes=0-" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(body)
+	}))
+}
+
+func TestDownloadAttemptSendsRangeHeaderOnFreshDownload(t *testing.T) {
+	want := []byte("pretend this is a multi-gigabyte gguf shard")
+	srv := cloudFrontLikeServer(t, want)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	tmpPath := filepath.Join(dir, "download.part")
+	file := hfFile{Path: "model-Q4_K_M.gguf", Size: int64(len(want))}
+
+	// ProxyReader (used by proxyOrNop) panics on a nil receiver, so this
+	// needs a real (if throwaway) bar rather than nil.
+	prog := newProgressPool(40)
+	bar := addLayerBar(prog, "test", "test done", file.Size, "")
+
+	desc, err := downloadAttempt(context.Background(), hfDownloadClient(), srv.URL, "", dir, tmpPath, 0, file, bar, "")
+	if err != nil {
+		bar.Abort(false) // avoid hanging prog.Wait() below on a never-completed bar
+		prog.Wait()
+		t.Fatalf("downloadAttempt: %v (fresh downloads must send Range too, not just resumes)", err)
+	}
+	prog.Wait()
+
+	got, err := os.ReadFile(filepath.Join(dir, "blobs", desc.Digest.Algorithm().String(), desc.Digest.Hex()))
+	if err != nil {
+		t.Fatalf("reading downloaded blob: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("downloaded content = %q, want %q", got, want)
+	}
+}
+
+func TestHFGetBytesSendsRangeHeaderOnFreshDownload(t *testing.T) {
+	want := []byte("pretend this is a small config.json fetched through the same bug-prone path")
+	srv := cloudFrontLikeServer(t, want)
+	defer srv.Close()
+
+	prog := newProgressPool(40)
+	bar := addLayerBar(prog, "test", "test done", int64(len(want)), "")
+
+	got, err := hfGetBytes(context.Background(), hfDownloadClient(), srv.URL, "", bar)
+	if err != nil {
+		bar.Abort(false)
+		prog.Wait()
+		t.Fatalf("hfGetBytes: %v (must send Range even for a fresh, whole-file request)", err)
+	}
+	prog.Wait()
+
+	if string(got) != string(want) {
+		t.Errorf("hfGetBytes = %q, want %q", got, want)
+	}
+}

--- a/go-shim/transfer_docker.go
+++ b/go-shim/transfer_docker.go
@@ -473,6 +473,11 @@ func streamHFGet(ctx context.Context, client *http.Client, url, token string, pu
 		if token != "" {
 			req.Header.Set("Authorization", "Bearer "+token)
 		}
+		// See downloadAttempt's identical header in hf.go: some HF CDNs
+		// 400 a full-object GET with no Range at all past a few tens of
+		// GB, which isHTTP4xx treats as permanent — every retry would
+		// just repeat the same failure otherwise.
+		req.Header.Set("Range", "bytes=0-")
 		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
@@ -495,12 +500,15 @@ func hfGetBytes(ctx context.Context, client *http.Client, url, token string, bar
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
+	// See streamHFGet's identical header — simpler to always send this
+	// than to branch by file size.
+	req.Header.Set("Range", "bytes=0-")
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 200 && resp.StatusCode != 206 {
 		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
 	}
 	sr := newStallReadCloser(resp.Body, dlStallTimeout, cancel)


### PR DESCRIPTION
Some HF CDNs (seen on a CloudFront/S3-fronted Xet-CAS bridge) reject a full-object GET with no `Range` header at all once the file crosses a few tens of GB, returning HTTP 400:

```
$ curl -sL -o /dev/null -w '%{http_code}\n' '.../Ornith-1.5-397B-Q4_K_M.gguf'
400
$ curl -sL -o /dev/null -w '%{http_code}\n' -H 'Range: bytes=0-1023' '.../Ornith-1.5-397B-Q4_K_M.gguf'
206
```

`isHTTP4xx` treats 400 as permanent, but every retry re-sent the identical unranged request, so it failed the same way every time — this broke every `ornith-1.5/397b-*` transfer in `docker/llmman-publisher`'s scheduled run.

`downloadAttempt` (`hf.go`) already sent `Range` on a resumed download but skipped it on the first attempt; `streamHFGet`/`hfGetBytes` (`transfer_docker.go`) never sent one at all. All three now always send `Range: bytes=<offset>-` (`bytes=0-` fresh). `hfGetBytes` also now accepts `206`, not just `200`.

## Testing

`go-shim/hf_range_get_test.go`: a local `httptest` server reproducing the observed 400-without-Range/206-with-Range behavior, for both `downloadAttempt` and `hfGetBytes`. Fails on pre-fix code, passes after.

```
go test -run 'TestDownloadAttemptSendsRangeHeaderOnFreshDownload|TestHFGetBytesSendsRangeHeaderOnFreshDownload' -v ./go-shim/...
```