### PR TITLE
fix: bound metadata fetch and validate refs

### DIFF
--- a/go-shim/backend_podman.go
+++ b/go-shim/backend_podman.go
@@ -370,6 +370,13 @@ func copyImageWithProgress(ctx context.Context, pctx *signature.PolicyContext, d
 	copyImageMu.Lock()
 	defer copyImageMu.Unlock()
 
+	// copy.Image fetches the manifest and every blob inside this one
+	// retryStream, so the manifest phase is not separately bounded to a
+	// single attempt the way the Rust HF metadata GET is (hf::client::once). A
+	// typo'd but syntactically valid OCI registry host can still run the
+	// full retry budget on its manifest lookup here: a known residual, left
+	// as a follow-up. Malformed refs never reach this path: validate_reference
+	// (Rust, Layer B) rejects them up front.
 	var manifestData []byte
 	err := retryStream(ctx, progressKey, isHTTP4xx, func() error {
 		data, err := copyImageAttempt(ctx, pctx, dst, src, present, pastTense, opts, changed, progressKey)

--- a/go-shim/is_http4xx_test.go
+++ b/go-shim/is_http4xx_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsHTTP4xx(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not permanent", nil, false},
+		{"HTTP 400 substring is permanent", errors.New("GET https://example.com/f: HTTP 400"), true},
+		{"HTTP 401 substring is permanent", errors.New("GET https://example.com/f: HTTP 401"), true},
+		{"HTTP 403 substring is permanent", errors.New("GET https://example.com/f: HTTP 403"), true},
+		{"HTTP 404 substring is permanent", errors.New("GET https://example.com/f: HTTP 404"), true},
+		{"HTTP 500 stays retryable", errors.New("GET https://example.com/f: HTTP 500"), false},
+		{"plain error stays retryable", errors.New("connection refused"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isHTTP4xx(c.err); got != c.want {
+				t.Errorf("isHTTP4xx(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}

--- a/src/bin/llmman-bench.rs
+++ b/src/bin/llmman-bench.rs
@@ -170,7 +170,7 @@ fn run(args: &Args) -> anyhow::Result<()> {
 
     let mut results = Vec::with_capacity(args.model.len());
     for raw_model in &args.model {
-        let model = shortnames::resolve_ollama_api(raw_model);
+        let model = shortnames::resolve_ollama_api(raw_model)?;
         // Fail fast on a bad/unresolvable reference rather than only
         // discovering it partway through warmup below.
         daemon::ensure_model_pulled(&model)?;

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -22,6 +22,11 @@ pub struct BuildArgs {
 }
 
 pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
+    // The build tag is a user-chosen label stored verbatim, not resolved, so
+    // this is its only validation gate. Check it before touching the store so
+    // a bad tag never creates the store tree.
+    crate::shortnames::validate_reference(&args.tag)?;
+
     let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
@@ -44,4 +49,26 @@ pub fn run(args: &BuildArgs) -> anyhow::Result<()> {
     let desc = store.build(&context_dir, &args.tag, &labels)?;
     println!("Built {} ({})", args.tag, desc.digest);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_rejects_an_invalid_tag_before_building() {
+        // Validation runs before default_store()/OciStore::open() and before
+        // the context dir is read, so a bad tag errors without touching the
+        // filesystem or env.
+        let args = BuildArgs {
+            tag: "hf.co//foo".into(),
+            context_dir: std::path::PathBuf::from("/nonexistent"),
+            label: Vec::new(),
+        };
+        let err = run(&args).expect_err("invalid tag must error");
+        assert!(
+            err.to_string().contains("invalid model reference"),
+            "expected a validation error, got: {err}"
+        );
+    }
 }

--- a/src/cmd/cp.rs
+++ b/src/cmd/cp.rs
@@ -21,14 +21,39 @@ pub struct CpArgs {
 /// to match ollama's naming for anyone coming from there, not because the
 /// underlying operation differs at all.
 pub fn run(args: &CpArgs) -> anyhow::Result<()> {
+    // Validate/resolve both refs before touching the store, so a bad ref
+    // never creates the store tree. DESTINATION is stored verbatim, not
+    // resolved/canonicalized, so this is its only client-side validation
+    // gate. resolve_ollama_api for SOURCE, not resolve: it must match how
+    // the model is actually stored, same reasoning as tag.rs/rm.rs.
+    crate::shortnames::validate_reference(&args.destination)?;
+    let source = crate::shortnames::resolve_ollama_api(&args.source)?;
+
     let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
-    // resolve_ollama_api, not resolve: SOURCE must match how the model is
-    // actually stored — same reasoning as tag.rs/rm.rs.
-    let source = crate::shortnames::resolve_ollama_api(&args.source);
     let desc = store.find(&source)?;
     store.tag(desc, &args.destination)?;
     println!("copied '{}' to '{}'", args.source, args.destination);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cp_rejects_an_invalid_destination_before_writing() {
+        // Validation runs before default_store()/OciStore::open(), so a bad
+        // destination errors without ever touching the filesystem or env.
+        let args = CpArgs {
+            source: "gemma4".into(),
+            destination: "hf.co//foo".into(),
+        };
+        let err = run(&args).expect_err("invalid destination must error");
+        assert!(
+            err.to_string().contains("invalid model reference"),
+            "expected a validation error, got: {err}"
+        );
+    }
 }

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -75,11 +75,13 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
         // talks to serve's Ollama/OpenAI/Anthropic-compat surfaces, all of
         // which resolve model names the same way (see ensure_model in
         // cmd::serve), so a bare name here must match what the daemon
-        // resolves it to at request time.
+        // resolves it to at request time. Fallible: it validates the raw
+        // reference first (see shortnames::validate_reference).
         None => (
             args.model
                 .as_deref()
                 .map(crate::shortnames::resolve_ollama_api)
+                .transpose()?
                 .unwrap_or_default(),
             providers::PLACEHOLDER_API_KEY.to_string(),
         ),
@@ -1034,7 +1036,7 @@ mod tests {
     #[test]
     fn local_models_are_unaffected_by_the_remote_prefix() {
         for local in ["qwen3.5:0.8b", "hf.co/unsloth/Qwen3.5-0.8B-GGUF"] {
-            let resolved = crate::shortnames::resolve_ollama_api(local);
+            let resolved = crate::shortnames::resolve_ollama_api(local).unwrap();
             assert!(
                 !providers::is_remote_ref(&resolved),
                 "{local} resolved to a provider-routed reference: {resolved}"

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -21,7 +21,11 @@ pub fn run(args: &ListArgs) -> anyhow::Result<()> {
     let mut images = store.list()?;
 
     if let Some(filter) = &args.reference {
-        images.retain(|i| matches_filter(&i.reference, filter));
+        // Resolve once up front so an invalid filter surfaces its
+        // validation error instead of silently matching nothing and
+        // printing an empty table.
+        let filter = crate::shortnames::resolve_ollama_api(filter)?;
+        images.retain(|i| matches_filter(&i.reference, &filter));
     }
 
     if images.is_empty() {
@@ -78,22 +82,21 @@ fn split_repo_tag(reference: &str) -> (&str, Option<&str>) {
 }
 
 /// Returns true if a stored image `reference` should be included given a
-/// user-supplied `filter`.
-///
-/// `filter` is first run through `shortnames::resolve_ollama_api` — the
-/// same resolution `rm`/`tag` apply to references they look up in the
-/// local store — so a bare owner/repo filter like `unsloth/Qwen3.5-0.8B`
-/// matches a stored `hf.co/unsloth/Qwen3.5-0.8B:latest` (registries default
-/// to `hf.co/`, exactly as they do when the model was pulled). The
-/// resolved filter then matches either the full stored reference verbatim,
-/// or — if the filter carried no explicit tag — just its repository part.
-fn matches_filter(reference: &str, filter: &str) -> bool {
-    let resolved = crate::shortnames::resolve_ollama_api(filter);
-    if reference == resolved {
+/// `resolved_filter` already run through `shortnames::resolve_ollama_api`
+/// by `run`: the same resolution `rm`/`tag` apply to references they look
+/// up in the local store, so a bare owner/repo filter like
+/// `unsloth/Qwen3.5-0.8B` matches a stored `hf.co/unsloth/Qwen3.5-0.8B:latest`
+/// (registries default to `hf.co/`, exactly as they do when the model was
+/// pulled). Resolution happens once in `run`, not here per image, so an
+/// invalid filter is a reported error rather than a silently empty table.
+/// The resolved filter matches either the full stored reference verbatim,
+/// or (when the filter carried no explicit tag) just its repository part.
+fn matches_filter(reference: &str, resolved_filter: &str) -> bool {
+    if reference == resolved_filter {
         return true;
     }
     let (ref_repo, _) = split_repo_tag(reference);
-    let (filter_repo, filter_tag) = split_repo_tag(&resolved);
+    let (filter_repo, filter_tag) = split_repo_tag(resolved_filter);
     filter_tag.is_none() && ref_repo == filter_repo
 }
 
@@ -145,6 +148,14 @@ fn render_format(template: &str, img: &ImageSummary) -> anyhow::Result<String> {
 mod tests {
     use super::*;
 
+    /// Mirrors `run`'s pipeline for a raw user filter: resolve once, then
+    /// match. Tests below feed raw filters, so they exercise the same
+    /// resolution `run` applies before calling `matches_filter`.
+    fn matches(reference: &str, filter: &str) -> bool {
+        let resolved = crate::shortnames::resolve_ollama_api(filter).unwrap();
+        matches_filter(reference, &resolved)
+    }
+
     fn sample() -> ImageSummary {
         ImageSummary {
             reference: "unsloth/Qwen3.5-0.8B:latest".into(),
@@ -178,15 +189,15 @@ mod tests {
     #[test]
     fn matches_filter_matches_repo_without_tag() {
         // Both sides already fully-qualified: exact-match path.
-        assert!(matches_filter(
+        assert!(matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "hf.co/unsloth/Qwen3.5-0.8B"
         ));
-        assert!(matches_filter(
+        assert!(matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "hf.co/unsloth/Qwen3.5-0.8B:latest"
         ));
-        assert!(!matches_filter(
+        assert!(!matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "hf.co/other/model"
         ));
@@ -198,23 +209,23 @@ mod tests {
         // HuggingFace) is stored under an `hf.co/`-prefixed reference; the
         // same bare owner/repo filter must resolve the same way `rm`/`tag`
         // do, or `llmman list <owner>/<repo>` never matches anything.
-        assert!(matches_filter(
+        assert!(matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "unsloth/Qwen3.5-0.8B"
         ));
         // Must not accidentally match a same-prefix but distinct repo.
-        assert!(!matches_filter(
+        assert!(!matches(
             "hf.co/unsloth/Qwen3.5-0.8B-GGUF:latest",
             "unsloth/Qwen3.5-0.8B"
         ));
         // An explicit tag on the filter requires an exact match, no
         // repo-only fallback.
-        assert!(!matches_filter(
+        assert!(!matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "unsloth/Qwen3.5-0.8B:q4"
         ));
         // Already-qualified filters still work as before.
-        assert!(matches_filter(
+        assert!(matches(
             "hf.co/unsloth/Qwen3.5-0.8B:latest",
             "hf.co/unsloth/Qwen3.5-0.8B"
         ));
@@ -224,7 +235,7 @@ mod tests {
     fn matches_filter_resolves_bare_names_to_docker_ai_default() {
         // Bare (slash-less) names go through resolve_ollama_api's
         // docker.io/ai/ default, same as `rm`/`tag`.
-        assert!(matches_filter("docker.io/ai/gemma4:latest", "gemma4"));
+        assert!(matches("docker.io/ai/gemma4:latest", "gemma4"));
     }
 
     #[test]

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -16,6 +16,7 @@ pub struct PullArgs {
 /// No store override of its own: set `LLMMAN_MODELS` before starting
 /// `llmman serve` to change the daemon's store for every client.
 pub fn run(args: &PullArgs) -> anyhow::Result<()> {
+    crate::shortnames::validate_reference(&args.reference)?;
     crate::daemon::ensure_server("")?;
     crate::daemon::stream_progress("/api/pull", &args.reference)?;
     println!("Pulled {}", args.reference);

--- a/src/cmd/push.rs
+++ b/src/cmd/push.rs
@@ -16,6 +16,10 @@ pub struct PushArgs {
 /// No store override of its own: set `LLMMAN_MODELS` before starting
 /// `llmman serve` to change the daemon's store for every client.
 pub fn run(args: &PushArgs) -> anyhow::Result<()> {
+    // Fast-fail before starting the daemon (which would create the store
+    // tree), mirroring pull.rs: push sends the raw ref to the daemon
+    // without resolving it locally, so this is its client-side gate.
+    crate::shortnames::validate_reference(&args.reference)?;
     crate::daemon::ensure_server("")?;
     crate::daemon::stream_progress("/api/push", &args.reference)?;
     println!("Pushed {}", args.reference);

--- a/src/cmd/resolve.rs
+++ b/src/cmd/resolve.rs
@@ -64,7 +64,7 @@ struct ResolveOutput<'a> {
 }
 
 pub fn run(args: &ResolveArgs) -> anyhow::Result<()> {
-    let reference = crate::shortnames::resolve_ollama_api(&args.reference);
+    let reference = crate::shortnames::resolve_ollama_api(&args.reference)?;
 
     let store_path = crate::default_store()?;
     let cache_path = args

--- a/src/cmd/rm.rs
+++ b/src/cmd/rm.rs
@@ -10,18 +10,36 @@ pub struct RmArgs {
 }
 
 pub fn run(args: &RmArgs) -> anyhow::Result<()> {
+    let mut any_err = false;
+
+    // Resolve (and validate) every reference before opening the store, so an
+    // invalid ref never creates the store tree.
+    // resolve_ollama_api, not resolve: a bare name pulled via the Ollama API
+    // (POST /api/pull, /api/chat, ...) is stored under docker.io/ai/<name>,
+    // not hf.co/<name>, so it must resolve the same way here or `llmman rm
+    // <bare-name>` looks for the wrong entry.
+    let mut refs = Vec::new();
+    for raw in &args.references {
+        match crate::shortnames::resolve_ollama_api(raw) {
+            Ok(r) => refs.push(r),
+            Err(e) => {
+                eprintln!("Error removing {raw}: {e}");
+                any_err = true;
+            }
+        }
+    }
+
+    // Nothing valid to remove: don't open (and thereby create) the store.
+    if refs.is_empty() {
+        anyhow::bail!("one or more removals failed");
+    }
+
     let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
 
-    let mut any_err = false;
     let mut any_removed = false;
-    for raw in &args.references {
-        // resolve_ollama_api, not resolve: a bare name pulled via the
-        // Ollama API (POST /api/pull, /api/chat, ...) is stored under
-        // docker.io/ai/<name>, not hf.co/<name> — must resolve the same
-        // way here or `llmman rm <bare-name>` looks for the wrong entry.
-        let reference = crate::shortnames::resolve_ollama_api(raw);
-        match store.remove(&reference) {
+    for reference in &refs {
+        match store.remove(reference) {
             Ok(()) => {
                 println!("Removed {}", reference);
                 any_removed = true;

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -106,7 +106,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     // longer "bare" by the time ensure_model resolves it server-side (it
     // already has a "/" and a "."), so the docker.io/ai/ default never
     // fires and this silently falls back to hf.co/<name> instead.
-    let model = crate::shortnames::resolve_ollama_api(&args.model);
+    let model = crate::shortnames::resolve_ollama_api(&args.model)?;
     let prompt = args.prompt.join(" ");
 
     // Starts `llmman serve` detached, left running indefinitely, if one

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1308,6 +1308,17 @@ impl AppError {
     fn status(status: StatusCode, message: impl Into<String>) -> Self {
         Self(anyhow!(message.into()), status)
     }
+
+    /// Wraps a rejected model reference as a 400: the reference is client
+    /// input, so the client error is built right where the reference is
+    /// rejected, via `.map_err(AppError::bad_request)` at each resolve
+    /// site. A constructor rather than a `From<InvalidReference>` impl
+    /// because the blanket `From` above already covers every
+    /// `Into<anyhow::Error>` type (it would produce a 500 through `?`),
+    /// and a specific impl would overlap with it.
+    fn bad_request(e: crate::shortnames::InvalidReference) -> Self {
+        Self(e.into(), StatusCode::BAD_REQUEST)
+    }
 }
 
 impl IntoResponse for AppError {
@@ -2173,10 +2184,13 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
 /// `docker.io/ai/m:latest`. `remove` missed, and the reply still said
 /// `"unload"`, leaving the caller believing a model it can still see in
 /// `llmman ps` had been evicted.
-fn unload_key(state: &AppState, model: &str) -> String {
-    let resolved = crate::shortnames::resolve_ollama_api(model);
+fn unload_key(
+    state: &AppState,
+    model: &str,
+) -> Result<String, crate::shortnames::InvalidReference> {
+    let resolved = crate::shortnames::resolve_ollama_api(model)?;
     let tagged = crate::storage::default_tag(&resolved);
-    canonical_ref(&state.0.store_path, &tagged)
+    Ok(canonical_ref(&state.0.store_path, &tagged))
 }
 
 /// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
@@ -2428,7 +2442,9 @@ fn try_admit(max_queue: usize) -> Result<QueueGuard, AppError> {
 /// anyway — only ever the very first one, against a model that isn't
 /// locally resolvable at all yet.
 async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
-    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    // An invalid reference is never locally resolvable, so treat it like any
+    // other unresolvable case: return None and let ensure_model reject it.
+    let model_ref = crate::shortnames::resolve_ollama_api(model_ref).ok()?;
     let model_ref = crate::storage::default_tag(&model_ref);
     let model_ref = canonical_ref(&state.0.store_path, &model_ref);
 
@@ -2749,7 +2765,8 @@ async fn ensure_model(
         ));
     }
 
-    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    let model_ref =
+        crate::shortnames::resolve_ollama_api(model_ref).map_err(AppError::bad_request)?;
     // Default the tag before the lock below: otherwise two concurrent
     // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
     // locks and both spawn a process for the same model.
@@ -4124,7 +4141,8 @@ async fn handle_show(
     // Resolve the same way handle_pull stored it — otherwise a bare name
     // (e.g. "gemma4", pulled and stored as "docker.io/ai/gemma4") would
     // never be found by show/delete even though it's in the local store.
-    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    let model_ref =
+        crate::shortnames::resolve_ollama_api(model_ref).map_err(AppError::bad_request)?;
     let model_ref = model_ref.as_str();
     eprintln!("[llmman] /api/show model={model_ref:?}");
     let store = OciStore::open(&state.0.store_path)?;
@@ -4181,7 +4199,13 @@ async fn handle_pull(
         let body = serde_json::json!({"error": "model is required"});
         return (StatusCode::BAD_REQUEST, Json(body)).into_response();
     }
-    let model = crate::shortnames::resolve_ollama_api(model_ref);
+    let model = match crate::shortnames::resolve_ollama_api(model_ref) {
+        Ok(m) => m,
+        Err(e) => {
+            let body = serde_json::json!({"error": e.to_string()});
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
     eprintln!("[llmman] /api/pull model={model:?}");
     let store_path = state.0.store_path.clone();
 
@@ -4245,7 +4269,13 @@ async fn handle_push(
         let body = serde_json::json!({"error": "model is required"});
         return (StatusCode::BAD_REQUEST, Json(body)).into_response();
     }
-    let model = crate::shortnames::resolve_ollama_api(model_ref);
+    let model = match crate::shortnames::resolve_ollama_api(model_ref) {
+        Ok(m) => m,
+        Err(e) => {
+            let body = serde_json::json!({"error": e.to_string()});
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+        }
+    };
     eprintln!("[llmman] /api/push model={model:?}");
     let store_path = state.0.store_path.clone();
 
@@ -4374,7 +4404,8 @@ async fn handle_delete(
         .filter(|s| !s.is_empty())
         .unwrap_or(&req.model);
     // See handle_show: resolve the same way handle_pull stored it.
-    let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
+    let model_ref =
+        crate::shortnames::resolve_ollama_api(model_ref).map_err(AppError::bad_request)?;
     let store = OciStore::open(&state.0.store_path)?;
     store.remove(&model_ref)?;
     Ok(StatusCode::OK)
@@ -4421,7 +4452,7 @@ async fn handle_ollama_chat(
     // empty message, and a `keep_alive: 0` never unloads anything.
     if req.messages.is_empty() {
         if is_explicit_unload(&req.keep_alive) {
-            let canonical = unload_key(&state, &req.model);
+            let canonical = unload_key(&state, &req.model).map_err(AppError::bad_request)?;
             let _guard = acquire_load_lock(&canonical).await;
             state.0.manager.lock().await.running.remove(&canonical);
             return Ok(Json(empty_chat_chunk(req.model, "unload")).into_response());
@@ -4509,7 +4540,7 @@ async fn handle_ollama_generate(
     // `LLMMAN_KEEP_ALIVE=0` turned a plain preload into an eviction.
     let is_unload = req.prompt.is_empty() && is_explicit_unload(&req.keep_alive);
     if is_unload {
-        let canonical = unload_key(&state, &req.model);
+        let canonical = unload_key(&state, &req.model).map_err(AppError::bad_request)?;
         // Wait for an in-flight load of this model to publish itself first,
         // so it can't race ahead of this remove.
         let _guard = acquire_load_lock(&canonical).await;
@@ -5567,24 +5598,28 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         .as_deref()
         .filter(|m| !crate::providers::is_remote_ref(m))
     {
-        let model = crate::shortnames::resolve_ollama_api(model);
-        let state_clone = state.clone();
-        tokio::spawn(async move {
-            match ensure_model(&state_clone, &model, None).await {
-                // ensure_model's own keep_alive (the daemon default, 5
-                // minutes) would otherwise start counting down the
-                // moment this finishes loading, with no request traffic
-                // to reset it — the idle reaper could unload a model
-                // asked for on the command line before it's ever
-                // actually used, defeating the whole point of
-                // pre-loading it. Pin it ("never unload") instead — a
-                // model named explicitly at startup is meant to stay
-                // warm for the daemon's lifetime, not just its first 5
-                // idle minutes.
-                Ok((_, _, guard)) => refresh_activity(guard, None).await,
-                Err(e) => eprintln!("[llmman] pre-load failed: {:#}", e.0),
+        match crate::shortnames::resolve_ollama_api(model) {
+            Ok(model) => {
+                let state_clone = state.clone();
+                tokio::spawn(async move {
+                    match ensure_model(&state_clone, &model, None).await {
+                        // ensure_model's own keep_alive (the daemon default, 5
+                        // minutes) would otherwise start counting down the
+                        // moment this finishes loading, with no request traffic
+                        // to reset it — the idle reaper could unload a model
+                        // asked for on the command line before it's ever
+                        // actually used, defeating the whole point of
+                        // pre-loading it. Pin it ("never unload") instead — a
+                        // model named explicitly at startup is meant to stay
+                        // warm for the daemon's lifetime, not just its first 5
+                        // idle minutes.
+                        Ok((_, _, guard)) => refresh_activity(guard, None).await,
+                        Err(e) => eprintln!("[llmman] pre-load failed: {:#}", e.0),
+                    }
+                });
             }
-        });
+            Err(e) => eprintln!("[llmman] pre-load failed: {e}"),
+        }
     }
 
     axum::serve(listener, app)
@@ -8319,12 +8354,12 @@ mod tests {
     /// (see `ensure_model`'s `default_tag` call).
     #[test]
     fn ensure_model_key_pipeline_converges_aliases_before_the_lock() {
-        let tagless = crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(
-            "regression-test-model",
-        ));
-        let tagged = crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(
-            "regression-test-model:latest",
-        ));
+        let tagless = crate::storage::default_tag(
+            &crate::shortnames::resolve_ollama_api("regression-test-model").unwrap(),
+        );
+        let tagged = crate::storage::default_tag(
+            &crate::shortnames::resolve_ollama_api("regression-test-model:latest").unwrap(),
+        );
         assert_eq!(
             tagless, tagged,
             "tagless and :latest aliases must resolve to one key"
@@ -8340,6 +8375,59 @@ mod tests {
         drop(a);
         drop(b);
         release_load_lock(&tagless);
+    }
+
+    /// An invalid client ref is rejected at the top of `ensure_model`, before
+    /// any resolve/pull/network work runs. The reference error is built as a
+    /// 400 right at the resolve site (`AppError::bad_request`), so it must
+    /// survive `into_response` unchanged.
+    #[tokio::test]
+    async fn ensure_model_rejects_an_invalid_ref_with_400() {
+        let state = test_state();
+        let err = ensure_model(&state, "hf.co/../x", None)
+            .await
+            .err()
+            .expect("invalid ref must be rejected");
+        assert_eq!(err.into_response().status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// /api/push validates the client ref before resolving it: an invalid
+    /// ref returns a 400, matching /api/pull's early rejection.
+    #[tokio::test]
+    async fn handle_push_rejects_an_invalid_ref_with_400() {
+        let state = test_state();
+        let req = OllamaPushRequest {
+            model: "hf.co/../x".to_string(),
+            name: String::new(),
+        };
+        let resp = handle_push(State(state), Json(req)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// /api/delete resolves (and so validates) the client ref before it ever
+    /// opens the store: an invalid ref returns a 400 and touches nothing.
+    #[tokio::test]
+    async fn handle_delete_rejects_an_invalid_ref_with_400() {
+        let state = test_state();
+        let req = OllamaDeleteRequest {
+            model: "hf.co//foo".to_string(),
+            name: None,
+        };
+        let resp = handle_delete(State(state), Json(req)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// /api/show resolves (and so validates) the client ref before it ever
+    /// opens the store: an invalid ref returns a 400 and touches nothing.
+    #[tokio::test]
+    async fn handle_show_rejects_an_invalid_ref_with_400() {
+        let state = test_state();
+        let req = OllamaShowRequest {
+            model: "hf:///foo".to_string(),
+            name: None,
+        };
+        let resp = handle_show(State(state), Json(req)).await.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     /// Regression: a call site that drops its guard but not its own `Arc`

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -43,9 +43,11 @@ pub struct ShowArgs {
 }
 
 pub fn run(args: &ShowArgs) -> anyhow::Result<()> {
+    // Resolve/validate before opening the store so a bad ref never creates
+    // the store tree, matching cp.rs/build.rs.
+    let reference = crate::shortnames::resolve_ollama_api(&args.model)?;
     let store_path = crate::default_store()?;
     let store = OciStore::open(&store_path)?;
-    let reference = crate::shortnames::resolve_ollama_api(&args.model);
     let desc = store.find(&reference)?;
     let manifest = store.read_manifest(&desc.digest)?;
 

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -32,7 +32,7 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
         anyhow::bail!("llmman serve is not running (nothing is loaded) — nothing to stop");
     }
 
-    let reference = crate::shortnames::resolve_ollama_api(&args.model);
+    let reference = crate::shortnames::resolve_ollama_api(&args.model)?;
 
     // The unload endpoint itself always reports success even when
     // nothing by that name was running (canonical_ref falls back

--- a/src/cmd/transfer.rs
+++ b/src/cmd/transfer.rs
@@ -47,8 +47,8 @@ pub struct TransferArgs {
 /// daemon (like `pull`/`push`): a transfer never touches the daemon's
 /// persistent store, so there's no shared state to coordinate.
 pub fn run(args: &TransferArgs) -> anyhow::Result<()> {
-    let source = crate::shortnames::resolve(&args.source);
-    let destination = crate::shortnames::resolve(&args.destination);
+    let source = crate::shortnames::resolve(&args.source)?;
+    let destination = crate::shortnames::resolve(&args.destination)?;
 
     let rt = tokio::runtime::Runtime::new().context("start tokio runtime")?;
     let changed = rt.block_on(async {

--- a/src/hf/api.rs
+++ b/src/hf/api.rs
@@ -22,14 +22,15 @@ pub struct HfFile {
     pub kind: String, // "file" or "directory"
 }
 
-/// Issues an authenticated GET and decodes JSON, retrying transient
-/// failures with the shared backoff budget — mirrors `hfGet`.
+/// Issues an authenticated GET and decodes JSON in a single attempt. This
+/// is a cheap metadata request, so a bad or nonexistent host must fail
+/// fast rather than run the retry backoff.
 async fn get_json<T: serde::de::DeserializeOwned>(
     client: &reqwest::Client,
     url: &str,
     token: Option<&str>,
 ) -> Result<T> {
-    let body = super::client::retry(&format!("GET {url}"), || async {
+    let body = super::client::once(&format!("GET {url}"), || async {
         let mut req = client.get(url);
         if let Some(t) = token {
             req = req.bearer_auth(t);

--- a/src/hf/client.rs
+++ b/src/hf/client.rs
@@ -20,7 +20,7 @@ const RETRY_BASE: Duration = Duration::from_secs(1);
 /// No bytes at all for this long aborts the current attempt.
 const STALL_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// A non-2xx HTTP response, carrying enough structure for [`retry`] to
+/// A non-2xx HTTP response, carrying enough structure for a retry loop to
 /// react to more than just "was this permanent": a server-supplied
 /// `Retry-After` (RFC 9110 §10.2.3), mirroring `huggingface_hub`'s own
 /// handling of it on a 429.
@@ -49,7 +49,7 @@ impl HttpStatusError {
     }
 }
 
-/// How long [`retry`] will ever honor a server-supplied `Retry-After`
+/// How long a retry loop will ever honor a server-supplied `Retry-After`
 /// for. `huggingface_hub` trusts it completely; an unbounded wait here
 /// could eat a whole CI job's time budget on one file, so this caps it
 /// well short of that instead.
@@ -116,46 +116,21 @@ fn rand_unit() -> f64 {
     (nanos % 1_000_000) as f64 / 1_000_000.0
 }
 
-/// Calls `attempt` up to [`MAX_ATTEMPTS`] times with exponential backoff
-/// — or the previous attempt's `Retry-After`, if it had one — stopping
-/// immediately once the most recent error is [`is_permanent`]. Every
-/// attempt restarts its work entirely from scratch (mirrors
-/// `retryStream`'s own doc comment: there's no partial state to resume
-/// into on this side of a registry push either way).
-pub async fn retry<T, F, Fut>(label: &str, mut attempt: F) -> Result<T>
+/// Runs `attempt` exactly once, with no retry loop or backoff. The cheap
+/// metadata requests (the model-info GET and the HEAD size/etag probes)
+/// use this so a bad or nonexistent host fails immediately rather than
+/// running a full backoff budget. The HF client attaches its bearer token
+/// up front (no 401 auth handshake to retry), and the per-request timeout
+/// reqwest already applies still bounds a slow-but-resolvable host. A 4xx
+/// surfaces as-is.
+pub async fn once<T, F, Fut>(label: &str, attempt: F) -> Result<T>
 where
-    F: FnMut() -> Fut,
+    F: FnOnce() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
-    let mut last_err: Option<anyhow::Error> = None;
-    for i in 0..MAX_ATTEMPTS {
-        if i > 0 {
-            let delay = last_err
-                .as_ref()
-                .and_then(retry_after_of)
-                .unwrap_or_else(|| retry_delay(i));
-            eprintln!(
-                "\n[llmman] retrying {label} (attempt {}/{MAX_ATTEMPTS}, wait {delay:?})",
-                i + 1
-            );
-            tokio::time::sleep(delay).await;
-        }
-        match attempt().await {
-            Ok(v) => return Ok(v),
-            Err(e) => {
-                let permanent = is_permanent(&e);
-                eprintln!("[llmman] {label} error: {e:#}");
-                last_err = Some(e);
-                if permanent {
-                    break;
-                }
-            }
-        }
-    }
-    Err(anyhow!(
-        "{label} failed after {MAX_ATTEMPTS} attempts: {:#}",
-        last_err.expect("loop always runs at least once")
-    ))
+    attempt().await.inspect_err(|e| {
+        eprintln!("[llmman] {label} error: {e:#}");
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -310,70 +285,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_stops_immediately_on_permanent_error() {
+    async fn once_runs_the_attempt_a_single_time_on_failure() {
         let attempts = AtomicU32::new(0);
-        let result: Result<()> = retry("test", || {
+        let result: Result<()> = once("test", || {
             attempts.fetch_add(1, Ordering::SeqCst);
-            async {
-                Err(anyhow::Error::new(HttpStatusError::new(
-                    "GET x",
-                    404,
-                    &HeaderMap::new(),
-                )))
-            }
+            async { Err(anyhow!("boom")) }
         })
         .await;
         assert!(result.is_err());
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn retry_succeeds_after_transient_failures() {
-        let attempts = AtomicU32::new(0);
-        let result = retry("test", || {
-            let n = attempts.fetch_add(1, Ordering::SeqCst);
-            async move {
-                if n < 2 {
-                    Err(anyhow!("transient"))
-                } else {
-                    Ok(42)
-                }
-            }
-        })
-        .await
-        .unwrap();
-        assert_eq!(result, 42);
-        assert_eq!(attempts.load(Ordering::SeqCst), 3);
-    }
-
-    #[tokio::test]
-    async fn retry_honors_retry_after_over_exponential_backoff() {
-        let attempts = AtomicU32::new(0);
-        let start = Instant::now();
-        retry::<(), _, _>("test", || {
-            let n = attempts.fetch_add(1, Ordering::SeqCst);
-            async move {
-                if n == 0 {
-                    Err(anyhow::Error::new(HttpStatusError {
-                        prefix: "GET x".to_string(),
-                        status: 429,
-                        retry_after: Some(Duration::from_millis(100)),
-                    }))
-                } else {
-                    Ok(())
-                }
-            }
-        })
-        .await
-        .unwrap();
-        // Default exponential backoff for the first retry is ~0.75-1.25s;
-        // a Retry-After of 100ms is a clearly distinguishable, much
-        // shorter wait if actually honored.
-        assert!(
-            start.elapsed() < Duration::from_millis(500),
-            "elapsed={:?}",
-            start.elapsed()
-        );
     }
 
     #[tokio::test]

--- a/src/hf/pull.rs
+++ b/src/hf/pull.rs
@@ -247,10 +247,11 @@ async fn download_layer(
     let url = format!("{endpoint}{owner}/{repo}/resolve/{commit}/{}", file.path);
     let label = format!("Pulling {}", basename(&file.path));
 
-    // Tolerates ultimate failure (falls back to a plain, un-Xet'd GET
-    // self-hashed after download) but still worth a few retries first —
-    // a transient HEAD failure shouldn't cost the Xet fast path.
-    let meta = super::client::retry(&format!("HEAD {}", file.path), || {
+    // Single attempt: this is a cheap metadata probe, so a bad or
+    // nonexistent host must fail fast rather than run the retry backoff.
+    // Failure is tolerated anyway (falls back to a plain, un-Xet'd GET
+    // self-hashed after download).
+    let meta = super::client::once(&format!("HEAD {}", file.path), || {
         download::head_metadata(head_client, url.clone(), token)
     })
     .await

--- a/src/hf/transfer.rs
+++ b/src/hf/transfer.rs
@@ -251,7 +251,9 @@ mod docker {
         let url = format!("{endpoint}{owner}/{repo}/resolve/{commit}/{}", file.path);
         let label = format!("Transferring {}", basename(&file.path));
 
-        let meta = super::super::client::retry(&format!("HEAD {}", file.path), || {
+        // Single attempt: this is a cheap metadata probe, so a bad or
+        // nonexistent host must fail fast rather than run the retry backoff.
+        let meta = super::super::client::once(&format!("HEAD {}", file.path), || {
             download::head_metadata(head_client, url.clone(), token)
         })
         .await
@@ -431,15 +433,14 @@ mod docker {
         .await
     }
 
-    /// Retries `attempt` (the whole open-a-fresh-stream-and-push cycle)
-    /// up to `client::MAX_ATTEMPTS` times, honoring `Retry-After`/
-    /// exponential backoff between tries — mirrors `client::retry`, but
-    /// as its own copy rather than a call to it: `client::retry`'s
-    /// `FnMut() -> Fut` bound doesn't accommodate a closure that also
-    /// needs the attempt number (to seed the exponential backoff — see
-    /// `download::should_retry`), and threading that through would need
-    /// the exact borrow-capturing shape that function's own doc comment
-    /// already explains doesn't work here.
+    /// The push-side retry loop: retries `attempt` (the whole
+    /// open-a-fresh-stream-and-push cycle) up to `client::MAX_ATTEMPTS`
+    /// times, honoring `Retry-After`/exponential backoff between tries.
+    /// It is its own loop rather than a shared helper because `attempt`
+    /// needs the attempt number to seed the backoff (see
+    /// `download::should_retry`); the metadata path's `client::once` runs
+    /// a single attempt and the blob-download loop lives in `download.rs`,
+    /// so there is no shared retry helper to call here.
     async fn retry_push<F, Fut>(label: &str, mut attempt: F) -> Result<bool>
     where
         F: FnMut(u32) -> Fut,

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -75,25 +75,338 @@ fn aliases() -> &'static HashMap<String, String> {
     CACHE.get_or_init(load_aliases)
 }
 
-/// Returns true if `reference` already carries an explicit registry host:
-/// it has a "/" (so there's an actual leading path component to examine),
-/// and that first component contains a dot or colon (a "host:port" form,
-/// e.g. "localhost:5000" — a real repository name never contains a colon
-/// itself, matching docker/distribution's own reference grammar) or
-/// equals "localhost" outright. Requiring a "/" here matters: without
-/// one, a slash-less reference like "qwen3.5:0.8B" would otherwise be
-/// misread as "already has host qwen3.5:0.8B" just because its tag
-/// separator is a colon, when there's no host/path structure there at
-/// all — leaving it neither hf.co- nor docker.io/ai-prefixed, so it
-/// reaches the Go shim raw and dead-ends in its HuggingFace-only parser
-/// with a misleading error instead of either default ever being applied.
-fn has_host(reference: &str) -> bool {
-    match reference.split_once('/') {
-        Some((first, _)) => {
-            first.contains('.') || first.contains(':') || first.eq_ignore_ascii_case("localhost")
-        }
-        None => false,
+/// Registry/HF URI schemes [`parse_registry_ref`] strips before parsing the
+/// remainder. Any other `scheme://` prefix is rejected up front (the
+/// object-store schemes in [`PASSTHROUGH_SCHEMES`] are handled separately by
+/// [`validate_reference`] before the parser runs).
+const REGISTRY_SCHEMES: &[&str] = &["hf", "huggingface", "ms", "modelscope"];
+
+/// Object-store URI scheme prefixes that [`resolve_inner`] forwards verbatim
+/// to the Go shim, so [`validate_reference`] does not apply the registry
+/// per-part grammar of [`parse_registry_ref`] to their remainder. This is a
+/// validation choice, not a claim that the remainder is
+/// unstructured: the Go handlers do parse it (`pullNGC` expects 2-3
+/// components, `pullGCS`/`pullS3` split bucket and key), and a shape they
+/// reject still fails downstream. Shared by both functions so validation and
+/// resolution cannot drift.
+pub(crate) const PASSTHROUGH_SCHEMES: &[&str] = &["ngc://", "s3://", "gs://"];
+
+/// A model reference that [`validate_reference`] rejected. Carries the full
+/// human-readable message (already includes the offending reference and the
+/// reason) so callers can surface it directly.
+#[derive(Debug)]
+pub struct InvalidReference(String);
+
+impl std::fmt::Display for InvalidReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
+}
+
+impl std::error::Error for InvalidReference {}
+
+/// A registry/HF reference decomposed into its parts by
+/// [`parse_registry_ref`]. Every field has already passed its per-part byte
+/// allowlist and length bound, so a `ParsedRef` cannot hold a malformed part.
+struct ParsedRef<'a> {
+    /// Known URI scheme ("hf", "huggingface", "ms", "modelscope"), if any.
+    scheme: Option<&'a str>,
+    /// Registry host, optionally with a ":port" suffix.
+    host: Option<&'a str>,
+    /// Path components between the host (if any) and the model.
+    namespace: Vec<&'a str>,
+    model: &'a str,
+    tag: Option<&'a str>,
+    digest: Option<&'a str>,
+}
+
+/// Maximum byte length for a registry host (including an optional ":port").
+const MAX_HOST_LEN: usize = 350;
+/// Maximum byte length for every part other than the host (namespace
+/// component, model, tag, digest).
+/// 128 rather than 80 because real model names exceed 80 bytes: HuggingFace
+/// caps repo names at 96 characters, and several of the top-500 GGUF repos
+/// by downloads run close to that cap.
+const MAX_PART_LEN: usize = 128;
+
+/// True for the bytes allowed as the first byte of a name part.
+fn is_part_first_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// True for the bytes allowed after the first byte of a name part.
+fn is_part_byte(b: u8) -> bool {
+    is_part_first_byte(b) || b == b'.' || b == b'-'
+}
+
+/// Validate one name part against the byte allowlist: first byte
+/// `[A-Za-z0-9_]`, remaining bytes `[A-Za-z0-9_.-]` (minus '.' when
+/// `allow_dot` is false), at most `max_len` bytes. Returns the failure
+/// detail; the caller prefixes the full reference.
+fn check_part(part: &str, kind: &str, allow_dot: bool, max_len: usize) -> Result<(), String> {
+    if part.is_empty() {
+        return Err(format!("{kind} is empty"));
+    }
+    if part.len() > max_len {
+        return Err(format!("{kind} exceeds {max_len} bytes"));
+    }
+    let bytes = part.as_bytes();
+    if !is_part_first_byte(bytes[0]) {
+        return Err(format!(
+            "{kind} {part:?} starts with invalid character {:?}",
+            bytes[0] as char
+        ));
+    }
+    for &b in &bytes[1..] {
+        if !is_part_byte(b) || (b == b'.' && !allow_dot) {
+            return Err(format!(
+                "{kind} {part:?} contains invalid character {:?}",
+                b as char
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Validate a registry host: a DNS-name allowlist ('.' permitted) plus at
+/// most one ":port" suffix of 1-5 digits, MAX_HOST_LEN bytes total.
+fn check_host(host: &str) -> Result<(), String> {
+    if host.len() > MAX_HOST_LEN {
+        return Err(format!("host exceeds {MAX_HOST_LEN} bytes"));
+    }
+    let (name, port) = match host.split_once(':') {
+        Some((name, port)) => (name, Some(port)),
+        None => (host, None),
+    };
+    check_part(name, "host", true, MAX_HOST_LEN)?;
+    if let Some(port) = port {
+        if port.is_empty() || port.len() > 5 || !port.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(format!("host port {port:?} is not 1-5 digits"));
+        }
+    }
+    Ok(())
+}
+
+/// Validate an "@digest" suffix: `<algo>:<hex>` where algo is `[a-z0-9]+`
+/// and hex is non-empty `[0-9a-fA-F]+`, MAX_PART_LEN bytes total.
+fn check_digest(digest: &str) -> Result<(), String> {
+    if digest.len() > MAX_PART_LEN {
+        return Err(format!("digest exceeds {MAX_PART_LEN} bytes"));
+    }
+    let Some((algo, hex)) = digest.split_once(':') else {
+        return Err(format!(
+            "digest {digest:?} is missing the algorithm separator ':'"
+        ));
+    };
+    if algo.is_empty()
+        || !algo
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    {
+        return Err(format!("digest algorithm {algo:?} is not [a-z0-9]+"));
+    }
+    if hex.is_empty() || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(format!("digest value {hex:?} is not hexadecimal"));
+    }
+    Ok(())
+}
+
+/// True if a leading path component names a registry host rather than a
+/// namespace: it contains a dot or colon (a "host:port" form, e.g.
+/// "localhost:5000"; a real repository name never contains a colon itself,
+/// matching docker/distribution's own reference grammar) or equals
+/// "localhost" outright.
+fn is_host_component(first: &str) -> bool {
+    first.contains('.') || first.contains(':') || first.eq_ignore_ascii_case("localhost")
+}
+
+/// Split a registry/HF reference into scheme / host / namespace / model /
+/// tag / digest and validate each part against its byte allowlist and
+/// length bound. Malformed input fails by construction: any byte outside a
+/// part's allowlist (whitespace, control chars, '%', '?', '#', a stray
+/// ':' or '/'), an empty component, a ".." component, or an over-length
+/// part has no valid decomposition, so no per-shape reject rules exist.
+///
+/// Grammar (matching the shapes [`resolve_inner`] resolves):
+///   - Optional known scheme prefix ([`REGISTRY_SCHEMES`] only; any other
+///     "scheme://" is malformed). The remainder parses with the same rules,
+///     so "hf://owner/repo" has no host and "hf://hf.co/owner/repo" does.
+///   - "@digest" (split at the first '@'): `<algo>:<hex>`.
+///   - ":tag" (a ':' after the last '/'): a name part. A ':' before the
+///     last '/' belongs to the host:port instead.
+///   - The rest splits on '/': the first of two or more components is the
+///     host when it contains '.' or ':' or equals "localhost" (the same
+///     rule [`has_host`] exposes); everything between host and model is
+///     namespace components.
+///   - Host: `[A-Za-z0-9_.-]` plus one optional ":port" of 1-5 digits,
+///     at most [`MAX_HOST_LEN`] bytes.
+///   - Namespace components, model, tag: first byte `[A-Za-z0-9_]`, rest
+///     `[A-Za-z0-9_.-]`, at most [`MAX_PART_LEN`] bytes each. '.' is
+///     rejected in namespace components (it only belongs in a host, a
+///     model name, or a tag).
+fn parse_registry_ref(reference: &str) -> Result<ParsedRef<'_>, InvalidReference> {
+    let fail = |detail: String| {
+        InvalidReference(format!("invalid model reference {reference:?}: {detail}"))
+    };
+
+    if reference.trim().is_empty() {
+        return Err(fail("empty".to_owned()));
+    }
+
+    let (scheme, rest) = match reference.split_once("://") {
+        Some((scheme, rest)) if REGISTRY_SCHEMES.contains(&scheme) => (Some(scheme), rest),
+        Some((scheme, _)) => {
+            return Err(fail(format!("unsupported or malformed scheme {scheme:?}")));
+        }
+        None => (None, reference),
+    };
+    if rest.is_empty() {
+        return Err(fail("empty reference after scheme".to_owned()));
+    }
+
+    let (rest, digest) = match rest.split_once('@') {
+        Some((rest, digest)) => {
+            check_digest(digest).map_err(&fail)?;
+            (rest, Some(digest))
+        }
+        None => (rest, None),
+    };
+
+    // A ':' after the last '/' starts the tag; a ':' before it can only be
+    // a host:port and is validated as part of the host below.
+    let last_component_start = rest.rfind('/').map_or(0, |i| i + 1);
+    let (name, tag) = match rest[last_component_start..].find(':') {
+        Some(offset) => {
+            let i = last_component_start + offset;
+            (&rest[..i], Some(&rest[i + 1..]))
+        }
+        None => (rest, None),
+    };
+    if let Some(tag) = tag {
+        check_part(tag, "tag", true, MAX_PART_LEN).map_err(&fail)?;
+    }
+
+    let components: Vec<&str> = name.split('/').collect();
+    let (host, path) = match components.split_first() {
+        Some((first, path)) if !path.is_empty() && is_host_component(first) => (Some(*first), path),
+        _ => (None, components.as_slice()),
+    };
+    if let Some(host) = host {
+        check_host(host).map_err(&fail)?;
+    }
+    // `path` is non-empty: `components` has at least one element (split of a
+    // non-empty string), and the host branch only fires when more follow it.
+    let (model, namespace) = path.split_last().expect("path has at least the model");
+    for component in namespace {
+        check_part(component, "namespace component", false, MAX_PART_LEN).map_err(&fail)?;
+    }
+    check_part(model, "model", true, MAX_PART_LEN).map_err(&fail)?;
+
+    let parsed = ParsedRef {
+        scheme,
+        host,
+        namespace: namespace.to_vec(),
+        model,
+        tag,
+        digest,
+    };
+    // The decomposition must be lossless: rejoining the parts reproduces
+    // the input byte for byte, so no byte of an accepted reference can
+    // hide between parts (a stray delimiter fails a check above instead).
+    // Enforced on every parse in debug builds; the rejoin test pins the
+    // same property against a fixed corpus.
+    debug_assert_eq!(rejoin(&parsed), reference);
+    Ok(parsed)
+}
+
+/// Reserialize a [`ParsedRef`] back into reference syntax: the inverse of
+/// [`parse_registry_ref`], used by its lossless-decomposition assertion.
+fn rejoin(parsed: &ParsedRef<'_>) -> String {
+    let mut out = String::new();
+    if let Some(scheme) = parsed.scheme {
+        out.push_str(scheme);
+        out.push_str("://");
+    }
+    let mut components: Vec<&str> = Vec::new();
+    components.extend(parsed.host);
+    components.extend(parsed.namespace.iter().copied());
+    components.push(parsed.model);
+    out.push_str(&components.join("/"));
+    if let Some(tag) = parsed.tag {
+        out.push(':');
+        out.push_str(tag);
+    }
+    if let Some(digest) = parsed.digest {
+        out.push('@');
+        out.push_str(digest);
+    }
+    out
+}
+
+/// Rejects a raw user-supplied model reference that can never resolve to a
+/// real source, before any resolution or network I/O runs.
+///
+/// Validation branches by the same categories [`resolve_inner`] resolves
+/// by, so the two cannot drift:
+///   (a) local absolute path ("/..."): checked only for blank and control
+///       chars; it is forwarded verbatim to the local-directory importer,
+///       so the registry grammar does not apply.
+///   (b) passthrough object-store URI ([`PASSTHROUGH_SCHEMES`]): the
+///       remainder is an opaque object key, so only a non-empty remainder
+///       and no control chars are required.
+///   (c) everything else (bare names, owner/repo, host/owner/repo, and the
+///       hf/huggingface/ms/modelscope schemes): parsed into host /
+///       namespace / model / tag / digest by [`parse_registry_ref`], each
+///       part checked against a byte allowlist with length bounds, so
+///       malformed input fails by construction rather than by enumerating
+///       bad shapes.
+pub fn validate_reference(reference: &str) -> Result<(), InvalidReference> {
+    let reject = |detail: &str| {
+        Err(InvalidReference(format!(
+            "invalid model reference {reference:?}: {detail}"
+        )))
+    };
+
+    if reference.trim().is_empty() {
+        return reject("empty");
+    }
+
+    // (a) Absolute paths go to the local-directory importer. A space is not a
+    // control character, so a path like /models/My Model/x.gguf stays valid.
+    if reference.starts_with('/') {
+        if reference.chars().any(|c| c.is_ascii_control()) {
+            return reject("contains a control character");
+        }
+        return Ok(());
+    }
+
+    // (b) Object-store passthrough URIs carry an opaque key after the bucket,
+    // so a trailing slash or other registry-illegal character is legitimate.
+    for scheme in PASSTHROUGH_SCHEMES {
+        if let Some(rest) = reference.strip_prefix(scheme) {
+            if rest.is_empty() {
+                return reject(&format!("empty reference after {scheme:?} scheme"));
+            }
+            if reference.chars().any(|c| c.is_ascii_control()) {
+                return reject("contains a control character");
+            }
+            return Ok(());
+        }
+    }
+
+    // (c) Registry/HF references: parse-by-construction.
+    parse_registry_ref(reference).map(|_| ())
+}
+
+/// Returns true if `reference` already carries an explicit registry host,
+/// derived from [`parse_registry_ref`]'s decomposition rather than guessed
+/// from the raw string: the parser only assigns a host when there is a "/"
+/// (so a slash-less "qwen3.5:0.8B" is never misread as a host just because
+/// its tag separator is a colon) and the first component is host-shaped
+/// per [`is_host_component`]. An unparsable reference has no host; callers
+/// reach this only with already-validated references.
+fn has_host(reference: &str) -> bool {
+    parse_registry_ref(reference).is_ok_and(|parsed| parsed.host.is_some())
 }
 
 /// Resolve `reference` through the short-name alias table, then default the
@@ -109,12 +422,20 @@ fn has_host(reference: &str) -> bool {
 ///   1. Exact alias match  → return the mapped value
 ///   2. Has a registry host → return as-is
 ///   3. No host            → prepend `hf.co/`
-pub fn resolve(reference: &str) -> String {
+pub fn resolve(reference: &str) -> Result<String, InvalidReference> {
+    validate_reference(reference)?;
+    Ok(resolve_inner(reference))
+}
+
+/// The resolution body of [`resolve`] without validation. Callers that have
+/// already validated the reference (or that validate a bare shortcut first,
+/// like [`resolve_ollama_api`]) use this to avoid validating twice.
+fn resolve_inner(reference: &str) -> String {
     // ── URI schemes that bypass alias lookup and hf.co defaulting ─────────
     // Local absolute paths and object-store URIs are forwarded as-is to
     // crate::sources, which dispatches them to the appropriate source
     // handler.
-    for passthrough in &["ngc://", "s3://", "gs://"] {
+    for passthrough in PASSTHROUGH_SCHEMES {
         if reference.starts_with(passthrough) {
             return reference.to_owned();
         }
@@ -184,14 +505,18 @@ fn is_bare(reference: &str) -> bool {
 /// push) go through this same resolution server-side, so the docker.io/ai/
 /// default is consistent regardless of whether a bare name reaches llmman
 /// via the CLI or directly over HTTP.
-pub fn resolve_ollama_api(reference: &str) -> String {
+pub fn resolve_ollama_api(reference: &str) -> Result<String, InvalidReference> {
+    // Validate up front: the bare-name branch below returns without calling
+    // resolve, so validation cannot be deferred to it.
+    validate_reference(reference)?;
     if is_bare(reference) {
         if let Some(mapped) = aliases().get(reference) {
-            return mapped.clone();
+            return Ok(mapped.clone());
         }
-        return format!("docker.io/ai/{reference}");
+        return Ok(format!("docker.io/ai/{reference}"));
     }
-    resolve(reference)
+    // Already validated: use the non-validating body so we don't validate twice.
+    Ok(resolve_inner(reference))
 }
 
 #[cfg(test)]
@@ -199,20 +524,254 @@ mod tests {
     use super::*;
 
     #[test]
+    fn validate_reference_accepts_valid_shapes() {
+        for r in [
+            "gemma4",
+            "qwen3.5:0.8B",
+            "unsloth/Qwen3.5-0.8B-GGUF",
+            "hf.co/foo/bar",
+            "localhost:5000/foo/bar:tag",
+            "docker.io/ai/gemma4@sha256:abc",
+            "hf://owner/repo",
+            "ms://x",
+            "ngc://x",
+            "s3://b/k",
+            "gs://b/k",
+            // Passthrough object-store keys are opaque: a trailing slash and
+            // deeper key paths are legitimate, unlike registry/HF forms.
+            "s3://bucket/models/qwen/",
+            "gs://bucket/a/b/",
+            "ngc://org/team/model",
+            "/abs/path/model.gguf",
+            "/models/My Model/x.gguf",
+        ] {
+            assert!(validate_reference(r).is_ok(), "{r:?} should be accepted");
+        }
+    }
+
+    #[test]
+    fn validate_reference_rejects_bad_shapes() {
+        for r in [
+            "",
+            "   ",
+            "oci://",
+            "http://x",
+            "hf://",
+            "a\tb",
+            "/abs/pa\tth",
+            "s3://",
+            "s3://bucket/k\tey",
+            "../../../etc/passwd",
+            "a/../b",
+            "docker.io/ai/%2e%2e",
+            "hf:///foo",
+            "ms:///x",
+            "hf.co//foo",
+            "owner//repo",
+            "trailing/slash/",
+            "hf.co/owner/repo?expand[]=siblings",
+            "hf.co/owner/repo#frag",
+            // Newly rejected by the per-part parser; pinned so a grammar
+            // relaxation cannot silently re-accept them.
+            "a b",
+            "model:",
+            "m:t:x",
+            "a@b/c",
+            "m@sha256:abc:tag",
+        ] {
+            assert!(validate_reference(r).is_err(), "{r:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn validate_reference_rejects_over_length_parts() {
+        // Host over 350 bytes.
+        assert!(validate_reference(&format!("{}.com/ns/model", "a".repeat(350))).is_err());
+        // Host at the bound stays valid ("a"*346 + ".com" = 350 bytes).
+        assert!(validate_reference(&format!("{}.com/ns/model", "a".repeat(346))).is_ok());
+        // Model over 128 bytes; at the bound stays valid.
+        assert!(validate_reference(&"a".repeat(129)).is_err());
+        assert!(validate_reference(&"a".repeat(128)).is_ok());
+        // Tag and namespace component over 128 bytes.
+        assert!(validate_reference(&format!("model:{}", "t".repeat(129))).is_err());
+        assert!(validate_reference(&format!("hf.co/{}/model", "n".repeat(129))).is_err());
+    }
+
+    /// Real repos exceed 80 bytes in the model part: 4 of the top 500 GGUF
+    /// repos on HuggingFace by downloads do, including these two. They are
+    /// why [`MAX_PART_LEN`] is 128 rather than 80.
+    #[test]
+    fn validate_reference_accepts_long_real_model_names() {
+        for r in [
+            "hf.co/DavidAU/Qwen3.6-40B-Claude-4.6-Opus-Deckard-Heretic-Uncensored-Thinking-NEO-CODE-Di-IMatrix-MAX-GGUF",
+            "hf.co/mradermacher/Llama3.3-8B-Instruct-Thinking-Heretic-Uncensored-Claude-4.5-Opus-High-Reasoning-i1-GGUF",
+        ] {
+            assert!(validate_reference(r).is_ok(), "{r:?} should be accepted");
+        }
+    }
+
+    #[test]
+    fn validate_reference_rejects_dotted_namespace_components() {
+        // '.' belongs in hosts, models, and tags, not namespace components.
+        assert!(validate_reference("hf.co/own.er/repo").is_err());
+        assert!(validate_reference("docker.io/a.i/gemma4").is_err());
+        // A dotted model and a dotted tag stay valid.
+        assert!(validate_reference("hf.co/owner/re.po").is_ok());
+        assert!(validate_reference("qwen3.5:0.8B").is_ok());
+    }
+
+    #[test]
+    fn validate_reference_rejects_malformed_digests() {
+        for r in [
+            "docker.io/ai/gemma4@sha256",
+            "docker.io/ai/gemma4@sha256:",
+            "docker.io/ai/gemma4@:abc",
+            "docker.io/ai/gemma4@sha256:xyz-nonhex",
+            "docker.io/ai/gemma4@SHA256:abc",
+            "docker.io/ai/gemma4@",
+        ] {
+            assert!(validate_reference(r).is_err(), "{r:?} should be rejected");
+        }
+        // Uppercase hex and a tag before the digest stay valid.
+        assert!(validate_reference("docker.io/ai/gemma4@sha256:ABCDEF").is_ok());
+        assert!(validate_reference("docker.io/ai/gemma4:tag@sha256:abc").is_ok());
+    }
+
+    #[test]
+    fn validate_reference_applies_the_port_rule() {
+        assert!(validate_reference("localhost:5000/x").is_ok());
+        assert!(validate_reference("host.example:99999/x").is_ok());
+        // Six digits, empty, and non-numeric ports are rejected.
+        assert!(validate_reference("host.example:999999/x").is_err());
+        assert!(validate_reference("localhost:/x").is_err());
+        assert!(validate_reference("host.example:8o80/x").is_err());
+    }
+
+    /// For every valid reference, splitting into parts and rejoining them
+    /// must reproduce the input byte for byte: the parser loses nothing.
+    #[test]
+    fn parse_registry_ref_parts_rejoin_to_the_input() {
+        for r in [
+            "gemma4",
+            "qwen3.5:0.8B",
+            "unsloth/Qwen3.5-0.8B-GGUF",
+            "hf.co/foo/bar",
+            "localhost:5000/foo/bar:tag",
+            "docker.io/ai/gemma4@sha256:abc",
+            "docker.io/ai/gemma4:tag@sha256:ABCDEF",
+            "hf://owner/repo",
+            "huggingface://owner/repo",
+            "hf://hf.co/owner/repo",
+            "ms://owner/repo",
+            "modelscope://owner/repo",
+            "example.com:5000/ns/model:tag",
+            "localhost/ns/model",
+        ] {
+            let parsed = parse_registry_ref(r).unwrap_or_else(|e| panic!("{e}"));
+            // Deliberate copy of rejoin(): an independent oracle, so a bug
+            // in rejoin() itself cannot self-confirm through the
+            // debug_assert. Update both when the grammar grows a field.
+            let mut rejoined = String::new();
+            if let Some(scheme) = parsed.scheme {
+                rejoined.push_str(scheme);
+                rejoined.push_str("://");
+            }
+            let mut components: Vec<&str> = Vec::new();
+            components.extend(parsed.host);
+            components.extend(&parsed.namespace);
+            components.push(parsed.model);
+            rejoined.push_str(&components.join("/"));
+            if let Some(tag) = parsed.tag {
+                rejoined.push(':');
+                rejoined.push_str(tag);
+            }
+            if let Some(digest) = parsed.digest {
+                rejoined.push('@');
+                rejoined.push_str(digest);
+            }
+            assert_eq!(rejoined, r);
+        }
+    }
+
+    /// Fuzz-shaped invariant: no input that parses successfully may contain
+    /// a ".." component or a part over its length bound. Nasty inputs must
+    /// either fail to parse or decompose into parts that hold the invariant.
+    #[test]
+    fn parse_registry_ref_holds_the_part_invariants() {
+        let long = "a".repeat(400);
+        let nasty = [
+            "../../../etc/passwd".to_owned(),
+            "a/../b".to_owned(),
+            "hf.co/../x".to_owned(),
+            "hf://../x".to_owned(),
+            "%2e%2e/x".to_owned(),
+            "a?b".to_owned(),
+            "a#b".to_owned(),
+            "a b".to_owned(),
+            "a\tb".to_owned(),
+            "a\0b".to_owned(),
+            ":/x".to_owned(),
+            "://x".to_owned(),
+            "x@sha256:..".to_owned(),
+            "x:..".to_owned(),
+            long.clone(),
+            format!("{long}/m"),
+            format!("{long}.com/m"),
+            format!("m:{long}"),
+            format!("m@sha256:{long}"),
+            format!("hf.co/{long}/m"),
+            "hf.co/owner/repo".to_owned(),
+            "qwen3.5:0.8B".to_owned(),
+        ];
+        for r in &nasty {
+            let Ok(parsed) = parse_registry_ref(r) else {
+                continue;
+            };
+            let mut parts: Vec<(&str, usize)> = vec![
+                (parsed.model, MAX_PART_LEN),
+                (parsed.tag.unwrap_or("x"), MAX_PART_LEN),
+                (parsed.digest.unwrap_or("x"), MAX_PART_LEN),
+                (parsed.host.unwrap_or("x"), MAX_HOST_LEN),
+            ];
+            for ns in &parsed.namespace {
+                parts.push((ns, MAX_PART_LEN));
+            }
+            for (part, bound) in parts {
+                assert_ne!(part, "..", "{r:?} parsed with a \"..\" part");
+                assert!(part.len() <= bound, "{r:?} parsed with an over-length part");
+                // Every byte of a successfully parsed part must be inside
+                // the allowlist (host additionally allows one ':' for the
+                // port; digest one ':' for the algo separator), so a parser
+                // regression cannot let a space or delimiter through.
+                assert!(
+                    part.bytes().all(|b| is_part_byte(b) || b == b':'),
+                    "{r:?} parsed a part with a byte outside the allowlist: {part:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn resolve_ollama_api_defaults_bare_names_to_docker_ai() {
-        assert_eq!(resolve_ollama_api("gemma4"), "docker.io/ai/gemma4");
+        assert_eq!(resolve_ollama_api("gemma4").unwrap(), "docker.io/ai/gemma4");
         // A tag with no dot is still "bare" by this rule (only "/"
-        // disqualifies it) — matches the ai/<name>:<tag> shape on Docker Hub.
-        assert_eq!(resolve_ollama_api("gemma4:e4b"), "docker.io/ai/gemma4:e4b");
+        // disqualifies it): matches the ai/<name>:<tag> shape on Docker Hub.
+        assert_eq!(
+            resolve_ollama_api("gemma4:e4b").unwrap(),
+            "docker.io/ai/gemma4:e4b"
+        );
         // Dots in the name and/or tag don't disqualify "bare" either — only
         // a "/" does. Regression test: this used to fall through unchanged
         // (neither hf.co- nor docker.io/ai-prefixed) because has_host()
         // mistook the dotted version number for an explicit registry host,
         // and dead-ended in the Go shim's HF-only parser with a misleading
         // "invalid HuggingFace reference" error instead.
-        assert_eq!(resolve_ollama_api("qwen3.5"), "docker.io/ai/qwen3.5");
         assert_eq!(
-            resolve_ollama_api("qwen3.5:0.8B"),
+            resolve_ollama_api("qwen3.5").unwrap(),
+            "docker.io/ai/qwen3.5"
+        );
+        assert_eq!(
+            resolve_ollama_api("qwen3.5:0.8B").unwrap(),
             "docker.io/ai/qwen3.5:0.8B"
         );
     }
@@ -221,13 +780,16 @@ mod tests {
     fn resolve_ollama_api_leaves_structured_references_to_resolve() {
         // Owner/repo (has a "/") falls back to resolve()'s hf.co default.
         assert_eq!(
-            resolve_ollama_api("unsloth/Qwen3.5-0.8B-GGUF"),
-            resolve("unsloth/Qwen3.5-0.8B-GGUF")
+            resolve_ollama_api("unsloth/Qwen3.5-0.8B-GGUF").unwrap(),
+            resolve("unsloth/Qwen3.5-0.8B-GGUF").unwrap()
         );
         // Already has an explicit host.
-        assert_eq!(resolve_ollama_api("hf.co/foo/bar"), "hf.co/foo/bar");
         assert_eq!(
-            resolve_ollama_api("docker.io/ai/gemma4"),
+            resolve_ollama_api("hf.co/foo/bar").unwrap(),
+            "hf.co/foo/bar"
+        );
+        assert_eq!(
+            resolve_ollama_api("docker.io/ai/gemma4").unwrap(),
             "docker.io/ai/gemma4"
         );
     }
@@ -235,11 +797,11 @@ mod tests {
     #[test]
     fn resolve_ollama_api_matches_resolve_for_uri_schemes_and_paths() {
         assert_eq!(
-            resolve_ollama_api("hf://unsloth/Qwen3.5-0.8B-GGUF"),
-            resolve("hf://unsloth/Qwen3.5-0.8B-GGUF")
+            resolve_ollama_api("hf://unsloth/Qwen3.5-0.8B-GGUF").unwrap(),
+            resolve("hf://unsloth/Qwen3.5-0.8B-GGUF").unwrap()
         );
         assert_eq!(
-            resolve_ollama_api("/abs/path/model.gguf"),
+            resolve_ollama_api("/abs/path/model.gguf").unwrap(),
             "/abs/path/model.gguf"
         );
     }
@@ -265,22 +827,34 @@ mod tests {
     #[test]
     fn resolve_fills_in_default_registry_like_ollama_parse_name() {
         // Bare model name (ollama: "model" -> registry.ollama.ai/library/model:latest).
-        assert_eq!(resolve_ollama_api("mistral"), "docker.io/ai/mistral");
-        assert_eq!(resolve_ollama_api("mistral:7b"), "docker.io/ai/mistral:7b");
+        assert_eq!(
+            resolve_ollama_api("mistral").unwrap(),
+            "docker.io/ai/mistral"
+        );
+        assert_eq!(
+            resolve_ollama_api("mistral:7b").unwrap(),
+            "docker.io/ai/mistral:7b"
+        );
         // namespace/model (ollama: -> registry.ollama.ai/namespace/model).
-        assert_eq!(resolve("namespace/model"), "hf.co/namespace/model");
+        assert_eq!(resolve("namespace/model").unwrap(), "hf.co/namespace/model");
         // Fully-qualified references pass through untouched...
         assert_eq!(
-            resolve("example.com/ns/model:tag"),
+            resolve("example.com/ns/model:tag").unwrap(),
             "example.com/ns/model:tag"
         );
         // ...including a host:port first component (ollama's
         // "host:port/namespace/model:tag" case) and localhost.
         assert_eq!(
-            resolve("example.com:5000/ns/model:tag"),
+            resolve("example.com:5000/ns/model:tag").unwrap(),
             "example.com:5000/ns/model:tag"
         );
-        assert_eq!(resolve("localhost/ns/model"), "localhost/ns/model");
+        assert_eq!(resolve("localhost/ns/model").unwrap(), "localhost/ns/model");
+        // A dot-free, colon-free first component is NOT a host, even in a
+        // 3-component reference: the hf.co default applies. This pins the
+        // on-disk store key for such references; changing the host-detection
+        // rule (e.g. "3+ components always have a host") is a breaking change.
+        assert_eq!(resolve("a/b/c").unwrap(), "hf.co/a/b/c");
+        assert_eq!(resolve("hf://a/b/c").unwrap(), "hf.co/a/b/c");
     }
 
     /// Ported from ollama's types/model/name_test.go scheme cases
@@ -291,14 +865,23 @@ mod tests {
     /// object-store schemes pass through verbatim.
     #[test]
     fn resolve_splits_uri_schemes_like_ollama_parse_name() {
-        assert_eq!(resolve("hf://owner/repo"), "hf.co/owner/repo");
-        assert_eq!(resolve("huggingface://owner/repo"), "hf.co/owner/repo");
-        assert_eq!(resolve("hf://hf.co/owner/repo"), "hf.co/owner/repo");
-        assert_eq!(resolve("modelscope://owner/repo"), "ms://owner/repo");
-        assert_eq!(resolve("ms://owner/repo"), "ms://owner/repo");
-        assert_eq!(resolve("s3://bucket/key"), "s3://bucket/key");
-        assert_eq!(resolve("gs://bucket/key"), "gs://bucket/key");
-        assert_eq!(resolve("ngc://org/model"), "ngc://org/model");
+        assert_eq!(resolve("hf://owner/repo").unwrap(), "hf.co/owner/repo");
+        assert_eq!(
+            resolve("huggingface://owner/repo").unwrap(),
+            "hf.co/owner/repo"
+        );
+        assert_eq!(
+            resolve("hf://hf.co/owner/repo").unwrap(),
+            "hf.co/owner/repo"
+        );
+        assert_eq!(
+            resolve("modelscope://owner/repo").unwrap(),
+            "ms://owner/repo"
+        );
+        assert_eq!(resolve("ms://owner/repo").unwrap(), "ms://owner/repo");
+        assert_eq!(resolve("s3://bucket/key").unwrap(), "s3://bucket/key");
+        assert_eq!(resolve("gs://bucket/key").unwrap(), "gs://bucket/key");
+        assert_eq!(resolve("ngc://org/model").unwrap(), "ngc://org/model");
     }
 
     #[test]
@@ -322,8 +905,48 @@ mod tests {
         assert!(has_host("localhost:5000/foo/bar"));
         assert!(has_host("registry.example.com:5000/foo"));
         assert_eq!(
-            resolve("localhost:5000/foo/bar:tag"),
+            resolve("localhost:5000/foo/bar:tag").unwrap(),
             "localhost:5000/foo/bar:tag"
         );
+    }
+
+    #[test]
+    fn resolve_and_resolve_ollama_api_reject_invalid_references() {
+        assert!(resolve("hf:///foo").is_err());
+        assert!(resolve("hf.co//foo").is_err());
+        assert!(resolve_ollama_api("hf.co//foo").is_err());
+        assert!(resolve_ollama_api("ms:///x").is_err());
+        // Valid references still resolve to the expected value.
+        assert_eq!(resolve("hf://owner/repo").unwrap(), "hf.co/owner/repo");
+        assert_eq!(resolve_ollama_api("gemma4").unwrap(), "docker.io/ai/gemma4");
+    }
+
+    #[test]
+    fn validate_reference_rejects_malformed_scheme_prefixes() {
+        // Single-slash "scheme:/" must not slip past the scheme gate and be
+        // read by has_host as a host:port (regression: "http:" was probed).
+        assert!(validate_reference("http:/evil.test/x").is_err());
+        assert!(validate_reference("oci:/registry/ns/model").is_err());
+        assert!(validate_reference("hf:/owner/repo").is_err());
+        // Unknown double-slash schemes stay rejected.
+        assert!(validate_reference("http://evil.test/x").is_err());
+        assert!(validate_reference("oci://registry/ns/model").is_err());
+        // Prefixes outside the URI scheme grammar are rejected too. There
+        // is no ":/" gate: "scheme://" forms hit the unknown-scheme arm of
+        // the "://" split, and single-slash "x:/..." forms parse "x:" as a
+        // host whose empty port check_host rejects, so nothing
+        // colon-slash-shaped reaches has_host.
+        assert!(validate_reference("1a://evil.test/x").is_err());
+        assert!(validate_reference("my_scheme://x").is_err());
+        assert!(validate_reference("://x").is_err());
+        assert!(validate_reference("1a:/evil.test/x").is_err());
+        assert!(validate_reference(":/x").is_err());
+        assert!(validate_reference("localhost:/foo").is_err());
+        // Known scheme://, host:port, tag and digest colons stay valid.
+        assert!(validate_reference("hf://owner/repo").is_ok());
+        assert!(validate_reference("s3://bucket/models/qwen/").is_ok());
+        assert!(validate_reference("localhost:5000/foo/bar:tag").is_ok());
+        assert!(validate_reference("docker.io/ai/gemma4@sha256:abc").is_ok());
+        assert!(validate_reference("qwen3.5:0.8B").is_ok());
     }
 }


### PR DESCRIPTION
Closes #302. Reshaped per review: instead of classifying transport errors (fragile, and asymmetric between the Rust HF client and the Go path, as @ericcurtin caught), this bounds the cheap request and validates refs up front.

A malformed or unresolvable reference used to run the 8-attempt (~127s) blob-download retry budget on a cheap metadata request before failing. Two changes:

- Bound the metadata GET/HEAD to a single attempt on both the Rust HF client and the Go HF path, so any bad host fails at once regardless of error type. Blob downloads and pushes keep the full budget. The OCI image-copy path wraps manifest and blobs in one retry, so its manifest phase is a documented residual (a typo'd but syntactically valid OCI registry host); malformed refs are rejected before reaching it.
- Add `validate_reference`, an up-front gate at the `pull`/`run`/`launch` entry points and the daemon pull handler, rejecting blank, control-char, unknown-scheme, `..`, and percent-encoded refs before any network I/O.

Both retry classifiers revert to 4xx-only; the dead `retry` helper and the direct `http` dependency are removed.

## Testing

Unit tests for `validate_reference` (accepts bare/owner-repo/host-owner-repo with port/tag/@digest, all known schemes, local paths; rejects the garbage classes) and a single-attempt metadata test. `cargo fmt`/`clippy`/`test` and `go test ./...` pass. Verified end to end: the three #302 repros and `hf.coo/microsoft/phi-2` (typo host, the NXDOMAIN case) now fail in under 2s instead of ~127s.

Follow-ups from the review: a fuzz target for `validate_reference` (no valid parse yields a `..` or over-length part), and bounding the OCI copy path's manifest phase.