### PR TITLE
fix(go-shim): honor a 429's Retry-After header when retrying

### DIFF
--- a/go-shim/hf.go
+++ b/go-shim/hf.go
@@ -354,7 +354,7 @@ func hfGet(ctx context.Context, client *http.Client, url, token string, dst any)
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
-			return fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+			return newHTTPStatusError("GET "+url, resp)
 		}
 		body, err = io.ReadAll(resp.Body)
 		return err
@@ -971,6 +971,9 @@ func downloadHFBlobAttempts(ctx context.Context, client *http.Client, url, token
 	for attempt := 0; attempt < dlMaxAttempts; attempt++ {
 		if attempt > 0 {
 			delay := retryDelay(attempt)
+			if ra, ok := retryAfter(lastErr); ok {
+				delay = ra
+			}
 			fmt.Fprintf(os.Stderr, "\n[llmman] retrying %s (attempt %d/%d, wait %v)\n",
 				filepath.Base(file.Path), attempt+1, dlMaxAttempts, delay)
 			select {
@@ -1042,7 +1045,7 @@ func downloadAttempt(ctx context.Context, client *http.Client, url, token, layou
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 && resp.StatusCode != 206 {
-		return ocispec.Descriptor{}, fmt.Errorf("download %s: HTTP %d", file.Path, resp.StatusCode)
+		return ocispec.Descriptor{}, newHTTPStatusError("download "+file.Path, resp)
 	}
 	if startOffset > 0 && resp.StatusCode == 200 {
 		// Server ignored Range header — restart from zero.

--- a/go-shim/retry_after_test.go
+++ b/go-shim/retry_after_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfterDelaySeconds(t *testing.T) {
+	cases := []struct {
+		name    string
+		header  string
+		wantDur time.Duration
+		wantOK  bool
+	}{
+		{"absent", "", 0, false},
+		{"typical", "30", 30 * time.Second, true},
+		{"zero is a valid, distinct result (retry immediately)", "0", 0, true},
+		{"negative", "-5", 0, false},
+		{"whitespace", "  12  ", 12 * time.Second, true},
+		{"huge value is capped, not left to overflow", "999999999999", retryAfterCap, true},
+		{"http-date form is not supported (matches huggingface_hub)", "Wed, 21 Oct 2015 07:28:00 GMT", 0, false},
+		{"garbage", "soon", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := http.Header{}
+			if c.header != "" {
+				h.Set("Retry-After", c.header)
+			}
+			gotDur, gotOK := parseRetryAfter(h)
+			if gotDur != c.wantDur || gotOK != c.wantOK {
+				t.Errorf("parseRetryAfter(%q) = (%v, %v), want (%v, %v)", c.header, gotDur, gotOK, c.wantDur, c.wantOK)
+			}
+		})
+	}
+}
+
+func TestRetryAfterFromError(t *testing.T) {
+	if _, ok := retryAfter(nil); ok {
+		t.Error("retryAfter(nil) ok = true, want false")
+	}
+	if _, ok := retryAfter(errors.New("plain error, not an httpStatusError")); ok {
+		t.Error("retryAfter(plain error) ok = true, want false")
+	}
+
+	resp := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"7"}}}
+	err := newHTTPStatusError("GET https://example.com/f", resp)
+	if got, ok := retryAfter(err); !ok || got != 7*time.Second {
+		t.Errorf("retryAfter(429 w/ Retry-After: 7) = (%v, %v), want (7s, true)", got, ok)
+	}
+	// err.Error() must still contain the "HTTP <code>" substring isHTTP4xx greps for.
+	if want := "GET https://example.com/f: HTTP 429"; err.Error() != want {
+		t.Errorf("err.Error() = %q, want %q", err.Error(), want)
+	}
+
+	// Wrapped (via %w) errors must still be found by errors.As.
+	wrapped := errWrap{err}
+	if got, ok := retryAfter(wrapped); !ok || got != 7*time.Second {
+		t.Errorf("retryAfter(wrapped) = (%v, %v), want (7s, true)", got, ok)
+	}
+
+	// A zero Retry-After ("retry immediately") must not be mistaken for "absent".
+	zeroResp := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": []string{"0"}}}
+	zeroErr := newHTTPStatusError("GET https://example.com/f", zeroResp)
+	if got, ok := retryAfter(zeroErr); !ok || got != 0 {
+		t.Errorf("retryAfter(Retry-After: 0) = (%v, %v), want (0, true)", got, ok)
+	}
+}
+
+// errWrap is a minimal error wrapper (like fmt.Errorf("...: %w", err))
+// confirming retryAfter's errors.As unwraps through one level.
+type errWrap struct{ err error }
+
+func (e errWrap) Error() string { return "wrapped: " + e.err.Error() }
+func (e errWrap) Unwrap() error { return e.err }
+
+// TestRetryStreamHonorsRetryAfterOverExponentialBackoff confirms
+// retryStream waits the server-specified duration on a 429 instead of
+// the usual exponential backoff (~0.75-1.25s for the first retry), by
+// using a Retry-After short enough (100ms) to tell the two apart.
+func TestRetryStreamHonorsRetryAfterOverExponentialBackoff(t *testing.T) {
+	attempts := 0
+	start := time.Now()
+	err := retryStream(context.Background(), "test", isHTTP4xx, func() error {
+		attempts++
+		if attempts == 1 {
+			return &httpStatusError{
+				prefix: "GET https://example.com/f", statusCode: 429,
+				retryAfter: 100 * time.Millisecond, hasRetryAfter: true,
+			}
+		}
+		return nil
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("retryStream: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("elapsed = %v, want well under ~0.75-1.25s — retryStream doesn't appear to be honoring Retry-After", elapsed)
+	}
+}

--- a/go-shim/shared_oci.go
+++ b/go-shim/shared_oci.go
@@ -5,12 +5,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -391,6 +394,72 @@ func (sw *stallWriter) finalSpeed() float64 {
 	return float64(sw.total) / elapsed
 }
 
+// httpStatusError wraps a non-2xx HTTP response so retryStream can react
+// to more than just "was this permanent" (isHTTP4xx's job): specifically,
+// a server-supplied Retry-After (RFC 9110 §10.2.3), mirroring
+// huggingface_hub's own handling of it on a 429 (utils/_http.py
+// _http_backoff_base). Its Error() string preserves the exact
+// "<prefix>: HTTP <code>" shape every existing fmt.Errorf(...) call site
+// already produced, including the substring isHTTP4xx greps for.
+type httpStatusError struct {
+	prefix        string
+	statusCode    int
+	retryAfter    time.Duration // valid only if hasRetryAfter
+	hasRetryAfter bool
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("%s: HTTP %d", e.prefix, e.statusCode)
+}
+
+// newHTTPStatusError builds an httpStatusError for a non-2xx resp, with
+// prefix reproducing what the call site's own fmt.Errorf used to put
+// before "HTTP %d" (e.g. "GET https://...", "download foo.gguf").
+func newHTTPStatusError(prefix string, resp *http.Response) error {
+	e := &httpStatusError{prefix: prefix, statusCode: resp.StatusCode}
+	e.retryAfter, e.hasRetryAfter = parseRetryAfter(resp.Header)
+	return e
+}
+
+// retryAfterCap bounds how long retryStream will ever honor a
+// server-supplied Retry-After for. huggingface_hub trusts it completely
+// (sleeps exactly that long — see _http_backoff_base); here, an
+// unbounded wait on one blob could eat most of a CI job's own time
+// budget (e.g. llmman-publisher's transfer.yml 360-minute ceiling), so
+// this caps it well short of that instead.
+const retryAfterCap = 5 * time.Minute
+
+// parseRetryAfter parses a Retry-After header's delay-seconds form (e.g.
+// "Retry-After: 30"), reporting ok=false if the header is absent,
+// negative, or malformed. Doesn't parse the HTTP-date form
+// ("Wed, 21 Oct 2015 07:28:00 GMT") — huggingface_hub's own
+// _parse_retry_after doesn't either, and every 429 seen from
+// huggingface.co uses delay-seconds. Caps secs before converting to a
+// Duration so an absurd value (e.g. 1e18) can't overflow int64 nanoseconds.
+func parseRetryAfter(h http.Header) (d time.Duration, ok bool) {
+	secs, err := strconv.Atoi(strings.TrimSpace(h.Get("Retry-After")))
+	if err != nil || secs < 0 {
+		return 0, false
+	}
+	if capSecs := int(retryAfterCap / time.Second); secs > capSecs {
+		secs = capSecs
+	}
+	return time.Duration(secs) * time.Second, true
+}
+
+// retryAfter returns the Retry-After duration attached to err by
+// newHTTPStatusError, or (0, false) if err isn't one of those (including
+// err == nil, on retryStream's very first attempt). A zero-second
+// Retry-After ("retry immediately") is a valid, distinct result — hence
+// the separate ok, rather than overloading 0 to also mean "absent".
+func retryAfter(err error) (time.Duration, bool) {
+	var hse *httpStatusError
+	if !errors.As(err, &hse) || !hse.hasRetryAfter {
+		return 0, false
+	}
+	return hse.retryAfter, true
+}
+
 // isHTTP4xx returns true for permanent HTTP client errors (no point retrying).
 func isHTTP4xx(err error) bool {
 	if err == nil {
@@ -406,20 +475,24 @@ func isHTTP4xx(err error) bool {
 }
 
 // retryStream calls attempt up to dlMaxAttempts times with exponential
-// backoff (2s, 4s, ...) between tries, stopping immediately (no further
-// retries) once isPermanent reports the most recent error isn't worth
-// retrying (e.g. a 404 — see isHTTP4xx). Every attempt is expected to
-// restart its work entirely from scratch: unlike downloadHFBlob's local
-// .part-file resume, there's no partial state to pick up from here (see
-// the callers' own comments for why) — this only saves the operator from
-// having to notice a transient failure and manually re-run the whole
-// command, it doesn't avoid re-sending bytes a failed attempt already
-// sent.
+// backoff (2s, 4s, ...) between tries — or the previous attempt's
+// Retry-After (capped at retryAfterCap), if it had one — stopping
+// immediately (no further retries) once isPermanent reports the most
+// recent error isn't worth retrying (e.g. a 404 — see isHTTP4xx). Every
+// attempt is expected to restart its work entirely from scratch: unlike
+// downloadHFBlob's local .part-file resume, there's no partial state to
+// pick up from here (see the callers' own comments for why) — this only
+// saves the operator from having to notice a transient failure and
+// manually re-run the whole command, it doesn't avoid re-sending bytes a
+// failed attempt already sent.
 func retryStream(ctx context.Context, label string, isPermanent func(error) bool, attempt func() error) error {
 	var lastErr error
 	for i := 0; i < dlMaxAttempts; i++ {
 		if i > 0 {
 			delay := retryDelay(i)
+			if ra, ok := retryAfter(lastErr); ok {
+				delay = ra
+			}
 			fmt.Fprintf(os.Stderr, "\n[llmman] retrying %s (attempt %d/%d, wait %v)\n", label, i+1, dlMaxAttempts, delay)
 			select {
 			case <-ctx.Done():

--- a/go-shim/transfer_docker.go
+++ b/go-shim/transfer_docker.go
@@ -484,7 +484,7 @@ func streamHFGet(ctx context.Context, client *http.Client, url, token string, pu
 		}
 		if resp.StatusCode != 200 && resp.StatusCode != 206 {
 			resp.Body.Close()
-			return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+			return nil, newHTTPStatusError("GET "+url, resp)
 		}
 		return newStallReadCloser(resp.Body, dlStallTimeout, cancel), nil
 	})
@@ -509,7 +509,7 @@ func hfGetBytes(ctx context.Context, client *http.Client, url, token string, bar
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 && resp.StatusCode != 206 {
-		return nil, fmt.Errorf("GET %s: HTTP %d", url, resp.StatusCode)
+		return nil, newHTTPStatusError("GET "+url, resp)
 	}
 	sr := newStallReadCloser(resp.Body, dlStallTimeout, cancel)
 	defer sr.Close()


### PR DESCRIPTION
`retryStream`/`downloadHFBlobAttempts` always used a fixed exponential backoff (~2 minutes total across 8 attempts) regardless of what the server said, even on a 429. HuggingFace's anonymous rate-limit window can outlast that budget, so a rate-limited request exhausted every retry and failed before the limit actually lifted — this is what took down `laguna-s-2.1/bf16` in [docker/llmman-publisher run 32801621593](https://github.com/docker/llmman-publisher/actions/runs/32801621593).

`huggingface_hub`'s own client parses `Retry-After` on a 429 and waits exactly that long instead of guessing. This mirrors that:

- Every `"...: HTTP %d"` error built from a `*http.Response` now goes through `newHTTPStatusError` (`shared_oci.go`), which captures `Retry-After` via `parseRetryAfter` (delay-seconds form only, matching `huggingface_hub`'s own restriction).
- `retryStream` and `downloadHFBlobAttempts`'s own retry loop both use that duration for their next wait instead of exponential backoff, when present — including a valid `Retry-After: 0`, kept distinct from "absent" via an explicit `ok` bool rather than overloading zero.
- Capped at 5 minutes so one blob can't eat a CI job's whole time budget; the cap is applied before converting to a `Duration` so an absurd header value can't overflow int64 nanoseconds.
- `httpStatusError.Error()` preserves the exact `"HTTP <code>"` substring `isHTTP4xx` already greps for, so this is behavior-neutral elsewhere.

## Testing

`go-shim/retry_after_test.go` covers parsing (including zero and the overflow-capped case), `errors.As` unwrapping through a wrapped error, and an end-to-end `retryStream` run confirming it actually waits the server-specified duration.

```
go test -run 'TestParseRetryAfterDelaySeconds|TestRetryAfterFromError|TestRetryStreamHonorsRetryAfterOverExponentialBackoff' -v ./go-shim/...
```