### PR TITLE
fix(vllm-plugin): use bfloat16, not float16, in the vllm serve e2e test

### DIFF
--- a/vllm-plugin/tests/test_e2e.py
+++ b/vllm-plugin/tests/test_e2e.py
@@ -242,11 +242,13 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
     real `ModelConfig` for an `oci://` reference during vLLM's own
     startup is what triggers the pull.
 
-    `--dtype float16`: the one dtype vLLM's CPU platform supports on
-    every OS in ci.yml's matrix (bf16 isn't supported on macOS CPU).
-    `--enforce-eager`: skips CUDA-graph startup work that doesn't apply
-    on CPU. `--max-model-len 1024`: bounds the CPU KV-cache for this
-    test's tiny prompt/reply.
+    `--dtype bfloat16`: MODEL_SAFETENSORS' own native dtype, and a hard
+    requirement, not just a preference — Qwen3.5's CPU Gated DeltaNet
+    kernel asserts BF16 input and crashes on any real forward pass with
+    float16 (which still loads and passes `/health` fine). `--enforce-
+    eager`: skips CUDA-graph startup work that doesn't apply on CPU.
+    `--max-model-len 1024`: bounds the CPU KV-cache for this test's
+    tiny prompt/reply.
     """
     pytest.importorskip("vllm")
     binary = shutil.which("vllm")
@@ -267,7 +269,7 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
         "--port",
         str(port),
         "--dtype",
-        "float16",
+        "bfloat16",
         "--enforce-eager",
         "--max-model-len",
         "1024",
@@ -296,7 +298,15 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
 
     try:
         _wait_for_health(port, VLLM_STARTUP_TIMEOUT, proc, log_path)
-        reply = _chat(port, PROMPT)
+        try:
+            reply = _chat(port, PROMPT)
+        except Exception as e:
+            # Unlike _wait_for_health, urlopen's own errors carry no
+            # server-side context — attach the log tail like it does.
+            pytest.fail(
+                f"chat request to vllm serve failed: {e!r}\n"
+                f"--- {log_path} tail ---\n{_tail(log_path)}"
+            )
         assert "pong" in reply.lower(), (
             f'expected the served model\'s reply to contain "pong", got: {reply!r}\n'
             f"--- {log_path} tail ---\n{_tail(log_path)}"


### PR DESCRIPTION
## Summary

main's CI has been red on every commit since #274 introduced this test: every Linux lane fails `pytest -m e2e` with a 500 from the test's own chat request.

## Root cause

Reproduced locally end-to-end (real vLLM 0.27.1 CPU wheel + real `qwen3.5:0.8b-safetensors` weights, no mocks): the server starts fine with `--dtype float16`, but the first real chat request crashes vLLM's engine with `AssertionError: CPU GDN attention requires BF16.` Qwen3.5 is a hybrid linear-attention (Gated DeltaNet) architecture, and vLLM's CPU kernel for it hard-requires BF16. The model's own `config.json` already declares `"dtype": "bfloat16"` — float16 was just an untested guess.

## Fix

- `--dtype float16` → `--dtype bfloat16`. Confirmed fixed by running the real test against a real `vllm serve` subprocess — it now passes and returns `"pong"`.
- Attaches the `vllm serve` log tail to the test's `_chat()` failures too (like `_wait_for_health` already does), so a future regression here doesn't surface as a bare, context-free `HTTPError`.

## Testing

- `py_compile` + `ruff check`.
- Full non-e2e `vllm-plugin` suite (23 passed, 1 skipped, 4 deselected).
- The real previously-failing e2e test, run for real: throwaway Linux container, real vLLM CPU wheel, real weights pulled via `crane`, stubbed only `llmman resolve`'s output — passes in 44s.