### PR TITLE
fix(vllm-plugin): use vllm-metal's Metal GPU on macOS e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,14 @@ env:
   # than each duplicating the full "llama-<release>-bin-..." filename
   # independently.
   LLAMA_CPP_RELEASE: b10293
-  # vLLM version the e2e job's "Install vLLM (CPU, e2e)" step installs,
-  # for vllm-plugin/tests/test_e2e.py's real `vllm serve` test.
+  # vLLM version the e2e job's "Install vLLM (e2e)" step installs, for
+  # vllm-plugin/tests/test_e2e.py's real `vllm serve` test.
   VLLM_VERSION: "0.27.1"
+  # vllm-metal (github.com/vllm-project/vllm-metal), macOS's Metal-GPU
+  # vLLM platform below, has no stable release channel — only several-
+  # a-day nightlies — so this pins one verified build instead of
+  # floating on "latest" in a release-gating job. Bump deliberately.
+  VLLM_METAL_VERSION: "0.3.0.dev20260825040033"
 
 jobs:
   build:
@@ -299,7 +304,8 @@ jobs:
   #
   # Also runs vllm-plugin/tests/test_e2e.py (Linux x86_64/aarch64 and
   # macOS aarch64, both `matrix.backend` entries) against this job's own
-  # installed `llmman` binary and a real (CPU-only) `vllm serve`.
+  # installed `llmman` binary and a real `vllm serve` — CPU-only on
+  # Linux, Metal-GPU-backed (via vllm-metal) on macOS.
   # --------------------------------------------------------------------------
   e2e:
     name: E2E (launch claude/opencode/codex/hermes/openclaw, vllm-plugin) — ${{ matrix.target }} (${{ matrix.backend }})
@@ -325,9 +331,9 @@ jobs:
     # legitimately take this long in wall-clock time before giving up.
     #
     # +90 on top of that 180 (270 total) for the vllm-plugin steps'
-    # own per-step budgets below: up to 60 min for "Install vLLM (CPU,
-    # e2e)" (a from-source build on macOS) plus up to 30 min for
-    # "pytest -m e2e (vllm-plugin)".
+    # own per-step budgets below: up to 60 min for "Install vLLM (e2e)"
+    # (wheel downloads, but a slow/retried one on a bad connection) plus
+    # up to 30 min for "pytest -m e2e (vllm-plugin)".
     timeout-minutes: 270
     strategy:
       fail-fast: false
@@ -841,8 +847,9 @@ jobs:
 
       # ── vllm-plugin e2e (Linux + macOS) ──────────────────────────────────
       # `vllm-plugin/tests/test_e2e.py` against this job's own installed
-      # `llmman` binary and a real CPU-only `vllm serve`. Excludes
-      # Windows: no vLLM CPU wheel/backend exists for it.
+      # `llmman` binary and a real `vllm serve` — CPU-only on Linux,
+      # Metal-GPU-backed (via vllm-metal) on macOS. Excludes Windows: no
+      # vLLM CPU wheel/backend exists for it.
       #
       # Uses a venv, not the bare system python3 (Ubuntu 24.04's is PEP
       # 668-locked). Both vllm-plugin and vllm (next step) install into
@@ -863,13 +870,18 @@ jobs:
           "$RUNNER_TEMP/vllm-plugin-venv/bin/pip" install -e ./vllm-plugin pytest
           echo "$RUNNER_TEMP/vllm-plugin-venv/bin" >> "$GITHUB_PATH"
 
-      # No GPU assumed, so this installs vLLM's CPU platform, not the
-      # default CUDA wheel. Linux has prebuilt CPU wheels; macOS Apple
-      # Silicon doesn't, so that leg builds from source instead
-      # (cmake/ninja/Xcode assumed present on the macos-15 runner image).
-      # LD_PRELOAD (x86_64 only): vLLM's CPU wheel needs Intel OpenMP
-      # preloaded; located via a glob scoped to this venv.
-      - name: Install vLLM (CPU, e2e)
+      # No GPU assumed on Linux, so that leg installs vLLM's CPU wheel,
+      # not the default CUDA one. macOS installs that same upstream
+      # "+cpu" wheel (a GitHub release asset since v0.26.0; PyPI still
+      # has none) plus vllm-metal on top, which overrides vLLM's
+      # CpuPlatform autodetection with a real Metal-GPU MetalPlatform via
+      # its own `vllm.platform_plugins` entry point — building vLLM's
+      # CPU backend from source on macOS instead (this job's prior
+      # approach) hung forever inside its own CPU worker, regardless of
+      # --dtype (see git history).
+      # LD_PRELOAD (Linux x86_64 only): vLLM's CPU wheel needs Intel
+      # OpenMP preloaded; located via a glob scoped to this venv.
+      - name: Install vLLM (e2e)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         timeout-minutes: 60
         shell: bash
@@ -878,10 +890,10 @@ jobs:
           venv="$RUNNER_TEMP/vllm-plugin-venv"
 
           if [ "${{ runner.os }}" = "macOS" ]; then
-            src="$RUNNER_TEMP/vllm-source"
-            git clone --branch "v${VLLM_VERSION}" --depth 1 https://github.com/vllm-project/vllm.git "$src"
-            "$venv/bin/pip" install -r "$src/requirements/cpu.txt"
-            "$venv/bin/pip" install -e "$src"
+            "$venv/bin/pip" install \
+              "https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}%2Bcpu-cp312-cp312-macosx_11_0_arm64.whl"
+            "$venv/bin/pip" install \
+              "https://github.com/vllm-project/vllm-metal/releases/download/v${VLLM_METAL_VERSION}/vllm_metal-${VLLM_METAL_VERSION}-cp312-cp312-macosx_15_0_arm64.whl"
           else
             case "${{ matrix.target }}" in
               x86_64-*) arch=x86_64 ;;

--- a/vllm-plugin/tests/test_e2e.py
+++ b/vllm-plugin/tests/test_e2e.py
@@ -17,7 +17,9 @@ aarch64. That ordering matters for the two lightweight tests below:
 `launch_e2e.rs`'s `warm_model()` has already pulled `MODEL` into the
 default store, so `resolve()` here hits a warm cache instead of a
 second ~740MB download. The `vllm serve` test pays its own separate
-pull instead (see its own docstring).
+pull instead (see its own docstring). That test runs on vLLM's CPU
+platform on Linux and vllm-metal's Metal-GPU platform on macOS (see
+ci.yml's "Install vLLM (e2e)" step).
 
 Every test here skips (not fails) when its own prerequisite (`llmman`,
 `vllm`) isn't available, same as `tests/launch_e2e.rs`.
@@ -31,6 +33,7 @@ import shutil
 import signal
 import socket
 import subprocess
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -67,9 +70,9 @@ PROMPT = "Reply with exactly the single word: pong"
 # oci://... argument.
 SERVED_MODEL_NAME = "vllm-llmman-e2e"
 
-# Generous: a cold ~1.7GB pull plus real CPU weight loading, no GPU
-# assumed anywhere. 1.5x launch_e2e.rs's own TIMEOUT (600s) for CPU-only
-# inference and a larger checkout.
+# Generous: a cold ~1.7GB pull plus real weight loading. 1.5x
+# launch_e2e.rs's own TIMEOUT (600s) for CPU-only inference and a
+# larger checkout.
 VLLM_STARTUP_TIMEOUT = 900
 
 
@@ -242,13 +245,25 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
     real `ModelConfig` for an `oci://` reference during vLLM's own
     startup is what triggers the pull.
 
-    `--dtype bfloat16`: MODEL_SAFETENSORS' own native dtype, and a hard
-    requirement, not just a preference — Qwen3.5's CPU Gated DeltaNet
-    kernel asserts BF16 input and crashes on any real forward pass with
-    float16 (which still loads and passes `/health` fine). `--enforce-
-    eager`: skips CUDA-graph startup work that doesn't apply on CPU.
-    `--max-model-len 1024`: bounds the CPU KV-cache for this test's
-    tiny prompt/reply.
+    Two different real backends here, same test, same assertions:
+
+    - Linux: vLLM's own CPU platform. `--dtype bfloat16`: a hard
+      requirement, not just a preference — Qwen3.5's CPU Gated DeltaNet
+      kernel asserts BF16 and crashes on a real forward pass with
+      float16 (which still loads and passes `/health` fine).
+      `--enforce-eager`: skips CUDA-graph startup work that doesn't
+      apply on CPU.
+    - macOS: vllm-metal's Metal-GPU platform (see ci.yml's "Install vLLM
+      (e2e)" step) instead of vLLM's own CPU backend, which hung
+      indefinitely on macOS CI runners regardless of `--dtype`. Flags/
+      env here are lifted from vllm-metal's own CI smoke test
+      (scripts/test.sh) for this same model family: no `--dtype`/
+      `--enforce-eager`; `--max-num-seqs 1` plus
+      `VLLM_METAL_MEMORY_FRACTION` bound GDN linear-attention state
+      under a CI runner's limited Metal memory.
+
+    `--max-model-len 1024`: bounds the KV-cache either way, for this
+    test's tiny prompt/reply.
     """
     pytest.importorskip("vllm")
     binary = shutil.which("vllm")
@@ -268,16 +283,20 @@ def test_vllm_serve_resolves_and_serves_a_real_oci_reference(tmp_path):
         "127.0.0.1",
         "--port",
         str(port),
-        "--dtype",
-        "bfloat16",
-        "--enforce-eager",
         "--max-model-len",
         "1024",
     ]
     env = dict(os.environ)
-    # Bounds vLLM CPU's own KV-cache arena, well under its default
-    # sizing heuristic, to avoid OOM on a shared/constrained CI runner.
-    env.setdefault("VLLM_CPU_KVCACHE_SPACE", "4")
+    if sys.platform == "darwin":
+        cmd += ["--max-num-seqs", "1"]
+        env.setdefault("GLOO_SOCKET_IFNAME", "lo0")
+        env.setdefault("VLLM_METAL_USE_PAGED_ATTENTION", "1")
+        env.setdefault("VLLM_METAL_MEMORY_FRACTION", "0.8")
+    else:
+        cmd += ["--dtype", "bfloat16", "--enforce-eager"]
+        # Bounds vLLM CPU's own KV-cache arena, well under its default
+        # sizing heuristic, to avoid OOM on a shared/constrained CI runner.
+        env.setdefault("VLLM_CPU_KVCACHE_SPACE", "4")
 
     log_file = open(log_path, "wb")
     try:


### PR DESCRIPTION
## Problem

`main`'s CI has been red since #274: `test_vllm_serve_resolves_and_serves_a_real_oci_reference`'s
real `vllm serve` subprocess hangs indefinitely on macOS runners
(`aarch64-apple-darwin`, both docker/podman lanes), regardless of
`--dtype`. Root cause: vLLM's CPU backend, built from source on that
leg (no prebuilt wheel used), hangs past its own
`distributed_init_method=...backend=gloo` log line.

## Fix

Instead of skipping macOS coverage, use
[vllm-metal](https://github.com/vllm-project/vllm-metal) — an official
`vllm-project` plugin that runs vLLM on Apple Silicon via a real Metal
GPU (MLX) instead of the CPU backend. It supports this test's model
family (Qwen3.5 hybrid GDN) and its own CI smoke-tests the same
checkpoint on the same `macos-15` runner image this repo uses.

- `ci.yml`: macOS installs vLLM's prebuilt CPU wheel (a GitHub release
  asset, unused until now) plus a pinned `vllm-metal` build on top,
  which overrides vLLM's `CpuPlatform` with a real `MetalPlatform`.
  `vllm-metal` ships only nightlies with no stable channel, so a new
  `VLLM_METAL_VERSION` pins one verified build rather than floating on
  "latest" in a release-gating job.
- `test_e2e.py`: the real `vllm serve` test branches its command/env
  by platform instead of skipping on macOS, using flags/env lifted from
  `vllm-metal`'s own smoke test.

## Risk

`vllm-metal` is alpha/nightly-only; pinning bounds a bad upstream build
to "needs a manual bump," not "main randomly reddens."

## Verification

`py_compile`/`ruff`/`yaml.safe_load` on the changed files; confirmed
both pinned wheel URLs resolve (HTTP 200). The `e2e` job only runs on
push to `main`/tags (not `pull_request`), so this PR's own checks won't
exercise the macOS lane — real verification happens after merge.
