### PR TITLE
Add LLMMAN_HOST to override the serve daemon's bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Start the inference server. Uses `llama-server` from [llama.cpp](https://github.
 llmman serve
 ```
 
-The server listens on `127.0.0.1:17434` and exposes:
+The server listens on `127.0.0.1:17434` by default, overridable via `LLMMAN_HOST`, and exposes:
 
 | API | Endpoints |
 |-----|-----------|
@@ -99,10 +99,11 @@ An idle, unused model is automatically unloaded after `keep_alive`
 `LLMMAN_KEEP_ALIVE`), and `llmman ps`/`/api/ps` reports each model's
 `expires_at`.
 
-Daemon-wide `llama-server` tuning, set before `llmman serve` starts:
+Daemon-wide settings, set before `llmman serve` starts:
 
 | Variable | Effect |
 |----------|--------|
+| `LLMMAN_HOST` | `[host][:port]` `llmman serve` binds to. Every `llmman` client in the same environment connects to it too, rewriting a wildcard host to loopback first. Defaults to `127.0.0.1:17434`. |
 | `LLMMAN_CONTEXT_LENGTH` | Context size (`--ctx-size`) for every model this daemon loads. Defaults to a VRAM-tiered value when unset. |
 | `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`, matching Ollama's `OLLAMA_FLASH_ATTENTION`. |
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0` — trades output quality for memory at long context lengths, matching Ollama's `OLLAMA_KV_CACHE_TYPE`. |

--- a/src/bin/llmman-bench.rs
+++ b/src/bin/llmman-bench.rs
@@ -30,7 +30,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 
-use llmman::daemon::{self, SERVER};
+use llmman::daemon;
 use llmman::shortnames;
 
 // ---------------------------------------------------------------------------
@@ -150,8 +150,8 @@ fn run(args: &Args) -> anyhow::Result<()> {
     // instead of a raw connection-refused a few requests in.
     if !daemon::server_alive() {
         anyhow::bail!(
-            "llmman serve is not running on 127.0.0.1:17434 — start it first (`llmman serve`), \
-             then retry"
+            "llmman serve is not running on {} — start it first (`llmman serve`), then retry",
+            daemon::bind_addr()
         );
     }
     if args.verbose {
@@ -520,7 +520,7 @@ async fn one_request(
 ) -> anyhow::Result<Sample> {
     let start = Instant::now();
     let resp = client
-        .post(format!("{SERVER}/v1/chat/completions"))
+        .post(format!("{}/v1/chat/completions", daemon::server()))
         .json(&BenchRequest {
             model,
             messages: [BenchMessage {
@@ -612,7 +612,7 @@ async fn one_request(
 /// `unloadModel` — a failed unload shouldn't fail the whole run.
 async fn unload_model(client: &Client, model: &str) {
     let _ = client
-        .post(format!("{SERVER}/api/generate"))
+        .post(format!("{}/api/generate", daemon::server()))
         .json(&serde_json::json!({ "model": model, "keep_alive": 0 }))
         .send()
         .await;

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -10,7 +10,7 @@ use std::process::Command;
 use anyhow::Context;
 use clap::Args;
 
-use crate::daemon::SERVER;
+use crate::daemon;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -230,11 +230,12 @@ fn launch_claude(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     }
     args.extend_from_slice(extra_args);
 
+    let server = daemon::server();
     exec_with_env(
         &bin,
         &args,
         &[
-            ("ANTHROPIC_BASE_URL", SERVER),
+            ("ANTHROPIC_BASE_URL", server.as_str()),
             ("ANTHROPIC_API_KEY", "llmman"),
         ],
     )
@@ -259,7 +260,7 @@ fn launch_opencode(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 }
 
 fn opencode_config(model: &str) -> String {
-    let base_url = format!("{SERVER}/v1");
+    let base_url = format!("{}/v1", daemon::server());
     serde_json::json!({
         "$schema": "https://opencode.ai/config.json",
         "provider": {
@@ -336,7 +337,7 @@ fn write_codex_config() -> anyhow::Result<()> {
     }
 
     let profile_path = config_dir.join("llmman.config.toml");
-    let contents = format!("openai_base_url = \"{SERVER}/v1\"\n");
+    let contents = format!("openai_base_url = \"{}/v1\"\n", daemon::server());
     // Avoid rewriting (and bumping the mtime of) a file that's already
     // correct.
     if std::fs::read_to_string(&profile_path).ok().as_deref() != Some(contents.as_str()) {
@@ -373,11 +374,12 @@ fn strip_legacy_llmman_profile(existing: &str) -> String {
 
 /// aider: set OPENAI_API_KEY and OPENAI_BASE_URL.
 fn launch_aider(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+    let base_url = format!("{}/v1", daemon::server());
     let mut args: Vec<String> = Vec::new();
     if !model.is_empty() {
         args.extend(["--model".to_string(), format!("openai/{model}")]);
     }
-    args.extend(["--openai-api-base".to_string(), format!("{SERVER}/v1")]);
+    args.extend(["--openai-api-base".to_string(), base_url.clone()]);
     args.extend_from_slice(extra_args);
 
     exec_with_env(
@@ -385,7 +387,7 @@ fn launch_aider(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         &args,
         &[
             ("OPENAI_API_KEY", "llmman"),
-            ("OPENAI_BASE_URL", &format!("{SERVER}/v1")),
+            ("OPENAI_BASE_URL", base_url.as_str()),
         ],
     )
 }
@@ -396,7 +398,7 @@ fn launch_copilot(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         anyhow::anyhow!("gh (GitHub CLI) is not installed — https://cli.github.com")
     })?;
 
-    let base_url = format!("{SERVER}/v1");
+    let base_url = format!("{}/v1", daemon::server());
     let mut args = vec!["copilot".to_string()];
     if !model.is_empty() {
         args.extend(["--model".to_string(), model.to_string()]);
@@ -418,11 +420,12 @@ fn launch_gemini(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     }
     args.extend_from_slice(extra_args);
 
+    let base_url = format!("{}/v1", daemon::server());
     exec_with_env(
         &bin,
         &args,
         &[
-            ("GEMINI_BASE_URL", &format!("{SERVER}/v1")),
+            ("GEMINI_BASE_URL", base_url.as_str()),
             ("GEMINI_API_KEY", "llmman"),
         ],
     )
@@ -437,7 +440,8 @@ fn launch_simple(
 ) -> anyhow::Result<()> {
     let bin = find_on_path(binary)
         .ok_or_else(|| anyhow::anyhow!("{binary} is not installed — {install_hint}"))?;
-    exec_with_env(&bin, extra_args, &[("OLLAMA_HOST", SERVER)])
+    let server = daemon::server();
+    exec_with_env(&bin, extra_args, &[("OLLAMA_HOST", server.as_str())])
 }
 
 /// hermes: writes its own `~/.hermes/config.yaml` provider entry
@@ -496,7 +500,7 @@ fn write_hermes_config(model: &str) -> anyhow::Result<()> {
     // keyword (`null`, `true`, ...) or contain metacharacters (`:`, `#`,
     // ...) still parses back as the literal string it is.
     let model = yaml_quote(model);
-    let base_url = yaml_quote(&format!("{SERVER}/v1"));
+    let base_url = yaml_quote(&format!("{}/v1", daemon::server()));
     let ours = format!(
         "model:\n  provider: llmman\n  default: {model}\n  base_url: {base_url}\n  api_key: llmman\n\
          providers:\n  llmman:\n    name: llmman\n    api: {base_url}\n    default_model: {model}\n    models:\n      - {model}\n"
@@ -592,7 +596,7 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
                 "--auth-choice",
                 "ollama",
                 "--custom-base-url",
-                &format!("{SERVER}/v1"),
+                &format!("{}/v1", daemon::server()),
                 "--custom-model-id",
                 effective_model,
                 "--skip-health",
@@ -620,7 +624,7 @@ fn exec_with_env(bin: &PathBuf, args: &[String], extra_env: &[(&str, &str)]) -> 
 
     // Inherit the current environment and overlay OLLAMA_HOST + integration vars.
     let mut env: std::collections::HashMap<String, String> = std::env::vars().collect();
-    env.insert("OLLAMA_HOST".to_string(), SERVER.to_string());
+    env.insert("OLLAMA_HOST".to_string(), daemon::server());
     for (k, v) in extra_env {
         env.insert(k.to_string(), v.to_string());
     }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -36,7 +36,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 
-use crate::daemon::SERVER;
+use crate::daemon;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -554,7 +554,7 @@ async fn chat_submit_async(
     tokio::pin!(ctrl_c);
 
     let send = client
-        .post(format!("{SERVER}/api/chat"))
+        .post(format!("{}/api/chat", daemon::server()))
         .json(&ChatReq {
             model,
             messages,

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -3990,7 +3990,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         .route("/v1/messages", post(handle_anthropic_messages))
         .with_state(app_state);
 
-    let addr = "127.0.0.1:17434";
+    let addr = crate::daemon::bind_addr();
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .with_context(|| format!("bind {addr}"))?;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,5 +1,6 @@
 //! Shared client-side helpers for talking to a local `llmman serve`
-//! instance over its Ollama-protocol HTTP API (127.0.0.1:17434).
+//! instance over its Ollama-protocol HTTP API — `http://127.0.0.1:17434`
+//! by default, overridable via `LLMMAN_HOST`.
 //!
 //! Used by any CLI subcommand that acts as a client of that API rather than
 //! calling the FFI/model-management logic directly — currently `pull`,
@@ -10,21 +11,143 @@
 
 use std::io::BufRead;
 use std::process::{Command, Stdio};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::Context;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Deserialize;
 
-/// The fixed loopback origin `llmman serve` always binds to (see
-/// cmd::serve's own doc comment on why this isn't configurable).
-pub const SERVER: &str = "http://127.0.0.1:17434";
+/// Default bind host/port when `LLMMAN_HOST` is unset/blank.
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: u16 = 17434;
 
-/// Quick synchronous reachability check — none of this module's callers
-/// run inside an async runtime, so a plain TCP connect attempt is enough
-/// (no need to actually round-trip an HTTP request just to check liveness).
+/// `(scheme, host, port)` parsed from `LLMMAN_HOST`, cached for the
+/// process's life.
+static PARSED_HOST: OnceLock<(String, String, u16)> = OnceLock::new();
+
+fn parsed_host() -> &'static (String, String, u16) {
+    PARSED_HOST.get_or_init(|| parse_host(std::env::var("LLMMAN_HOST").ok().as_deref()))
+}
+
+/// Parses `[scheme://]host[:port][/path]` — a bare host, `host:port`, or
+/// nothing at all also work. `path` is discarded (unused). An explicit
+/// `http://`/`https://` scheme shifts the default port to 80/443 when no
+/// port is given; anything else keeps `DEFAULT_PORT`. A missing/
+/// unparseable host or port falls back to its own default, independently.
+fn parse_host(value: Option<&str>) -> (String, String, u16) {
+    let raw = value.unwrap_or("");
+    let trimmed = raw.trim().trim_matches(|c| c == '"' || c == '\'');
+
+    let mut default_port = DEFAULT_PORT;
+    let (scheme, hostport) = match trimmed.split_once("://") {
+        Some((scheme, rest)) => {
+            match scheme {
+                "http" => default_port = 80,
+                "https" => default_port = 443,
+                _ => {}
+            }
+            (scheme.to_string(), rest)
+        }
+        None => ("http".to_string(), trimmed),
+    };
+
+    // Drop a trailing path, if any (e.g. "host:port/some/path") — never used.
+    let hostport = hostport.split_once('/').map_or(hostport, |(h, _)| h);
+
+    let (host, port) = split_host_port(hostport);
+    let port = port
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(default_port);
+    let host = host.unwrap_or_else(|| DEFAULT_HOST.to_string());
+    (scheme, host, port)
+}
+
+/// Minimal `net.SplitHostPort` equivalent for what `parse_host` can pass
+/// in: empty, a bare host, `host:port`, or a bracketed IPv6 literal
+/// (`[::1]` or `[::1]:port`). A bare multi-colon literal (e.g. `::1`) is
+/// kept whole with no port rather than guessed at.
+fn split_host_port(hostport: &str) -> (Option<String>, Option<&str>) {
+    if hostport.is_empty() {
+        return (None, None);
+    }
+    if let Some(rest) = hostport.strip_prefix('[') {
+        return match rest.split_once(']') {
+            Some((host, after)) => {
+                let port = after.strip_prefix(':').filter(|p| !p.is_empty());
+                (Some(host.to_string()), port)
+            }
+            None => (Some(hostport.to_string()), None), // malformed bracket; keep as one host
+        };
+    }
+    match hostport.rsplit_once(':') {
+        Some((host, port)) if !host.contains(':') && !port.is_empty() => {
+            (Some(host.to_string()), Some(port))
+        }
+        _ => (Some(hostport.to_string()), None),
+    }
+}
+
+/// Renders `host:port`, bracketing `host` if it's an IPv6 literal.
+fn format_host_port(host: &str, port: u16) -> String {
+    if host.parse::<std::net::Ipv6Addr>().is_ok() {
+        format!("[{host}]:{port}")
+    } else {
+        format!("{host}:{port}")
+    }
+}
+
+/// The `http://host:port` origin every client in this process talks to.
+/// Always `http` (`llmman serve` has no TLS support) and built from
+/// `connect_addr`, not the raw configured host, so a wildcard bind
+/// (`0.0.0.0`/`[::]`) still gets a host clients can actually reach.
+pub fn server() -> String {
+    format!("http://{}", connect_addr())
+}
+
+/// The bare `host:port` `llmman serve`'s own listener binds — the raw
+/// configured host, since a wildcard bind (`0.0.0.0`/`::`) is meaningful
+/// here, unlike for `connect_addr`.
+pub fn bind_addr() -> String {
+    let (_, host, port) = parsed_host();
+    format_host_port(host, *port)
+}
+
+/// The bare `host:port` a client should *connect* to — like `bind_addr`,
+/// but a wildcard host is rewritten to loopback first, since a client
+/// can't connect to "every interface".
+fn connect_addr() -> String {
+    let (_, host, port) = parsed_host();
+    format_host_port(connectable_host(host), *port)
+}
+
+/// Rewrites a wildcard host (any `is_unspecified` IP, e.g. `0.0.0.0`/`::`)
+/// to its loopback equivalent, by value rather than by exact spelling —
+/// so an expanded IPv6 form (`0:0:0:0:0:0:0:0`) is caught too.
+fn connectable_host(host: &str) -> &str {
+    match host.parse::<std::net::IpAddr>() {
+        Ok(ip) if ip.is_unspecified() => {
+            if ip.is_ipv4() {
+                "127.0.0.1"
+            } else {
+                "::1"
+            }
+        }
+        _ => host,
+    }
+}
+
+/// Quick reachability check with a short timeout — a plain TCP connect
+/// attempt is enough (no need to round-trip an HTTP request), but with
+/// `LLMMAN_HOST` possibly pointing at a remote, unreachable address, an
+/// unbounded `TcpStream::connect` could hang far longer than any caller
+/// (`ensure_server`, `ps`) wants to wait.
 pub fn server_alive() -> bool {
-    std::net::TcpStream::connect("127.0.0.1:17434").is_ok()
+    use std::net::ToSocketAddrs;
+    let Ok(mut addrs) = connect_addr().to_socket_addrs() else {
+        return false;
+    };
+    addrs.any(|addr| std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(2)).is_ok())
 }
 
 /// The daemon's self-identity from GET /api/version — the identity fields
@@ -39,6 +162,25 @@ struct DaemonIdentity {
     exe: Option<String>,
     #[serde(default)]
     pid: Option<u32>,
+}
+
+/// Whether the configured host is this machine — a remote one's PID
+/// belongs to another machine, so spawning/killing based on it must be
+/// skipped.
+fn host_is_local() -> bool {
+    let (_, host, _) = parsed_host();
+    is_local_host(host)
+}
+
+/// By value rather than by exact spelling, same as `connectable_host` —
+/// a loopback or unspecified IP (in any form) is local; a bare
+/// "localhost" is too, since it always resolves to one.
+fn is_local_host(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_loopback() || ip.is_unspecified())
 }
 
 /// Returns the running daemon's identity if it should be stopped and
@@ -64,7 +206,7 @@ fn stale_daemon() -> Option<DaemonIdentity> {
         .timeout(Some(Duration::from_secs(2)))
         .build()
         .ok()?
-        .get(format!("{SERVER}/api/version"))
+        .get(format!("{}/api/version", server()))
         .send()
         .ok()?;
     if !resp.status().is_success() {
@@ -104,8 +246,9 @@ fn stop_stale_daemon(identity: &DaemonIdentity) -> anyhow::Result<()> {
         return Ok(());
     }
     anyhow::bail!(
-        "a stale llmman serve daemon is still holding 127.0.0.1:17434 after being asked to stop; \
-         stop it manually (e.g. pkill -f 'llmman serve') and retry"
+        "a stale llmman serve daemon is still holding {} after being asked to stop; \
+         stop it manually (e.g. pkill -f 'llmman serve') and retry",
+        bind_addr()
     )
 }
 
@@ -199,6 +342,11 @@ fn kill_daemon(identity: &DaemonIdentity, _force: bool) {
 /// integration it's about to hand off to).
 pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
     if server_alive() {
+        // A remote LLMMAN_HOST: reuse whatever's there, and never touch
+        // its PID (see host_is_local) or spawn a "replacement" over it.
+        if !host_is_local() {
+            return Ok(());
+        }
         // Reuse the running daemon — unless it outlived its own install
         // (see stale_daemon): reusing that one means serving with a
         // long-obsolete build whose llama-server (and bug fixes) are gone.
@@ -206,6 +354,11 @@ pub fn ensure_server(preload_model: &str) -> anyhow::Result<()> {
             None => return Ok(()),
             Some(identity) => stop_stale_daemon(&identity)?,
         }
+    } else if !host_is_local() {
+        anyhow::bail!(
+            "LLMMAN_HOST={} is unreachable, and llmman can't start a daemon on a remote host",
+            server()
+        );
     }
     let exe = std::env::current_exe().context("could not resolve own executable")?;
 
@@ -482,7 +635,7 @@ pub fn stream_progress(path: &str, reference: &str) -> anyhow::Result<()> {
         .build()
         .context("build http client")?;
     let resp = client
-        .post(format!("{SERVER}{path}"))
+        .post(format!("{}{path}", server()))
         .json(&serde_json::json!({"model": reference}))
         .send()
         .with_context(|| format!("request {path} for {reference}"))?;
@@ -602,7 +755,7 @@ pub fn stream_progress(path: &str, reference: &str) -> anyhow::Result<()> {
 /// no download/pull side effects.
 fn model_exists(reference: &str) -> anyhow::Result<bool> {
     let resp = reqwest::blocking::Client::new()
-        .post(format!("{SERVER}/api/show"))
+        .post(format!("{}/api/show", server()))
         .json(&serde_json::json!({"model": reference}))
         .send()
         .with_context(|| format!("request /api/show for {reference}"))?;
@@ -634,7 +787,7 @@ pub fn ensure_model_pulled(reference: &str) -> anyhow::Result<()> {
 /// by `llmman stop`.
 pub fn unload(reference: &str) -> anyhow::Result<()> {
     let resp = reqwest::blocking::Client::new()
-        .post(format!("{SERVER}/api/generate"))
+        .post(format!("{}/api/generate", server()))
         .json(&serde_json::json!({"model": reference, "keep_alive": 0}))
         .send()
         .with_context(|| format!("request /api/generate (unload) for {reference}"))?;
@@ -646,11 +799,11 @@ pub fn unload(reference: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// A plain `GET {SERVER}{path}` returning the parsed JSON body — for
+/// A plain `GET {server()}{path}` returning the parsed JSON body — for
 /// callers (currently just `ps`) that don't need `stream_progress`'s
 /// newline-delimited-JSON streaming, just a single request/response.
 pub fn get_json<T: serde::de::DeserializeOwned>(path: &str) -> anyhow::Result<T> {
-    let resp = reqwest::blocking::get(format!("{SERVER}{path}"))
+    let resp = reqwest::blocking::get(format!("{}{path}", server()))
         .with_context(|| format!("request {path}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
@@ -659,4 +812,148 @@ pub fn get_json<T: serde::de::DeserializeOwned>(path: &str) -> anyhow::Result<T>
     }
     resp.json()
         .with_context(|| format!("parse response from {path}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unset/blank `LLMMAN_HOST` — the common case — resolves to the
+    /// documented default.
+    #[test]
+    fn parse_host_defaults_when_unset_or_blank() {
+        assert_eq!(
+            parse_host(None),
+            ("http".to_string(), "127.0.0.1".to_string(), 17434)
+        );
+        assert_eq!(
+            parse_host(Some("  ")),
+            ("http".to_string(), "127.0.0.1".to_string(), 17434)
+        );
+    }
+
+    #[test]
+    fn parse_host_accepts_a_bare_host() {
+        assert_eq!(
+            parse_host(Some("0.0.0.0")),
+            ("http".to_string(), "0.0.0.0".to_string(), 17434)
+        );
+    }
+
+    #[test]
+    fn parse_host_accepts_a_bare_host_and_port() {
+        assert_eq!(
+            parse_host(Some("0.0.0.0:8080")),
+            ("http".to_string(), "0.0.0.0".to_string(), 8080)
+        );
+    }
+
+    #[test]
+    fn parse_host_accepts_an_explicit_scheme() {
+        assert_eq!(
+            parse_host(Some("https://example.com:9999")),
+            ("https".to_string(), "example.com".to_string(), 9999)
+        );
+    }
+
+    /// An explicit `http://`/`https://` scheme with no port shifts the
+    /// *default* port to 80/443.
+    #[test]
+    fn parse_host_shifts_default_port_for_http_and_https_schemes() {
+        assert_eq!(
+            parse_host(Some("http://example.com")),
+            ("http".to_string(), "example.com".to_string(), 80)
+        );
+        assert_eq!(
+            parse_host(Some("https://example.com")),
+            ("https".to_string(), "example.com".to_string(), 443)
+        );
+    }
+
+    /// A non-http(s) scheme (or none at all) keeps llmman's own default
+    /// port rather than shifting to 80.
+    #[test]
+    fn parse_host_keeps_default_port_for_other_schemes() {
+        assert_eq!(
+            parse_host(Some("grpc://example.com")),
+            ("grpc".to_string(), "example.com".to_string(), 17434)
+        );
+    }
+
+    #[test]
+    fn parse_host_accepts_a_bracketed_ipv6_literal_with_port() {
+        assert_eq!(
+            parse_host(Some("[::1]:8080")),
+            ("http".to_string(), "::1".to_string(), 8080)
+        );
+    }
+
+    #[test]
+    fn parse_host_accepts_a_bare_ipv6_literal_with_no_port() {
+        assert_eq!(
+            parse_host(Some("::1")),
+            ("http".to_string(), "::1".to_string(), 17434)
+        );
+    }
+
+    /// An out-of-range/unparseable port falls back to the default port,
+    /// keeping whatever host was given.
+    #[test]
+    fn parse_host_falls_back_to_default_port_when_unparseable() {
+        assert_eq!(
+            parse_host(Some("example.com:not-a-port")),
+            ("http".to_string(), "example.com".to_string(), 17434)
+        );
+        assert_eq!(
+            parse_host(Some("example.com:99999")),
+            ("http".to_string(), "example.com".to_string(), 17434)
+        );
+    }
+
+    #[test]
+    fn parse_host_trims_whitespace_and_surrounding_quotes() {
+        assert_eq!(
+            parse_host(Some("  \"0.0.0.0:8080\"  ")),
+            ("http".to_string(), "0.0.0.0".to_string(), 8080)
+        );
+    }
+
+    #[test]
+    fn parse_host_drops_a_trailing_path() {
+        assert_eq!(
+            parse_host(Some("example.com:8080/some/path")),
+            ("http".to_string(), "example.com".to_string(), 8080)
+        );
+    }
+
+    #[test]
+    fn format_host_port_brackets_ipv6_literals() {
+        assert_eq!(format_host_port("::1", 17434), "[::1]:17434");
+        assert_eq!(format_host_port("127.0.0.1", 17434), "127.0.0.1:17434");
+        assert_eq!(format_host_port("example.com", 17434), "example.com:17434");
+    }
+
+    #[test]
+    fn connectable_host_rewrites_wildcard_hosts_to_loopback() {
+        assert_eq!(connectable_host("0.0.0.0"), "127.0.0.1");
+        assert_eq!(connectable_host("::"), "::1");
+        assert_eq!(connectable_host("0:0:0:0:0:0:0:0"), "::1"); // expanded IPv6 form
+        assert_eq!(connectable_host("example.com"), "example.com");
+    }
+
+    #[test]
+    fn is_local_host_only_accepts_loopback_and_wildcard_hosts() {
+        for host in [
+            "127.0.0.1",
+            "::1",
+            "0:0:0:0:0:0:0:1", // expanded IPv6 loopback
+            "localhost",
+            "0.0.0.0",
+            "::",
+        ] {
+            assert!(is_local_host(host), "{host} should be local");
+        }
+        assert!(!is_local_host("example.com"));
+        assert!(!is_local_host("192.168.1.5"));
+    }
 }

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -23,8 +23,9 @@
 //! store) is assumed available and NOT treated as skippable: a pull
 //! failure is a real failure here, not an environment-setup gap.
 //!
-//! `llmman serve` is a process-wide singleton bound to a fixed loopback
-//! port (127.0.0.1:17434 — see `daemon::SERVER`), so these tests can't
+//! `llmman serve` is a process-wide singleton bound to a single loopback
+//! port (127.0.0.1:17434 by default, or wherever `LLMMAN_HOST` points —
+//! see `daemon::server`/`daemon::bind_addr`), so these tests can't
 //! isolate their own daemon instance from each other or from one already
 //! running on the machine: `llmman launch` (via `daemon::ensure_server`)
 //! just reuses whatever's already listening there, preloaded with


### PR DESCRIPTION
Adds `LLMMAN_HOST` to control the address `llmman serve` binds to.

- `daemon::SERVER` is replaced by three functions, parsed from `LLMMAN_HOST` once per process:
  - `bind_addr()` — raw `host:port` the listener binds (wildcard hosts kept as-is).
  - `server()` — `http://host:port` every client talks to; wildcard hosts rewritten to loopback, scheme forced to `http`.
  - `connect_addr()` — bare `host:port` for the liveness check, same loopback rewrite.
- Host classification (`connectable_host`/`is_local_host`) parses the IP by value, so expanded IPv6 forms are caught too.
- `ensure_server`'s stale-daemon replacement is skipped for a remote host, so a remote PID is never used for local process control.
- `server_alive` uses a short `connect_timeout` instead of an unbounded connect, since a remote host may not respond.
- Defaults to `127.0.0.1:17434` when unset — no behavior change.
- README documents the variable; unit tests cover the parser.

Tested: `cargo test --lib` (264 passed), `cargo clippy`/`cargo fmt --check` clean.