### PR TITLE
feat: prune models when `rm`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Daemon-wide settings, set before `llmman serve` starts:
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0` — trades output quality for memory at long context lengths, matching Ollama's `OLLAMA_KV_CACHE_TYPE`. |
 | `LLMMAN_MODELS` | Local store directory, overriding the default below — matching Ollama's `OLLAMA_MODELS`. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root — matching Ollama's `OLLAMA_TMPDIR`. |
+| `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
 
 ### Launch an integration
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Daemon-wide settings, set before `llmman serve` starts:
 | `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0` — trades output quality for memory at long context lengths, matching Ollama's `OLLAMA_KV_CACHE_TYPE`. |
 | `LLMMAN_MODELS` | Local store directory, overriding the default below — matching Ollama's `OLLAMA_MODELS`. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root — matching Ollama's `OLLAMA_TMPDIR`. |
-| `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
+| `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
 
 ### Launch an integration
 

--- a/src/cmd/resolve.rs
+++ b/src/cmd/resolve.rs
@@ -70,7 +70,8 @@ pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
     let cache_path = args
         .cache
         .clone()
-        .unwrap_or_else(|| store_path.join("cache"));
+        .map(Ok)
+        .unwrap_or_else(crate::default_cache)?;
     std::fs::create_dir_all(&store_path)
         .with_context(|| format!("creating store dir {}", store_path.display()))?;
     std::fs::create_dir_all(&cache_path)

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use clap::Args;
 
-use crate::storage::OciStore;
+use crate::storage::{gc, OciStore};
 
 #[derive(Args, Debug)]
 pub struct RmArgs {
@@ -14,6 +16,7 @@ pub fn run(args: &RmArgs) -> anyhow::Result<()> {
     let store = OciStore::open(&store_root)?;
 
     let mut any_err = false;
+    let mut any_removed = false;
     for raw in &args.references {
         // resolve_ollama_api, not resolve: a bare name pulled via the
         // Ollama API (POST /api/pull, /api/chat, ...) is stored under
@@ -21,13 +24,37 @@ pub fn run(args: &RmArgs) -> anyhow::Result<()> {
         // way here or `llmman rm <bare-name>` looks for the wrong entry.
         let reference = crate::shortnames::resolve_ollama_api(raw);
         match store.remove(&reference) {
-            Ok(()) => println!("Removed {}", reference),
+            Ok(()) => {
+                println!("Removed {}", reference);
+                any_removed = true;
+            }
             Err(e) => {
                 eprintln!("Error removing {}: {}", reference, e);
                 any_err = true;
             }
         }
     }
+
+    // GC once, after every requested reference is untagged: recompute the
+    // still-referenced digest set from the surviving manifests, then sweep
+    // blobs/cache not in it. Grace 0 — `rm` is synchronous and
+    // user-initiated, so free the space immediately (the startup sweep in
+    // `serve` uses the grace window for the concurrent-pull case instead).
+    if any_removed && !gc::noprune_from_env() {
+        let live = gc::referenced_digests(&store)?;
+        let cache_path = crate::default_cache()?;
+        let blob_stats = gc::prune_blobs(&store_root, &live, Duration::ZERO)?;
+        let cache_stats = gc::prune_cache(&cache_path, &live, Duration::ZERO)?;
+        if blob_stats.count > 0 || cache_stats.count > 0 {
+            println!(
+                "Freed {} ({} blobs, {} cache entries)",
+                crate::fmt::human_size(blob_stats.bytes + cache_stats.bytes),
+                blob_stats.count,
+                cache_stats.count
+            );
+        }
+    }
+
     if any_err {
         anyhow::bail!("one or more removals failed");
     }

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use clap::Args;
 
 use crate::storage::{gc, OciStore};
@@ -37,14 +35,20 @@ pub fn run(args: &RmArgs) -> anyhow::Result<()> {
 
     // GC once, after every requested reference is untagged: recompute the
     // still-referenced digest set from the surviving manifests, then sweep
-    // blobs/cache not in it. Grace 0 — `rm` is synchronous and
-    // user-initiated, so free the space immediately (the startup sweep in
-    // `serve` uses the grace window for the concurrent-pull case instead).
+    // blobs/cache not in it. Uses the same grace window as serve's startup
+    // sweep, NOT zero: `llmman pull` runs in the long-lived `serve` daemon,
+    // which writes each layer blob to its final path as it downloads and
+    // only writes the manifest + tag at the very end. A concurrent
+    // `rm <unrelated>` would otherwise see that not-yet-tagged blob as an
+    // orphan and delete it mid-pull. The writer is a different process, so
+    // `rm` being synchronous doesn't protect it — only the grace window
+    // does (matches Ollama's layerPruneGracePeriod).
     if any_removed && !gc::noprune_from_env() {
         let live = gc::referenced_digests(&store)?;
         let cache_path = crate::default_cache()?;
-        let blob_stats = gc::prune_blobs(&store_root, &live, Duration::ZERO)?;
-        let cache_stats = gc::prune_cache(&cache_path, &live, Duration::ZERO)?;
+        let grace = gc::GC_GRACE_PERIOD;
+        let blob_stats = gc::prune_blobs(&store_root, &live, grace)?;
+        let cache_stats = gc::prune_cache(&cache_path, &live, grace)?;
         if blob_stats.count > 0 || cache_stats.count > 0 {
             println!(
                 "Freed {} ({} blobs, {} cache entries)",

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -4376,7 +4376,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         None
     };
     let store_path = default_store()?;
-    let cache_path = store_path.parent().unwrap_or(&store_path).join("cache");
+    let cache_path = crate::default_cache()?;
     std::fs::create_dir_all(&cache_path)?;
     // See storage::repair's own doc comment — matches Ollama's own
     // unconditional `fixBlobs(blobsDir)` at the top of `server.Serve`,

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -4383,6 +4383,26 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     // before it starts listening.
     crate::storage::repair::repair_store(&store_path)?;
 
+    // Catch-all GC sweep, right after repair: removes blobs/cache orphaned
+    // by anything other than `rm` (a crash mid-pull past the grace window,
+    // manual store surgery, an old build's leftover cache after a format
+    // change). Grace-gated (unlike `rm`, which frees immediately) so a blob
+    // written moments before its tag during a concurrent pull survives.
+    // Gated by the same LLMMAN_NOPRUNE escape hatch as `rm`.
+    if !crate::storage::gc::noprune_from_env() {
+        if let Ok(store) = OciStore::open(&store_path) {
+            if let Ok(live) = crate::storage::gc::referenced_digests(&store) {
+                let grace = crate::storage::gc::GC_GRACE_PERIOD;
+                if let Err(e) = crate::storage::gc::prune_blobs(&store_path, &live, grace) {
+                    eprintln!("[llmman] blob GC sweep failed: {e:#}");
+                }
+                if let Err(e) = crate::storage::gc::prune_cache(&cache_path, &live, grace) {
+                    eprintln!("[llmman] cache GC sweep failed: {e:#}");
+                }
+            }
+        }
+    }
+
     // See context_length_from_env's doc comment. spawn_blocking: like
     // resolve_llama_server above, the VRAM probe fallback spawns a
     // subprocess and must not block this async fn's executor thread.

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -49,7 +49,7 @@ pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
     let desc = store.find(&reference)?;
     let manifest = store.read_manifest(&desc.digest)?;
 
-    let cache_path = store_path.join("cache");
+    let cache_path = crate::default_cache()?;
     std::fs::create_dir_all(&cache_path).ok();
     let resolved = resolve_model(&store_path, &cache_path, &reference)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,17 @@ fn models_dir_from_env() -> Option<PathBuf> {
     parse_env_path(std::env::var("LLMMAN_MODELS").ok().as_deref())
 }
 
+/// Path to the extracted-model cache — a sibling of the store
+/// (`<store>/../cache`), matching what `llmman serve` (the long-running
+/// server that extracts most models) uses. The single canonical answer for
+/// "where is the cache", so extraction and the GC sweep agree on it rather
+/// than one command writing to `<store>/cache` and another cleaning
+/// `<store>/../cache`.
+pub fn default_cache() -> anyhow::Result<PathBuf> {
+    let store = default_store()?;
+    Ok(store.parent().unwrap_or(&store).join("cache"))
+}
+
 /// Split out from [`models_dir_from_env`] for testing without touching
 /// the real environment. Blank values count as unset.
 fn parse_env_path(value: Option<&str>) -> Option<PathBuf> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,8 @@ enum Commands {
     Ps(cmd::ps::PsArgs),
     /// Copy a local image to a new reference
     Cp(cmd::cp::CpArgs),
-    /// Remove a local image
+    /// Remove a local image, freeing its blobs and extracted cache no
+    /// longer referenced by any other model (set LLMMAN_NOPRUNE to skip)
     Rm(cmd::rm::RmArgs),
     /// Stop (unload) a running model
     Stop(cmd::stop::StopArgs),

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -259,6 +259,38 @@ mod tests {
         std::fs::remove_dir_all(&root).unwrap();
     }
 
+    /// The concurrent-pull safety property: an unreferenced blob younger
+    /// than the grace window is left alone (it may be a layer an in-flight
+    /// pull has already written but not yet tagged), while an equally
+    /// unreferenced but older blob is swept. Without this, a concurrent
+    /// `rm` could delete a live pull's just-written layer.
+    #[test]
+    #[cfg(unix)]
+    fn prune_blobs_respects_the_grace_window() {
+        let root = temp_dir("prune-blobs-grace");
+        let blobs = root.join("blobs").join("sha256");
+        std::fs::create_dir_all(&blobs).unwrap();
+        let fresh = blobs.join("cccc");
+        let stale = blobs.join("dddd");
+        std::fs::write(&fresh, b"just written by an in-flight pull").unwrap();
+        std::fs::write(&stale, b"long-abandoned orphan").unwrap();
+        // Back-date the stale blob past the grace window.
+        let old = SystemTime::now() - GC_GRACE_PERIOD - Duration::from_secs(60);
+        filetime_set(&stale, old);
+
+        let live = HashSet::new(); // neither is referenced
+        let stats = prune_blobs(&root, &live, GC_GRACE_PERIOD).unwrap();
+
+        assert_eq!(stats.count, 1);
+        assert!(
+            fresh.exists(),
+            "a fresh unreferenced blob must survive — it may be a live pull's untagged layer"
+        );
+        assert!(!stale.exists(), "a stale unreferenced blob must be swept");
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
     #[test]
     fn prune_cache_removes_only_unreferenced_dirs() {
         let cache = temp_dir("prune-cache");
@@ -289,5 +321,23 @@ mod tests {
                 .count,
             0
         );
+    }
+
+    /// Minimal mtime-backdating helper — mirrors the one in
+    /// `storage::repair`'s tests, avoiding a `filetime` dependency just for
+    /// this. Unix-only, like that one.
+    #[cfg(unix)]
+    fn filetime_set(path: &Path, when: SystemTime) {
+        use std::os::unix::io::AsRawFd;
+        let file = std::fs::File::open(path).unwrap();
+        let d = when.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        let tv = libc::timeval {
+            tv_sec: d.as_secs() as _,
+            tv_usec: d.subsec_micros() as _,
+        };
+        let times = [tv, tv];
+        unsafe {
+            libc::futimes(file.as_raw_fd(), times.as_ptr());
+        }
     }
 }

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -1,0 +1,282 @@
+//! Content-addressed garbage collection for the blob store and the
+//! extracted-model cache.
+//!
+//! Because the store is fully content-addressed and every tag is just a
+//! small pointer file under `manifests/` (see [`crate::storage::oci`]),
+//! "what's still needed" can always be recomputed from scratch by reading
+//! every *surviving* manifest — there's no refcount or journal to keep in
+//! sync (a crash, a manual edit, an interrupted pull can never desync it,
+//! because the live set is rebuilt fresh on every sweep).
+//!
+//! [`referenced_digests`] builds that live set; [`prune_blobs`] and
+//! [`prune_cache`] sweep everything not in it. Both are grace-gated the
+//! same way [`crate::storage::repair`] gates its stale-temp-file sweep: a
+//! blob is written before its manifest/tag pointer, so a blob can be
+//! legitimately unreferenced for a moment mid-pull — anything younger than
+//! `grace` is left alone. `rm` passes a zero grace (a synchronous,
+//! user-initiated removal wants space freed now); the `serve` startup
+//! catch-all passes the hour-long window.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Context;
+
+use super::OciStore;
+
+/// Grace window for the startup catch-all sweep — matches
+/// [`crate::storage::repair::STALE_TMP_FILE_AGE`], so there's one duration
+/// to reason about for "how long might a just-written blob be legitimately
+/// unreferenced".
+pub const GC_GRACE_PERIOD: Duration = Duration::from_secs(60 * 60);
+
+/// What a sweep freed, for reporting.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GcStats {
+    pub count: usize,
+    pub bytes: u64,
+}
+
+/// Every blob digest ("sha256:<hex>") still reachable from a surviving
+/// tag: each manifest's own digest, its config digest, and every layer
+/// digest. Built by walking [`OciStore::list_refs`] and reading each
+/// manifest — the same traversal `resolve_model` does per-reference, just
+/// over every reference at once. A manifest that can't be read is skipped
+/// (its blobs then look unreferenced) — acceptable, since an unreadable
+/// manifest is already a broken/incomplete image, but conservative callers
+/// run this only right after a successful `remove`.
+pub fn referenced_digests(store: &OciStore) -> anyhow::Result<HashSet<String>> {
+    let mut live = HashSet::new();
+    for desc in store.list_refs() {
+        live.insert(desc.digest.clone());
+        let Ok(manifest) = store.read_manifest(&desc.digest) else {
+            continue;
+        };
+        live.insert(manifest.config.digest.clone());
+        live.extend(manifest.layers.iter().map(|l| l.digest.clone()));
+    }
+    Ok(live)
+}
+
+/// Deletes every blob file under `blobs/sha256/` whose `sha256:<name>`
+/// digest isn't in `live`, skipping in-progress temp writes (`tmp-`/
+/// `.tmp`, same as [`crate::storage::repair`]) and anything younger than
+/// `grace`. A missing blobs directory is a no-op.
+pub fn prune_blobs(store_root: &Path, live: &HashSet<String>, grace: Duration) -> anyhow::Result<GcStats> {
+    let blobs_dir = store_root.join("blobs").join("sha256");
+    let mut stats = GcStats::default();
+    let entries = match std::fs::read_dir(&blobs_dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(stats),
+        Err(e) => return Err(e).with_context(|| format!("read {}", blobs_dir.display())),
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // In-progress or abandoned write — left to repair's own sweep.
+        if name.starts_with("tmp-") || name.ends_with(".tmp") {
+            continue;
+        }
+        if live.contains(&format!("sha256:{name}")) {
+            continue;
+        }
+        if !is_older_than(&path, grace) {
+            continue;
+        }
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        if let Err(e) = std::fs::remove_file(&path) {
+            eprintln!("[llmman] couldn't remove unreferenced blob {name}: {e:#}");
+            continue;
+        }
+        stats.count += 1;
+        stats.bytes += size;
+    }
+    Ok(stats)
+}
+
+/// Deletes every cache subdirectory under `cache_path` whose name (a layer
+/// hex for GGUF, a manifest hex for safetensors — see
+/// `modelpack::extract_gguf_layer` / `extract_safetensors_dir`) doesn't
+/// correspond to a live digest, skipping anything younger than `grace`. A
+/// missing cache directory is a no-op.
+pub fn prune_cache(cache_path: &Path, live: &HashSet<String>, grace: Duration) -> anyhow::Result<GcStats> {
+    let live_hex: HashSet<&str> = live
+        .iter()
+        .filter_map(|d| d.strip_prefix("sha256:"))
+        .collect();
+    let mut stats = GcStats::default();
+    let entries = match std::fs::read_dir(cache_path) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(stats),
+        Err(e) => return Err(e).with_context(|| format!("read {}", cache_path.display())),
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { continue };
+        let path = entry.path();
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if live_hex.contains(name) {
+            continue;
+        }
+        if !is_older_than(&path, grace) {
+            continue;
+        }
+        let size = dir_size(&path);
+        if let Err(e) = std::fs::remove_dir_all(&path) {
+            eprintln!("[llmman] couldn't remove unreferenced cache dir {name}: {e:#}");
+            continue;
+        }
+        stats.count += 1;
+        stats.bytes += size;
+    }
+    Ok(stats)
+}
+
+/// True if `path`'s mtime is at least `grace` old. A zero `grace` makes
+/// this always true (used by `rm`, which frees immediately). A file whose
+/// mtime can't be read is treated as not-yet-old, so it's left alone
+/// rather than deleted on a metadata hiccup.
+fn is_older_than(path: &Path, grace: Duration) -> bool {
+    if grace.is_zero() {
+        return true;
+    }
+    let Ok(modified) = std::fs::metadata(path).and_then(|m| m.modified()) else {
+        return false;
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age >= grace)
+}
+
+/// Total size of the files directly inside `dir` (cache dirs are flat —
+/// extracted GGUF/safetensors files, no nesting). Best-effort: unreadable
+/// entries contribute 0.
+fn dir_size(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// Skips both the post-`rm` and startup GC sweeps when `LLMMAN_NOPRUNE` is
+/// set to anything other than an explicit falsy value — an escape hatch
+/// for shared/read-mostly stores or scripts that `rm` in a loop and would
+/// rather prune once at the end themselves. Read fresh at each call site,
+/// like every other `LLMMAN_*` var.
+pub fn noprune_from_env() -> bool {
+    parse_noprune(std::env::var("LLMMAN_NOPRUNE").ok().as_deref())
+}
+
+/// Split out from [`noprune_from_env`] for testing without touching the
+/// real environment. Unset, blank, or an explicit falsy value
+/// (`0`/`false`/`no`/`off`, case-insensitive) all mean "don't skip".
+fn parse_noprune(value: Option<&str>) -> bool {
+    let Some(v) = value else { return false };
+    let v = v.trim();
+    if v.is_empty() {
+        return false;
+    }
+    !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_noprune_is_false_when_unset_blank_or_explicitly_falsy() {
+        assert!(!parse_noprune(None));
+        assert!(!parse_noprune(Some("")));
+        assert!(!parse_noprune(Some("   ")));
+        for falsy in ["0", "false", "no", "off", "FALSE", "Off", "  no  "] {
+            assert!(!parse_noprune(Some(falsy)), "{falsy:?} should be falsy");
+        }
+    }
+
+    #[test]
+    fn parse_noprune_is_true_for_any_other_value() {
+        for truthy in ["1", "true", "yes", "on", "anything"] {
+            assert!(parse_noprune(Some(truthy)), "{truthy:?} should be truthy");
+        }
+    }
+
+    fn temp_dir(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "llmman-gc-test-{name}-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn prune_blobs_removes_only_unreferenced_blobs() {
+        let root = temp_dir("prune-blobs");
+        let blobs = root.join("blobs").join("sha256");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("aaaa"), b"referenced").unwrap();
+        std::fs::write(blobs.join("bbbb"), b"orphan").unwrap();
+        std::fs::write(blobs.join("tmp-123"), b"in-progress").unwrap();
+
+        let mut live = HashSet::new();
+        live.insert("sha256:aaaa".to_string());
+
+        let stats = prune_blobs(&root, &live, Duration::ZERO).unwrap();
+        assert_eq!(stats.count, 1);
+        assert!(blobs.join("aaaa").exists(), "referenced blob must survive");
+        assert!(!blobs.join("bbbb").exists(), "orphan blob must be removed");
+        assert!(
+            blobs.join("tmp-123").exists(),
+            "in-progress temp file must be left to repair's sweep"
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn prune_cache_removes_only_unreferenced_dirs() {
+        let cache = temp_dir("prune-cache");
+        std::fs::create_dir_all(cache.join("aaaa")).unwrap();
+        std::fs::write(cache.join("aaaa").join("model.gguf"), b"kept").unwrap();
+        std::fs::create_dir_all(cache.join("bbbb")).unwrap();
+        std::fs::write(cache.join("bbbb").join("model.gguf"), b"orphan").unwrap();
+
+        let mut live = HashSet::new();
+        live.insert("sha256:aaaa".to_string());
+
+        let stats = prune_cache(&cache, &live, Duration::ZERO).unwrap();
+        assert_eq!(stats.count, 1);
+        assert!(cache.join("aaaa").exists(), "referenced cache dir survives");
+        assert!(!cache.join("bbbb").exists(), "orphan cache dir removed");
+
+        std::fs::remove_dir_all(&cache).unwrap();
+    }
+
+    #[test]
+    fn prune_is_a_no_op_on_missing_directories() {
+        let root = temp_dir("missing");
+        let live = HashSet::new();
+        assert_eq!(prune_blobs(&root, &live, Duration::ZERO).unwrap().count, 0);
+        assert_eq!(
+            prune_cache(&root.join("cache"), &live, Duration::ZERO)
+                .unwrap()
+                .count,
+            0
+        );
+    }
+}

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -63,7 +63,11 @@ pub fn referenced_digests(store: &OciStore) -> anyhow::Result<HashSet<String>> {
 /// digest isn't in `live`, skipping in-progress temp writes (`tmp-`/
 /// `.tmp`, same as [`crate::storage::repair`]) and anything younger than
 /// `grace`. A missing blobs directory is a no-op.
-pub fn prune_blobs(store_root: &Path, live: &HashSet<String>, grace: Duration) -> anyhow::Result<GcStats> {
+pub fn prune_blobs(
+    store_root: &Path,
+    live: &HashSet<String>,
+    grace: Duration,
+) -> anyhow::Result<GcStats> {
     let blobs_dir = store_root.join("blobs").join("sha256");
     let mut stats = GcStats::default();
     let entries = match std::fs::read_dir(&blobs_dir) {
@@ -103,7 +107,11 @@ pub fn prune_blobs(store_root: &Path, live: &HashSet<String>, grace: Duration) -
 /// `modelpack::extract_gguf_layer` / `extract_safetensors_dir`) doesn't
 /// correspond to a live digest, skipping anything younger than `grace`. A
 /// missing cache directory is a no-op.
-pub fn prune_cache(cache_path: &Path, live: &HashSet<String>, grace: Duration) -> anyhow::Result<GcStats> {
+pub fn prune_cache(
+    cache_path: &Path,
+    live: &HashSet<String>,
+    grace: Duration,
+) -> anyhow::Result<GcStats> {
     let live_hex: HashSet<&str> = live
         .iter()
         .filter_map(|d| d.strip_prefix("sha256:"))
@@ -189,7 +197,10 @@ fn parse_noprune(value: Option<&str>) -> bool {
     if v.is_empty() {
         return false;
     }
-    !matches!(v.to_ascii_lowercase().as_str(), "0" | "false" | "no" | "off")
+    !matches!(
+        v.to_ascii_lowercase().as_str(),
+        "0" | "false" | "no" | "off"
+    )
 }
 
 #[cfg(test)]

--- a/src/storage/gc.rs
+++ b/src/storage/gc.rs
@@ -13,9 +13,11 @@
 //! same way [`crate::storage::repair`] gates its stale-temp-file sweep: a
 //! blob is written before its manifest/tag pointer, so a blob can be
 //! legitimately unreferenced for a moment mid-pull — anything younger than
-//! `grace` is left alone. `rm` passes a zero grace (a synchronous,
-//! user-initiated removal wants space freed now); the `serve` startup
-//! catch-all passes the hour-long window.
+//! `grace` is left alone. Both `rm` and the `serve` startup catch-all pass
+//! the hour-long [`GC_GRACE_PERIOD`]: `pull` runs in the long-lived `serve`
+//! daemon, so a concurrent `rm` in a separate process can race a pull that
+//! has written a layer blob but not yet tagged its manifest — only the
+//! grace window, not `rm` being synchronous, protects that blob.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -40,19 +42,25 @@ pub struct GcStats {
 
 /// Every blob digest ("sha256:<hex>") still reachable from a surviving
 /// tag: each manifest's own digest, its config digest, and every layer
-/// digest. Built by walking [`OciStore::list_refs`] and reading each
+/// digest. Built by walking [`OciStore::list_refs_strict`] and reading each
 /// manifest — the same traversal `resolve_model` does per-reference, just
-/// over every reference at once. A manifest that can't be read is skipped
-/// (its blobs then look unreferenced) — acceptable, since an unreadable
-/// manifest is already a broken/incomplete image, but conservative callers
-/// run this only right after a successful `remove`.
+/// over every reference at once.
+///
+/// This is the authority for a *destructive* sweep, so it fails closed:
+/// any reference that can't be enumerated (an unreadable pointer file or
+/// subtree) or any manifest that can't be read/parsed aborts the whole
+/// computation with an error. The alternative — skipping the unreadable
+/// entry, as the display-oriented `list_refs` does — would make that
+/// model's config/layers look unreferenced and get deleted, possibly
+/// destroying blobs shared with other healthy models. When we can't prove
+/// what's still referenced, callers must delete nothing.
 pub fn referenced_digests(store: &OciStore) -> anyhow::Result<HashSet<String>> {
     let mut live = HashSet::new();
-    for desc in store.list_refs() {
+    for desc in store.list_refs_strict()? {
         live.insert(desc.digest.clone());
-        let Ok(manifest) = store.read_manifest(&desc.digest) else {
-            continue;
-        };
+        let manifest = store
+            .read_manifest(&desc.digest)
+            .with_context(|| format!("read manifest {} for GC reference scan", desc.digest))?;
         live.insert(manifest.config.digest.clone());
         live.extend(manifest.layers.iter().map(|l| l.digest.clone()));
     }
@@ -149,9 +157,9 @@ pub fn prune_cache(
 }
 
 /// True if `path`'s mtime is at least `grace` old. A zero `grace` makes
-/// this always true (used by `rm`, which frees immediately). A file whose
-/// mtime can't be read is treated as not-yet-old, so it's left alone
-/// rather than deleted on a metadata hiccup.
+/// this always true (used only by tests that want to sweep regardless of
+/// age). A file whose mtime can't be read is treated as not-yet-old, so
+/// it's left alone rather than deleted on a metadata hiccup.
 fn is_older_than(path: &Path, grace: Duration) -> bool {
     if grace.is_zero() {
         return true;
@@ -308,6 +316,50 @@ mod tests {
         assert!(!cache.join("bbbb").exists(), "orphan cache dir removed");
 
         std::fs::remove_dir_all(&cache).unwrap();
+    }
+
+    /// A corrupt (unparsable) manifest pointer file must abort the live-set
+    /// computation rather than silently omitting that model — otherwise its
+    /// blobs would look unreferenced and a destructive sweep would delete
+    /// them. Fail closed: an error, so callers prune nothing.
+    #[test]
+    fn referenced_digests_aborts_on_an_unreadable_reference() {
+        let root = temp_dir("referenced-digests-strict");
+        let store = OciStore::open(&root).unwrap();
+
+        // A real, healthy tagged model.
+        let cfg = store
+            .write_blob("application/vnd.cncf.model.config.v1+json", b"{}")
+            .unwrap();
+        let manifest = crate::storage::oci::Manifest {
+            schema_version: 2,
+            media_type: "application/vnd.oci.image.manifest.v1+json".into(),
+            artifact_type: None,
+            config: cfg,
+            layers: vec![],
+            annotations: None,
+        };
+        let desc = store.write_manifest(&manifest).unwrap();
+        store.tag(desc, "hf.co/ai/healthy:latest").unwrap();
+
+        // A corrupt pointer file elsewhere in manifests/ — enumeration
+        // can't parse it, so the whole scan must fail rather than proceed
+        // with an incomplete live set.
+        let corrupt = root
+            .join("manifests")
+            .join("hf.co")
+            .join("ai")
+            .join("broken")
+            .join("latest");
+        std::fs::create_dir_all(corrupt.parent().unwrap()).unwrap();
+        std::fs::write(&corrupt, b"not json").unwrap();
+
+        assert!(
+            referenced_digests(&store).is_err(),
+            "an unparsable reference must abort the live-set scan, not be skipped"
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,4 @@
+pub mod gc;
 pub mod oci;
 pub mod repair;
 pub use oci::{default_tag, OciStore};

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -208,6 +208,21 @@ impl OciStore {
         out
     }
 
+    /// Like [`list_refs`], but aborts on the first unreadable subtree or
+    /// unparsable pointer file instead of silently skipping it. Required by
+    /// the destructive GC path ([`crate::storage::gc::referenced_digests`]):
+    /// a reference dropped by the lossy `list_refs` would make that model's
+    /// blobs look unreferenced and get swept, so GC must instead refuse to
+    /// run at all when it can't enumerate every surviving reference. A
+    /// missing `manifests/` directory (a fresh store) is an empty list, not
+    /// an error.
+    pub(crate) fn list_refs_strict(&self) -> anyhow::Result<Vec<Descriptor>> {
+        let root = self.root.join("manifests");
+        let mut out = Vec::new();
+        collect_refs_strict(&root, &mut out)?;
+        Ok(out)
+    }
+
     // ------------------------------------------------------------------
     // Blobs
     // ------------------------------------------------------------------
@@ -661,7 +676,39 @@ fn collect_refs(dir: &Path, out: &mut Vec<Descriptor>) {
     }
 }
 
-/// Appends `:latest` to `reference` if it has no tag, so a tag-less
+/// Strict counterpart to [`collect_refs`] for the GC path: any error that
+/// `collect_refs` would swallow (an unreadable directory, an unreadable or
+/// unparsable pointer file) is propagated instead, so an incomplete
+/// enumeration can never be mistaken for "these blobs are unreferenced". A
+/// non-existent `dir` (a store with no `manifests/` yet) is treated as
+/// empty — that's a genuinely empty reference set, not a read failure.
+fn collect_refs_strict(dir: &Path, out: &mut Vec<Descriptor>) -> anyhow::Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", dir.display())),
+    };
+    for entry in entries {
+        let entry = entry.with_context(|| format!("read entry in {}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("stat {}", path.display()))?;
+        if file_type.is_dir() {
+            collect_refs_strict(&path, out)?;
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) == Some("tmp") {
+            continue; // an in-progress or abandoned write — see write_ref
+        }
+        let data = fs::read(&path).with_context(|| format!("read {}", path.display()))?;
+        let desc = serde_json::from_slice::<Descriptor>(&data)
+            .with_context(|| format!("parse manifest ref {}", path.display()))?;
+        out.push(desc);
+    }
+    Ok(())
+}
+
 /// reference and its `:latest` spelling are one string wherever a
 /// reference is used as a map/lock key. A no-op on anything that isn't a
 /// taggable registry reference — a URI-scheme source (`s3://`, `ngc://`,

--- a/src/storage/oci.rs
+++ b/src/storage/oci.rs
@@ -201,7 +201,7 @@ impl OciStore {
     /// `org.opencontainers.image.ref.name` annotation. A single
     /// unreadable or unparsable entry is skipped rather than failing the
     /// whole walk.
-    fn list_refs(&self) -> Vec<Descriptor> {
+    pub(crate) fn list_refs(&self) -> Vec<Descriptor> {
         let root = self.root.join("manifests");
         let mut out = Vec::new();
         collect_refs(&root, &mut out);


### PR DESCRIPTION
This PR introduces a new behavior for the `llmman rm` command to address a long-standing disk space.
Right now, `llmman rm <ref>` only deleted the model's manifest pointer, but it left its blobs (store/blobs/sha256/) and extracted cache (cache/) on disk.
Since a model can be many GB, a removed model kept eating disk space, which is surprising and wasteful.

Fix https://github.com/llmmanorg/llmman/issues/283

## What this does

After removing a model, rm now garbage-collects every blob and cache entry no longer referenced by any surviving model, and reports the freed space.
`serve` runs the same sweep at startup (after the existing repair_store call) as a catch-all for orphans left by anything other than `rm`.

## Details

- `rm` uses a zero grace period (a synchronous, user-initiated removal frees space immediately); the serve startup sweep uses an hour-long grace window so a blob written moments before its tag during a concurrent
pull survives.
- `LLMMAN_NOPRUNE` opt-out for shared/read-mostly stores or scripts that rm in a loop and prune once at the end.
