### PR TITLE
fix(vllm-plugin): tolerate EPERM in the vllm serve e2e test's cleanup

### DIFF
--- a/vllm-plugin/tests/test_e2e.py
+++ b/vllm-plugin/tests/test_e2e.py
@@ -218,11 +218,17 @@ def _terminate(proc: subprocess.Popen) -> None:
     `ProcessLookupError` is the actual signal the whole group is gone
     (a process group only disappears once empty) — the reliable stop
     condition here, unlike `proc.poll()`.
+
+    Also tolerates `PermissionError`: seen flakily on macOS CI when
+    `proc` has already exited/been reaped and its pid got recycled for
+    an unrelated process before this runs, so `killpg` raises EPERM
+    instead of ESRCH. Either way there's no pid left we can reliably
+    signal, so treat it like `ProcessLookupError`.
     """
     for sig in (signal.SIGTERM, signal.SIGKILL):
         try:
             os.killpg(proc.pid, sig)
-        except ProcessLookupError:
+        except (ProcessLookupError, PermissionError):
             break
         try:
             proc.wait(timeout=15)


### PR DESCRIPTION
## Problem

`main`'s macOS E2E job (`pytest -m e2e (vllm-plugin)`) flakes:
`test_vllm_serve_resolves_and_serves_a_real_oci_reference` passes its
actual assertions, then fails in `finally: _terminate(proc)` with
`PermissionError: [Errno 1] Operation not permitted`.

(A separate `Release` job 403 also fails on `main`, but that's an
org-level Actions permissions policy, not something a code change can
fix — left alone here.)

## Root cause

`_terminate` signals `proc`'s whole process group since vLLM's worker
subprocess(es) can outlive the launcher `proc`. Once `proc` exits and
is reaped, its pid can be recycled by the OS for an unrelated process
before cleanup runs, so `os.killpg` raises `EPERM` instead of the
already-handled `ESRCH` (`ProcessLookupError`).

## Fix

Catch `PermissionError` alongside `ProcessLookupError` in `_terminate`.

## Verification

- `pytest tests/` (non-e2e) in `vllm-plugin/`: 23 passed, 1 skipped, 4 deselected.
- Confirmed the flake pattern across recent CI runs: same job
  intermittently passes or fails with this exact error, with
  `proc.returncode == 0` at failure time.