### PR TITLE
fix(daemon): fail fast when llmman serve dies at startup

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -421,30 +421,102 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
     for _ in 0..120 {
         std::thread::sleep(Duration::from_millis(500));
         if server_alive() {
+            // The connect proves the daemon was alive an instant ago, not
+            // that it survived: if it died right after accepting, report
+            // its real exit status instead of an Ok the caller's next
+            // request would contradict. A death after this check is
+            // inherently unobservable from here.
+            bail_if_exited(&mut child, log_path.as_deref())?;
             return Ok(());
         }
         // The daemon is in its own process group but still our child, so
         // try_wait catches an immediate startup failure (e.g. llama-server
         // auto-download failing) instead of polling a dead port for 60s.
-        if let Some(status) = child.try_wait().context("wait on llmman serve")? {
-            anyhow::bail!(
-                "llmman serve exited during startup ({status}){}",
-                log_tail(log_path.as_deref())
-            );
-        }
+        bail_if_exited(&mut child, log_path.as_deref())?;
     }
     // The daemon may have exited right after the final poll above: check
     // once more so that narrow window still reports the exit status
     // instead of the generic timeout.
-    if let Some(status) = child.try_wait().context("wait on llmman serve")? {
-        anyhow::bail!(
-            "llmman serve exited during startup ({status}){}",
-            log_tail(log_path.as_deref())
-        );
+    bail_if_exited(&mut child, log_path.as_deref())?;
+    // The last in-loop probe is up to 500ms stale by now; a daemon that
+    // bound in that window is a healthy start, not a timeout.
+    if server_alive() {
+        return Ok(());
     }
+    // Timed out with the daemon alive but not listening: stop it before
+    // reporting failure, rather than leave a half-started daemon running
+    // detached after the user was told the start failed. TERM the group
+    // first, then escalate to a group KILL after a short grace (like
+    // stop_stale_daemon, so a slow-to-exit child is actually reaped too),
+    // then wait so no zombie outlives this call. The message must say the
+    // daemon was stopped: a slow first run (llama-server's one-time
+    // download can exceed this budget) would otherwise converge on a
+    // plain retry, and now it will not.
+    signal_group(child.id(), false);
+    std::thread::sleep(Duration::from_millis(500));
+    signal_group(child.id(), true);
+    let _ = child.wait();
     anyhow::bail!(
-        "llmman serve did not start within 60s{}",
+        "llmman serve did not start within 60s and was stopped; run 'llmman serve' in the \
+         foreground to watch what startup is doing (e.g. a first-time llama-server download){}",
         log_tail(log_path.as_deref())
+    )
+}
+
+/// Best-effort signal to the daemon's whole process group (the daemon is
+/// its own group leader, see detach), with no plain-pid fallback: unlike
+/// kill_daemon's stale-daemon path, callers here may hold an
+/// already-reaped pid, and a single-pid signal to a freed pid is the one
+/// form that could hit an innocent reused process. Failures are ignored;
+/// an already-empty group is the common case.
+#[cfg(unix)]
+fn signal_group(pid: u32, force: bool) {
+    let signal = if force { "-KILL" } else { "-TERM" };
+    let _ = Command::new("kill")
+        .args([signal, &format!("-{pid}")])
+        .status();
+}
+
+/// Windows equivalent: taskkill's /T already targets the whole process
+/// tree, and fails harmlessly on an already-dead pid.
+#[cfg(windows)]
+fn signal_group(pid: u32, force: bool) {
+    let mut args = vec!["/PID".to_string(), pid.to_string(), "/T".to_string()];
+    if force {
+        args.push("/F".to_string());
+    }
+    let _ = Command::new("taskkill").args(&args).status();
+}
+
+/// Bails with the daemon's exit status (and its log tail) if the freshly
+/// spawned `llmman serve` child has already exited; returns Ok(()) while
+/// it's still running. On the exited branch this also best-effort kills
+/// the daemon's whole process group first, so a llama-server child the
+/// daemon spawned before dying is not left holding a loaded model.
+fn bail_if_exited(
+    child: &mut std::process::Child,
+    log_path: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let pid = child.id();
+    let Some(status) = child.try_wait().context("wait on llmman serve")? else {
+        return Ok(());
+    };
+    // The daemon may have spawned a llama-server before dying, and that
+    // child shares the daemon's process group (see detach), so signal the
+    // group rather than orphan a loaded model. The leader itself is dead
+    // and reaped by now; only the group form of the signal is meaningful
+    // (see signal_group on why there is deliberately no single-pid
+    // fallback here).
+    signal_group(pid, false);
+    // Reading the log now needs no explicit sync: a daemon that fails via
+    // its error-exit path reports on stderr, which Rust never buffers,
+    // and that fd is redirected straight to the log file, so the reason
+    // is visible to any reader before the exit is observable. A daemon
+    // killed by a signal writes nothing; log_tail's "(see path)" fallback
+    // covers that.
+    anyhow::bail!(
+        "llmman serve exited during startup ({status}){}",
+        log_tail(log_path)
     )
 }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -472,8 +472,12 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
 #[cfg(unix)]
 fn signal_group(pid: u32, force: bool) {
     let signal = if force { "-KILL" } else { "-TERM" };
+    // Stdio nulled: an already-empty group makes kill print "No such
+    // process", which would land in front of the real startup error.
     let _ = Command::new("kill")
         .args([signal, &format!("-{pid}")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .status();
 }
 
@@ -485,7 +489,13 @@ fn signal_group(pid: u32, force: bool) {
     if force {
         args.push("/F".to_string());
     }
-    let _ = Command::new("taskkill").args(&args).status();
+    // Stdio nulled like the Unix branch: taskkill reports a missing PID
+    // loudly, which would land in front of the real startup error.
+    let _ = Command::new("taskkill")
+        .args(&args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
 }
 
 /// Bails with the daemon's exit status (and its log tail) if the freshly
@@ -501,6 +511,13 @@ fn bail_if_exited(
     let Some(status) = child.try_wait().context("wait on llmman serve")? else {
         return Ok(());
     };
+    // An exited child is not always a failed startup: two concurrent
+    // clients can both spawn a daemon, and the loser exits with "address
+    // in use" while the winner serves. If something is listening now, the
+    // start succeeded, whoever's daemon it is.
+    if server_alive() {
+        return Ok(());
+    }
     // The daemon may have spawned a llama-server before dying, and that
     // child shares the daemon's process group (see detach), so signal the
     // group rather than orphan a loaded model. The leader itself is dead
@@ -1089,7 +1106,9 @@ mod tests {
         let tail = log_tail(Some(&path));
         std::fs::remove_file(&path).unwrap();
         assert!(tail.contains("last lines of"), "got: {tail}");
-        assert!(!tail.contains("one"), "got: {tail}");
-        assert!(tail.contains("two\nthree\nfour\nfive\nsix"), "got: {tail}");
+        // Only the part after the header line is the log excerpt; the
+        // header contains the temp path, which may itself contain "one".
+        let excerpt = tail.split_once('\n').map(|(_, rest)| rest).unwrap_or("");
+        assert_eq!(excerpt, "two\nthree\nfour\nfive\nsix", "got: {tail}");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -416,15 +416,54 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
         }
     }
     detach(&mut cmd);
-    cmd.spawn().context("spawn llmman serve")?;
+    let mut child = cmd.spawn().context("spawn llmman serve")?;
 
     for _ in 0..120 {
         std::thread::sleep(Duration::from_millis(500));
         if server_alive() {
             return Ok(());
         }
+        // The daemon is in its own process group but still our child, so
+        // try_wait catches an immediate startup failure (e.g. llama-server
+        // auto-download failing) instead of polling a dead port for 60s.
+        if let Some(status) = child.try_wait().context("wait on llmman serve")? {
+            anyhow::bail!(
+                "llmman serve exited during startup ({status}){}",
+                log_tail(log_path.as_deref())
+            );
+        }
     }
-    anyhow::bail!("llmman serve did not start within 60s")
+    // The daemon may have exited right after the final poll above: check
+    // once more so that narrow window still reports the exit status
+    // instead of the generic timeout.
+    if let Some(status) = child.try_wait().context("wait on llmman serve")? {
+        anyhow::bail!(
+            "llmman serve exited during startup ({status}){}",
+            log_tail(log_path.as_deref())
+        );
+    }
+    anyhow::bail!(
+        "llmman serve did not start within 60s{}",
+        log_tail(log_path.as_deref())
+    )
+}
+
+/// The last few lines of the daemon's log, formatted for appending to an
+/// error message; empty if there's no log path, just a pointer to the
+/// path if the file is unreadable or has no content.
+fn log_tail(log_path: Option<&std::path::Path>) -> String {
+    let Some(path) = log_path else {
+        return String::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return format!(" (see {})", path.display());
+    };
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        return format!(" (see {})", path.display());
+    }
+    let tail = &lines[lines.len().saturating_sub(5)..];
+    format!("; last lines of {}:\n{}", path.display(), tail.join("\n"))
 }
 
 /// Puts the about-to-be-spawned child in its own process group (Unix) or
@@ -955,5 +994,29 @@ mod tests {
         }
         assert!(!is_local_host("example.com"));
         assert!(!is_local_host("192.168.1.5"));
+    }
+
+    #[test]
+    fn log_tail_none_path_is_empty() {
+        assert_eq!(log_tail(None), "");
+    }
+
+    #[test]
+    fn log_tail_missing_file_points_at_path() {
+        let path = std::env::temp_dir().join(format!("llmman-log-tail-missing-{}", std::process::id()));
+        let tail = log_tail(Some(&path));
+        assert!(tail.contains("see "), "got: {tail}");
+        assert!(tail.contains(&path.display().to_string()), "got: {tail}");
+    }
+
+    #[test]
+    fn log_tail_returns_last_five_nonempty_lines() {
+        let path = std::env::temp_dir().join(format!("llmman-log-tail-{}", std::process::id()));
+        std::fs::write(&path, "one\ntwo\n\nthree\nfour\nfive\nsix\n").unwrap();
+        let tail = log_tail(Some(&path));
+        std::fs::remove_file(&path).unwrap();
+        assert!(tail.contains("last lines of"), "got: {tail}");
+        assert!(!tail.contains("one"), "got: {tail}");
+        assert!(tail.contains("two\nthree\nfour\nfive\nsix"), "got: {tail}");
     }
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -434,31 +434,42 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
         // auto-download failing) instead of polling a dead port for 60s.
         bail_if_exited(&mut child, log_path.as_deref())?;
     }
+    // The last in-loop probe is up to 500ms stale by now; a daemon that
+    // bound in that window is a healthy start, not a timeout. Same shape
+    // as the in-loop success path: prove the daemon survived the accept
+    // before reporting Ok.
+    if server_alive() {
+        bail_if_exited(&mut child, log_path.as_deref())?;
+        return Ok(());
+    }
     // The daemon may have exited right after the final poll above: check
     // once more so that narrow window still reports the exit status
     // instead of the generic timeout.
     bail_if_exited(&mut child, log_path.as_deref())?;
-    // The last in-loop probe is up to 500ms stale by now; a daemon that
-    // bound in that window is a healthy start, not a timeout.
-    if server_alive() {
-        return Ok(());
+    // Timed out with the daemon alive but not listening. If startup is
+    // mid-way through llama-server's one-time auto-download (which can
+    // far exceed this budget; see llama_release's 30-minute HTTP budget),
+    // killing the daemon would discard the partial download (no resume,
+    // pid-specific staging files) and make every retry start from zero.
+    // Leave it running and say so instead.
+    if crate::llama_release::download_in_progress() {
+        anyhow::bail!(
+            "llmman serve did not start within 60s: startup is still downloading \
+             llama-server. The daemon was left running so the download can finish; \
+             retry this command once it does{}",
+            log_tail(log_path.as_deref())
+        );
     }
-    // Timed out with the daemon alive but not listening: stop it before
-    // reporting failure, rather than leave a half-started daemon running
-    // detached after the user was told the start failed. TERM the group
-    // first, then escalate to a group KILL after a short grace (like
-    // stop_stale_daemon, so a slow-to-exit child is actually reaped too),
-    // then wait so no zombie outlives this call. The message must say the
-    // daemon was stopped: a slow first run (llama-server's one-time
-    // download can exceed this budget) would otherwise converge on a
-    // plain retry, and now it will not.
-    signal_group(child.id(), false);
-    std::thread::sleep(Duration::from_millis(500));
-    signal_group(child.id(), true);
+    // Otherwise stop it before reporting failure, rather than leave a
+    // half-started daemon running detached after the user was told the
+    // start failed, then wait so no zombie outlives this call. The
+    // message must say the daemon was stopped, or the failure would read
+    // as retryable against a daemon that is no longer there.
+    stop_group(child.id());
     let _ = child.wait();
     anyhow::bail!(
         "llmman serve did not start within 60s and was stopped; run 'llmman serve' in the \
-         foreground to watch what startup is doing (e.g. a first-time llama-server download){}",
+         foreground to watch what startup is doing{}",
         log_tail(log_path.as_deref())
     )
 }
@@ -470,21 +481,24 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
 /// form that could hit an innocent reused process. Failures are ignored;
 /// an already-empty group is the common case.
 #[cfg(unix)]
-fn signal_group(pid: u32, force: bool) {
+fn signal_group(pid: u32, force: bool) -> bool {
     let signal = if force { "-KILL" } else { "-TERM" };
     // Stdio nulled: an already-empty group makes kill print "No such
     // process", which would land in front of the real startup error.
-    let _ = Command::new("kill")
+    // kill's exit status reports whether the signal found anyone, which
+    // is what lets stop_group skip a pointless escalation.
+    Command::new("kill")
         .args([signal, &format!("-{pid}")])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status();
+        .status()
+        .is_ok_and(|s| s.success())
 }
 
 /// Windows equivalent: taskkill's /T already targets the whole process
 /// tree, and fails harmlessly on an already-dead pid.
 #[cfg(windows)]
-fn signal_group(pid: u32, force: bool) {
+fn signal_group(pid: u32, force: bool) -> bool {
     let mut args = vec!["/PID".to_string(), pid.to_string(), "/T".to_string()];
     if force {
         args.push("/F".to_string());
@@ -496,6 +510,23 @@ fn signal_group(pid: u32, force: bool) {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+    // taskkill's exit codes don't reliably separate "no such pid" from
+    // "needs /F" (a windowless process rejects the graceful form), so
+    // always report possible survivors and let stop_group escalate.
+    true
+}
+
+/// Best-effort stop of the daemon's whole process group: TERM first, then
+/// escalate to a group KILL after a short grace so a slow-to-exit child
+/// is actually stopped too (the same two phases as stop_stale_daemon).
+/// The escalation is skipped when the TERM found nothing to signal (an
+/// already-empty group), which keeps bail_if_exited's fast-fail path free
+/// of the grace sleep.
+fn stop_group(pid: u32) {
+    if signal_group(pid, false) {
+        std::thread::sleep(Duration::from_millis(500));
+        signal_group(pid, true);
+    }
 }
 
 /// Bails with the daemon's exit status (and its log tail) if the freshly
@@ -519,12 +550,14 @@ fn bail_if_exited(
         return Ok(());
     }
     // The daemon may have spawned a llama-server before dying, and that
-    // child shares the daemon's process group (see detach), so signal the
+    // child shares the daemon's process group (see detach), so stop the
     // group rather than orphan a loaded model. The leader itself is dead
     // and reaped by now; only the group form of the signal is meaningful
     // (see signal_group on why there is deliberately no single-pid
-    // fallback here).
-    signal_group(pid, false);
+    // fallback here). stop_group only pays its grace sleep when the TERM
+    // actually found a survivor, so the common childless fast-fail stays
+    // fast.
+    stop_group(pid);
     // Reading the log now needs no explicit sync: a daemon that fails via
     // its error-exit path reports on stderr, which Rust never buffers,
     // and that fd is redirected straight to the log file, so the reason
@@ -1094,6 +1127,9 @@ mod tests {
     fn log_tail_missing_file_points_at_path() {
         let path =
             std::env::temp_dir().join(format!("llmman-log-tail-missing-{}", std::process::id()));
+        // A crashed prior run could have left the file behind; make sure
+        // the missing-file branch is actually the one under test.
+        let _ = std::fs::remove_file(&path);
         let tail = log_tail(Some(&path));
         assert!(tail.contains("see "), "got: {tail}");
         assert!(tail.contains(&path.display().to_string()), "got: {tail}");

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1003,7 +1003,8 @@ mod tests {
 
     #[test]
     fn log_tail_missing_file_points_at_path() {
-        let path = std::env::temp_dir().join(format!("llmman-log-tail-missing-{}", std::process::id()));
+        let path =
+            std::env::temp_dir().join(format!("llmman-log-tail-missing-{}", std::process::id()));
         let tail = log_tail(Some(&path));
         assert!(tail.contains("see "), "got: {tail}");
         assert!(tail.contains(&path.display().to_string()), "got: {tail}");

--- a/src/llama_release.rs
+++ b/src/llama_release.rs
@@ -378,6 +378,83 @@ fn find_binary(dir: &Path, name: &str) -> Option<PathBuf> {
 /// plain throttled text instead of redrawing a client-style progress bar.
 const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(5);
 
+/// How long a `.downloading` marker stays credible without being touched.
+/// A live download refreshes it every [`PROGRESS_LOG_INTERVAL`], so a
+/// marker older than this belongs to a download whose process died
+/// without running the guard's Drop (e.g. a SIGKILLed daemon).
+const DOWNLOAD_MARKER_STALE_AFTER: Duration = Duration::from_secs(60);
+
+/// The download-in-progress marker: a fixed path under [`install_root`]
+/// that both the downloading daemon (writer) and a client polling it
+/// (reader, see `daemon::ensure_server`) can derive independently.
+fn download_marker_path() -> Result<PathBuf> {
+    Ok(install_root()?.join(".downloading"))
+}
+
+/// Whether some process is currently mid-download of a llama-server
+/// release: the marker exists and was touched recently enough to belong
+/// to a live download rather than a crashed one.
+pub fn download_in_progress() -> bool {
+    download_marker_path().is_ok_and(|path| marker_is_fresh(&path, DOWNLOAD_MARKER_STALE_AFTER))
+}
+
+/// Split out from [`download_in_progress`] so tests can drive the path
+/// and threshold directly.
+fn marker_is_fresh(path: &Path, stale_after: Duration) -> bool {
+    let Ok(mtime) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return false;
+    };
+    // A backwards clock step can leave mtime in the future; that still
+    // means "touched just now", so count it as fresh.
+    std::time::SystemTime::now()
+        .duration_since(mtime)
+        .map_or(true, |age| age < stale_after)
+}
+
+/// Creates the marker on construction and removes it on drop, so success
+/// and every early `?` return both clear it. Best-effort throughout: a
+/// marker failure must never fail the download itself.
+struct DownloadMarker(Option<PathBuf>);
+
+impl DownloadMarker {
+    fn create() -> DownloadMarker {
+        match download_marker_path() {
+            Ok(p) => Self::create_at(p),
+            Err(_) => DownloadMarker(None),
+        }
+    }
+
+    /// The path-taking constructor behind [`DownloadMarker::create`], so
+    /// tests can run the guard's lifecycle against a temp path instead of
+    /// the real install root.
+    fn create_at(path: PathBuf) -> DownloadMarker {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        DownloadMarker(std::fs::write(&path, b"").ok().map(|_| path))
+    }
+
+    /// Refreshes the marker's mtime so a reader can tell this live
+    /// download from a crashed one whose Drop never ran.
+    fn touch(&self) {
+        if let Some(path) = &self.0 {
+            let _ = std::fs::write(path, b"");
+        }
+    }
+}
+
+impl Drop for DownloadMarker {
+    fn drop(&mut self) {
+        // With two concurrent downloads (pid-suffixed staging paths allow
+        // them), the first finisher removes the shared marker and the
+        // survivor's next touch recreates it within PROGRESS_LOG_INTERVAL;
+        // that short unprotected window is accepted.
+        if let Some(path) = &self.0 {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 /// Opens `dest` for writing without ever following an existing symlink
 /// there — `LLMMAN_TMPDIR` can point at a shared directory, and asset
 /// names are predictable, so a planted symlink must not redirect a
@@ -407,6 +484,7 @@ fn download_to_file(
     url: &str,
     dest: &Path,
     label: &str,
+    marker: &DownloadMarker,
 ) -> Result<()> {
     let mut resp = client
         .get(url)
@@ -416,7 +494,6 @@ fn download_to_file(
         anyhow::bail!("download {url} returned {}", resp.status());
     }
     let total = resp.content_length().unwrap_or(0);
-
     let mut file = create_new_file(dest)?;
     let mut buf = [0u8; 1 << 16];
     let mut downloaded = 0u64;
@@ -428,13 +505,16 @@ fn download_to_file(
         }
         file.write_all(&buf[..n]).context("write downloaded data")?;
         downloaded += n as u64;
-        if total > 0 && last_logged.elapsed() >= PROGRESS_LOG_INTERVAL {
-            eprintln!(
-                "[llmman] downloading {label}: {} / {} ({}%)",
-                human_size(downloaded),
-                human_size(total),
-                downloaded.saturating_mul(100) / total
-            );
+        if last_logged.elapsed() >= PROGRESS_LOG_INTERVAL {
+            marker.touch();
+            if total > 0 {
+                eprintln!(
+                    "[llmman] downloading {label}: {} / {} ({}%)",
+                    human_size(downloaded),
+                    human_size(total),
+                    downloaded.saturating_mul(100) / total
+                );
+            }
             last_logged = Instant::now();
         }
     }
@@ -574,9 +654,23 @@ fn try_ensure_from_network(
         "[llmman] downloading llama-server ({}) {tag}: {}",
         query.label, asset.name
     );
+    // One marker for everything from here to the end of the function, so
+    // a client that gave up waiting for this daemon (see ensure_server's
+    // timeout path) knows not to kill it mid-download or mid-extract; the
+    // downloads' progress loops keep it fresh. Extraction of a large
+    // archive can outlive the last touch by more than the staleness
+    // window; that residual gap is accepted.
+    let marker = DownloadMarker::create();
     let tmp = tmp_path(&asset.name)?;
     let _cleanup = RemoveOnDrop(&tmp);
-    download_to_file(&client, &asset.browser_download_url, &tmp, &asset.name)?;
+    download_to_file(
+        &client,
+        &asset.browser_download_url,
+        &tmp,
+        &asset.name,
+        &marker,
+    )?;
+    marker.touch();
     extract(&tmp, &asset.name, &dest)?;
 
     if let Some(companion_substr) = &query.companion_must_contain {
@@ -591,7 +685,9 @@ fn try_ensure_from_network(
                     &companion.browser_download_url,
                     &tmp2,
                     &companion.name,
+                    &marker,
                 )?;
+                marker.touch();
                 extract(&tmp2, &companion.name, &dest)?;
             }
             None => eprintln!(
@@ -792,6 +888,64 @@ mod tests {
         assert_eq!(parse_pointer_tag("  b10621  "), Some("b10621"));
         assert_eq!(parse_pointer_tag(""), None);
         assert_eq!(parse_pointer_tag("\n  \n"), None);
+    }
+
+    #[test]
+    fn marker_is_fresh_is_false_for_an_absent_file() {
+        let path =
+            std::env::temp_dir().join(format!("llmman-marker-absent-{}", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        assert!(!marker_is_fresh(&path, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn marker_is_fresh_is_true_for_a_just_written_file() {
+        let path = std::env::temp_dir().join(format!("llmman-marker-fresh-{}", std::process::id()));
+        std::fs::write(&path, b"").unwrap();
+        let fresh = marker_is_fresh(&path, Duration::from_secs(60));
+        let _ = std::fs::remove_file(&path);
+        assert!(fresh);
+    }
+
+    #[test]
+    fn marker_is_fresh_is_false_for_a_stale_mtime() {
+        let path = std::env::temp_dir().join(format!("llmman-marker-stale-{}", std::process::id()));
+        std::fs::write(&path, b"").unwrap();
+        let file = std::fs::File::options().write(true).open(&path).unwrap();
+        file.set_modified(std::time::SystemTime::now() - Duration::from_secs(120))
+            .unwrap();
+        drop(file);
+        let fresh = marker_is_fresh(&path, Duration::from_secs(60));
+        let _ = std::fs::remove_file(&path);
+        assert!(!fresh);
+    }
+
+    /// The guard's whole lifecycle: created on construction, refreshed by
+    /// touch, removed on drop. Runs against a temp path via create_at, not
+    /// the real install root, so a genuinely live download's marker is
+    /// never deleted by the test.
+    #[test]
+    fn download_marker_creates_touches_and_removes_the_marker() {
+        let path = std::env::temp_dir().join(format!(
+            "llmman-marker-lifecycle-{}/.downloading",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let marker = DownloadMarker::create_at(path.clone());
+        assert!(path.is_file(), "marker not created at {}", path.display());
+        // Backdate the mtime so the freshness assertion below can only
+        // pass because of the touch, not the recent creation.
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() - Duration::from_secs(120))
+            .unwrap();
+        assert!(!marker_is_fresh(&path, Duration::from_secs(60)));
+        marker.touch();
+        assert!(marker_is_fresh(&path, Duration::from_secs(60)));
+        drop(marker);
+        assert!(!path.exists(), "marker not removed on drop");
     }
 
     #[test]

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -974,7 +974,7 @@ mod tests {
 
         let blocked = dir.join("manifests").join("unreadable");
         std::fs::create_dir_all(&blocked).unwrap();
-        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0)).unwrap();
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o0)).unwrap();
 
         let images = store.list().unwrap();
         assert_eq!(images.len(), 1);

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -854,6 +854,104 @@ fn launch_openclaw_with_model() {
     );
 }
 
+/// Verifies `daemon::ensure_server`'s fast-fail path end to end: when the
+/// auto-spawned `llmman serve` dies during startup, the client command
+/// must report the daemon's exit within seconds (via the poll loop's
+/// try_wait) instead of polling a dead port for the full 60s, and its
+/// error must carry the exit status plus the daemon log's tail.
+///
+/// The daemon is made to die instantly and deterministically, with no
+/// network and no interference with any real daemon on the machine:
+///
+///   - `LLMMAN_HOST` points at a loopback port nothing listens on, so
+///     the client never reuses (or stops) the developer's real daemon;
+///   - a fake `llama-server` sits first on `PATH`, so serve's
+///     `resolve_llama_server` returns immediately without a download
+///     (it is found but never executed: serve dies before launching it);
+///   - `LLMMAN_MODELS` points at `<tmp>/store` while `<tmp>/cache`
+///     already exists as a regular FILE, so `serve_async`'s
+///     `create_dir_all(cache)` fails right after resolving llama-server,
+///     before the listener ever binds. `<tmp>/serve.log` itself stays
+///     writable, so the failure reaches the log and the client's error
+///     can quote its tail.
+///
+/// Unlike the launch tests above, this needs neither `SERIAL` (its
+/// daemon slot is its own unused port), `warm_model`, nor any binary on
+/// the real `PATH`.
+#[test]
+fn ensure_server_fails_fast_when_daemon_dies_at_startup() {
+    let dir = fresh_home("dead-daemon");
+    let bin_dir = dir.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("create fake bin dir");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let fake = bin_dir.join("llama-server");
+        std::fs::write(&fake, "#!/bin/sh\nexit 0\n").expect("write fake llama-server");
+        std::fs::set_permissions(&fake, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake llama-server");
+    }
+    // find_on_path probes only `{name}.exe` on Windows, so the fake must
+    // be an `.exe`; any content works because it is found, never executed.
+    #[cfg(windows)]
+    std::fs::write(bin_dir.join("llama-server.exe"), "not a real executable")
+        .expect("write fake llama-server");
+
+    std::fs::write(dir.join("cache"), "a file where serve expects a directory")
+        .expect("write cache blocker file");
+
+    // Bound once to reserve a definitely-free port number, then dropped:
+    // the port must NOT stay listening, or ensure_server would take a
+    // successful connect as "a daemon is already running" and never spawn
+    // the one under test.
+    let port = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind probe listener")
+        .local_addr()
+        .expect("probe listener addr")
+        .port();
+
+    let path = std::env::join_paths(std::iter::once(bin_dir).chain(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    )))
+    .expect("join PATH");
+
+    let mut cmd = Command::new(llmman_bin());
+    cmd.arg("pull").arg(MODEL);
+    cmd.env("LLMMAN_HOST", format!("127.0.0.1:{port}"))
+        .env("LLMMAN_MODELS", dir.join("store"))
+        .env("PATH", path);
+
+    let start = Instant::now();
+    // 45s: comfortably above the few seconds a fast-fail takes, but below
+    // ensure_server's own 60s poll, so a regression to the old
+    // wait-out-the-timeout behavior fails here as a timeout rather than
+    // passing slowly.
+    let output = spawn_with_timeout(
+        cmd,
+        Duration::from_secs(45),
+        "`llmman pull` against a daemon that dies at startup",
+    );
+    let elapsed = start.elapsed();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "pull against a dead daemon unexpectedly succeeded\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.contains("exited during startup"),
+        "expected the daemon's startup exit to be reported\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stderr.contains("last lines of"),
+        "expected the error to quote the daemon log's tail\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "fast-fail took {elapsed:?}; it should report within seconds, \
+         not wait out ensure_server's 60s poll"
+    );
+}
+
 /// True for the one openclaw-specific failure shape confirmed live in
 /// CI that isn't an llmman bug: its own onboarding independently
 /// re-verifies whatever model it's given against a real public Docker


### PR DESCRIPTION
Closes #289.

[`ensure_server`](https://github.com/llmmanorg/llmman/blob/721fc9eba5b6e785a4f9846431802bd3791d2b33/src/daemon.rs#L200-L275) spawned the daemon detached, [discarded the `Child`, and polled `server_alive()` 120 times at 500ms](https://github.com/llmmanorg/llmman/blob/721fc9eba5b6e785a4f9846431802bd3791d2b33/src/daemon.rs#L266-L274). A daemon that exited during startup (for example, a failed llama-server auto-download) was never detected: the client polled a dead port for the full 60s, printed nothing, and reported only "llmman serve did not start within 60s" while the real error sat unmentioned in serve.log.

Changes, all in `src/daemon.rs`:

- Keep the `Child` from `spawn()` and call `try_wait()` inside the poll loop. If the daemon exited, bail immediately with its exit status and the last five non-empty lines of serve.log. The daemon is in its own process group but is still our child, so `try_wait()` works on all platforms.
- Run one final `try_wait()` before the timeout bail, so an exit landing after the last poll still reports the status instead of the generic timeout.
- New `log_tail` helper formats the serve.log excerpt: empty when there is no log path, just the path when the file is unreadable or empty. The timeout message now uses it too, so users know where to look.

Drive-by: `cargo clippy --all-targets` was failing on main ([`non_octal_unix_permissions` in a test](https://github.com/llmmanorg/llmman/blob/721fc9eba5b6e785a4f9846431802bd3791d2b33/src/storage/oci.rs#L977)); changed `from_mode(0)` to `from_mode(0o0)`.

## Testing

- 3 new unit tests for `log_tail`; full lib suite passes (255 tests), clippy clean.
- Verified end-to-end on a machine where the daemon dies at startup: `llmman pull gemma4` went from 60s of silence to failing in ~0.5s with:

      Error: llmman serve exited during startup (exit status: 1); last lines of /home/.../serve.log:
      Error: no llama-server on PATH and automatic download failed: no vulkan llama.cpp release asset found in v0.3.0 (...)