### PR TITLE
feat: add Ollama-mirroring env vars to llmman serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tower-http",
  "walkdir",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chrono     = { version = "0.4", features = ["serde"] }
 dirs       = "5"
 tar        = "0.4"
 axum       = "0.7"
+tower-http = { version = "0.6", features = ["cors"] }
 libc       = "0.2"
 tokio-util = { version = "0.7", features = ["io"] }
 toml       = { version = "0.8", default-features = false, features = ["parse"] }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ llmman pull gemma4
 ### Transfer a model between locations
 
 Transfer an image directly from a source to a destination without storing
-it locally first — e.g. HuggingFace straight to an OCI registry:
+it locally first, e.g. HuggingFace straight to an OCI registry:
 
 ```
 llmman transfer hf.co/unsloth/Qwen3.5-0.8B-GGUF docker.io/owner/model:latest
@@ -59,7 +59,7 @@ Any source `llmman pull` understands (an OCI registry, `hf://`, `ms://`, ...) ca
 
 ### Serve
 
-Start the inference server. GGUF models are served by `llama-server` from [llama.cpp](https://github.com/ggml-org/llama.cpp), used from `PATH` if it's already there; otherwise `llmman` downloads and caches a prebuilt release matching your OS/arch/GPU automatically (see `--llama-cpp-version` to pin a specific release). Safetensors models are served by [`vllm`](https://github.com/vllm-project/vllm) (plain `vllm` is CPU-only on macOS, unless you separately install [vllm-metal](https://github.com/vllm-project/vllm-metal) for Metal GPU support) — or, on Apple Silicon macOS, by [`mlx-lm`](https://github.com/ml-explore/mlx-lm)'s `mlx_lm.server` instead when it's on `PATH`: Metal-accelerated, with no vLLM dependency at all, and it supports more model families than vllm-metal does.
+Start the inference server. GGUF models are served by `llama-server` from [llama.cpp](https://github.com/ggml-org/llama.cpp), used from `PATH` if it's already there; otherwise `llmman` downloads and caches a prebuilt release matching your OS/arch/GPU automatically (see `--llama-cpp-version` to pin a specific release). Safetensors models are served by [`vllm`](https://github.com/vllm-project/vllm) (plain `vllm` is CPU-only on macOS, unless you separately install [vllm-metal](https://github.com/vllm-project/vllm-metal) for Metal GPU support), or, on Apple Silicon macOS, by [`mlx-lm`](https://github.com/ml-explore/mlx-lm)'s `mlx_lm.server` instead when it's on `PATH`: Metal-accelerated, with no vLLM dependency at all, and it supports more model families than vllm-metal does.
 
 ```
 llmman serve
@@ -90,26 +90,48 @@ Or with any Ollama, Anthropic or OpenAI-compatible client.
 Models are loaded on demand. Each model gets its own `llama-server` subprocess on a random loopback port; subsequent requests reuse the running process.
 
 `/api/chat` also supports Ollama's `tools` (function calling, streamed back
-as `message.tool_calls`), `images` (vision, base64 — same as Ollama's own
+as `message.tool_calls`), `images` (vision, base64, same as Ollama's own
 wire format), and `format` (`"json"` or a JSON Schema object, for
 constrained structured output).
 
 An idle, unused model is automatically unloaded after `keep_alive`
-(default 5 minutes, matching Ollama — set per-request, or daemon-wide via
+(default 5 minutes, matching Ollama; set per-request, or daemon-wide via
 `LLMMAN_KEEP_ALIVE`), and `llmman ps`/`/api/ps` reports each model's
 `expires_at`.
 
-Daemon-wide settings, set before `llmman serve` starts:
+Daemon-wide settings, set before `llmman serve` starts. llmman is a very
+different program underneath (no per-GPU memory estimator, no embedded
+inference engine, no cloud/desktop-app features), so an equivalent
+setting may not behave identically.
 
 | Variable | Effect |
 |----------|--------|
+| `LLMMAN_DEBUG` | Enables verbose diagnostic logging (a spawned backend's full command line, per-GPU probe detail, etc). Accepts `1`/`true`/`yes`/`on`, or any other non-zero integer. |
 | `LLMMAN_HOST` | `[host][:port]` `llmman serve` binds to. Every `llmman` client in the same environment connects to it too, rewriting a wildcard host to loopback first. Defaults to `127.0.0.1:17434`. |
 | `LLMMAN_CONTEXT_LENGTH` | Context size (`--ctx-size`) for every model this daemon loads. Defaults to a VRAM-tiered value when unset. |
-| `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`, matching Ollama's `OLLAMA_FLASH_ATTENTION`. |
-| `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0` — trades output quality for memory at long context lengths, matching Ollama's `OLLAMA_KV_CACHE_TYPE`. |
-| `LLMMAN_MODELS` | Local store directory, overriding the default below — matching Ollama's `OLLAMA_MODELS`. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
-| `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root — matching Ollama's `OLLAMA_TMPDIR`. |
+| `LLMMAN_KEEP_ALIVE` | The daemon-wide default `keep_alive` (how long an idle, unused model stays loaded before being unloaded). Defaults to 5 minutes. Overridden per-request by `/api/chat`/`/api/generate`'s own `keep_alive` field. |
+| `LLMMAN_MAX_LOADED_MODELS` | Caps how many models this daemon keeps loaded at once, as one flat daemon-wide total (llmman has no per-model memory estimate to size an automatic per-GPU figure against). Once at the cap, the least-recently-used idle model is evicted to make room; if every loaded model is busy, the request gets a `503` instead. Defaults to `0` (unbounded, today's behavior, unchanged). |
+| `LLMMAN_MAX_QUEUE` | Caps how many requests `llmman serve` admits into scheduling at once; anything beyond that gets an immediate `503` (`server busy, please try again.  maximum pending requests exceeded`, two spaces included). Defaults to `512`. |
+| `LLMMAN_MAX_TRANSFER_STREAMS` | Maximum number of a HuggingFace safetensors repo's files downloaded concurrently during `pull`. Has no effect on GGUF transfers, and is not read by `transfer`'s own `docker`-feature registry-push path, which streams files sequentially. Defaults to `4`. |
+| `LLMMAN_MODELS` | Local store directory, overriding the default below. `pull`/`push`/`run`/etc. go through the daemon and always use whichever store it was started with. |
+| `LLMMAN_NUM_PARALLEL` | Number of parallel request slots (`--parallel`) for GGUF models (llama-server only; no vllm/mlx equivalent). `--ctx-size` is scaled up by this value first, so each slot still gets the full configured/default context rather than an even split of it; ignored (with a warning) for a load with no explicit context size to scale. Unset leaves llama-server's own default of 1 untouched. |
+| `LLMMAN_ORIGINS` | A comma-separated list of extra allowed CORS origins for the HTTP API. A trailing `:*` on an entry matches any port on that scheme+host. Always includes every scheme/port on `localhost`/`127.0.0.1`/`0.0.0.0`/`[::1]` regardless of this variable. |
+| `LLMMAN_SCHED_SPREAD` | Truthy forwards `--split-mode layer` (spread a model across every GPU, already llama-server's own default); falsey forwards `--split-mode none` (restrict to one GPU). |
+| `LLMMAN_FLASH_ATTENTION` | Flash Attention mode (`--flash-attn`): `on`, `off`, or `auto` (llama-server's own default). Also accepts `1`/`0`/`true`/`false`. |
+| `LLMMAN_KV_CACHE_TYPE` | KV-cache quantization (`--cache-type-k`/`--cache-type-v`), e.g. `f16` (default), `q8_0`, `q4_0`. Trades output quality for memory at long context lengths. |
+| `LLMMAN_LLM_LIBRARY` | Forces which GPU backend `llmman serve`/`run` picks (`cpu`, `cuda`/`cuda12`, `cuda13`, `rocm`, `vulkan`, or macOS-only `metal`), bypassing autodetection. Has no effect when a `llama-server` binary is already on `PATH` (its own backend is fixed), or on macOS's local-binary download (one asset per architecture, no separate choice to make). |
+| `LLMMAN_GPU_OVERHEAD` | Bytes of VRAM to hold back from the VRAM-tiered `LLMMAN_CONTEXT_LENGTH` default, leaving headroom for whatever else shares the device. Applied as one combined-total subtraction rather than per-GPU (llmman only ever probes one combined VRAM total). |
+| `LLMMAN_IGPU_ENABLE` | Counts integrated GPUs (Vulkan only) when probing for an accelerator. Defaults to disabled, since an integrated GPU is usually a worse choice than the discrete/CPU fallback it would otherwise be skipped in favor of. |
+| `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). |
+| `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
 | `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
+| `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` | llama.cpp's own env-configurable `--fit`/`--fit-target` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |
+
+GPU device-selection variables `llmman serve` forwards to every
+`llama-server` it spawns (local or `--ociman` container):
+`CUDA_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`,
+`ROCR_VISIBLE_DEVICES`, `GGML_VK_VISIBLE_DEVICES`, `GPU_DEVICE_ORDINAL`,
+`HSA_OVERRIDE_GFX_VERSION`.
 
 ### Launch an integration
 
@@ -135,7 +157,7 @@ HuggingFace repo.
 
 On Apple Silicon macOS, `llmman serve` uses
 [`mlx_lm.server`](https://github.com/ml-explore/mlx-lm) instead of `vllm`
-for safetensors models whenever it's on `PATH` — Metal-accelerated, with
+for safetensors models whenever it's on `PATH`, Metal-accelerated, with
 no vLLM dependency at all (unlike getting the same acceleration out of
 `vllm serve` itself via [vllm-metal](https://github.com/vllm-project/vllm-metal)).
 Falls back to `vllm` otherwise. Doesn't support `/v1/embeddings`.
@@ -153,7 +175,7 @@ Set `LLMMAN_MODELS` to change this (matching Ollama's `OLLAMA_MODELS`).
 Commands that read or write the local store directly (`list`, `rm`,
 `build`, `serve`) all honor it. Commands that go through the background
 daemon instead (`pull`, `push`, `run`, `launch`, `ps`) always use whichever
-store the daemon was started with — set `LLMMAN_MODELS` before
+store the daemon was started with; set `LLMMAN_MODELS` before
 `llmman serve` to change it for all of them. `transfer`, `login`, and
 `logout` never touch a local store at all.
 
@@ -165,7 +187,7 @@ The registry transport is a compiled-in Go shim. Two backends are available via 
 
 ### Docker (default)
 
-Uses [`github.com/containerd/containerd`](https://github.com/containerd/containerd) — the same OCI resolver used by Docker.
+Uses [`github.com/containerd/containerd`](https://github.com/containerd/containerd), the same OCI resolver used by Docker.
 
 ```
 cargo build --release
@@ -173,7 +195,7 @@ cargo build --release
 
 ### Podman
 
-Uses [`github.com/podman-container-tools/container-libs`](https://github.com/podman-container-tools/container-libs) — the same library Podman uses internally.
+Uses [`github.com/podman-container-tools/container-libs`](https://github.com/podman-container-tools/container-libs), the same library Podman uses internally.
 
 ```
 cargo build --release --no-default-features --features podman

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -31,7 +31,37 @@ use crate::webui;
 // CLI args
 // ---------------------------------------------------------------------------
 
+/// `llmman serve --help`'s "Environment Variables:" section — mirrors
+/// `ollama serve -h`'s equivalent section. Static text, not built from
+/// live values like Ollama's (llmman's env vars mostly configure the
+/// daemon, not the CLI process printing `--help`).
+const SERVE_ENV_HELP: &str = "\
+Environment Variables:
+      LLMMAN_DEBUG                   Show additional debug information (e.g. LLMMAN_DEBUG=1)
+      LLMMAN_HOST                    [host][:port] to bind (default \"127.0.0.1:17434\")
+      LLMMAN_CONTEXT_LENGTH          Context length to use unless otherwise specified (default: VRAM-tiered)
+      LLMMAN_KEEP_ALIVE              The duration that models stay loaded in memory (default \"5m\")
+      LLMMAN_MAX_LOADED_MODELS       Maximum number of loaded models (default: unbounded)
+      LLMMAN_MAX_TRANSFER_STREAMS    Maximum parallel transfer streams for safetensors model pulls (default 4)
+      LLMMAN_MAX_QUEUE               Maximum number of queued requests (default 512)
+      LLMMAN_MODELS                  The path to the models directory
+      LLMMAN_NUM_PARALLEL            Maximum number of parallel requests per model (GGUF only)
+      LLMMAN_NOPRUNE                 Do not prune model blobs on startup
+      LLMMAN_ORIGINS                 A comma separated list of allowed CORS origins
+      LLMMAN_SCHED_SPREAD            Always schedule model across all GPUs
+      LLMMAN_FLASH_ATTENTION         Enable flash attention
+      LLMMAN_KV_CACHE_TYPE           Quantization type for the K/V cache (default: f16)
+      LLMMAN_LLM_LIBRARY             Set backend (cpu/cuda/cuda13/rocm/vulkan/metal) to bypass GPU autodetection
+      LLMMAN_GPU_OVERHEAD            Reserve a portion of VRAM (bytes)
+      LLMMAN_IGPU_ENABLE             Enable integrated GPUs
+      LLMMAN_LOAD_TIMEOUT            How long to allow model loads to stall before giving up (default \"10m\")
+      LLMMAN_TMPDIR                  Staging directory for llama-server release downloads
+      LLAMA_ARG_FIT                  Enable llama.cpp automatic fit of unset memory options (default \"on\")
+      LLAMA_ARG_FIT_TARGET           Target free VRAM margin per device for llama.cpp fit (MiB)
+";
+
 #[derive(Args, Debug)]
+#[command(after_help = SERVE_ENV_HELP)]
 pub struct ServeArgs {
     /// Model to pre-load immediately on startup (e.g. hf.co/unsloth/Qwen3.5-0.8B-GGUF:latest)
     #[arg(value_name = "MODEL")]
@@ -192,6 +222,81 @@ fn parse_sched_spread(value: Option<&str>) -> Option<&'static str> {
     }
 }
 
+/// `--parallel <n>` for every `llama-server` this daemon spawns (GGUF
+/// models only — vllm/mlx_lm.server handle concurrency their own way,
+/// with no equivalent flag), from `LLMMAN_NUM_PARALLEL`. Mirrors
+/// Ollama's `OLLAMA_NUM_PARALLEL`; unset leaves llama-server's own
+/// default of 1 untouched.
+fn num_parallel_from_env() -> Option<u32> {
+    parse_num_parallel(std::env::var("LLMMAN_NUM_PARALLEL").ok().as_deref())
+}
+
+/// `0` is rejected, same as llama-server's own `--parallel` validation.
+fn parse_num_parallel(value: Option<&str>) -> Option<u32> {
+    let n: u32 = value?.trim().parse().ok()?;
+    (n != 0).then_some(n)
+}
+
+/// The `--ctx-size` value to actually forward to llama-server: `ctx_size`
+/// (the per-request context every other computation — retries, error
+/// messages, `LLMMAN_CONTEXT_LENGTH` itself — is expressed in) times
+/// `num_parallel`. llama-server splits one `--ctx-size` evenly across
+/// every `--parallel` slot rather than giving each its own full amount,
+/// so forwarding `ctx_size` unscaled would silently divide a request's
+/// real context by `num_parallel`; Ollama avoids exactly this by
+/// launching with `NumCtx * numParallel` (`llm/llama_server.go`).
+/// Callers should only ever pass a non-`None` `num_parallel` alongside
+/// a `Some` `ctx_size` — see `ensure_model`'s own `num_parallel`
+/// fallback, which drops it to `None` otherwise (nothing safe to scale
+/// against).
+fn backend_ctx_size(ctx_size: Option<u32>, num_parallel: Option<u32>) -> Option<u32> {
+    ctx_size.map(|c| c.saturating_mul(num_parallel.unwrap_or(1)))
+}
+
+/// `num_parallel` unless `ctx_size` is `None` (a high-VRAM host
+/// deferring to the model's own trained context, nothing safe to scale
+/// against — see `backend_ctx_size`'s doc comment), in which case
+/// `None`: forwarding `--parallel` unscaled would silently divide that
+/// trained context across slots instead.
+fn effective_num_parallel(ctx_size: Option<u32>, num_parallel: Option<u32>) -> Option<u32> {
+    ctx_size.and(num_parallel)
+}
+
+/// Matches Ollama's own default for `OLLAMA_MAX_QUEUE`.
+const DEFAULT_MAX_QUEUE: usize = 512;
+
+/// Maximum number of requests [`ensure_model`] admits at once before
+/// rejecting with a 503, from `LLMMAN_MAX_QUEUE` (mirrors Ollama's
+/// `OLLAMA_MAX_QUEUE`). See [`try_admit`].
+fn max_queue_from_env() -> usize {
+    parse_max_queue(std::env::var("LLMMAN_MAX_QUEUE").ok().as_deref())
+}
+
+/// Unlike most other `parse_*` functions here, `0` is a real value (see
+/// `try_admit_against`'s doc comment), not "unset".
+fn parse_max_queue(value: Option<&str>) -> usize {
+    match value.map(str::trim) {
+        Some(v) if !v.is_empty() => v.parse().unwrap_or(DEFAULT_MAX_QUEUE),
+        _ => DEFAULT_MAX_QUEUE,
+    }
+}
+
+/// Maximum number of models [`ensure_model`] keeps loaded at once, from
+/// `LLMMAN_MAX_LOADED_MODELS` (mirrors Ollama's `OLLAMA_MAX_LOADED_MODELS`,
+/// but as one flat daemon-wide total, not per-GPU — llmman has no
+/// per-model memory estimate to size a per-GPU figure against). `0` =
+/// unbounded. See [`enforce_max_loaded_models`].
+fn max_loaded_models_from_env() -> usize {
+    parse_max_loaded_models(std::env::var("LLMMAN_MAX_LOADED_MODELS").ok().as_deref())
+}
+
+fn parse_max_loaded_models(value: Option<&str>) -> usize {
+    value
+        .map(str::trim)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
 /// Which local engine backs a resolved `ModelPath::SafeTensors`
 /// directory: `mlx_lm.server` (see `spawn_mlx_server`) when this host is
 /// Apple Silicon macOS (`crate::hostgpu::detect() == HostGpu::Metal`)
@@ -218,30 +323,7 @@ fn use_mlx_for_safetensors() -> bool {
         && which_binary("mlx_lm.server").is_ok()
 }
 
-/// Explicit `--context-shift`/`--no-context-shift` override from
-/// `LLMMAN_CONTEXT_SHIFT`, or `None` if unset/empty/unparseable — in
-/// which case [`supports_context_shift`]'s per-model default applies
-/// instead, same as leaving Ollama's own `--think`-style env vars unset
-/// defers to its per-model `supportsContextShift`.
-fn context_shift_override_from_env() -> Option<bool> {
-    parse_context_shift(std::env::var("LLMMAN_CONTEXT_SHIFT").ok().as_deref())
-}
-
-/// [`context_shift_override_from_env`]'s parsing, split out so it's
-/// testable without mutating the real process environment.
-fn parse_context_shift(value: Option<&str>) -> Option<bool> {
-    let v = value?.trim();
-    if v.is_empty() {
-        return None;
-    }
-    Some(!matches!(
-        v.to_ascii_lowercase().as_str(),
-        "0" | "false" | "no" | "off"
-    ))
-}
-
-/// Whether `model_ref` gets `--context-shift` by default, absent an
-/// explicit `LLMMAN_CONTEXT_SHIFT` override. Enabled except for
+/// Whether `model_ref` gets `--context-shift`. Enabled except for
 /// DeepSeek-family ("deepseek2" architecture) models, mirroring Ollama's
 /// own `supportsContextShift` (`server/sched.go`) — their MLA-compressed
 /// KV cache can't be shifted the way llama-server expects. Ollama
@@ -251,14 +333,6 @@ fn parse_context_shift(value: Option<&str>) -> Option<bool> {
 /// instead.
 fn supports_context_shift(model_ref: &str) -> bool {
     !model_ref.to_ascii_lowercase().contains("deepseek")
-}
-
-/// Resolves the `--context-shift`/`--no-context-shift` value to spawn
-/// `model_ref` with: `env_override` (see
-/// [`context_shift_override_from_env`]) when set, else
-/// [`supports_context_shift`]'s per-model default.
-fn resolve_context_shift(model_ref: &str, env_override: Option<bool>) -> bool {
-    env_override.unwrap_or_else(|| supports_context_shift(model_ref))
 }
 
 // ---------------------------------------------------------------------------
@@ -358,16 +432,18 @@ struct Inner {
     // every spawn_llama_server/container::spawn call, local or
     // containerized.
     kv_cache_type: Option<String>,
-    // See context_shift_override_from_env's doc comment — resolved
-    // per-model (see resolve_context_shift) rather than forwarded
-    // verbatim, unlike this struct's other passthrough fields.
-    context_shift_override: Option<bool>,
     // See sched_spread_from_env's doc comment — this is only the
     // *initial* value passed to spawn_llama_server/container::spawn;
     // ensure_model's OOM retry loop may relax an explicit `"none"` to
     // `"layer"` for that one load if the restriction itself looks like
     // the cause.
     split_mode: Option<&'static str>,
+    // See num_parallel_from_env's doc comment.
+    num_parallel: Option<u32>,
+    // See max_queue_from_env's doc comment; enforced by try_admit.
+    max_queue: usize,
+    // See max_loaded_models_from_env's doc comment.
+    max_loaded_models: usize,
     store_path: PathBuf,
     cache_path: PathBuf,
     client: Client,
@@ -375,6 +451,13 @@ struct Inner {
 
 struct ModelManager {
     running: HashMap<String, RunningModel>,
+    // Loads admitted by `enforce_max_loaded_models` but not yet in
+    // `running` (still pulling/spawning/waiting-for-ready, or already
+    // failed and about to release their slot) — counted alongside
+    // `running.len()` when checking `LLMMAN_MAX_LOADED_MODELS`, so two
+    // concurrent loads of two *different* new models can't both pass
+    // that check and overshoot the cap.
+    pending_loads: usize,
 }
 
 /// Everything `handle_ps` (and, transitively, `llmman ps`) needs to know
@@ -1196,18 +1279,29 @@ fn finalize_tool_calls(
 // Error type
 // ---------------------------------------------------------------------------
 
-struct AppError(anyhow::Error);
+#[derive(Debug)]
+struct AppError(anyhow::Error, StatusCode);
 
 impl<E: Into<anyhow::Error>> From<E> for AppError {
     fn from(e: E) -> Self {
-        Self(e.into())
+        Self(e.into(), StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}
+
+impl AppError {
+    /// Builds an `AppError` with its own status code, instead of the
+    /// plain 500 every `?`/`From` conversion above produces — used by
+    /// `ensure_model`'s admission-control checks (`LLMMAN_MAX_QUEUE`/
+    /// `LLMMAN_MAX_LOADED_MODELS`), which need `503`.
+    fn status(status: StatusCode, message: impl Into<String>) -> Self {
+        Self(anyhow!(message.into()), status)
     }
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let body = serde_json::json!({ "error": format!("{:#}", self.0) });
-        (StatusCode::INTERNAL_SERVER_ERROR, Json(body)).into_response()
+        (self.1, Json(body)).into_response()
     }
 }
 
@@ -1373,31 +1467,17 @@ fn parse_keep_alive_str(s: &str) -> Option<Option<Duration>> {
     matched_any.then_some(Some(total))
 }
 
-/// Directly sets a running model's `keep_alive` deadline and resets its
-/// idle clock to now, without touching `in_flight` — used by a load-only
-/// `/api/generate` request (empty prompt, not the unload sentinel), which
-/// wants to set/refresh a model's `keep_alive` without itself counting as
-/// an in-flight generation. A no-op if the model isn't (or is no longer)
-/// running.
-async fn refresh_activity(state: &AppState, model_key: &str, keep_alive: Option<Duration>) {
-    let mut mgr = state.0.manager.lock().await;
-    if let Some(m) = mgr.running.get_mut(model_key) {
-        m.last_active = Instant::now();
-        m.last_active_wall = chrono::Utc::now();
-        m.keep_alive = keep_alive;
-    }
-}
-
-/// Held for the duration of one `/api/chat`, `/api/generate`, `/v1/*`, or
-/// `/v1/messages` request against `model_key`. While at least one
-/// `ActivityGuard` for a model is outstanding, `reap_idle_models` will
-/// never unload it — regardless of how long its `keep_alive` deadline has
-/// already passed — so a generation slower than its own `keep_alive`
-/// can't be killed mid-stream. On drop (successful completion, client
-/// disconnect, or panic) it resets the idle clock to now and, if this
-/// request carried an explicit `keep_alive` override, records it for the
-/// *next* idle check — mirroring Ollama's own runner refcounting
-/// (llm/server.go) at a coarser, whole-model granularity.
+/// Represents `ensure_model`'s own `in_flight` claim (see its doc
+/// comment), from the moment it's first made inside `ensure_model`
+/// until this guard drops. While outstanding, `reap_idle_models`/
+/// `LLMMAN_MAX_LOADED_MODELS` eviction will never touch this model —
+/// including in the gap between `ensure_model` resolving it and a
+/// caller actually starting to use it, since whichever stack frame the
+/// guard is currently sitting in still drops (and releases) it even if
+/// that caller's task is cancelled there. On drop it also resets the
+/// idle clock and, if this request carried an explicit `keep_alive`
+/// override, records it for the next idle check — mirroring Ollama's
+/// own runner refcounting (llm/server.go) at a coarser granularity.
 ///
 /// Must be moved into (captured by) whatever `Stream`/`Body` backs the
 /// actual HTTP response — see `stream_ollama`, `stream_anthropic`, and
@@ -1417,6 +1497,19 @@ struct ActivityGuard {
     /// resolve an explicit value (a request's own `keep_alive`, or the
     /// daemon default when it's absent) via `resolve_keep_alive`.
     keep_alive: Option<Option<Duration>>,
+}
+
+impl ActivityGuard {
+    /// Constructs the guard for a model `ensure_model` has just claimed
+    /// (`in_flight` already incremented by the caller, under the
+    /// manager lock) — never call this without having done that first.
+    fn new(state: &AppState, model_key: &str) -> Self {
+        Self {
+            state: state.clone(),
+            model_key: model_key.to_string(),
+            keep_alive: None,
+        }
+    }
 }
 
 impl Drop for ActivityGuard {
@@ -1446,26 +1539,22 @@ impl Drop for ActivityGuard {
     }
 }
 
-/// Marks `model_key` as having one more in-flight request and returns the
-/// guard that un-marks it (and starts its idle clock) on drop — see
-/// [`ActivityGuard`]. Applies a `Some` `keep_alive` override immediately
-/// too (not just on drop), so a model can't be reaped while this request
-/// is still waiting on something upstream of actually streaming a
-/// response; a `None` override never touches `keep_alive` at all, here or
-/// on drop, exactly as if this request hadn't happened (`last_active` is
-/// still always refreshed, both here and on drop, regardless). A no-op
-/// (the returned guard's drop will be too) if `model_key` isn't found —
-/// defensive only; every caller obtains it from `ensure_model`
+/// Applies `keep_alive` to the model `guard` already claims (see
+/// [`ActivityGuard`]), immediately (not just on drop) so it can't be
+/// reaped while this request is still waiting on something upstream of
+/// actually streaming a response. A `None` override never touches
+/// `keep_alive` at all, here or on drop, exactly as if this request
+/// hadn't happened (`last_active` is still always refreshed, both here
+/// and on drop, regardless). A no-op if `guard`'s model isn't found —
+/// defensive only; every caller obtains `guard` from `ensure_model`
 /// immediately beforehand.
 async fn begin_activity(
-    state: &AppState,
-    model_key: &str,
+    mut guard: ActivityGuard,
     keep_alive: Option<Option<Duration>>,
 ) -> ActivityGuard {
     {
-        let mut mgr = state.0.manager.lock().await;
-        if let Some(m) = mgr.running.get_mut(model_key) {
-            m.in_flight += 1;
+        let mut mgr = guard.state.0.manager.lock().await;
+        if let Some(m) = mgr.running.get_mut(&guard.model_key) {
             m.last_active = Instant::now();
             m.last_active_wall = chrono::Utc::now();
             if let Some(kx) = keep_alive {
@@ -1473,10 +1562,23 @@ async fn begin_activity(
             }
         }
     }
-    ActivityGuard {
-        state: state.clone(),
-        model_key: model_key.to_string(),
-        keep_alive,
+    guard.keep_alive = keep_alive;
+    guard
+}
+
+/// Applies `keep_alive` to the model `guard` already claims, then
+/// releases the claim immediately — used by a load-only `/api/generate`
+/// request (or the CLI `--model` pre-load), which shouldn't hold it open
+/// like a real generation would. `guard` itself does the actual release
+/// on drop, same as always, so this stays cancellation-safe too: even a
+/// task dropped mid-lock-wait here still drops `guard` and releases the
+/// claim, whether or not this update ever landed.
+async fn refresh_activity(guard: ActivityGuard, keep_alive: Option<Duration>) {
+    let mut mgr = guard.state.0.manager.lock().await;
+    if let Some(m) = mgr.running.get_mut(&guard.model_key) {
+        m.last_active = Instant::now();
+        m.last_active_wall = chrono::Utc::now();
+        m.keep_alive = keep_alive;
     }
 }
 
@@ -1588,6 +1690,7 @@ async fn spawn_llama_server(
     kv_cache_type: Option<&str>,
     context_shift: bool,
     split_mode: Option<&str>,
+    num_parallel: Option<u32>,
 ) -> anyhow::Result<(tokio::process::Child, OutputTail)> {
     let mut cmd = tokio::process::Command::new(bin);
     cmd.args([
@@ -1635,6 +1738,10 @@ async fn spawn_llama_server(
     if let Some(mode) = split_mode {
         cmd.args(["--split-mode", mode]);
     }
+    // See num_parallel_from_env's doc comment.
+    if let Some(n) = num_parallel {
+        cmd.args(["--parallel", &n.to_string()]);
+    }
     // See GPU_VISIBLE_DEVICE_VARS's own doc comment — already inherited
     // by default, forwarded explicitly here for clarity.
     for var in GPU_VISIBLE_DEVICE_VARS {
@@ -1642,6 +1749,13 @@ async fn spawn_llama_server(
             cmd.env(var, val);
         }
     }
+    // See LLAMA_CPP_ENV_PASSTHROUGH_VARS's doc comment.
+    for var in LLAMA_CPP_ENV_PASSTHROUGH_VARS {
+        if let Ok(val) = std::env::var(var) {
+            cmd.env(var, val);
+        }
+    }
+    crate::debug_log!("spawning {}: {:?}", bin.display(), cmd);
     // Piped (not inherited) so a startup crash's own explanation — e.g. a
     // dynamic linker's "error while loading shared libraries" — can be
     // captured into `tail` and surfaced by `wait_for_ready`, not just
@@ -1684,13 +1798,6 @@ async fn spawn_vllm_server(
         "--served-model-name",
         model_name,
     ]);
-    // vllm's default --gpu-memory-utilization (0.9 of the *device's
-    // total* memory) routinely exceeds what's actually free on a
-    // unified-memory host or any box already running other GPU
-    // workloads, so it refuses to start. Let a user work around it.
-    if let Ok(extra) = std::env::var("LLMMAN_VLLM_ARGS") {
-        cmd.args(extra.split_whitespace());
-    }
     // Own process group so ModelProcess's Drop impl can kill vllm's whole
     // worker tree, not just this one pid, without also killing ourselves.
     #[cfg(unix)]
@@ -1753,19 +1860,47 @@ fn which_binary(name: &str) -> anyhow::Result<PathBuf> {
     find_on_path(name).ok_or_else(|| anyhow::anyhow!("{name} not found on PATH"))
 }
 
-/// Polls `process`'s `/health` endpoint until it reports ready, bailing
-/// out immediately — instead of only after the full 600s deadline below —
-/// the moment `process` itself has already exited. Without this check, a
-/// backend that crashes on startup (a missing shared library, a bad
-/// model, an out-of-memory abort, ...) left `llmman launch`/any HTTP
-/// client hanging for up to 10 minutes on a port nothing was ever going
-/// to answer on again, with the real reason sitting only in `serve.log`
-/// (see `ModelProcess::is_alive`'s doc comment on the same non-blocking
-/// `try_wait` this reuses). `stderr_tail`, when given (currently only for
-/// a local llama-server child — see `spawn_llama_server`), lets that
-/// reason be included right in the error instead of just "the process
-/// exited", so it reaches whatever's actually waiting on this (a chat UI
-/// via the HTTP response), not only the log file.
+/// [`wait_for_ready`]'s default deadline — longer than Ollama's own 5m
+/// default since vllm can take several minutes to load a large model.
+/// Overridable via `LLMMAN_LOAD_TIMEOUT`.
+const DEFAULT_LOAD_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// `None` = wait forever, from an `LLMMAN_LOAD_TIMEOUT` of 0 or
+/// negative (mirrors Ollama's `OLLAMA_LOAD_TIMEOUT`).
+fn load_timeout_from_env() -> Option<Duration> {
+    match std::env::var("LLMMAN_LOAD_TIMEOUT") {
+        Ok(v) => parse_load_timeout(&v).unwrap_or(Some(DEFAULT_LOAD_TIMEOUT)),
+        Err(_) => Some(DEFAULT_LOAD_TIMEOUT),
+    }
+}
+
+/// Reuses [`parse_keep_alive_str`]'s duration syntax, but unlike
+/// keep_alive, a zero value also means "forever" here (matches
+/// `OLLAMA_LOAD_TIMEOUT`'s documented behavior). Unlike a plain
+/// delegation, a leading `-` is only treated as "forever" once the
+/// magnitude after it actually parses as a duration —
+/// `parse_keep_alive_str`'s own dash-prefix shortcut accepts any
+/// `"-..."` unconditionally, which would otherwise make a typo like
+/// `LLMMAN_LOAD_TIMEOUT=-garbage` disable the timeout forever instead of
+/// falling back to the documented default.
+fn parse_load_timeout(value: &str) -> Option<Option<Duration>> {
+    let trimmed = value.trim();
+    if let Some(magnitude) = trimmed.strip_prefix('-') {
+        return parse_keep_alive_str(magnitude).map(|_| None);
+    }
+    Some(match parse_keep_alive_str(trimmed)? {
+        Some(d) if d.is_zero() => None,
+        other => other,
+    })
+}
+
+/// Poll interval between `/health` checks in [`wait_for_ready`].
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// Polls `process`'s `/health` endpoint until ready, bailing out early
+/// if `process` itself exits first (so a crash-on-startup doesn't hang
+/// the caller for the whole deadline). `stderr_tail`, when given (local
+/// llama-server only), includes the crash reason in the error.
 async fn wait_for_ready(
     client: &Client,
     port: u16,
@@ -1773,12 +1908,18 @@ async fn wait_for_ready(
     stderr_tail: Option<&OutputTail>,
 ) -> anyhow::Result<()> {
     let url = format!("http://127.0.0.1:{port}/health");
-    // vllm can take several minutes to load large models.
-    let deadline = Instant::now() + Duration::from_secs(600);
+    // `None` = wait forever (LLMMAN_LOAD_TIMEOUT of 0 or negative, or a
+    // value so large that adding it to `Instant::now()` would overflow
+    // — `checked_add`, not `+`, so a huge-but-validly-parsed timeout
+    // can't panic the request task).
+    let load_timeout = load_timeout_from_env();
+    let deadline = load_timeout.and_then(|d| Instant::now().checked_add(d));
     loop {
-        if Instant::now() > deadline {
+        let remaining = deadline.map(|d| d.saturating_duration_since(Instant::now()));
+        if remaining.is_some_and(|r| r.is_zero()) {
             return Err(anyhow!(
-                "inference server on port {port} did not become ready within 600s"
+                "inference server on port {port} did not become ready within {:?}",
+                load_timeout.unwrap_or_default()
             ));
         }
         if !process.is_alive() {
@@ -1793,22 +1934,29 @@ async fn wait_for_ready(
                 None => anyhow!("inference server on port {port} exited before becoming ready"),
             });
         }
-        if let Ok(resp) = client.get(&url).send().await {
-            // llama-server: 200 + {"status":"ok"}   vllm: 200 + {}
-            // mlx_lm.server: 200 + {"status":"ok"} — but, unlike the other
-            // two, this only means its HTTP listener itself is up, not
-            // that any model has finished loading (mlx_lm.server never
-            // preloads one at all here — see spawn_mlx_server's doc
-            // comment on why). Its own request-handling path still waits
-            // out that load before answering, so this is only ever a
-            // "the process didn't crash outright" check for that engine,
-            // not a full readiness one — an intentional, documented
-            // trade-off, not an oversight.
+        // Bound the request by POLL_INTERVAL, not the full remaining
+        // deadline — otherwise a /health that connects but then stalls
+        // could occupy up to the whole deadline (or forever, if unset)
+        // without rechecking process liveness or the deadline.
+        let bound = remaining.map_or(POLL_INTERVAL, |r| r.min(POLL_INTERVAL));
+        let attempt_start = Instant::now();
+        if let Ok(resp) = client.get(&url).timeout(bound).send().await {
+            // llama-server/vllm: 200 once loaded. mlx_lm.server: 200 as
+            // soon as its listener is up, not once a model is loaded
+            // (see spawn_mlx_server) — an accepted, documented gap for
+            // that one engine only.
             if resp.status().is_success() {
                 return Ok(());
             }
         }
-        sleep(Duration::from_millis(500)).await;
+        // Only the unused remainder of one POLL_INTERVAL — not another
+        // full one on top of whatever the attempt above already took —
+        // so a consistently-stalling /health still gets rechecked every
+        // POLL_INTERVAL, not every 2x that. Still never past the
+        // overall deadline either.
+        let sleep_for = POLL_INTERVAL.saturating_sub(attempt_start.elapsed());
+        let remaining = deadline.map(|d| d.saturating_duration_since(Instant::now()));
+        sleep(remaining.map_or(sleep_for, |r| sleep_for.min(r))).await;
     }
 }
 
@@ -1979,11 +2127,17 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
 }
 
 /// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
-async fn check_running(state: &AppState, model_ref: &str) -> Option<u16> {
+/// If so, claims it (`in_flight += 1`, under the same lock as the
+/// liveness check) and returns the same [`ActivityGuard`] `ensure_model`
+/// itself would, so eviction can never see this model as idle, and the
+/// claim always has an owner, from this moment until the caller's own
+/// `begin_activity`/`refresh_activity` takes over.
+async fn check_running(state: &AppState, model_ref: &str) -> Option<(u16, ActivityGuard)> {
     let mut mgr = state.0.manager.lock().await;
     if let Some(m) = mgr.running.get_mut(model_ref) {
         if m.process.is_alive() {
-            return Some(m.port);
+            m.in_flight += 1;
+            return Some((m.port, ActivityGuard::new(state, model_ref)));
         }
         eprintln!(
             "[llmman] {model_ref} was marked running on port {} but its process has exited — reloading",
@@ -2025,6 +2179,172 @@ async fn evict_other_models(state: &AppState, model_ref: &str) -> bool {
         running.process.stop_and_wait().await;
     }
     any
+}
+
+/// Releases a `pending_loads` reservation on drop — see
+/// [`enforce_max_loaded_models`]. Mirrors [`ActivityGuard`]'s
+/// Drop-can't-be-async workaround.
+struct PendingLoadGuard {
+    state: AppState,
+    armed: bool,
+}
+
+impl std::fmt::Debug for PendingLoadGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingLoadGuard")
+            .field("armed", &self.armed)
+            .finish()
+    }
+}
+
+impl Drop for PendingLoadGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let state = self.state.clone();
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        handle.spawn(async move {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.pending_loads = mgr.pending_loads.saturating_sub(1);
+        });
+    }
+}
+
+/// Reserves a loaded-model slot for a brand-new load, enforcing
+/// `LLMMAN_MAX_LOADED_MODELS` (`0` = unbounded). Counts
+/// `running.len() + pending_loads`, holding the reservation until the
+/// caller's load finishes — closes a race where two concurrent loads of
+/// different models could both pass a plain `running.len()` check.
+///
+/// At the cap, evicts the least-recently-active idle model — reserving
+/// this caller's own slot in the same locked step as removing it, so a
+/// concurrent caller can't steal that room while the eviction's
+/// `stop_and_wait` is still in flight. If the cap is only exceeded by
+/// other reservations (not real running models), waits for one to
+/// resolve instead of evicting a fine model. Returns 503 if nothing can
+/// be freed.
+async fn enforce_max_loaded_models(
+    state: &AppState,
+    max_loaded: usize,
+) -> Result<PendingLoadGuard, AppError> {
+    if max_loaded == 0 {
+        return Ok(PendingLoadGuard {
+            state: state.clone(),
+            armed: false,
+        });
+    }
+    loop {
+        let mut mgr = state.0.manager.lock().await;
+        if mgr.running.len() + mgr.pending_loads < max_loaded {
+            mgr.pending_loads += 1;
+            return Ok(PendingLoadGuard {
+                state: state.clone(),
+                armed: true,
+            });
+        }
+        if mgr.running.len() < max_loaded {
+            // Capacity is only used up by other loads' reservations,
+            // not real running models — wait for one to resolve rather
+            // than evicting a model that's still fine.
+            drop(mgr);
+            sleep(POLL_INTERVAL).await;
+            continue;
+        }
+        let victim = mgr
+            .running
+            .iter()
+            .filter(|(_, m)| m.in_flight == 0)
+            .min_by_key(|(_, m)| m.last_active)
+            .map(|(k, _)| k.clone());
+        let Some(victim) = victim else {
+            return Err(AppError::status(
+                StatusCode::SERVICE_UNAVAILABLE,
+                format!(
+                    "max loaded models ({max_loaded}) reached, and every loaded model is busy — try again"
+                ),
+            ));
+        };
+        // Reserve this caller's own slot atomically with removing the
+        // victim, under the same lock — otherwise a concurrent caller
+        // could see the room this eviction is about to free and steal
+        // it while `stop_and_wait` below is still in flight, briefly
+        // running one backend over the configured cap.
+        mgr.pending_loads += 1;
+        let mut running = mgr
+            .running
+            .remove(&victim)
+            .expect("victim key was just looked up under this same lock");
+        drop(mgr); // release the lock before the (possibly slow) stop below
+        eprintln!(
+            "[llmman] evicting {victim} to free a loaded-model slot (LLMMAN_MAX_LOADED_MODELS={max_loaded})"
+        );
+        running.process.stop_and_wait().await;
+        return Ok(PendingLoadGuard {
+            state: state.clone(),
+            armed: true,
+        });
+    }
+}
+
+/// Ollama's own `ErrMaxQueue` message text (`server/sched.go`), reused
+/// verbatim so clients matching on it see the same thing from llmman.
+const MAX_QUEUE_ERROR: &str = "server busy, please try again.  maximum pending requests exceeded";
+
+/// How many callers are currently past `ensure_model`'s own already-
+/// loaded fast path at once — admission control for `LLMMAN_MAX_QUEUE`,
+/// mirroring Ollama's `pendingReqCh`. Released the moment `ensure_model`
+/// returns (same point Ollama's own channel slot frees, not once
+/// generation finishes).
+static PENDING_REQUESTS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// RAII admission guard for whichever counter admitted it (real callers
+/// always get [`PENDING_REQUESTS`] via [`try_admit`]; tests can use
+/// their own dedicated `static`, via [`try_admit_against`], to stay
+/// isolated from other parallel tests).
+struct QueueGuard(&'static std::sync::atomic::AtomicUsize);
+
+impl Drop for QueueGuard {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// Admits one more caller past `max_queue` against `counter`, or rejects
+/// with a 503 carrying [`MAX_QUEUE_ERROR`]. `0` is treated as `1`: it
+/// matches Ollama's own `make(chan T, 0)` unbuffered `pendingReqCh`,
+/// which still hands a request directly to its always-listening
+/// consumer goroutine rather than rejecting every single one outright
+/// — a one-in-flight-at-a-time cap is the closest llmman gets to that
+/// same direct handoff, having no consumer-goroutine equivalent of its
+/// own. Not "unbounded" either way. `fetch_update` (not a plain
+/// increment-then-check) so rejected callers never inflate the counter.
+fn try_admit_against(
+    counter: &'static std::sync::atomic::AtomicUsize,
+    max_queue: usize,
+) -> Result<QueueGuard, AppError> {
+    let cap = max_queue.max(1);
+    let admitted = counter
+        .fetch_update(
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+            |n| (n < cap).then_some(n + 1),
+        )
+        .is_ok();
+    if admitted {
+        Ok(QueueGuard(counter))
+    } else {
+        Err(AppError::status(
+            StatusCode::SERVICE_UNAVAILABLE,
+            MAX_QUEUE_ERROR,
+        ))
+    }
+}
+
+fn try_admit(max_queue: usize) -> Result<QueueGuard, AppError> {
+    try_admit_against(&PENDING_REQUESTS, max_queue)
 }
 
 /// If `model_ref` would be served by `Engine::Mlx` were it loaded right
@@ -2083,14 +2403,27 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
     is_safetensors.then_some(model_ref)
 }
 
-/// Ensures `model_ref` is loaded and returns `(canonical_ref, port)`. The
-/// canonical name is what it's actually registered under with its backend
-/// (`--served-model-name`), which can differ from a tagless `model_ref`
-/// (e.g. `hf.co/owner/repo` canonicalizes to `...:latest`). Callers must
-/// forward this canonical name, not their own input, as the "model" field
-/// sent to the backend — vllm validates it strictly and 404s otherwise
-/// (llama-server doesn't, so this went unnoticed for GGUF models).
-async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16), AppError> {
+/// Ensures `model_ref` is loaded and returns `(canonical_ref, port,
+/// guard)`. The canonical name is what it's actually registered under
+/// with its backend (`--served-model-name`), which can differ from a
+/// tagless `model_ref` (e.g. `hf.co/owner/repo` canonicalizes to
+/// `...:latest`). Callers must forward this canonical name, not their
+/// own input, as the "model" field sent to the backend — vllm validates
+/// it strictly and 404s otherwise (llama-server doesn't, so this went
+/// unnoticed for GGUF models).
+///
+/// `guard` is an already-claimed [`ActivityGuard`] — every successful
+/// return (a cache hit via [`check_running`], or a fresh load's own
+/// insert below) claims one `in_flight` unit first, so a concurrent
+/// `LLMMAN_MAX_LOADED_MODELS` eviction can never see this model as
+/// idle. Pass `guard` on to [`begin_activity`]/[`refresh_activity`],
+/// which take over the claim rather than adding a second one; dropping
+/// it any other way (including the whole task being cancelled) still
+/// releases it correctly.
+async fn ensure_model(
+    state: &AppState,
+    model_ref: &str,
+) -> Result<(String, u16, ActivityGuard), AppError> {
     let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
     // Default the tag before the lock below: otherwise two concurrent
     // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
@@ -2099,16 +2432,24 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
     let model_ref = canonical_ref(&state.0.store_path, &model_ref);
     let model_ref = model_ref.as_str();
 
-    if let Some(port) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port));
+    // Already loaded and reusable — bypasses LLMMAN_MAX_QUEUE entirely,
+    // same as Ollama's own GetRunner bypassing pendingReqCh for a
+    // reusable runner (server/sched.go): only a request that actually
+    // needs scheduling work (waiting on a concurrent load, or starting
+    // a fresh one) below counts against the cap.
+    if let Some((port, guard)) = check_running(state, model_ref).await {
+        return Ok((model_ref.to_string(), port, guard));
     }
+
+    // See try_admit's doc comment — held for the rest of this function.
+    let _queue_guard = try_admit(state.0.max_queue)?;
 
     let _guard = acquire_load_lock(model_ref).await;
 
     // Someone else may have finished loading this model while we
     // waited for the lock above.
-    if let Some(port) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port));
+    if let Some((port, guard)) = check_running(state, model_ref).await {
+        return Ok((model_ref.to_string(), port, guard));
     }
 
     // If the model is not in the local store, pull it now.
@@ -2131,8 +2472,8 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
     let model_ref = model_ref.as_str();
 
     // Re-check in case that stored form differs from the key above.
-    if let Some(port) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port));
+    if let Some((port, guard)) = check_running(state, model_ref).await {
+        return Ok((model_ref.to_string(), port, guard));
     }
 
     let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
@@ -2149,7 +2490,10 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
             })
         })
         .unwrap_or_default();
-    let context_shift = resolve_context_shift(model_ref, state.0.context_shift_override);
+    let context_shift = supports_context_shift(model_ref);
+    // See enforce_max_loaded_models's doc comment — held for the rest
+    // of this function.
+    let _pending_load_guard = enforce_max_loaded_models(state, state.0.max_loaded_models).await?;
     // OOM retry loop — on a local llama-server load that fails with a
     // memory-allocation-looking error, tries progressively more invasive
     // fallbacks before giving up (see each branch's own comment for which
@@ -2167,6 +2511,21 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
     let mut port = find_free_port()?;
     loop {
         eprintln!("[llmman] loading {model_ref} on port {port}");
+        // A `None` ctx_size (a high-VRAM host deferring to the model's
+        // own trained context) has nothing safe to scale — forwarding
+        // --parallel unscaled in that case would silently divide that
+        // trained context across slots instead, exactly what scaling
+        // exists to prevent. Fall back to llama-server's own
+        // single-slot default rather than risk that.
+        let num_parallel = effective_num_parallel(ctx_size, state.0.num_parallel);
+        if state.0.num_parallel.is_some() && num_parallel.is_none() {
+            eprintln!(
+                "[llmman] {model_ref}: no explicit ctx-size to scale, ignoring LLMMAN_NUM_PARALLEL for this load"
+            );
+        }
+        // See backend_ctx_size's doc comment — the value actually
+        // forwarded as --ctx-size, scaled up for num_parallel.
+        let scaled_ctx_size = backend_ctx_size(ctx_size, num_parallel);
         // Only a local llama-server child captures a stderr tail (see
         // spawn_llama_server) — every retry below only fires for that case.
         let mut stderr_tail: Option<OutputTail> = None;
@@ -2179,11 +2538,12 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
                     mmproj.as_deref(),
                     port,
                     state.0.llama_cpp_version.as_deref(),
-                    ctx_size,
+                    scaled_ctx_size,
                     state.0.flash_attention.as_deref(),
                     state.0.kv_cache_type.as_deref(),
                     context_shift,
                     split_mode,
+                    num_parallel,
                 )?,
             ),
             (ModelPath::Gguf(path, mmproj), None) => {
@@ -2193,11 +2553,12 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
                     path,
                     mmproj.as_deref(),
                     port,
-                    ctx_size,
+                    scaled_ctx_size,
                     state.0.flash_attention.as_deref(),
                     state.0.kv_cache_type.as_deref(),
                     context_shift,
                     split_mode,
+                    num_parallel,
                 )
                 .await?;
                 stderr_tail = Some(tail);
@@ -2308,10 +2669,15 @@ async fn ensure_model(state: &AppState, model_ref: &str) -> Result<(String, u16)
             last_active_wall: chrono::Utc::now(),
             backend_model_path,
             keep_alive: default_keep_alive(),
-            in_flight: 0,
+            // 1, not 0 — see this function's own doc comment.
+            in_flight: 1,
         },
     );
-    Ok((model_ref.to_string(), port))
+    Ok((
+        model_ref.to_string(),
+        port,
+        ActivityGuard::new(state, model_ref),
+    ))
 }
 
 /// The `"model"` value to actually put in the JSON request body sent to
@@ -2612,9 +2978,10 @@ async fn collect_completion(
     let raw = resp.bytes().await.context("read llama-server response")?;
     eprintln!("[llmman] llama-server raw {} bytes", raw.len());
     if raw.is_empty() {
-        return Err(AppError(anyhow!(
-            "inference backend returned empty response body"
-        )));
+        return Err(AppError(
+            anyhow!("inference backend returned empty response body"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ));
     }
 
     let text = String::from_utf8_lossy(&raw);
@@ -2744,7 +3111,10 @@ async fn post_chat(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(AppError(anyhow!("inference backend {status}: {body}")));
+        return Err(AppError(
+            anyhow!("inference backend {status}: {body}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ));
     }
     Ok(resp)
 }
@@ -3318,9 +3688,12 @@ async fn handle_show(
     let model_ref = model_ref.as_str();
     eprintln!("[llmman] /api/show model={model_ref:?}");
     let store = OciStore::open(&state.0.store_path)?;
-    let desc = store
-        .find(model_ref)
-        .map_err(|_| AppError(anyhow!("model not found: {model_ref}")))?;
+    let desc = store.find(model_ref).map_err(|_| {
+        AppError(
+            anyhow!("model not found: {model_ref}"),
+            StatusCode::INTERNAL_SERVER_ERROR,
+        )
+    })?;
     Ok(Json(OllamaShowResponse {
         model_info: serde_json::json!({ "digest": desc.digest, "size": desc.size }),
         details: OllamaModelDetails {
@@ -3578,9 +3951,9 @@ async fn handle_ollama_chat(
         req.model,
         req.messages.len()
     );
-    let (model, port) = ensure_model(&state, &req.model).await?;
+    let (model, port, guard) = ensure_model(&state, &req.model).await?;
     let keep_alive = resolve_keep_alive(&req.keep_alive);
-    let activity = begin_activity(&state, &model, Some(keep_alive)).await;
+    let activity = begin_activity(guard, Some(keep_alive)).await;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     // See backend_wire_model's own doc comment — usually just `model`
     // itself, but a different value for an Engine::Mlx backend. Only
@@ -3671,12 +4044,12 @@ async fn handle_ollama_generate(
         .into_response());
     }
 
-    let (model, port) = ensure_model(&state, &req.model).await?;
+    let (model, port, guard) = ensure_model(&state, &req.model).await?;
     // Empty prompt = load-only request (mirrors ollama server/routes.go:429)
     // — including "preload with a custom keep_alive", so refresh it here
     // even though no generation is happening.
     if req.prompt.is_empty() {
-        refresh_activity(&state, &model, resolve_keep_alive(&req.keep_alive)).await;
+        refresh_activity(guard, resolve_keep_alive(&req.keep_alive)).await;
         return Ok(Json(OllamaGenerateChunk {
             model: req.model,
             created_at: now_rfc3339(),
@@ -3689,7 +4062,7 @@ async fn handle_ollama_generate(
     }
 
     let keep_alive = resolve_keep_alive(&req.keep_alive);
-    let activity = begin_activity(&state, &model, Some(keep_alive)).await;
+    let activity = begin_activity(guard, Some(keep_alive)).await;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     // See backend_wire_model's own doc comment.
     let wire_model = backend_wire_model(&state, &model).await;
@@ -3790,14 +4163,14 @@ async fn resolve_openai_request(
     let mut req: serde_json::Value =
         serde_json::from_slice(&body).context("parse OpenAI request body")?;
     let model = req["model"].as_str().unwrap_or("").to_string();
-    let (model, port) = ensure_model(state, &model).await?;
+    let (model, port, guard) = ensure_model(state, &model).await?;
     // The OpenAI-compatible surface has no `keep_alive` field of its own
     // (real Ollama's doesn't either) — `None` leaves whatever this model
     // already has untouched (its load-time default, or an explicit value
     // pinned via `/api/chat`) rather than overwriting it, e.g. clobbering
     // a `keep_alive: -1` ("never unload") pin with the daemon default the
     // instant one OpenAI-compatible request comes in.
-    let activity = begin_activity(state, &model, None).await;
+    let activity = begin_activity(guard, None).await;
     // See backend_wire_model's own doc comment — usually just `model`
     // itself, but a different value for an Engine::Mlx backend.
     let wire_model = backend_wire_model(state, &model).await;
@@ -4006,10 +4379,10 @@ async fn handle_openai_transcriptions(
         });
         return Ok((StatusCode::BAD_REQUEST, Json(body)).into_response());
     };
-    let (model, port) = ensure_model(&state, &model).await?;
+    let (_, port, guard) = ensure_model(&state, &model).await?;
     // No `keep_alive` field on this API surface either — see
     // resolve_openai_request's own comment on the same choice.
-    let activity = begin_activity(&state, &model, None).await;
+    let activity = begin_activity(guard, None).await;
     let url = format!("http://127.0.0.1:{port}/v1/audio/transcriptions");
     proxy(&state.0.client, &url, &headers, body, activity).await
 }
@@ -4203,11 +4576,11 @@ async fn handle_anthropic_messages(
 ) -> Result<Response, AppError> {
     // Backend needs its canonical name (see ensure_model); the response
     // below still echoes req.model back, unchanged from before.
-    let (canonical_model, port) = ensure_model(&state, &req.model).await?;
+    let (canonical_model, port, guard) = ensure_model(&state, &req.model).await?;
     // The Anthropic Messages API has no `keep_alive` field of its own —
     // `None` leaves it untouched, same as the OpenAI-compatible surface
     // (see resolve_openai_request's own comment on why).
-    let activity = begin_activity(&state, &canonical_model, None).await;
+    let activity = begin_activity(guard, None).await;
     let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
 
     let messages = build_anthropic_messages(&req);
@@ -4275,25 +4648,96 @@ fn opt_u32(opts: &Option<serde_json::Value>, key: &str) -> Option<u32> {
 }
 
 // ---------------------------------------------------------------------------
+// CORS — mirrors Ollama's gin-contrib/cors setup (AllowWildcard +
+// AllowOrigins). `origin_matches` is this crate's own stand-in for its
+// wildcard matching (tower-http has no glob support built in).
+// ---------------------------------------------------------------------------
+
+/// Default CORS origin patterns, matching Ollama's own hardcoded
+/// localhost/127.0.0.1/0.0.0.0 set (minus its desktop-app-only schemes —
+/// llmman has no desktop app).
+fn default_allowed_origins() -> Vec<String> {
+    let mut origins = Vec::new();
+    for host in ["localhost", "127.0.0.1", "0.0.0.0", "[::1]"] {
+        for scheme in ["http", "https"] {
+            origins.push(format!("{scheme}://{host}"));
+            origins.push(format!("{scheme}://{host}:*"));
+        }
+    }
+    origins
+}
+
+/// `LLMMAN_ORIGINS` (comma-separated, mirrors `OLLAMA_ORIGINS`) plus
+/// [`default_allowed_origins`]'s fixed set, always.
+fn allowed_origins_from_env() -> Vec<String> {
+    let mut origins: Vec<String> = std::env::var("LLMMAN_ORIGINS")
+        .ok()
+        .map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    origins.extend(default_allowed_origins());
+    origins
+}
+
+/// A single `*` anywhere in `pattern` matches any substring there (e.g.
+/// `https://*.example.com`, or a bare `*` for "allow everything") —
+/// matches `gin-contrib/cors`'s own `AllowWildcard`, which Ollama's CORS
+/// setup enables. A second `*` never matches (single-wildcard only, same
+/// as that library). No `*` at all requires a byte-for-byte match.
+fn origin_matches(origin: &str, pattern: &str) -> bool {
+    match pattern.split_once('*') {
+        Some((prefix, suffix)) if !suffix.contains('*') => {
+            origin.len() >= prefix.len() + suffix.len()
+                && origin.starts_with(prefix)
+                && origin.ends_with(suffix)
+        }
+        Some(_) => false,
+        None => origin == pattern,
+    }
+}
+
+/// This daemon's CORS layer: any method/header, but `Origin` must match
+/// [`allowed_origins_from_env`].
+fn cors_layer() -> tower_http::cors::CorsLayer {
+    let patterns = allowed_origins_from_env();
+    tower_http::cors::CorsLayer::new()
+        .allow_methods(tower_http::cors::AllowMethods::any())
+        .allow_headers(tower_http::cors::AllowHeaders::any())
+        .allow_origin(tower_http::cors::AllowOrigin::predicate(
+            move |origin, _parts| {
+                origin
+                    .to_str()
+                    .is_ok_and(|origin| patterns.iter().any(|p| origin_matches(origin, p)))
+            },
+        ))
+}
+
+// ---------------------------------------------------------------------------
 // llama-server binary resolution
 // ---------------------------------------------------------------------------
 
-/// Env var names Ollama documents for selecting specific GPU device(s)
-/// within whichever backend is active (see docs/gpu.mdx's "Overrides"
-/// sections: `CUDA_VISIBLE_DEVICES`, `HIP_VISIBLE_DEVICES`,
-/// `ROCR_VISIBLE_DEVICES`, `GGML_VK_VISIBLE_DEVICES`). A local
-/// `llama-server` child already inherits these from `llmman serve`'s own
-/// environment with no extra code — they're forwarded explicitly here
-/// anyway so intent doesn't silently depend on `Command`'s default
-/// env-inheritance behavior, and so the exact same list can be reused
-/// as-is by `crate::container::spawn`, whose `docker run`/`podman run`
-/// does *not* inherit the host environment into the container on its own.
+/// GPU device-selection vars Ollama documents. A local `llama-server`
+/// child inherits these for free; forwarded explicitly here so
+/// `crate::container::spawn`'s `docker run`/`podman run` (which does
+/// *not* inherit the host env) can reuse the same list.
 pub const GPU_VISIBLE_DEVICE_VARS: &[&str] = &[
     "CUDA_VISIBLE_DEVICES",
     "HIP_VISIBLE_DEVICES",
     "ROCR_VISIBLE_DEVICES",
     "GGML_VK_VISIBLE_DEVICES",
+    "GPU_DEVICE_ORDINAL",
+    "HSA_OVERRIDE_GFX_VERSION",
 ];
+
+/// llama.cpp's own env-configurable arguments (`common/arg.cpp`'s
+/// `set_env`), forwarded the same way as [`GPU_VISIBLE_DEVICE_VARS`] —
+/// llama-server reads these itself, llmman just makes sure they reach it.
+pub const LLAMA_CPP_ENV_PASSTHROUGH_VARS: &[&str] = &["LLAMA_ARG_FIT", "LLAMA_ARG_FIT_TARGET"];
 
 /// Resolves the `llama-server` binary to run locally (no `--ociman`):
 /// prefers whatever is already on `PATH` untouched, unless
@@ -4417,6 +4861,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     let state = AppState(Arc::new(Inner {
         manager: Mutex::new(ModelManager {
             running: HashMap::new(),
+            pending_loads: 0,
         }),
         llama_server_bin: StdMutex::new(llama_server_bin),
         // Canonicalized now, while the file certainly still exists —
@@ -4431,8 +4876,10 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         ctx_size_explicit: ctx_size_explicit.is_some(),
         flash_attention: flash_attention_from_env(),
         kv_cache_type: kv_cache_type_from_env(),
-        context_shift_override: context_shift_override_from_env(),
         split_mode: sched_spread_from_env(),
+        num_parallel: num_parallel_from_env(),
+        max_queue: max_queue_from_env(),
+        max_loaded_models: max_loaded_models_from_env(),
         store_path,
         cache_path,
         client: Client::new(),
@@ -4479,6 +4926,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         )
         // Anthropic API
         .route("/v1/messages", post(handle_anthropic_messages))
+        .layer(cors_layer())
         .with_state(app_state);
 
     let addr = crate::daemon::bind_addr();
@@ -4498,15 +4946,16 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         tokio::spawn(async move {
             match ensure_model(&state_clone, &model).await {
                 // ensure_model's own keep_alive (the daemon default, 5
-                // minutes) would otherwise start counting down the moment
-                // this finishes loading — with no request traffic and no
-                // ActivityGuard to reset it, the idle reaper could unload
-                // a model asked for on the command line before it's ever
-                // actually used, defeating the whole point of pre-loading
-                // it. Pin it ("never unload") instead — a model named
-                // explicitly at startup is meant to stay warm for the
-                // daemon's lifetime, not just its first 5 idle minutes.
-                Ok((canonical, _)) => refresh_activity(&state_clone, &canonical, None).await,
+                // minutes) would otherwise start counting down the
+                // moment this finishes loading, with no request traffic
+                // to reset it — the idle reaper could unload a model
+                // asked for on the command line before it's ever
+                // actually used, defeating the whole point of
+                // pre-loading it. Pin it ("never unload") instead — a
+                // model named explicitly at startup is meant to stay
+                // warm for the daemon's lifetime, not just its first 5
+                // idle minutes.
+                Ok((_, _, guard)) => refresh_activity(guard, None).await,
                 Err(e) => eprintln!("[llmman] pre-load failed: {:#}", e.0),
             }
         });
@@ -4661,6 +5110,39 @@ mod tests {
             Some(Duration::from_secs(600))
         );
         assert_eq!(resolve_keep_alive(&Some(serde_json::json!(-1))), None);
+    }
+
+    #[test]
+    fn parse_load_timeout_accepts_the_same_duration_syntax_as_keep_alive() {
+        assert_eq!(
+            parse_load_timeout("300"),
+            Some(Some(Duration::from_secs(300)))
+        );
+        assert_eq!(
+            parse_load_timeout("10m"),
+            Some(Some(Duration::from_secs(600)))
+        );
+        assert_eq!(parse_load_timeout("garbage"), None);
+    }
+
+    #[test]
+    fn parse_load_timeout_treats_zero_or_negative_as_infinite() {
+        // Unlike keep_alive (where 0 means "unload immediately"),
+        // OLLAMA_LOAD_TIMEOUT documents 0 as meaning "wait forever", same
+        // as any negative value.
+        assert_eq!(parse_load_timeout("0"), Some(None));
+        assert_eq!(parse_load_timeout("-1"), Some(None));
+        assert_eq!(parse_load_timeout("-10m"), Some(None));
+    }
+
+    #[test]
+    fn parse_load_timeout_rejects_a_dash_prefixed_non_duration_instead_of_disabling_forever() {
+        // A bare "starts with '-'" isn't enough — the magnitude must
+        // actually parse as a duration, or this must fall through to
+        // the default (via load_timeout_from_env's own unwrap_or), not
+        // silently disable the timeout forever.
+        assert_eq!(parse_load_timeout("-garbage"), None);
+        assert_eq!(parse_load_timeout("-"), None);
     }
 
     /// Regression test for `handle_ollama_generate`'s unload-sentinel
@@ -5014,6 +5496,7 @@ mod tests {
         AppState(Arc::new(Inner {
             manager: Mutex::new(ModelManager {
                 running: HashMap::new(),
+                pending_loads: 0,
             }),
             llama_server_bin: StdMutex::new(None),
             exe: None,
@@ -5023,8 +5506,14 @@ mod tests {
             ctx_size_explicit: false,
             flash_attention: None,
             kv_cache_type: None,
-            context_shift_override: None,
             split_mode: None,
+            num_parallel: None,
+            // usize::MAX, not 0 — 0 now means "admit almost nothing"
+            // (see try_admit_against's doc comment), and no test here
+            // calls ensure_model (the only caller of try_admit) directly
+            // anyway.
+            max_queue: usize::MAX,
+            max_loaded_models: 0,
             store_path: std::env::temp_dir(),
             cache_path: std::env::temp_dir(),
             client: Client::new(),
@@ -5298,24 +5787,324 @@ mod tests {
         assert!(!evict_other_models(&state, "the-model-being-loaded").await);
     }
 
+    /// Regression test: a cache hit must claim `in_flight`, exactly like
+    /// a fresh load's own insert, so `enforce_max_loaded_models` can
+    /// never see it as idle in the window between `ensure_model`
+    /// returning and the caller's own `begin_activity`/
+    /// `refresh_activity` — see `check_running`'s doc comment.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn check_running_claims_in_flight_on_a_live_hit() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running
+                .insert("m".into(), running_model_fixture(None, Duration::ZERO, 0));
+        }
+
+        // Held, not dropped immediately — otherwise its own release
+        // could already have run by the next line.
+        let (_, _guard) = check_running(&state, "m").await.unwrap();
+        assert_eq!(
+            state.0.manager.lock().await.running["m"].in_flight,
+            1,
+            "a cache hit must claim in_flight so it can't be evicted before the caller claims it"
+        );
+    }
+
+    /// Regression test: the claim `check_running`/`ensure_model` hands
+    /// back must release itself even if the caller's task is dropped
+    /// before ever reaching `begin_activity`/`refresh_activity` — the
+    /// whole point of returning an [`ActivityGuard`] instead of a plain
+    /// bool/count.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unclaimed_activity_guard_still_releases_on_drop() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running
+                .insert("m".into(), running_model_fixture(None, Duration::ZERO, 0));
+        }
+
+        let (_, guard) = check_running(&state, "m").await.unwrap();
+        assert_eq!(state.0.manager.lock().await.running["m"].in_flight, 1);
+
+        drop(guard); // simulates the caller's task being cancelled here
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            state.0.manager.lock().await.running["m"].in_flight,
+            0,
+            "the claim must still be released even if never handed off"
+        );
+    }
+
+    #[test]
+    fn parse_max_queue_defaults_to_ollamas_own_512_on_anything_unparseable() {
+        assert_eq!(parse_max_queue(None), 512);
+        assert_eq!(parse_max_queue(Some("")), 512);
+        assert_eq!(parse_max_queue(Some("garbage")), 512);
+        assert_eq!(parse_max_queue(Some("10")), 10);
+        // Unlike most other LLMMAN_*/parse_* pairs, an explicit "0" is a
+        // real value (disables the bound), not treated as unset.
+        assert_eq!(parse_max_queue(Some("0")), 0);
+    }
+
+    #[test]
+    fn parse_max_loaded_models_defaults_to_unbounded_on_anything_unparseable() {
+        assert_eq!(parse_max_loaded_models(None), 0);
+        assert_eq!(parse_max_loaded_models(Some("")), 0);
+        assert_eq!(parse_max_loaded_models(Some("garbage")), 0);
+        assert_eq!(parse_max_loaded_models(Some("3")), 3);
+    }
+
+    #[test]
+    fn try_admit_rejects_once_the_cap_is_reached_and_releases_on_drop() {
+        // A dedicated counter, not the real PENDING_REQUESTS — isolates
+        // this from other tests running in parallel.
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+        let first =
+            try_admit_against(&COUNTER, 1).expect("first admission under the cap must succeed");
+        assert!(
+            try_admit_against(&COUNTER, 1).is_err(),
+            "a second admission at the cap must be rejected"
+        );
+
+        drop(first);
+        assert!(
+            try_admit_against(&COUNTER, 1).is_ok(),
+            "dropping an admitted guard must free its slot for the next caller"
+        );
+    }
+
+    #[test]
+    fn try_admit_with_a_zero_cap_admits_one_at_a_time_not_none_or_unbounded() {
+        // Approximates Ollama's own unbuffered pendingReqCh at
+        // OLLAMA_MAX_QUEUE=0 — neither "reject everything" nor
+        // "unbounded".
+        static COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+        let first = try_admit_against(&COUNTER, 0).expect("one admission must still succeed");
+        assert!(
+            try_admit_against(&COUNTER, 0).is_err(),
+            "a second concurrent admission must still be rejected"
+        );
+        drop(first);
+        assert!(
+            try_admit_against(&COUNTER, 0).is_ok(),
+            "dropping the first must free the slot for the next caller"
+        );
+    }
+
+    #[test]
+    fn default_allowed_origins_covers_every_scheme_and_localhost_spelling() {
+        let origins = default_allowed_origins();
+        for expected in [
+            "http://localhost:*",
+            "https://localhost:*",
+            "http://127.0.0.1:*",
+            "https://127.0.0.1:*",
+            "http://0.0.0.0:*",
+            "https://0.0.0.0:*",
+            "http://[::1]:*",
+            "https://[::1]:*",
+        ] {
+            assert!(
+                origins.iter().any(|o| o == expected),
+                "missing default origin pattern {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn origin_matches_a_trailing_wildcard_port_pattern() {
+        assert!(origin_matches(
+            "http://localhost:3000",
+            "http://localhost:*"
+        ));
+        assert!(origin_matches("http://localhost:1", "http://localhost:*"));
+        assert!(origin_matches("http://localhost:", "http://localhost:*"));
+        assert!(!origin_matches(
+            "http://evil.example:3000",
+            "http://localhost:*"
+        ));
+        assert!(!origin_matches(
+            "http://localhost.evil.example",
+            "http://localhost:*"
+        ));
+    }
+
+    #[test]
+    fn origin_matches_a_wildcard_anywhere_in_the_pattern() {
+        // Subdomain wildcard, mirroring gin-contrib/cors's own
+        // AllowWildcard (not just llmman's default `:*` port entries).
+        assert!(origin_matches(
+            "https://foo.example.com",
+            "https://*.example.com"
+        ));
+        assert!(!origin_matches(
+            "https://example.com",
+            "https://*.example.com"
+        ));
+        // A bare "*" allows every origin.
+        assert!(origin_matches("https://anything.at.all", "*"));
+        // More than one '*' never matches.
+        assert!(!origin_matches("https://example.com", "https://*.*.com"));
+    }
+
+    #[test]
+    fn origin_matches_a_plain_pattern_only_byte_for_byte() {
+        assert!(origin_matches("https://example.com", "https://example.com"));
+        assert!(!origin_matches(
+            "https://example.com:8080",
+            "https://example.com"
+        ));
+        assert!(!origin_matches("http://example.com", "https://example.com"));
+    }
+
+    #[test]
+    fn allowed_origins_from_env_always_includes_the_localhost_defaults() {
+        let origins = allowed_origins_from_env();
+        assert!(origins.iter().any(|o| o == "http://localhost:*"));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforce_max_loaded_models_is_a_no_op_when_unbounded() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "m1".into(),
+                running_model_fixture(None, Duration::from_secs(0), 0),
+            );
+        }
+        assert!(enforce_max_loaded_models(&state, 0).await.is_ok());
+        assert_eq!(state.0.manager.lock().await.running.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforce_max_loaded_models_evicts_the_least_recently_active_idle_model_first() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "oldest-idle".into(),
+                running_model_fixture(None, Duration::from_secs(300), 0),
+            );
+            mgr.running.insert(
+                "newest-idle".into(),
+                running_model_fixture(None, Duration::from_secs(1), 0),
+            );
+        }
+
+        // Already at the cap (2 running, max_loaded 2) — a caller about
+        // to insert a third must first free exactly one slot.
+        assert!(enforce_max_loaded_models(&state, 2).await.is_ok());
+
+        let mgr = state.0.manager.lock().await;
+        assert_eq!(mgr.running.len(), 1);
+        assert!(
+            !mgr.running.contains_key("oldest-idle"),
+            "the least-recently-active idle model must be evicted first"
+        );
+        assert!(mgr.running.contains_key("newest-idle"));
+    }
+
+    /// Regression test: the freed slot from an eviction must already be
+    /// reserved (`pending_loads`) for the caller that triggered it, in
+    /// the same locked step as the removal — not left open for a
+    /// concurrent caller to steal while `stop_and_wait` is in flight.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforce_max_loaded_models_reserves_its_own_slot_when_evicting() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "victim".into(),
+                running_model_fixture(None, Duration::from_secs(300), 0),
+            );
+        }
+
+        let guard = enforce_max_loaded_models(&state, 1).await.unwrap();
+        let mgr = state.0.manager.lock().await;
+        assert_eq!(mgr.running.len(), 0, "the sole idle model must be evicted");
+        assert_eq!(
+            mgr.pending_loads, 1,
+            "the freed slot must already be reserved for this caller"
+        );
+        drop(mgr);
+        drop(guard);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforce_max_loaded_models_rejects_with_503_when_every_loaded_model_is_busy() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "busy-1".into(),
+                running_model_fixture(None, Duration::from_secs(0), 1),
+            );
+        }
+
+        let err = enforce_max_loaded_models(&state, 1)
+            .await
+            .expect_err("every model at/over the cap is busy, so this must reject");
+        assert_eq!(err.1, StatusCode::SERVICE_UNAVAILABLE);
+
+        // Nothing evicted — a busy model must survive.
+        assert_eq!(state.0.manager.lock().await.running.len(), 1);
+    }
+
+    /// Regression test: a second concurrent load of a *different* model
+    /// must not also pass the `max_loaded` check while a first load is
+    /// still pending (not yet in `running`) — see
+    /// `enforce_max_loaded_models`'s doc comment on the reservation this
+    /// closes a race on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enforce_max_loaded_models_reserves_a_pending_slot_for_an_in_flight_load() {
+        let state = test_state();
+        let guard1 = enforce_max_loaded_models(&state, 1).await.unwrap();
+        assert_eq!(state.0.manager.lock().await.pending_loads, 1);
+
+        let state2 = state.clone();
+        let second = tokio::spawn(async move { enforce_max_loaded_models(&state2, 1).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !second.is_finished(),
+            "a second load must wait for the first reservation, not double up on it"
+        );
+
+        drop(guard1);
+        tokio::time::timeout(Duration::from_secs(2), second)
+            .await
+            .expect("second load must proceed once the first reservation is released")
+            .unwrap()
+            .expect("second load must succeed once a slot is actually free");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn begin_activity_marks_in_flight_and_its_drop_releases_it_and_updates_keep_alive() {
         let state = test_state();
         {
             let mut mgr = state.0.manager.lock().await;
+            // in_flight: 1, as ensure_model's own claim (fresh load or
+            // cache hit — either way it always claims one) already left
+            // it before this test's begin_activity call, same as a real
+            // handler would see it.
             mgr.running.insert(
                 "m".into(),
-                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 1),
             );
         }
 
-        let guard = begin_activity(&state, "m", Some(Some(Duration::from_secs(42)))).await;
+        let claim = ActivityGuard::new(&state, "m");
+        let guard = begin_activity(claim, Some(Some(Duration::from_secs(42)))).await;
         {
             let mgr = state.0.manager.lock().await;
             let m = &mgr.running["m"];
             assert_eq!(
                 m.in_flight, 1,
-                "begin_activity must mark one in-flight request"
+                "begin_activity must not add a second claim on top of ensure_model's own"
             );
             assert_eq!(m.keep_alive, Some(Duration::from_secs(42)));
         }
@@ -5351,13 +6140,15 @@ mod tests {
         {
             let mut mgr = state.0.manager.lock().await;
             // "Forever" — as if pinned via `/api/chat`'s `keep_alive: -1`.
+            // in_flight: 1, as ensure_model's own prior claim.
             mgr.running.insert(
                 "m".into(),
-                running_model_fixture(None, Duration::from_secs(600), 0),
+                running_model_fixture(None, Duration::from_secs(600), 1),
             );
         }
 
-        let guard = begin_activity(&state, "m", None).await;
+        let claim = ActivityGuard::new(&state, "m");
+        let guard = begin_activity(claim, None).await;
         {
             let mgr = state.0.manager.lock().await;
             let m = &mgr.running["m"];
@@ -5382,27 +6173,54 @@ mod tests {
         );
     }
 
+    /// Regression test: the load-only `/api/generate` path calls
+    /// `refresh_activity` instead of `begin_activity` — it must release
+    /// `ensure_model`'s own provisional claim itself, since no
+    /// `ActivityGuard` will ever do it.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn refresh_activity_releases_ensure_models_own_claim() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "m".into(),
+                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 1),
+            );
+        }
+
+        refresh_activity(ActivityGuard::new(&state, "m"), None).await;
+        // The guard's own Drop (releasing the claim) spawns a task —
+        // give it a moment to run, same as every other ActivityGuard
+        // drop test in this file.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            state.0.manager.lock().await.running["m"].in_flight,
+            0,
+            "refresh_activity must release ensure_model's claim, with no guard to do it later"
+        );
+    }
+
     /// Regression test for `serve_async`'s `ServeArgs::model` pre-load:
-    /// `ensure_model` alone leaves a freshly loaded model at the daemon
-    /// default `keep_alive` (5 minutes) with nothing to reset its idle
-    /// clock (no request has been served yet, so no `ActivityGuard`
-    /// exists) — the idle reaper would unload a model asked for on the
-    /// command line before it's ever actually used, defeating the whole
-    /// point of pre-loading it. `refresh_activity(state, model, None)`
-    /// (what the pre-load task now calls right after `ensure_model`
-    /// succeeds) must pin it to "never unload" instead.
+    /// without an explicit pin, a freshly loaded model sits at the
+    /// daemon default `keep_alive` (5 minutes) — the idle reaper would
+    /// unload a model asked for on the command line before it's ever
+    /// actually used, defeating the whole point of pre-loading it.
+    /// `refresh_activity(guard, None)` (what the pre-load task now calls
+    /// right after `ensure_model` succeeds) must pin it to "never
+    /// unload" instead.
     #[tokio::test(flavor = "multi_thread")]
     async fn refresh_activity_with_none_pins_a_model_to_never_unload() {
         let state = test_state();
         {
             let mut mgr = state.0.manager.lock().await;
+            // in_flight: 1, as ensure_model's own prior claim.
             mgr.running.insert(
                 "preloaded".into(),
-                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 1),
             );
         }
 
-        refresh_activity(&state, "preloaded", None).await;
+        refresh_activity(ActivityGuard::new(&state, "preloaded"), None).await;
 
         let mgr = state.0.manager.lock().await;
         assert_eq!(
@@ -5476,35 +6294,46 @@ mod tests {
     }
 
     #[test]
-    fn parse_context_shift_is_unset_when_absent_or_empty() {
-        // No explicit override — resolve_context_shift's per-model
-        // default applies instead. See context_shift_override_from_env's
-        // doc comment.
-        assert_eq!(parse_context_shift(None), None);
-        assert_eq!(parse_context_shift(Some("")), None);
-        assert_eq!(parse_context_shift(Some("   ")), None);
-        // An unrecognized-but-non-empty value is still an explicit
-        // override, same as the old bool-returning parser — it just
-        // isn't one of the recognized falsey spellings below.
-        assert_eq!(parse_context_shift(Some("garbage")), Some(true));
+    fn parse_num_parallel_accepts_a_positive_integer() {
+        assert_eq!(parse_num_parallel(Some("4")), Some(4));
+        assert_eq!(parse_num_parallel(Some(" 1 ")), Some(1));
     }
 
     #[test]
-    fn parse_context_shift_recognizes_every_falsey_spelling() {
-        assert_eq!(parse_context_shift(Some("0")), Some(false));
-        assert_eq!(parse_context_shift(Some("false")), Some(false));
-        assert_eq!(parse_context_shift(Some("no")), Some(false));
-        assert_eq!(parse_context_shift(Some("off")), Some(false));
-        // Case-insensitive, whitespace-tolerant.
-        assert_eq!(parse_context_shift(Some(" FALSE \n")), Some(false));
+    fn parse_num_parallel_rejects_zero_and_unparseable_values() {
+        assert_eq!(parse_num_parallel(Some("0")), None);
+        assert_eq!(parse_num_parallel(None), None);
+        assert_eq!(parse_num_parallel(Some("")), None);
+        assert_eq!(parse_num_parallel(Some("-1")), None);
+        assert_eq!(parse_num_parallel(Some("garbage")), None);
     }
 
     #[test]
-    fn parse_context_shift_recognizes_explicit_truthy_spellings_too() {
-        assert_eq!(parse_context_shift(Some("1")), Some(true));
-        assert_eq!(parse_context_shift(Some("true")), Some(true));
-        assert_eq!(parse_context_shift(Some("on")), Some(true));
-        assert_eq!(parse_context_shift(Some("yes")), Some(true));
+    fn backend_ctx_size_scales_by_num_parallel_so_each_slot_keeps_the_full_context() {
+        // llama-server splits one --ctx-size evenly across every
+        // --parallel slot, so this must scale up to compensate —
+        // matching Ollama's own NumCtx * numParallel.
+        assert_eq!(backend_ctx_size(Some(4096), Some(4)), Some(16384));
+        assert_eq!(backend_ctx_size(Some(4096), Some(1)), Some(4096));
+        assert_eq!(backend_ctx_size(Some(4096), None), Some(4096));
+        assert_eq!(backend_ctx_size(None, Some(4)), None);
+        assert_eq!(backend_ctx_size(None, None), None);
+    }
+
+    #[test]
+    fn backend_ctx_size_saturates_instead_of_overflowing() {
+        assert_eq!(backend_ctx_size(Some(u32::MAX), Some(2)), Some(u32::MAX));
+    }
+
+    #[test]
+    fn effective_num_parallel_drops_to_none_without_a_ctx_size_to_scale() {
+        // Nothing to scale --parallel against, so don't forward it at
+        // all rather than let llama-server silently divide the model's
+        // own trained context across slots.
+        assert_eq!(effective_num_parallel(None, Some(4)), None);
+        assert_eq!(effective_num_parallel(Some(4096), Some(4)), Some(4));
+        assert_eq!(effective_num_parallel(Some(4096), None), None);
+        assert_eq!(effective_num_parallel(None, None), None);
     }
 
     #[test]
@@ -5514,17 +6343,6 @@ mod tests {
         assert!(!supports_context_shift("DeepSeek-V2.5:latest")); // case-insensitive
         assert!(supports_context_shift("qwen3.5:latest"));
         assert!(supports_context_shift("gpt-oss:20b"));
-    }
-
-    #[test]
-    fn resolve_context_shift_lets_an_explicit_override_win_over_the_model_default() {
-        // An explicit LLMMAN_CONTEXT_SHIFT always wins, even against a
-        // deepseek model that would otherwise default to disabled.
-        assert!(resolve_context_shift("deepseek-v3:latest", Some(true)));
-        assert!(!resolve_context_shift("qwen3.5:latest", Some(false)));
-        // No override — falls back to the per-model default.
-        assert!(!resolve_context_shift("deepseek-v3:latest", None));
-        assert!(resolve_context_shift("qwen3.5:latest", None));
     }
 
     #[test]

--- a/src/container.rs
+++ b/src/container.rs
@@ -223,6 +223,9 @@ pub fn pull_image(ociman: ContainerManager, llama_cpp_version: Option<&str>) -> 
 ///
 /// `split_mode`, when given, forwards `--split-mode <mode>`.
 ///
+/// `num_parallel`, when given, forwards `--parallel <n>` — see
+/// `cmd::serve::num_parallel_from_env`'s doc comment.
+///
 /// `mmproj_path`, when given, forwards `--mmproj <path>`, mounted as its
 /// own `/mmproj` read-only volume (it's extracted into a different cache
 /// directory than `model_path`, so it can't share that mount).
@@ -237,6 +240,7 @@ pub fn spawn(
     kv_cache_type: Option<&str>,
     context_shift: bool,
     split_mode: Option<&str>,
+    num_parallel: Option<u32>,
 ) -> Result<tokio::process::Child> {
     let backend = detect_backend();
     let image = backend.image_ref(llama_cpp_version);
@@ -294,6 +298,14 @@ pub fn spawn(
             args.push(format!("{var}={val}"));
         }
     }
+    // Same as above, for llama.cpp's own env-configurable arguments —
+    // see LLAMA_CPP_ENV_PASSTHROUGH_VARS's doc comment.
+    for var in crate::cmd::serve::LLAMA_CPP_ENV_PASSTHROUGH_VARS {
+        if let Ok(val) = std::env::var(var) {
+            args.push("-e".into());
+            args.push(format!("{var}={val}"));
+        }
+    }
     args.push(image);
     args.extend([
         "-m".into(),
@@ -333,7 +345,12 @@ pub fn spawn(
         args.push("--split-mode".into());
         args.push(mode.to_string());
     }
+    if let Some(n) = num_parallel {
+        args.push("--parallel".into());
+        args.push(n.to_string());
+    }
 
+    crate::debug_log!("spawning {} {}", ociman.binary(), args.join(" "));
     tokio::process::Command::new(ociman.binary())
         .args(&args)
         .stdin(std::process::Stdio::null())

--- a/src/hf/mod.rs
+++ b/src/hf/mod.rs
@@ -70,6 +70,30 @@ fn hf_home() -> PathBuf {
         .join("huggingface")
 }
 
+/// Matches Ollama's own default for `OLLAMA_MAX_TRANSFER_STREAMS`.
+const DEFAULT_MAX_TRANSFER_STREAMS: usize = 4;
+
+/// Maximum number of a safetensors repo's files [`pull::pull`] downloads
+/// concurrently, from `LLMMAN_MAX_TRANSFER_STREAMS` (mirrors Ollama's
+/// `OLLAMA_MAX_TRANSFER_STREAMS`). No effect on GGUF transfers, which
+/// stay sequential.
+pub fn max_transfer_streams() -> usize {
+    parse_max_transfer_streams(std::env::var("LLMMAN_MAX_TRANSFER_STREAMS").ok().as_deref())
+}
+
+/// Unset/blank/unparseable falls back to the default. An explicit `0`
+/// is clamped to `1` (sequential), not bumped up to the default — same
+/// as Ollama's own `max(1, envconfig.MaxTransferStreams())` — since `0`
+/// would otherwise deadlock `buffer_unordered` (nothing would poll) and
+/// an operator explicitly minimizing concurrency shouldn't get more of
+/// it than unset would.
+fn parse_max_transfer_streams(value: Option<&str>) -> usize {
+    match value.map(str::trim).and_then(|v| v.parse::<usize>().ok()) {
+        None => DEFAULT_MAX_TRANSFER_STREAMS,
+        Some(n) => n.max(1),
+    }
+}
+
 /// Path to the active-token file, honoring `HF_TOKEN_PATH`.
 pub fn token_path() -> PathBuf {
     if let Ok(p) = std::env::var("HF_TOKEN_PATH") {
@@ -376,6 +400,22 @@ mod tests {
         assert!(!is_hf_host("registry.example.com"));
         assert!(!is_hf_host("docker.io"));
         assert!(!is_hf_host("modelscope.cn"));
+    }
+
+    #[test]
+    fn parse_max_transfer_streams_defaults_to_four_on_unset_or_unparseable() {
+        assert_eq!(parse_max_transfer_streams(None), 4);
+        assert_eq!(parse_max_transfer_streams(Some("")), 4);
+        assert_eq!(parse_max_transfer_streams(Some("garbage")), 4);
+        assert_eq!(parse_max_transfer_streams(Some("8")), 8);
+        assert_eq!(parse_max_transfer_streams(Some(" 2 ")), 2);
+    }
+
+    #[test]
+    fn parse_max_transfer_streams_clamps_an_explicit_zero_to_one() {
+        // Matches Ollama's own max(1, ...) — an explicit 0 means
+        // "minimize concurrency", not "same as unset".
+        assert_eq!(parse_max_transfer_streams(Some("0")), 1);
     }
 
     #[test]

--- a/src/hf/pull.rs
+++ b/src/hf/pull.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use sha2::{Digest as _, Sha256};
 
 use super::api::{self, HfFile};
@@ -135,28 +136,47 @@ pub async fn pull(reference: &str, layout_dir: &Path, progress_key: &str) -> Res
             if to_download.is_empty() {
                 anyhow::bail!("no model files found in repository {owner}/{repo}");
             }
-            let mut layers = Vec::new();
-            for f in &to_download {
-                let mut d = download_layer(
-                    &dl_client,
-                    &head_client,
-                    &endpoint,
-                    &owner,
-                    &repo,
-                    &commit,
-                    f,
-                    token.as_deref(),
-                    layout_dir,
-                    progress_key,
-                )
-                .await?;
-                d.media_type = api::safetensors_media_type(&f.path).to_string();
-                d.annotations = Some(BTreeMap::from([(
-                    oci::ANNOTATION_FILEPATH.to_string(),
-                    f.path.clone(),
-                )]));
-                layers.push(d);
-            }
+            // Concurrent, bounded by LLMMAN_MAX_TRANSFER_STREAMS (the
+            // GGUF branch above stays sequential). Indexed so `layers`'
+            // order doesn't depend on finish order.
+            let max_streams = super::max_transfer_streams();
+            let mut indexed_layers: Vec<(usize, Descriptor)> =
+                stream::iter(to_download.iter().enumerate())
+                    .map(|(i, f)| {
+                        let dl_client = &dl_client;
+                        let head_client = &head_client;
+                        let endpoint = &endpoint;
+                        let owner = &owner;
+                        let repo = &repo;
+                        let commit = &commit;
+                        let token = token.as_deref();
+                        async move {
+                            let mut d = download_layer(
+                                dl_client,
+                                head_client,
+                                endpoint,
+                                owner,
+                                repo,
+                                commit,
+                                f,
+                                token,
+                                layout_dir,
+                                progress_key,
+                            )
+                            .await?;
+                            d.media_type = api::safetensors_media_type(&f.path).to_string();
+                            d.annotations = Some(BTreeMap::from([(
+                                oci::ANNOTATION_FILEPATH.to_string(),
+                                f.path.clone(),
+                            )]));
+                            Ok::<(usize, Descriptor), anyhow::Error>((i, d))
+                        }
+                    })
+                    .buffer_unordered(max_streams)
+                    .try_collect()
+                    .await?;
+            indexed_layers.sort_by_key(|(i, _)| *i);
+            let layers: Vec<Descriptor> = indexed_layers.into_iter().map(|(_, d)| d).collect();
             oci::build_cncf_manifest(layout_dir, &meta, &format!("{owner}/{repo}"), "", layers)?
         }
     };
@@ -166,6 +186,43 @@ pub async fn pull(reference: &str, layout_dir: &Path, progress_key: &str) -> Res
 
 fn basename(path: &str) -> String {
     path.rsplit('/').next().unwrap_or(path).to_string()
+}
+
+/// Deletes its `.part` path on drop unless [`disarm`](Self::disarm) was
+/// called first — so a concurrent download cancelled mid-flight (a
+/// sibling in the same `buffer_unordered` batch failing first) still
+/// cleans up its temp file, not just a normal error return.
+struct TmpFileGuard<'a>(&'a Path, bool);
+
+impl TmpFileGuard<'_> {
+    fn disarm(&mut self) {
+        self.1 = false;
+    }
+}
+
+impl Drop for TmpFileGuard<'_> {
+    fn drop(&mut self) {
+        if self.1 {
+            let _ = std::fs::remove_file(self.0);
+        }
+    }
+}
+
+/// Moves `tmp_path` to `dest` in the content-addressed blob store.
+/// Returns `false` (not moved) if `dest` already had this content — a
+/// concurrent sibling download of identical bytes can win the rename
+/// first now that safetensors files download in parallel; POSIX
+/// overwrites silently, but Windows can error, so `dest` is rechecked
+/// rather than failing the whole pull over that race.
+fn move_into_place(tmp_path: &Path, dest: &Path) -> Result<bool> {
+    if dest.exists() {
+        return Ok(false);
+    }
+    match std::fs::rename(tmp_path, dest) {
+        Ok(()) => Ok(true),
+        Err(_) if dest.exists() => Ok(false),
+        Err(e) => Err(e).with_context(|| format!("move downloaded blob to {}", dest.display())),
+    }
 }
 
 /// Downloads one file straight into `layout_dir`'s content-addressed
@@ -223,6 +280,7 @@ async fn download_layer(
         std::process::id(),
         sanitize(&file.path)
     ));
+    let mut tmp_guard = TmpFileGuard(&tmp_path, true);
 
     let req = FetchRequest {
         url,
@@ -285,7 +343,7 @@ async fn download_layer(
                 }
             }
         }
-        let _ = std::fs::remove_file(&tmp_path);
+        // tmp_guard's drop removes tmp_path.
         return Err(last_err.unwrap()).with_context(|| {
             format!(
                 "download {} failed after {} attempts",
@@ -299,11 +357,11 @@ async fn download_layer(
     std::fs::create_dir_all(&dest_dir)?;
     let dest = dest_dir.join(digest.trim_start_matches("sha256:"));
     let total = std::fs::metadata(&tmp_path)?.len() as i64;
-    if !dest.exists() {
-        std::fs::rename(&tmp_path, &dest)?;
-    } else {
-        let _ = std::fs::remove_file(&tmp_path);
+    if move_into_place(&tmp_path, &dest)? {
+        tmp_guard.disarm(); // already moved away; nothing left to clean up
     }
+    // else: same content already at `dest` — tmp_guard's drop removes
+    // this now-redundant copy.
 
     Ok(Descriptor {
         media_type: oci::MEDIA_TYPE_MODEL_WEIGHT_RAW.to_string(),
@@ -340,5 +398,85 @@ impl Write for HashingProgressWriter<'_> {
     }
     fn flush(&mut self) -> std::io::Result<()> {
         self.file.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tmp_file_guard_removes_the_file_on_drop_by_default() {
+        let dir = std::env::temp_dir().join(format!("llmman-tmpguard-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("armed.part");
+        std::fs::write(&path, b"partial").unwrap();
+
+        {
+            let _guard = TmpFileGuard(&path, true);
+        }
+        assert!(
+            !path.exists(),
+            "an armed guard must remove its file on drop"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn tmp_file_guard_leaves_the_file_alone_once_disarmed() {
+        let dir = std::env::temp_dir().join(format!(
+            "llmman-tmpguard-test-disarm-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("disarmed.part");
+        std::fs::write(&path, b"done").unwrap();
+
+        {
+            let mut guard = TmpFileGuard(&path, true);
+            guard.disarm();
+        }
+        assert!(path.exists(), "a disarmed guard must not remove its file");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn move_into_place_moves_the_file_when_dest_is_absent() {
+        let dir = std::env::temp_dir().join(format!("llmman-move-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = dir.join("a.part");
+        let dest = dir.join("dest");
+        std::fs::write(&tmp, b"content").unwrap();
+
+        assert!(move_into_place(&tmp, &dest).unwrap());
+        assert!(!tmp.exists());
+        assert!(dest.exists());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Regression test: a concurrent sibling download of identical
+    /// content winning the rename first (`dest` already exists) must
+    /// not be treated as an error — the caller's own `.part` file is
+    /// just redundant, not a failure.
+    #[test]
+    fn move_into_place_tolerates_a_destination_that_already_exists() {
+        let dir =
+            std::env::temp_dir().join(format!("llmman-move-test-existing-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = dir.join("a.part");
+        let dest = dir.join("dest");
+        std::fs::write(&tmp, b"content").unwrap();
+        std::fs::write(&dest, b"content").unwrap(); // a sibling already won
+
+        assert!(!move_into_place(&tmp, &dest).unwrap());
+        assert!(
+            tmp.exists(),
+            "move_into_place itself must leave the redundant tmp file for the caller's guard to clean up"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -48,7 +48,21 @@ pub enum HostGpu {
 
 /// Detects the best available accelerator on this host, in priority order
 /// CUDA > ROCm > Vulkan > CPU on Linux/Windows, or Metal > CPU on macOS.
+///
+/// A non-empty `LLMMAN_LLM_LIBRARY` (mirrors Ollama's
+/// `OLLAMA_LLM_LIBRARY`) bypasses every probe below — see
+/// [`llm_library_override`]. Doesn't affect [`detect_with_vram`]'s own
+/// VRAM sizing, which always probes the real hardware. Two paths that
+/// pick a backend without calling this at all are therefore also
+/// unaffected: an already-on-`PATH` `llama-server` binary (its backend
+/// is whatever it was built with, not llmman's to change), and macOS's
+/// own local-binary release download (llama.cpp publishes exactly one
+/// asset per macOS architecture — the arm64 one is always Metal-capable
+/// — so there's no separate choice to override there either).
 pub fn detect() -> HostGpu {
+    if let Some(forced) = llm_library_override() {
+        return forced;
+    }
     #[cfg(target_os = "macos")]
     {
         detect_macos()
@@ -63,7 +77,62 @@ pub fn detect() -> HostGpu {
     }
 }
 
+/// [`detect`]'s `LLMMAN_LLM_LIBRARY` override. Accepts (case-insensitive)
+/// `cpu`, `cuda`/`cuda12`, `cuda13`, `rocm`, `vulkan`, `metal`. Unset,
+/// blank, or unrecognized falls through to real autodetection.
+fn llm_library_override() -> Option<HostGpu> {
+    parse_llm_library(std::env::var("LLMMAN_LLM_LIBRARY").ok().as_deref())
+}
+
+fn parse_llm_library(value: Option<&str>) -> Option<HostGpu> {
+    let v = value?.trim();
+    if v.is_empty() {
+        return None;
+    }
+    match v.to_ascii_lowercase().as_str() {
+        "cpu" | "none" => Some(HostGpu::None),
+        "cuda" | "cuda12" | "cuda_v12" => Some(HostGpu::Cuda { major: 12 }),
+        "cuda13" | "cuda_v13" => Some(HostGpu::Cuda { major: 13 }),
+        "rocm" => Some(HostGpu::Rocm),
+        "vulkan" => Some(HostGpu::Vulkan),
+        "metal" => Some(HostGpu::Metal),
+        _ => None,
+    }
+}
+
 const GIB: u64 = 1024 * 1024 * 1024;
+
+/// Bytes of VRAM to hold back from [`default_ctx_size`]'s tiering, from
+/// `LLMMAN_GPU_OVERHEAD` (mirrors Ollama's `OLLAMA_GPU_OVERHEAD`).
+/// Subtracted once from the combined total, not per GPU — llmman only
+/// probes one combined VRAM figure. Unset/blank/unparseable is `0`.
+pub fn gpu_overhead_bytes() -> u64 {
+    parse_gpu_overhead(std::env::var("LLMMAN_GPU_OVERHEAD").ok().as_deref())
+}
+
+fn parse_gpu_overhead(value: Option<&str>) -> u64 {
+    value
+        .map(str::trim)
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Whether integrated GPUs count during Vulkan probing, from
+/// `LLMMAN_IGPU_ENABLE` (mirrors Ollama's `OLLAMA_IGPU_ENABLE`).
+/// Defaults to disabled, same as Ollama — an integrated GPU is usually a
+/// worse pick than the discrete/CPU fallback.
+pub fn igpu_enabled() -> bool {
+    parse_igpu_enabled(std::env::var("LLMMAN_IGPU_ENABLE").ok().as_deref())
+}
+
+fn parse_igpu_enabled(value: Option<&str>) -> bool {
+    match value.map(str::trim) {
+        Some(v) if !v.is_empty() => {
+            matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+        }
+        _ => false,
+    }
+}
 
 /// VRAM-tiered context-size default (used by `cmd::serve` when
 /// `LLMMAN_CONTEXT_LENGTH` isn't set). Below a 47GiB VRAM threshold,
@@ -82,9 +151,10 @@ pub fn default_ctx_size_for(vram_bytes: u64) -> Option<u32> {
     }
 }
 
-/// [`default_ctx_size_for`] applied to [`detect_with_vram`]'s live probe.
+/// [`default_ctx_size_for`] applied to [`detect_with_vram`]'s live probe,
+/// less [`gpu_overhead_bytes`] (floors at 0, never underflows).
 pub fn default_ctx_size() -> Option<u32> {
-    default_ctx_size_for(detect_with_vram().1)
+    default_ctx_size_for(detect_with_vram().1.saturating_sub(gpu_overhead_bytes()))
 }
 
 /// The hidden re-exec argument `main()` checks for, before anything else,
@@ -409,7 +479,7 @@ fn detect_cuda() -> Option<(HostGpu, u64)> {
                     CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
                     device,
                 );
-                eprintln!("[llmman] CUDA device {index} compute capability: {major}.{minor}");
+                crate::debug_log!("CUDA device {index} compute capability: {major}.{minor}");
 
                 if let Some(cu_device_total_mem) = &cu_device_total_mem {
                     let mut bytes: u64 = 0;
@@ -478,13 +548,16 @@ fn detect_rocm() -> Option<u64> {
 // ---------------------------------------------------------------------------
 // Vulkan — mirrors vulkan/probe.c: vkCreateInstance,
 // vkEnumeratePhysicalDevices, vkGetPhysicalDeviceProperties (skip
-// VK_PHYSICAL_DEVICE_TYPE_CPU, require apiVersion >= 1.2),
+// VK_PHYSICAL_DEVICE_TYPE_CPU always, and _INTEGRATED_GPU unless
+// LLMMAN_IGPU_ENABLE is set — llmman's own addition, not in probe.c —
+// and require apiVersion >= 1.2),
 // vkGetPhysicalDeviceQueueFamilyProperties (require a queue family with
 // both COMPUTE and TRANSFER bits set).
 // ---------------------------------------------------------------------------
 
 const VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO: i32 = 1;
 const VK_SUCCESS: i32 = 0;
+const VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: i32 = 1;
 const VK_PHYSICAL_DEVICE_TYPE_CPU: i32 = 4;
 const VK_QUEUE_COMPUTE_BIT: u32 = 0x2;
 const VK_QUEUE_TRANSFER_BIT: u32 = 0x4;
@@ -625,6 +698,9 @@ unsafe fn detect_vulkan_inner(lib: &Library) -> Option<Option<u64>> {
                 if device_type == VK_PHYSICAL_DEVICE_TYPE_CPU {
                     continue;
                 }
+                if device_type == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU && !igpu_enabled() {
+                    continue;
+                }
                 if api_version < vk_make_api_version(0, 1, 2, 0) {
                     continue;
                 }
@@ -695,6 +771,73 @@ mod tests {
         assert_eq!(default_ctx_size_for(46 * GIB), Some(32768));
         assert_eq!(default_ctx_size_for(47 * GIB), None);
         assert_eq!(default_ctx_size_for(80 * GIB), None);
+    }
+
+    #[test]
+    fn parse_llm_library_recognizes_every_documented_name_case_insensitively() {
+        assert_eq!(parse_llm_library(Some("cpu")), Some(HostGpu::None));
+        assert_eq!(parse_llm_library(Some("CPU")), Some(HostGpu::None));
+        assert_eq!(parse_llm_library(Some("none")), Some(HostGpu::None));
+        assert_eq!(
+            parse_llm_library(Some("cuda")),
+            Some(HostGpu::Cuda { major: 12 })
+        );
+        assert_eq!(
+            parse_llm_library(Some("cuda12")),
+            Some(HostGpu::Cuda { major: 12 })
+        );
+        assert_eq!(
+            parse_llm_library(Some("CUDA13")),
+            Some(HostGpu::Cuda { major: 13 })
+        );
+        assert_eq!(parse_llm_library(Some("rocm")), Some(HostGpu::Rocm));
+        assert_eq!(parse_llm_library(Some("Vulkan")), Some(HostGpu::Vulkan));
+        assert_eq!(parse_llm_library(Some("metal")), Some(HostGpu::Metal));
+    }
+
+    #[test]
+    fn parse_llm_library_falls_through_to_autodetection_when_unset_blank_or_unknown() {
+        assert_eq!(parse_llm_library(None), None);
+        assert_eq!(parse_llm_library(Some("")), None);
+        assert_eq!(parse_llm_library(Some("   ")), None);
+        assert_eq!(parse_llm_library(Some("intel-arc")), None);
+    }
+
+    #[test]
+    fn parse_gpu_overhead_defaults_to_zero_on_anything_unparseable() {
+        assert_eq!(parse_gpu_overhead(None), 0);
+        assert_eq!(parse_gpu_overhead(Some("")), 0);
+        assert_eq!(parse_gpu_overhead(Some("not-a-number")), 0);
+        assert_eq!(parse_gpu_overhead(Some("1073741824")), 1073741824);
+        assert_eq!(parse_gpu_overhead(Some(" 512 ")), 512);
+    }
+
+    #[test]
+    fn default_ctx_size_for_with_overhead_subtracted_can_drop_a_tier() {
+        // A host with 47GiB VRAM would defer to the model's own trained
+        // context; a 1GiB LLMMAN_GPU_OVERHEAD knocks it back under the
+        // 47GiB threshold into the capped 32768 tier.
+        let vram = 47 * GIB;
+        let overhead = 1 * GIB;
+        assert_eq!(default_ctx_size_for(vram), None);
+        assert_eq!(
+            default_ctx_size_for(vram.saturating_sub(overhead)),
+            Some(32768)
+        );
+    }
+
+    #[test]
+    fn parse_igpu_enabled_recognizes_truthy_spellings_only() {
+        assert!(!parse_igpu_enabled(None));
+        assert!(!parse_igpu_enabled(Some("")));
+        assert!(!parse_igpu_enabled(Some("0")));
+        assert!(!parse_igpu_enabled(Some("false")));
+        assert!(!parse_igpu_enabled(Some("no")));
+        assert!(!parse_igpu_enabled(Some("off")));
+        assert!(parse_igpu_enabled(Some("1")));
+        assert!(parse_igpu_enabled(Some("true")));
+        assert!(parse_igpu_enabled(Some("YES")));
+        assert!(parse_igpu_enabled(Some("on")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,39 @@ pub fn default_cache() -> anyhow::Result<PathBuf> {
     Ok(store.parent().unwrap_or(&store).join("cache"))
 }
 
+/// Whether verbose diagnostic logging is enabled, from `LLMMAN_DEBUG`
+/// (mirrors Ollama's `OLLAMA_DEBUG`). llmman has only one verbosity
+/// tier, so any truthy value or non-zero integer enables it (Ollama's
+/// `OLLAMA_DEBUG=2` TRACE spelling also works, just maps to the same
+/// tier).
+pub fn debug_enabled() -> bool {
+    parse_debug_enabled(std::env::var("LLMMAN_DEBUG").ok().as_deref())
+}
+
+fn parse_debug_enabled(value: Option<&str>) -> bool {
+    let v = match value.map(str::trim) {
+        Some(v) if !v.is_empty() => v,
+        _ => return false,
+    };
+    match v.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => true,
+        "0" | "false" | "no" | "off" => false,
+        other => other.parse::<i64>().map(|n| n != 0).unwrap_or(false),
+    }
+}
+
+/// Prints a `[llmman] [debug] ...` line to stderr, only when
+/// [`debug_enabled`]. A macro (not a plain function) so the `format!`
+/// args aren't even evaluated when debug logging is off.
+#[macro_export]
+macro_rules! debug_log {
+    ($($arg:tt)*) => {
+        if $crate::debug_enabled() {
+            eprintln!("[llmman] [debug] {}", format!($($arg)*));
+        }
+    };
+}
+
 /// Split out from [`models_dir_from_env`] for testing without touching
 /// the real environment. Blank values count as unset.
 fn parse_env_path(value: Option<&str>) -> Option<PathBuf> {
@@ -77,5 +110,26 @@ mod tests {
             parse_env_path(Some("  /custom/store  ")),
             Some(PathBuf::from("/custom/store"))
         );
+    }
+
+    #[test]
+    fn parse_debug_enabled_recognizes_boolean_spellings() {
+        assert!(!parse_debug_enabled(None));
+        assert!(!parse_debug_enabled(Some("")));
+        assert!(!parse_debug_enabled(Some("0")));
+        assert!(!parse_debug_enabled(Some("false")));
+        assert!(!parse_debug_enabled(Some("no")));
+        assert!(!parse_debug_enabled(Some("off")));
+        assert!(parse_debug_enabled(Some("1")));
+        assert!(parse_debug_enabled(Some("true")));
+        assert!(parse_debug_enabled(Some("YES")));
+        assert!(parse_debug_enabled(Some("on")));
+    }
+
+    #[test]
+    fn parse_debug_enabled_treats_any_nonzero_integer_as_enabled() {
+        assert!(parse_debug_enabled(Some("2")));
+        assert!(parse_debug_enabled(Some("-1")));
+        assert!(!parse_debug_enabled(Some("not-a-number")));
     }
 }

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -10,7 +10,6 @@
 //!   3. <binary>/../share/llmman/shortnames.conf    install-tree relative path
 //!   4. <binary-dir>/shortnames.conf                development (conf beside binary)
 //!   5. ~/.config/llmman/shortnames.conf            per-user aliases
-//!   6. $LLMMAN_SHORTNAMES_CONF                     env-var override
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -44,13 +43,6 @@ fn config_paths() -> Vec<PathBuf> {
     // ~/.config/llmman/shortnames.conf
     if let Some(cfg) = dirs::config_dir() {
         paths.push(cfg.join("llmman").join("shortnames.conf"));
-    }
-
-    // $LLMMAN_SHORTNAMES_CONF
-    if let Ok(env) = std::env::var("LLMMAN_SHORTNAMES_CONF") {
-        if !env.is_empty() {
-            paths.push(PathBuf::from(env));
-        }
     }
 
     paths


### PR DESCRIPTION
Ports the `OLLAMA_*` env vars `ollama serve -h` documents that llmman was missing, as their `LLMMAN_*` equivalents.

## New
- `LLMMAN_DEBUG` — verbose diagnostic logging.
- `LLMMAN_NUM_PARALLEL` — `--parallel` for GGUF/llama-server loads, scaling `--ctx-size` by the same factor first. Dropped, with a warning, for a load with no explicit ctx-size to scale against.
- `LLMMAN_MAX_LOADED_MODELS` — caps concurrently loaded models; evicts the LRU idle one, or 503s if none are free. `ensure_model` now returns an already-claimed `ActivityGuard` on every successful path, closing three races found in review, and making the claim cancellation-safe.
- `LLMMAN_MAX_QUEUE` — admission control around `ensure_model`, 503ing with Ollama's own "server busy" message past the cap. Only counts requests that need real scheduling work, not an already-loaded cache hit, matching Ollama's own `GetRunner` bypassing `pendingReqCh` for a reusable runner. `0` admits one caller at a time rather than none or unbounded, approximating Ollama's own unbuffered channel. Default 512, matching Ollama.
- `LLMMAN_ORIGINS` — real CORS support (new `tower-http` dependency), matching Ollama's `gin-contrib/cors` wildcard behavior and default localhost origins.
- `LLMMAN_LOAD_TIMEOUT` — bounds `wait_for_ready`'s stall deadline, with each poll (and its sleep) bounded to avoid overshooting; a huge-but-parseable value can't overflow and panic; a dash-prefixed value must actually parse as a duration before being treated as "wait forever".
- `LLMMAN_GPU_OVERHEAD` / `LLMMAN_IGPU_ENABLE` / `LLMMAN_LLM_LIBRARY` — VRAM headroom, integrated-GPU opt-in, and backend override for host GPU detection. The backend override is documented as having no effect on an already-on-`PATH` `llama-server` binary or macOS's own local-binary download, since neither has a real choice to override there.
- `LLMMAN_MAX_TRANSFER_STREAMS` — bounded concurrent safetensors downloads in `pull` (GGUF, and `transfer`'s own registry-push path, stay sequential). An explicit `0` clamps to `1`, matching Ollama's own `max(1, ...)`. Temp files are cleaned up via an RAII guard even if a sibling download's failure cancels this one mid-flight, and a rename race between two siblings downloading identical content is tolerated.
- `LLAMA_ARG_FIT`/`LLAMA_ARG_FIT_TARGET` and `GPU_DEVICE_ORDINAL`/`HSA_OVERRIDE_GFX_VERSION` now also forwarded into `--ociman` containers.
- `llmman serve --help` gained an Ollama-style "Environment Variables:" section.

## Not implemented
- `OLLAMA_NO_CLOUD` — no cloud feature in llmman to disable.

## Removed
`LLMMAN_CONTEXT_SHIFT`, `LLMMAN_VLLM_ARGS`, and `LLMMAN_SHORTNAMES_CONF` predated this PR but have no `OLLAMA_*` equivalent — removed entirely (code, docs, tests). Context-shift now always follows the per-model DeepSeek-family default.

## Documentation
README's env var table describes each setting on its own terms (no Ollama references in that section) and has no em dashes anywhere in the file. The implementation still mirrors Ollama's behavior as closely as the code's own doc comments describe.

## Testing
- ~57 unit tests.
- `cargo test --lib`: 334 passed, 0 failed.
- `cargo fmt --check` / `cargo clippy --lib`: clean, no new warnings.

Note: CI's `test` job runs `cargo test --bin llmman`, but all tests live under the `[lib]` target, so it currently runs 0 tests — a pre-existing gap, unrelated to this PR. Verified everything above with `cargo test --lib`.