### PR TITLE
feat(launch): add --provider for models.dev hosted providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,61 @@ Run `llmman launch` with no arguments to list the supported integrations (Claude
 
 Short names work wherever a model reference is accepted.
 
+#### Hosted providers
+
+`--provider` points the same integrations at a model llmman doesn't serve
+itself:
+
+```sh
+export OPENROUTER_API_KEY=...
+llmman launch opencode --provider openrouter --model qwen/qwen3-coder
+```
+
+The provider list is fetched at runtime from
+[models.dev](https://models.dev) — the same catalog `opencode` resolves
+its own providers from — so a newly added provider works without an
+llmman release. It's cached for 24 hours, and a stale copy is used if the
+fetch fails, so being offline means an out-of-date list rather than a
+broken command. `llmman launch --list-providers` prints the providers
+llmman can route to, with each one's API-key variable and whether it's
+set.
+
+Requests still go through `llmman serve`; `--provider` changes where the
+daemon forwards them, not who the integration talks to. So one endpoint
+and one place integrations are configured, whether a model is local or
+hosted, and both usable from the same session.
+
+The API key is read from the variable models.dev names for that provider
+and travels per request, never to disk. `hermes` is the exception: llmman
+configures it through a file on disk, so it can't carry a key and
+`llmman serve` needs the variable in its own environment instead. That
+fallback is only used for a daemon bound to loopback, and never for a
+browser request from another site — it bounds the blast radius rather
+than authenticating anyone, so on a shared machine prefer an integration
+that sends its own key. `cline`, `kimi`, `copilot`, `gemini` and `openclaw` can't be
+used with `--provider` at all — the first two pick their own model rather
+than taking llmman's, `copilot` has no way to send a key, `gemini` feeds
+its key to a native Google client llmman can't confirm it has redirected,
+and `openclaw` only takes a model during first-run onboarding.
+
+Being OpenAI-compatible doesn't mean implementing every OpenAI route.
+`codex` uses `/v1/responses`, which `openai`, `groq` and `openrouter`
+answer but `anthropic` and `mistral` don't; models.dev carries no
+capability data to filter on, so llmman turns that provider's bare 404
+into an explanation naming what's missing rather than guessing up front.
+
+`--provider` needs a local `llmman serve`. The daemon talks plain HTTP
+and has no authentication, so llmman will not hand an integration a real
+key to send to a remote `LLMMAN_HOST`, and a daemon bound to anything but
+loopback will not spend its own environment's key on behalf of a caller
+that didn't present one.
+
+Providers llmman cannot reach with a single bearer token over an
+OpenAI-compatible https endpoint are deliberately absent rather than
+half-supported: Amazon Bedrock (SigV4 request signing), Google Vertex
+(GCP service-account credentials), Azure, and the others whose endpoint
+is per-account or whose wire format isn't OpenAI's.
+
 ### Use with vLLM directly
 
 `llmman serve` already spawns `vllm` itself as a backend for safetensors

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -2,6 +2,14 @@
 //!
 //! Mirrors `ollama launch`: sets integration-specific environment variables
 //! pointing at the local inference server, then exec's the integration binary.
+//!
+//! `--provider` extends that to models llmman does not serve itself, from
+//! the same models.dev catalog opencode resolves its providers from (see
+//! [`crate::providers`]). It does not change the shape above: the
+//! integration is still pointed at `llmman serve`, which forwards upstream
+//! on its behalf. There is deliberately no path here that hands an
+//! integration a provider's URL directly — one endpoint, one place
+//! integrations are configured, whether or not the weights are local.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -10,6 +18,7 @@ use anyhow::Context;
 use clap::Args;
 
 use crate::daemon;
+use crate::providers::{self, Provider};
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -26,31 +35,68 @@ pub struct LaunchArgs {
     #[arg(long, short, value_name = "MODEL")]
     pub model: Option<String>,
 
+    /// Serve --model from this provider (openai, anthropic, openrouter, …)
+    /// instead of locally. Requires --model. See --list-providers.
+    #[arg(long, short = 'p', value_name = "PROVIDER")]
+    pub provider: Option<String>,
+
+    /// List the providers --provider accepts, and exit
+    #[arg(long)]
+    pub list_providers: bool,
+
     /// Extra arguments forwarded to the integration binary (after --)
     #[arg(last = true, value_name = "ARGS")]
     pub extra_args: Vec<String>,
 }
 
 pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
+    if args.list_providers {
+        return print_providers();
+    }
+
+    let provider = args
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+
     let Some(ref name) = args.integration else {
         print_integrations();
         return Ok(());
     };
 
-    // resolve_ollama_api, not resolve: every integration this launches talks
-    // to serve's Ollama/OpenAI/Anthropic-compat surfaces, all of which
-    // resolve model names the same way (see ensure_model in cmd::serve), so
-    // a bare name here must match what the daemon resolves it to at
-    // request time.
-    let model = args
-        .model
-        .as_deref()
-        .map(crate::shortnames::resolve_ollama_api)
-        .unwrap_or_default();
+    let (model, api_key) = match provider {
+        Some(provider) => {
+            check_provider_supported(name)?;
+            let per_request = !PROVIDER_NEEDS_DAEMON_KEY.contains(&name.to_lowercase().as_str());
+            resolve_provider_model(provider, args.model.as_deref(), name, per_request)?
+        }
+        // resolve_ollama_api, not resolve: every integration this launches
+        // talks to serve's Ollama/OpenAI/Anthropic-compat surfaces, all of
+        // which resolve model names the same way (see ensure_model in
+        // cmd::serve), so a bare name here must match what the daemon
+        // resolves it to at request time.
+        None => (
+            args.model
+                .as_deref()
+                .map(crate::shortnames::resolve_ollama_api)
+                .unwrap_or_default(),
+            providers::PLACEHOLDER_API_KEY.to_string(),
+        ),
+    };
 
     // Ensure serve is running (start it in background if needed), preloading
     // the requested model so the integration's first request finds it warm.
-    crate::daemon::ensure_server(&model)?;
+    //
+    // A provider-routed model is never preloaded: there is nothing local to
+    // warm up, and asking the daemon to load one would just fail. The daemon
+    // still has to be running — it is what forwards upstream.
+    let preload = if provider.is_some() {
+        ""
+    } else {
+        model.as_str()
+    };
+    crate::daemon::ensure_server(preload)?;
 
     // serve's preload above is fire-and-forget and only fires on a cold
     // `serve` start (see run() in cmd/serve.rs) — if the daemon was already
@@ -58,12 +104,255 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
     // only surface as an opaque failure once the integration made its first
     // request. Mirror `llmman run`'s behavior and pull it here instead,
     // synchronously and with progress, before ever handing off to the
-    // integration.
-    if !model.is_empty() {
-        crate::daemon::ensure_model_pulled(&model)?;
+    // integration. Nothing to pull for a provider-routed model.
+    if !preload.is_empty() {
+        crate::daemon::ensure_model_pulled(preload)?;
     }
 
-    launch(name, &model, &args.extra_args)
+    launch(name, &model, &api_key, &args.extra_args)
+}
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+/// Integrations `--provider` cannot drive, and why.
+///
+/// `launch_simple` only exports `OLLAMA_HOST`: it never passes a model,
+/// so the integration picks its own and the provider-routed reference
+/// never reaches the daemon. `copilot` takes a model but has no way to
+/// carry a key. Refusing is the same call the catalog filter makes — a
+/// combination llmman cannot actually drive is absent, not offered and
+/// then broken at the first request.
+const PROVIDER_UNSUPPORTED: &[(&str, &str)] = &[
+    (
+        "cline",
+        "it selects its own model rather than taking one from llmman",
+    ),
+    (
+        "kimi",
+        "it selects its own model rather than taking one from llmman",
+    ),
+    ("copilot", "it has no way to send a provider API key"),
+    ("copilot-cli", "it has no way to send a provider API key"),
+    // Its key variable feeds a native Google client, and llmman has not
+    // verified that GEMINI_BASE_URL still redirects it here. Getting that
+    // wrong sends someone's OpenRouter key to Google, which is a worse
+    // outcome than `--provider gemini` not working — the placeholder this
+    // used to pass was harmless either way, a real key is not.
+    (
+        "gemini",
+        "llmman cannot confirm it would send the key here rather than to Google",
+    ),
+    // launch_openclaw passes --custom-model-id only through onboarding,
+    // which runs once. Every later launch reuses whatever openclaw.json
+    // already names, so the provider reference would never reach the
+    // daemon and the session would quietly run on the old model.
+    (
+        "openclaw",
+        "it only takes a model during first-run onboarding",
+    ),
+];
+
+/// Integrations llmman configures through a file on disk. They take a
+/// model on every launch, so `--provider` works, but they cannot carry
+/// the key: writing a real one into `~/.hermes/config.yaml` would persist
+/// a credential, which this feature promises not to do. They rely on
+/// `llmman serve` having the variable itself — which it only uses for a
+/// daemon nobody else can reach (see `reachable_only_locally`).
+const PROVIDER_NEEDS_DAEMON_KEY: &[&str] = &["hermes"];
+
+fn check_provider_supported(integration: &str) -> anyhow::Result<()> {
+    let name = integration.to_lowercase();
+    if let Some((_, why)) = PROVIDER_UNSUPPORTED.iter().find(|(id, _)| *id == name) {
+        anyhow::bail!(
+            "--provider does not work with {name}: {why}\n\
+             Run it against a locally served model, or use another integration."
+        );
+    }
+    // The key would go to the integration in cleartext, and from there
+    // over plain http to a daemon somewhere else on the network. llmman
+    // controls neither hop, so it does not start the handoff. A wildcard
+    // bind is fine here — that hop is still loopback.
+    if !crate::daemon::connects_over_loopback() {
+        anyhow::bail!(
+            "--provider needs a local llmman serve: LLMMAN_HOST points at {}, and the \
+             provider key would cross the network in cleartext.\n\
+             Export the key where that daemon runs instead.",
+            crate::daemon::server()
+        );
+    }
+    // These reach the daemon over loopback, so the check above passes,
+    // but they send the placeholder key and the daemon will not fall back
+    // to its own on a bind anyone can reach. Say so here rather than let
+    // it surface as a 401 from inside the integration.
+    if PROVIDER_NEEDS_DAEMON_KEY.contains(&name.as_str())
+        && !crate::daemon::reachable_only_locally()
+    {
+        anyhow::bail!(
+            "--provider does not work with {name} while llmman serve is bound to {}: \
+             {name} is configured through a file, so it cannot send the key per request, \
+             and a daemon reachable from the network will not spend its own.\n\
+             Bind llmman serve to loopback, or use an integration that carries the key.",
+            crate::daemon::bind_addr()
+        );
+    }
+    Ok(())
+}
+
+/// Validates `--provider`/`--model` against the catalog, returning the
+/// reference the daemon routes on (see
+/// [`crate::providers::REMOTE_PREFIX`]) and the key `integration` should
+/// authenticate with.
+///
+/// `key_travels_per_request` is false for the integrations in
+/// [`PROVIDER_NEEDS_DAEMON_KEY`], which get the placeholder because they
+/// cannot carry a real key — so this shell having one is beside the
+/// point, and demanding it would reject a perfectly good daemon that has
+/// it while this shell does not.
+///
+/// Every check here is one the daemon would otherwise make at first
+/// request, by which point the integration has already taken over the
+/// terminal and reports whatever it makes of an HTTP error. Failing in
+/// llmman's own output, before the handoff, is the difference between a
+/// named missing environment variable and an opaque "connection error"
+/// inside someone else's TUI.
+fn resolve_provider_model(
+    provider: &str,
+    model: Option<&str>,
+    integration: &str,
+    key_travels_per_request: bool,
+) -> anyhow::Result<(String, String)> {
+    let catalog = providers::catalog()?;
+    let entry = catalog
+        .get(provider)
+        .ok_or_else(|| unknown_provider_error(provider, &catalog))?;
+
+    let model = model
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "--provider {provider} also needs --model\n\n{}",
+                example_models(entry)
+            )
+        })?;
+
+    // A warning, not an error: models.dev is a snapshot, and a provider
+    // can serve a model — a brand new release, a fine-tune, a private
+    // deployment — before the catalog lists it. Refusing here would make
+    // llmman the reason a working model can't be used.
+    if !entry.models.iter().any(|m| m == model) {
+        eprintln!(
+            "[llmman] warning: {} does not list model {model:?}\n{}",
+            entry.name,
+            example_models(entry)
+        );
+    }
+
+    // Read here rather than left to the daemon so a missing key names the
+    // variable to set, in llmman's own output. The key travels to the
+    // daemon per request, in the integration's own Authorization header
+    // (see client_api_key in cmd::serve) — never written to disk or
+    // passed on a command line.
+    //
+    // Unless the integration cannot carry one, in which case this shell's
+    // key is not the one that matters and its absence is not an error:
+    // what counts is the daemon's own environment, which llmman cannot
+    // read from here. A warning, because the two are usually the same
+    // shell, and the daemon's 401 already names the variable.
+    let key = match (entry.api_key(), key_travels_per_request) {
+        (Some(key), _) => key,
+        (None, false) => {
+            eprintln!(
+                "[llmman] warning: {} is unset here; {} needs it set where \
+                 llmman serve runs",
+                entry.key_env, integration
+            );
+            providers::PLACEHOLDER_API_KEY.to_string()
+        }
+        (None, true) => anyhow::bail!(
+            "no API key for {} — set {} in your environment",
+            entry.name,
+            entry.key_env
+        ),
+    };
+
+    Ok((providers::format_remote_ref(provider, model), key))
+}
+
+/// A few real model ids for `provider`, to turn "which models?" into
+/// something answerable without leaving the error message.
+fn example_models(provider: &Provider) -> String {
+    if provider.models.is_empty() {
+        return format!("{} lists no models", provider.name);
+    }
+    let shown: Vec<&str> = provider.models.iter().take(5).map(String::as_str).collect();
+    let more = provider.models.len().saturating_sub(shown.len());
+    let suffix = if more > 0 {
+        format!(", … ({more} more)")
+    } else {
+        String::new()
+    };
+    format!(
+        "{} models include: {}{suffix}",
+        provider.name,
+        shown.join(", ")
+    )
+}
+
+/// Suggests near-matches before falling back to `--list-providers`, so a
+/// typo or a half-remembered id ("together" for `togetherai`) is one line
+/// away from the right answer instead of a 170-entry list.
+fn unknown_provider_error(provider: &str, catalog: &providers::Catalog) -> anyhow::Error {
+    let needle = provider.to_lowercase();
+    let close: Vec<&str> = catalog
+        .ids()
+        .filter(|id| id.contains(&needle) || needle.contains(*id))
+        .take(10)
+        .collect();
+    if close.is_empty() {
+        anyhow::anyhow!(
+            "unknown provider {provider:?}\nRun 'llmman launch --list-providers' for the \
+             {} providers llmman can route to.",
+            catalog.len()
+        )
+    } else {
+        anyhow::anyhow!(
+            "unknown provider {provider:?}\nDid you mean: {}?\nRun 'llmman launch \
+             --list-providers' for all {} of them.",
+            close.join(", "),
+            catalog.len()
+        )
+    }
+}
+
+fn print_providers() -> anyhow::Result<()> {
+    let catalog = providers::catalog()?;
+    let width = catalog.ids().map(str::len).max().unwrap_or(0);
+    for provider in catalog.iter() {
+        // The key variable is the one thing a user has to act on, and
+        // whether it is already set is the question they are really
+        // asking, so mark it rather than making them check.
+        let status = if provider.api_key().is_some() {
+            "set"
+        } else {
+            "unset"
+        };
+        println!(
+            "  {:<width$}  {:<28}  {} ({status})",
+            provider.id,
+            provider.name,
+            provider.key_env,
+            width = width
+        );
+    }
+    println!(
+        "\n{} providers, from models.dev — the same catalog opencode uses.",
+        catalog.len()
+    );
+    println!("Usage: llmman launch <integration> --provider <provider> --model <model>");
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +441,8 @@ fn print_integrations() {
             );
         }
     }
-    println!("\nUsage: llmman launch <integration> [--model <model>]");
+    println!("\nUsage: llmman launch <integration> [--model <model>] [--provider <provider>]");
+    println!("       llmman launch --list-providers");
 }
 
 /// Extensions to try, in order, when resolving a bare command name on
@@ -193,16 +483,27 @@ fn find_on_path(binary: &str) -> Option<PathBuf> {
 // Launch dispatcher
 // ---------------------------------------------------------------------------
 
-fn launch(name: &str, model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+/// `api_key` is what the integration is told to authenticate with:
+/// [`providers::PLACEHOLDER_API_KEY`] for a locally-served model, or the
+/// real provider key under `--provider`.
+///
+/// Passing the real one is what makes `--provider` work against a daemon
+/// that is *already running* — `ensure_server` reuses one, so a daemon
+/// started before the key was exported would otherwise never see it (see
+/// `client_api_key` in cmd::serve). Only the launchers that pass a key in
+/// the integration's environment can do this; the ones that go through a
+/// config file on disk keep the placeholder rather than persist a
+/// credential, and need the key in the daemon's own environment.
+fn launch(name: &str, model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     match name.to_lowercase().as_str() {
-        "claude" => launch_claude(model, extra_args),
-        "opencode" => launch_opencode(model, extra_args),
-        "codex" => launch_codex(model, extra_args),
+        "claude" => launch_claude(model, api_key, extra_args),
+        "opencode" => launch_opencode(model, api_key, extra_args),
+        "codex" => launch_codex(model, api_key, extra_args),
         "cline" => launch_simple("cline", "cline is not installed: npm install -g cline", model, extra_args),
-        "aider" => launch_aider(model, extra_args),
+        "aider" => launch_aider(model, api_key, extra_args),
         "copilot" | "copilot-cli" => launch_copilot(model, extra_args),
         "kimi" => launch_simple("kimi", "kimi is not installed: https://kimi.ai", model, extra_args),
-        "gemini" => launch_gemini(model, extra_args),
+        "gemini" => launch_gemini(model, api_key, extra_args),
         "hermes" => launch_hermes(model, extra_args),
         "openclaw" => launch_openclaw(model, extra_args),
         other => anyhow::bail!(
@@ -218,7 +519,7 @@ fn launch(name: &str, model: &str, extra_args: &[String]) -> anyhow::Result<()> 
 
 /// claude: set ANTHROPIC_BASE_URL and a dummy ANTHROPIC_API_KEY so it talks to
 /// our server's Anthropic-compatible API.
-fn launch_claude(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_claude(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("claude").ok_or_else(|| {
         anyhow::anyhow!("claude is not installed — https://code.claude.com/docs/en/quickstart")
     })?;
@@ -235,14 +536,14 @@ fn launch_claude(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         &args,
         &[
             ("ANTHROPIC_BASE_URL", server.as_str()),
-            ("ANTHROPIC_API_KEY", "llmman"),
+            ("ANTHROPIC_API_KEY", api_key),
         ],
     )
 }
 
 /// opencode: pass a JSON config via OPENCODE_CONFIG_CONTENT pointing at our
 /// /v1 endpoint, matching exactly what ollama launch does.
-fn launch_opencode(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_opencode(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("opencode").or_else(|| {
         dirs::home_dir().and_then(|h| {
             let p = h.join(".opencode").join("bin").join("opencode");
@@ -253,12 +554,12 @@ fn launch_opencode(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         bin.ok_or_else(|| anyhow::anyhow!("opencode is not installed — https://opencode.ai"))?;
 
     let effective_model = if model.is_empty() { "default" } else { model };
-    let config = opencode_config(effective_model);
+    let config = opencode_config(effective_model, api_key);
 
     exec_with_env(&bin, extra_args, &[("OPENCODE_CONFIG_CONTENT", &config)])
 }
 
-fn opencode_config(model: &str) -> String {
+fn opencode_config(model: &str, api_key: &str) -> String {
     let base_url = format!("{}/v1", daemon::server());
     serde_json::json!({
         "$schema": "https://opencode.ai/config.json",
@@ -267,7 +568,8 @@ fn opencode_config(model: &str) -> String {
                 "npm": "@ai-sdk/openai-compatible",
                 "name": "Ollama",
                 "options": {
-                    "baseURL": base_url
+                    "baseURL": base_url,
+                    "apiKey": api_key
                 },
                 "models": {
                     model: { "name": model }
@@ -281,7 +583,7 @@ fn opencode_config(model: &str) -> String {
 
 /// codex: set OPENAI_API_KEY=llmman and write ~/.codex/config.toml with the
 /// ollama provider pointing at our /v1 endpoint.
-fn launch_codex(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_codex(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     // Write codex config
     write_codex_config()?;
 
@@ -307,7 +609,7 @@ fn launch_codex(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     args.extend(["--profile".to_string(), "llmman".to_string()]);
     args.extend_from_slice(extra_args);
 
-    exec_with_env(&bin, &args, &[("OPENAI_API_KEY", "llmman")])
+    exec_with_env(&bin, &args, &[("OPENAI_API_KEY", api_key)])
 }
 
 /// Writes codex's `llmman` profile.
@@ -372,7 +674,7 @@ fn strip_legacy_llmman_profile(existing: &str) -> String {
 }
 
 /// aider: set OPENAI_API_KEY and OPENAI_BASE_URL.
-fn launch_aider(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_aider(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let base_url = format!("{}/v1", daemon::server());
     let mut args: Vec<String> = Vec::new();
     if !model.is_empty() {
@@ -385,7 +687,7 @@ fn launch_aider(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         &PathBuf::from("aider"),
         &args,
         &[
-            ("OPENAI_API_KEY", "llmman"),
+            ("OPENAI_API_KEY", api_key),
             ("OPENAI_BASE_URL", base_url.as_str()),
         ],
     )
@@ -408,7 +710,7 @@ fn launch_copilot(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
 }
 
 /// gemini: set GOOGLE_GENAI_BASE_URL pointing at our Anthropic-compatible endpoint.
-fn launch_gemini(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
+fn launch_gemini(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
     let bin = find_on_path("gemini").ok_or_else(|| {
         anyhow::anyhow!("gemini is not installed — npm install -g @google/gemini-cli")
     })?;
@@ -425,7 +727,7 @@ fn launch_gemini(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
         &args,
         &[
             ("GEMINI_BASE_URL", base_url.as_str()),
-            ("GEMINI_API_KEY", "llmman"),
+            ("GEMINI_API_KEY", api_key),
         ],
     )
 }
@@ -640,6 +942,35 @@ fn exec_with_env(bin: &PathBuf, args: &[String], extra_env: &[(&str, &str)]) -> 
 mod tests {
     use super::*;
 
+    /// Every integration `--provider` refuses must be one `launch`
+    /// actually dispatches, or the refusal is for a name nobody can type
+    /// and the real one is still silently broken.
+    #[test]
+    fn every_provider_unsupported_integration_is_a_real_one() {
+        for (id, why) in PROVIDER_UNSUPPORTED {
+            assert!(
+                INTEGRATIONS.iter().any(|i| i.name == *id) || *id == "copilot-cli",
+                "{id} is not an integration"
+            );
+            assert!(!why.is_empty(), "{id} has no reason");
+            assert!(check_provider_supported(id).is_err(), "{id} was accepted");
+            // Case-insensitively, the way `launch` dispatches.
+            assert!(check_provider_supported(&id.to_uppercase()).is_err());
+        }
+        // Same for the ones that depend on the daemon holding the key:
+        // a name nobody can type protects nobody.
+        for id in PROVIDER_NEEDS_DAEMON_KEY {
+            assert!(
+                INTEGRATIONS.iter().any(|i| i.name == *id),
+                "{id} is not an integration"
+            );
+            assert!(
+                !PROVIDER_UNSUPPORTED.iter().any(|(u, _)| u == id),
+                "{id} is both refused outright and expected to work"
+            );
+        }
+    }
+
     /// Regression test for a real CodeRabbit finding: an unquoted model
     /// value in generated YAML could be misparsed as a non-string
     /// (`null`, `true`, ...) or broken outright by metacharacters.
@@ -652,6 +983,63 @@ mod tests {
             yaml_quote(r#"a "quoted" \ value"#),
             r#""a \"quoted\" \\ value""#
         );
+    }
+
+    fn provider(id: &str, models: &[&str]) -> Provider {
+        Provider {
+            id: id.to_string(),
+            name: format!("{id} Inc"),
+            base_url: "https://example.invalid/v1".to_string(),
+            key_env: "EXAMPLE_API_KEY".to_string(),
+            models: models.iter().map(|m| m.to_string()).collect(),
+        }
+    }
+
+    /// The listing has to stay short enough to read in an error message
+    /// while still saying how much was elided.
+    #[test]
+    fn example_models_lists_a_few_and_counts_the_rest() {
+        let few = provider("groq", &["a", "b"]);
+        assert_eq!(example_models(&few), "groq Inc models include: a, b");
+
+        let many = provider("groq", &["a", "b", "c", "d", "e", "f", "g"]);
+        assert_eq!(
+            example_models(&many),
+            "groq Inc models include: a, b, c, d, e, … (2 more)"
+        );
+
+        let none = provider("groq", &[]);
+        assert_eq!(example_models(&none), "groq Inc lists no models");
+    }
+
+    /// A provider-routed `--model` must come out under
+    /// `providers::REMOTE_PREFIX`, which is the only thing that stops the
+    /// daemon resolving it as a HuggingFace or registry reference — and
+    /// must keep an `<vendor>/<model>` id (openrouter's shape) intact.
+    #[test]
+    fn provider_models_are_encoded_under_the_remote_prefix() {
+        assert_eq!(
+            providers::format_remote_ref("openrouter", "qwen/qwen3-coder"),
+            "llmman.provider/openrouter/qwen/qwen3-coder"
+        );
+        assert_eq!(
+            providers::split_remote_ref(&providers::format_remote_ref("groq", "llama-3.3-70b")),
+            Some(("groq", "llama-3.3-70b"))
+        );
+    }
+
+    /// The default path must be untouched by provider support: no
+    /// `--provider` means the same shortname resolution, and so the same
+    /// daemon behavior, as before it existed.
+    #[test]
+    fn local_models_are_unaffected_by_the_remote_prefix() {
+        for local in ["qwen3.5:0.8b", "hf.co/unsloth/Qwen3.5-0.8B-GGUF"] {
+            let resolved = crate::shortnames::resolve_ollama_api(local);
+            assert!(
+                !providers::is_remote_ref(&resolved),
+                "{local} resolved to a provider-routed reference: {resolved}"
+            );
+        }
     }
 
     /// Regression test for the real openclaw onboarding failure

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -24,6 +24,7 @@ use tokio::time::{sleep, Duration, Instant};
 
 use crate::default_store;
 use crate::modelpack::{resolve_model, ModelPath};
+use crate::providers::PLACEHOLDER_API_KEY;
 use crate::storage::OciStore;
 use crate::webui;
 
@@ -2403,6 +2404,255 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
     is_safetensors.then_some(model_ref)
 }
 
+// ---------------------------------------------------------------------------
+// Request target: a local backend, or a remote provider
+// ---------------------------------------------------------------------------
+
+/// Where a resolved request is actually sent.
+///
+/// Until provider routing existed this was a bare `u16`: every backend
+/// was a `llama-server`/vllm/mlx child on loopback, so a port was the
+/// whole of "where does this go". [`Target::Remote`] is the same idea for
+/// a request that leaves the machine — see [`crate::providers`] for which
+/// providers qualify.
+///
+/// Requests are *routed* through, never redirected away from, this
+/// daemon: a provider-backed integration still talks to `llmman serve`
+/// exactly as a locally-served one does, and every surface, keep-alive
+/// guard and model-name rewrite below behaves the same either way.
+#[derive(Clone, Debug)]
+enum Target {
+    /// A locally spawned backend listening on loopback.
+    Local(u16),
+    /// A remote provider's OpenAI-compatible API.
+    Remote(Arc<RemoteTarget>),
+}
+
+/// Everything needed to forward one request to a remote provider,
+/// resolved once by [`resolve_remote_target`].
+///
+/// `Debug` is hand-written rather than derived so that the key cannot
+/// reach a log line or an `anyhow` context chain by someone later
+/// formatting a `Target`.
+struct RemoteTarget {
+    /// models.dev provider id, for diagnostics.
+    provider: String,
+    /// OpenAI-compatible base URL, without a trailing slash.
+    base_url: String,
+    /// The model id as the *provider* knows it — i.e. the incoming
+    /// reference with its [`crate::providers::REMOTE_PREFIX`] and
+    /// provider segment stripped back off.
+    model: String,
+    /// Bearer token for this request. See [`resolve_remote_target`] for
+    /// where it comes from.
+    api_key: String,
+}
+
+impl std::fmt::Debug for RemoteTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteTarget")
+            .field("provider", &self.provider)
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Target {
+    /// The absolute URL an OpenAI route maps to for this target.
+    ///
+    /// `route` is llmman's own internal path (`/v1/chat/completions`);
+    /// [`crate::providers::rebase_url`] re-bases it onto a remote
+    /// provider's own published version segment, which is not always
+    /// `/v1`.
+    fn url(&self, route: &str) -> String {
+        match self {
+            Self::Local(port) => format!("http://127.0.0.1:{port}{route}"),
+            Self::Remote(remote) => crate::providers::rebase_url(&remote.base_url, route),
+        }
+    }
+
+    /// Attaches this target's credentials to an outgoing request.
+    ///
+    /// A no-op for [`Target::Local`]: a loopback `llama-server` has no
+    /// auth, which is why nothing below ever forwarded the client's own
+    /// `Authorization` header upstream — and must keep not forwarding it,
+    /// so a key meant for one provider can never be relayed to another.
+    fn authorize(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match self {
+            Self::Local(_) => req,
+            Self::Remote(remote) => req.bearer_auth(&remote.api_key),
+        }
+    }
+
+    fn is_remote(&self) -> bool {
+        matches!(self, Self::Remote(_))
+    }
+
+    /// Names this target for an error message. "inference backend" is
+    /// what every failure here said before providers existed, and is
+    /// still right for a local one; naming the provider is the whole
+    /// difference between "something failed" and "your OpenRouter key is
+    /// wrong". Never includes the key.
+    fn describe(&self) -> String {
+        match self {
+            Self::Local(_) => "inference backend".to_string(),
+            Self::Remote(remote) => format!("provider {}", remote.provider),
+        }
+    }
+}
+
+/// The one route every typed request in this daemon is sent to: the
+/// Ollama and Anthropic surfaces are both translated into an OpenAI chat
+/// completion first (see `stream_ollama` / `handle_anthropic_messages`),
+/// so `post_chat` never needs any other.
+const CHAT_COMPLETIONS_ROUTE: &str = "/v1/chat/completions";
+
+/// Extracts the caller's own API key from a request, in either spelling
+/// the surfaces below accept: `Authorization: Bearer <key>` (OpenAI) or
+/// `x-api-key: <key>` (Anthropic).
+///
+/// This is what lets provider routing work against a daemon that is
+/// *already running* — the common case, since `daemon::ensure_server`
+/// reuses a live one, and a daemon started before the user had a provider
+/// key exported would otherwise never see one. The key travels per
+/// request, from the integration `llmman launch` configured, and is never
+/// persisted.
+fn client_api_key(headers: Option<&HeaderMap>) -> Option<String> {
+    let headers = headers?;
+    let usable = |k: &str| {
+        let k = k.trim();
+        (!k.is_empty() && k != PLACEHOLDER_API_KEY).then(|| k.to_string())
+    };
+    // The scheme is case-insensitive per RFC 7235, and clients do send
+    // `bearer`. Matching one spelling would silently drop a real key.
+    let bearer = headers
+        .get(reqwest::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| {
+            let (scheme, token) = v.trim().split_once(' ')?;
+            scheme.eq_ignore_ascii_case("bearer").then_some(token)
+        })
+        .and_then(usable);
+    // Each candidate is filtered before the choice between them, not
+    // after: a client that sends both a placeholder `Authorization` and a
+    // real `x-api-key` still has a real key.
+    bearer.or_else(|| {
+        headers
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok())
+            .and_then(usable)
+    })
+}
+
+/// Whether a request was made by a browser on some other site's behalf.
+///
+/// `cors_layer` keeps such a page from *reading* a response, but not from
+/// sending the request: a "simple" POST (`text/plain`, a form encoding)
+/// skips the preflight entirely, and these handlers parse the body
+/// without consulting `Content-Type`. Any page a user visits could
+/// therefore make a loopback daemon spend the provider key in its
+/// environment, and never need to see the reply to have cost them money.
+///
+/// `Sec-Fetch-Site` is what distinguishes them: browsers attach it to
+/// every request, `same-origin`/`none` for llmman's own web UI and the
+/// address bar, `cross-site`/`same-site` for another page's fetch. A CLI
+/// integration sends no such header at all, so this only ever withholds
+/// the daemon's own credentials from a browser acting for someone else —
+/// a caller that presents its own key is unaffected.
+fn is_cross_site(headers: Option<&HeaderMap>) -> bool {
+    headers
+        .and_then(|h| h.get("sec-fetch-site"))
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|site| {
+            let site = site.trim();
+            site.eq_ignore_ascii_case("cross-site") || site.eq_ignore_ascii_case("same-site")
+        })
+}
+
+/// Resolves a [`crate::providers::REMOTE_PREFIX`] reference into a
+/// [`Target::Remote`], or `None` for any ordinary local reference.
+///
+/// The API key is the caller's own (see [`client_api_key`]) when it sent
+/// one, else the provider's variable from this daemon's environment — so
+/// both `llmman launch --provider`, which puts the real key in the
+/// integration's requests, and a daemon started with the key already
+/// exported work.
+async fn resolve_remote_target(
+    model_ref: &str,
+    headers: Option<&HeaderMap>,
+) -> Result<Option<Target>, AppError> {
+    let Some((provider_id, model)) = crate::providers::split_remote_ref(model_ref) else {
+        return Ok(None);
+    };
+    let (provider_id, model) = (provider_id.to_string(), model.to_string());
+
+    // Blocking: the first call fetches models.dev (and caches it); every
+    // later one is a memoized lookup.
+    let catalog = tokio::task::spawn_blocking(crate::providers::catalog)
+        .await
+        .context("provider catalog task panicked")?
+        .map_err(|e| AppError(e, StatusCode::BAD_GATEWAY))?;
+
+    let provider = catalog.get(&provider_id).ok_or_else(|| {
+        AppError(
+            anyhow!(
+                "unknown provider {provider_id:?} — run 'llmman launch --list-providers' \
+                 for the providers llmman can route to"
+            ),
+            StatusCode::BAD_REQUEST,
+        )
+    })?;
+
+    // This router has no authentication, so the daemon's own key is
+    // withheld from the two cases where the caller is plainly not the
+    // operator: a bind the whole network can reach, and a browser acting
+    // for another site. That is a blast-radius bound, not authentication
+    // — on a shared machine any local account can still reach a loopback
+    // daemon, as it can already reach every other thing this daemon does.
+    // Presenting a key per request is what avoids relying on this at all.
+    let own_key = || {
+        (crate::daemon::reachable_only_locally() && !is_cross_site(headers))
+            .then(|| provider.api_key())
+            .flatten()
+    };
+    let api_key = client_api_key(headers).or_else(own_key).ok_or_else(|| {
+        AppError(
+            anyhow!(
+                "no API key for provider {provider_id:?} — send it as an Authorization \
+                 header{}",
+                if is_cross_site(headers) {
+                    ". This request came from another site, so llmman serve's own \
+                     environment is deliberately not used"
+                        .to_string()
+                } else if crate::daemon::reachable_only_locally() {
+                    format!(", or set {} where llmman serve runs", provider.key_env)
+                } else {
+                    ". llmman serve is not bound to loopback, so its own environment is \
+                     deliberately not used"
+                        .to_string()
+                }
+            ),
+            StatusCode::UNAUTHORIZED,
+        )
+    })?;
+
+    let target = RemoteTarget {
+        provider: provider_id,
+        base_url: provider.base_url.clone(),
+        model,
+        api_key,
+    };
+    // No key on this line: it is the one piece of a remote target that
+    // must never reach a log file.
+    eprintln!(
+        "[llmman] routing {} to provider {} ({})",
+        target.model, target.provider, target.base_url
+    );
+    Ok(Some(Target::Remote(Arc::new(target))))
+}
+
 /// Ensures `model_ref` is loaded and returns `(canonical_ref, port,
 /// guard)`. The canonical name is what it's actually registered under
 /// with its backend (`--served-model-name`), which can differ from a
@@ -2420,10 +2670,33 @@ async fn would_use_mlx(state: &AppState, model_ref: &str) -> Option<String> {
 /// which take over the claim rather than adding a second one; dropping
 /// it any other way (including the whole task being cancelled) still
 /// releases it correctly.
+///
+/// `headers` are the incoming request's, used only to pick up a caller-
+/// supplied provider API key (see [`resolve_remote_target`]); `None` from
+/// a surface that has none to offer.
 async fn ensure_model(
     state: &AppState,
     model_ref: &str,
-) -> Result<(String, u16, ActivityGuard), AppError> {
+    headers: Option<&HeaderMap>,
+) -> Result<(String, Target, ActivityGuard), AppError> {
+    // Before `resolve_ollama_api`, deliberately: a provider-routed
+    // reference names a model on someone else's servers, so none of the
+    // shortname aliasing, tag defaulting, store lookup, or pull below
+    // applies to it — and `resolve_ollama_api` would rewrite it into a
+    // registry path it is not.
+    //
+    // The guard is a real one even though nothing is running: every
+    // `ActivityGuard` operation looks the model up in `running` and is a
+    // no-op when absent (see its `Drop` impl and `begin_activity`), so a
+    // remote target needs no separate no-op path.
+    if let Some(target) = resolve_remote_target(model_ref, headers).await? {
+        return Ok((
+            model_ref.to_string(),
+            target,
+            ActivityGuard::new(state, model_ref),
+        ));
+    }
+
     let model_ref = crate::shortnames::resolve_ollama_api(model_ref);
     // Default the tag before the lock below: otherwise two concurrent
     // first-pulls of e.g. "gemma4" and "gemma4:latest" take different
@@ -2438,7 +2711,7 @@ async fn ensure_model(
     // needs scheduling work (waiting on a concurrent load, or starting
     // a fresh one) below counts against the cap.
     if let Some((port, guard)) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port, guard));
+        return Ok((model_ref.to_string(), Target::Local(port), guard));
     }
 
     // See try_admit's doc comment — held for the rest of this function.
@@ -2449,7 +2722,7 @@ async fn ensure_model(
     // Someone else may have finished loading this model while we
     // waited for the lock above.
     if let Some((port, guard)) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port, guard));
+        return Ok((model_ref.to_string(), Target::Local(port), guard));
     }
 
     // If the model is not in the local store, pull it now.
@@ -2473,7 +2746,7 @@ async fn ensure_model(
 
     // Re-check in case that stored form differs from the key above.
     if let Some((port, guard)) = check_running(state, model_ref).await {
-        return Ok((model_ref.to_string(), port, guard));
+        return Ok((model_ref.to_string(), Target::Local(port), guard));
     }
 
     let model_path = resolve_model(&state.0.store_path, &state.0.cache_path, model_ref)
@@ -2675,7 +2948,7 @@ async fn ensure_model(
     );
     Ok((
         model_ref.to_string(),
-        port,
+        Target::Local(port),
         ActivityGuard::new(state, model_ref),
     ))
 }
@@ -2696,7 +2969,13 @@ async fn ensure_model(
 /// a client asking for "gemma4:latest" should never see
 /// "/Users/.../cache/.../abcd1234" reflected back at it just because
 /// that happens to be how this one engine addresses it internally.
-async fn backend_wire_model(state: &AppState, canonical_model: &str) -> String {
+async fn backend_wire_model(state: &AppState, target: &Target, canonical_model: &str) -> String {
+    // A remote provider knows the model by its own id, not by the
+    // prefixed reference llmman routes on — see `providers::REMOTE_PREFIX`
+    // for why that reference has to be namespaced in the first place.
+    if let Target::Remote(remote) = target {
+        return remote.model.clone();
+    }
     state
         .0
         .manager
@@ -2750,7 +3029,8 @@ async fn local_llama_server_bin(state: &AppState) -> anyhow::Result<PathBuf> {
 
 async fn proxy(
     client: &Client,
-    url: &str,
+    target: &Target,
+    route: &str,
     headers: &HeaderMap,
     body: Bytes,
     activity: ActivityGuard,
@@ -2759,11 +3039,14 @@ async fn proxy(
     // through (reqwest::Body: From<Bytes>) avoids an extra full-size
     // allocation that `body.to_vec()` would add on top of it, which
     // matters most for large multipart audio uploads.
-    let mut req = client.post(url).body(body);
+    let mut req = target.authorize(client.post(target.url(route)).body(body));
     if let Some(ct) = headers.get("content-type") {
         req = req.header("content-type", ct);
     }
-    let resp = req.send().await.context("proxy request to llama-server")?;
+    let resp = req
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
     let status = resp.status();
     let resp_headers = resp.headers().clone();
 
@@ -2870,17 +3153,21 @@ fn rewrite_sse_line_model(line: &str, canonical_model: &str) -> String {
 /// when none is set explicitly.
 async fn proxy_rewriting_model(
     client: &Client,
-    url: &str,
+    target: &Target,
+    route: &str,
     headers: &HeaderMap,
     body: Bytes,
     activity: ActivityGuard,
     canonical_model: &str,
 ) -> Result<Response, AppError> {
-    let mut req = client.post(url).body(body);
+    let mut req = target.authorize(client.post(target.url(route)).body(body));
     if let Some(ct) = headers.get("content-type") {
         req = req.header("content-type", ct);
     }
-    let resp = req.send().await.context("proxy request to llama-server")?;
+    let resp = req
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
     let status = resp.status();
     let resp_headers = resp.headers().clone();
     let raw = resp
@@ -2918,17 +3205,21 @@ async fn proxy_rewriting_model(
 /// object carrying a `model` field gets rewritten.
 async fn stream_rewriting_model(
     client: &Client,
-    url: &str,
+    target: &Target,
+    route: &str,
     headers: &HeaderMap,
     body: Bytes,
     activity: ActivityGuard,
     canonical_model: String,
 ) -> Result<Response, AppError> {
-    let mut req = client.post(url).body(body);
+    let mut req = target.authorize(client.post(target.url(route)).body(body));
     if let Some(ct) = headers.get("content-type") {
         req = req.header("content-type", ct);
     }
-    let resp = req.send().await.context("proxy request to llama-server")?;
+    let resp = req
+        .send()
+        .await
+        .with_context(|| format!("proxy request to {}", target.describe()))?;
     let status = resp.status();
     // Only content-type is meaningful to forward for a stream the
     // caller is about to reconstruct line by line — content-length
@@ -3036,6 +3327,18 @@ fn apply_default_repeat_penalty_typed(oai_req: &mut OAIChatRequest) {
     }
 }
 
+/// Whether a request bound for `target` may carry `repeat_penalty`.
+///
+/// It is a llama.cpp extension, not an OpenAI field. Sending it to a
+/// local backend is the whole point of [`DEFAULT_REPEAT_PENALTY`];
+/// sending it to a provider is at best ignored and at worst a 400, since
+/// OpenAI rejects unrecognized arguments outright. A caller that asked
+/// for one explicitly is in the same position, so a remote request drops
+/// the field either way.
+fn repeat_penalty_applies(target: &Target) -> bool {
+    !target.is_remote()
+}
+
 /// POSTs oai_req to url and returns the still-streaming response, converting
 /// a non-2xx status into an AppError carrying the backend's error body.
 /// The *only* function that actually sends an `OAIChatRequest` to
@@ -3046,25 +3349,49 @@ fn apply_default_repeat_penalty_typed(oai_req: &mut OAIChatRequest) {
 /// exactly once instead of at every construction site.
 async fn post_chat(
     client: &Client,
-    url: &str,
+    target: &Target,
     oai_req: &mut OAIChatRequest,
 ) -> Result<reqwest::Response, AppError> {
-    apply_default_repeat_penalty_typed(oai_req);
-    let resp = client
-        .post(url)
-        .json(oai_req)
+    if repeat_penalty_applies(target) {
+        apply_default_repeat_penalty_typed(oai_req);
+    } else {
+        oai_req.repeat_penalty = None;
+    }
+    let resp = target
+        .authorize(
+            client
+                .post(target.url(CHAT_COMPLETIONS_ROUTE))
+                .json(oai_req),
+        )
         .send()
         .await
-        .context("send to llama-server")?;
+        .with_context(|| format!("send to {}", target.describe()))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         return Err(AppError(
-            anyhow!("inference backend {status}: {body}"),
-            StatusCode::INTERNAL_SERVER_ERROR,
+            anyhow!("{} {status}: {body}", target.describe()),
+            // A provider's own 4xx is the actionable answer — a bad key
+            // has to reach the user as 401, not as llmman's 500. A local
+            // backend keeps the blanket 500 it always returned.
+            remote_status(target, status),
         ));
     }
     Ok(resp)
+}
+
+/// The status llmman reports for an unsuccessful upstream response.
+///
+/// A [`Target::Local`] backend failing is llmman's own problem, so it
+/// stays a 500 as it always has. A provider's 4xx is about the caller's
+/// request or credentials, so it is passed through rather than buried;
+/// anything else from a provider is a bad gateway.
+fn remote_status(target: &Target, upstream: StatusCode) -> StatusCode {
+    match target {
+        Target::Local(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        Target::Remote(_) if upstream.is_client_error() => upstream,
+        Target::Remote(_) => StatusCode::BAD_GATEWAY,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3321,14 +3648,14 @@ fn fold_ollama_lines<I: IntoIterator<Item = String>>(lines: I) -> OllamaFold {
 async fn stream_ollama<T: Serialize + Send + 'static>(
     streaming: bool,
     client: Client,
-    url: String,
+    target: Target,
     mut oai_req: OAIChatRequest,
     activity: ActivityGuard,
     build_chunk: impl Fn(String, Option<String>, Option<Vec<OllamaToolCall>>, bool) -> T
         + Send
         + 'static,
 ) -> Result<Response, AppError> {
-    let resp = post_chat(&client, &url, &mut oai_req).await?;
+    let resp = post_chat(&client, &target, &mut oai_req).await?;
 
     // `stream: false` answers with the one JSON object Ollama returns.
     // llama-server is still asked to stream either way: a non-streaming
@@ -3391,12 +3718,12 @@ async fn stream_ollama<T: Serialize + Send + 'static>(
 
 async fn stream_anthropic(
     client: Client,
-    url: String,
+    target: Target,
     mut oai_req: OAIChatRequest,
     model: String,
     activity: ActivityGuard,
 ) -> Result<Response, AppError> {
-    let resp = post_chat(&client, &url, &mut oai_req).await?;
+    let resp = post_chat(&client, &target, &mut oai_req).await?;
 
     let msg_id = gen_id();
     let preamble = {
@@ -3726,6 +4053,27 @@ async fn handle_show(
         .as_deref()
         .filter(|s| !s.is_empty())
         .unwrap_or(&req.model);
+    // A provider-routed model is served by someone else and is never in
+    // the local store, so the lookup below would report it missing and
+    // send every caller that treats a 500 here as "needs pulling" — most
+    // of all `daemon::ensure_model_pulled`, which `llmman launch` and
+    // `llmman run` both call before their first request — off to pull a
+    // reference that names no registry. Answer for it directly instead.
+    if crate::providers::is_remote_ref(model_ref) {
+        eprintln!("[llmman] /api/show model={model_ref:?} (provider-routed)");
+        return Ok(Json(OllamaShowResponse {
+            model_info: serde_json::json!({ "digest": "", "size": 0 }),
+            details: OllamaModelDetails {
+                // Not "gguf": there are no local weights here at all, and
+                // claiming a format llmman never inspected would be a
+                // guess about someone else's serving stack.
+                format: String::new(),
+                family: String::new(),
+                parameter_size: String::new(),
+                quantization_level: String::new(),
+            },
+        }));
+    }
     // Resolve the same way handle_pull stored it — otherwise a bare name
     // (e.g. "gemma4", pulled and stored as "docker.io/ai/gemma4") would
     // never be found by show/delete even though it's in the local store.
@@ -3989,6 +4337,7 @@ async fn handle_delete(
 
 async fn handle_ollama_chat(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<OllamaChatRequest>,
 ) -> Result<Response, AppError> {
     eprintln!(
@@ -3996,15 +4345,15 @@ async fn handle_ollama_chat(
         req.model,
         req.messages.len()
     );
-    let (model, port, guard) = ensure_model(&state, &req.model).await?;
+    let (model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
     let keep_alive = resolve_keep_alive(&req.keep_alive);
     let activity = begin_activity(guard, Some(keep_alive)).await;
-    let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     // See backend_wire_model's own doc comment — usually just `model`
-    // itself, but a different value for an Engine::Mlx backend. Only
-    // this one outgoing request field, never the response chunk's own
-    // `model` field below (which must keep echoing back `model` as-is).
-    let wire_model = backend_wire_model(&state, &model).await;
+    // itself, but a different value for an Engine::Mlx backend or a
+    // remote provider. Only this one outgoing request field, never the
+    // response chunk's own `model` field below (which must keep echoing
+    // back `model` as-is).
+    let wire_model = backend_wire_model(&state, &target, &model).await;
     let oai = OAIChatRequest {
         model: wire_model,
         messages: req.messages.iter().map(ollama_message_to_oai).collect(),
@@ -4023,7 +4372,7 @@ async fn handle_ollama_chat(
     stream_ollama(
         req.stream,
         state.0.client.clone(),
-        url,
+        target,
         oai,
         activity,
         move |content, thinking, tool_calls, done| {
@@ -4057,6 +4406,7 @@ async fn handle_ollama_chat(
 
 async fn handle_ollama_generate(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<OllamaGenerateRequest>,
 ) -> Result<Response, AppError> {
     eprintln!(
@@ -4090,7 +4440,7 @@ async fn handle_ollama_generate(
         .into_response());
     }
 
-    let (model, port, guard) = ensure_model(&state, &req.model).await?;
+    let (model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
     // Empty prompt = load-only request (mirrors ollama server/routes.go:429)
     // — including "preload with a custom keep_alive", so refresh it here
     // even though no generation is happening.
@@ -4109,9 +4459,8 @@ async fn handle_ollama_generate(
 
     let keep_alive = resolve_keep_alive(&req.keep_alive);
     let activity = begin_activity(guard, Some(keep_alive)).await;
-    let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
     // See backend_wire_model's own doc comment.
-    let wire_model = backend_wire_model(&state, &model).await;
+    let wire_model = backend_wire_model(&state, &target, &model).await;
     let oai = OAIChatRequest {
         model: wire_model,
         messages: vec![OAIMessage::text("user", req.prompt.clone())],
@@ -4130,7 +4479,7 @@ async fn handle_ollama_generate(
     stream_ollama(
         req.stream,
         state.0.client.clone(),
-        url,
+        target,
         oai,
         activity,
         move |response, thinking, _tool_calls, done| OllamaGenerateChunk {
@@ -4197,20 +4546,22 @@ fn apply_default_repeat_penalty(req: &mut serde_json::Value) {
 ///
 /// The returned `Option<String>` is `Some(canonical_model)` only when
 /// the backend actually needed a different wire name than the one the
-/// client asked for (see `backend_wire_model`'s own doc comment — only
-/// ever true for an `Engine::Mlx` backend) — the signal
+/// client asked for (see `backend_wire_model`'s own doc comment — an
+/// `Engine::Mlx` backend, or any remote provider, which knows the model
+/// by its own unprefixed id) — the signal
 /// `proxy_openai_generation`/`proxy_openai_passthrough` need to decide
 /// whether the *response* also needs its own `"model"` field rewritten
 /// back before reaching the client, via `proxy_rewriting_model`/
 /// `stream_rewriting_model` instead of the plain `proxy`.
 async fn resolve_openai_request(
     state: &AppState,
+    headers: &HeaderMap,
     body: Bytes,
-) -> Result<(serde_json::Value, u16, ActivityGuard, Option<String>), AppError> {
+) -> Result<(serde_json::Value, Target, ActivityGuard, Option<String>), AppError> {
     let mut req: serde_json::Value =
         serde_json::from_slice(&body).context("parse OpenAI request body")?;
     let model = req["model"].as_str().unwrap_or("").to_string();
-    let (model, port, guard) = ensure_model(state, &model).await?;
+    let (model, target, guard) = ensure_model(state, &model, Some(headers)).await?;
     // The OpenAI-compatible surface has no `keep_alive` field of its own
     // (real Ollama's doesn't either) — `None` leaves whatever this model
     // already has untouched (its load-time default, or an explicit value
@@ -4219,11 +4570,12 @@ async fn resolve_openai_request(
     // instant one OpenAI-compatible request comes in.
     let activity = begin_activity(guard, None).await;
     // See backend_wire_model's own doc comment — usually just `model`
-    // itself, but a different value for an Engine::Mlx backend.
-    let wire_model = backend_wire_model(state, &model).await;
+    // itself, but a different value for an Engine::Mlx backend or a
+    // remote provider.
+    let wire_model = backend_wire_model(state, &target, &model).await;
     let response_model_override = (wire_model != model).then_some(model);
     req["model"] = serde_json::Value::String(wire_model);
-    Ok((req, port, activity, response_model_override))
+    Ok((req, target, activity, response_model_override))
 }
 
 /// OpenAI-passthrough for the endpoints that actually generate tokens —
@@ -4250,21 +4602,60 @@ async fn proxy_openai_generation(
     body: Bytes,
     llama_path: &str,
 ) -> Result<Response, AppError> {
-    let (mut req, port, activity, response_model_override) =
-        resolve_openai_request(state, body).await?;
-    apply_default_repeat_penalty(&mut req);
+    let (mut req, target, activity, response_model_override) =
+        resolve_openai_request(state, headers, body).await?;
+    if is_responses_route(llama_path) && !target.is_remote() {
+        sanitize_responses_request(&mut req);
+    }
+    if repeat_penalty_applies(&target) {
+        apply_default_repeat_penalty(&mut req);
+    } else {
+        // See repeat_penalty_applies: not an OpenAI field, and a strict
+        // provider rejects the whole request over it.
+        if let Some(req) = req.as_object_mut() {
+            req.remove("repeat_penalty");
+        }
+    }
     let streaming = req.get("stream").and_then(|v| v.as_bool()).unwrap_or(false);
     let body = Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);
-    let url = format!("http://127.0.0.1:{port}{llama_path}");
-    match response_model_override {
+    let resp = match response_model_override {
         Some(canonical) if streaming => {
-            stream_rewriting_model(&state.0.client, &url, headers, body, activity, canonical).await
+            stream_rewriting_model(
+                &state.0.client,
+                &target,
+                llama_path,
+                headers,
+                body,
+                activity,
+                canonical,
+            )
+            .await
         }
         Some(canonical) => {
-            proxy_rewriting_model(&state.0.client, &url, headers, body, activity, &canonical).await
+            proxy_rewriting_model(
+                &state.0.client,
+                &target,
+                llama_path,
+                headers,
+                body,
+                activity,
+                &canonical,
+            )
+            .await
         }
-        None => proxy(&state.0.client, &url, headers, body, activity).await,
-    }
+        None => {
+            proxy(
+                &state.0.client,
+                &target,
+                llama_path,
+                headers,
+                body,
+                activity,
+            )
+            .await
+        }
+    }?;
+    Ok(explain_missing_route(&target, llama_path, resp))
 }
 
 /// OpenAI-passthrough for the routes that don't generate anything a
@@ -4303,31 +4694,67 @@ async fn proxy_openai_passthrough(
     body: Bytes,
     llama_path: &str,
 ) -> Result<Response, AppError> {
-    if llama_path == "/v1/embeddings" {
+    let embeddings = llama_path == "/v1/embeddings";
+    if embeddings {
         if let Ok(peek) = serde_json::from_slice::<serde_json::Value>(&body) {
             if let Some(model_ref) = peek["model"].as_str() {
-                if let Some(canonical) = would_use_mlx(state, model_ref).await {
-                    return Ok(mlx_embeddings_unsupported_response(&canonical));
+                // A provider-routed model is never an `Engine::Mlx` one —
+                // it isn't local at all — so skip the whole check rather
+                // than letting `would_use_mlx` do a pointless store lookup
+                // against a reference that was never a store reference.
+                if !crate::providers::is_remote_ref(model_ref) {
+                    if let Some(canonical) = would_use_mlx(state, model_ref).await {
+                        return Ok(mlx_embeddings_unsupported_response(&canonical));
+                    }
                 }
             }
         }
     }
-    let (req, port, activity, response_model_override) =
-        resolve_openai_request(state, body).await?;
-    if llama_path == "/v1/embeddings" {
+    let (mut req, target, activity, response_model_override) =
+        resolve_openai_request(state, headers, body).await?;
+    if is_responses_route(llama_path) && !target.is_remote() {
+        sanitize_responses_request(&mut req);
+    }
+    // `!target.is_remote()`, not just `response_model_override.is_some()`:
+    // a remote target *always* sets that override (it addresses the model
+    // by its own unprefixed id — see `backend_wire_model`), so without
+    // this every provider-routed embeddings request would be rejected as
+    // an MLX one. Only a local backend can actually be `Engine::Mlx`.
+    if embeddings && !target.is_remote() {
         if let Some(canonical) = &response_model_override {
             drop(activity);
             return Ok(mlx_embeddings_unsupported_response(canonical));
         }
     }
     let body = Bytes::from(serde_json::to_vec(&req).context("re-serialize OpenAI request body")?);
-    let url = format!("http://127.0.0.1:{port}{llama_path}");
-    match response_model_override {
+    let resp = match response_model_override {
         Some(canonical) => {
-            proxy_rewriting_model(&state.0.client, &url, headers, body, activity, &canonical).await
+            proxy_rewriting_model(
+                &state.0.client,
+                &target,
+                llama_path,
+                headers,
+                body,
+                activity,
+                &canonical,
+            )
+            .await
         }
-        None => proxy(&state.0.client, &url, headers, body, activity).await,
-    }
+        None => {
+            proxy(
+                &state.0.client,
+                &target,
+                llama_path,
+                headers,
+                body,
+                activity,
+            )
+            .await
+        }
+    }?;
+    // `/v1/responses/input_tokens` comes through here, and a provider
+    // without the Responses API 404s it just the same.
+    Ok(explain_missing_route(&target, llama_path, resp))
 }
 
 /// The clear, specific error [`proxy_openai_passthrough`] returns
@@ -4426,12 +4853,31 @@ async fn handle_openai_transcriptions(
         });
         return Ok((StatusCode::BAD_REQUEST, Json(body)).into_response());
     };
-    let (_, port, guard) = ensure_model(&state, &model).await?;
+    // Every other surface rewrites `model` to the provider's own id
+    // before forwarding, but this body is multipart, not JSON: the raw
+    // relay below would hand the provider a reference it has never heard
+    // of. Refuse in llmman's own words rather than let that surface as
+    // someone else's "unknown model".
+    if crate::providers::is_remote_ref(&model) {
+        let body = serde_json::json!({
+            "error": "llmman does not route /v1/audio/transcriptions to a provider — \
+                      use a locally served model with audio support"
+        });
+        return Ok((StatusCode::BAD_REQUEST, Json(body)).into_response());
+    }
+    let (_, target, guard) = ensure_model(&state, &model, Some(&headers)).await?;
     // No `keep_alive` field on this API surface either — see
     // resolve_openai_request's own comment on the same choice.
     let activity = begin_activity(guard, None).await;
-    let url = format!("http://127.0.0.1:{port}/v1/audio/transcriptions");
-    proxy(&state.0.client, &url, &headers, body, activity).await
+    proxy(
+        &state.0.client,
+        &target,
+        "/v1/audio/transcriptions",
+        &headers,
+        body,
+        activity,
+    )
+    .await
 }
 
 // -- OpenAI Responses API (/v1/responses) ------------------------------------
@@ -4452,7 +4898,6 @@ async fn handle_openai_responses(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, AppError> {
-    let body = sanitize_responses_request(body)?;
     proxy_openai_generation(&state, &headers, body, "/v1/responses").await
 }
 
@@ -4463,20 +4908,60 @@ async fn handle_openai_responses_input_tokens(
 ) -> Result<Response, AppError> {
     // A token-counting call, not a generation request — repeat_penalty has
     // nothing to apply to here.
-    let body = sanitize_responses_request(body)?;
     proxy_openai_passthrough(&state, &headers, body, "/v1/responses/input_tokens").await
 }
 
-/// Applies both `/v1/responses` request-shape workarounds below and
-/// re-serializes once, rather than parsing the body twice.
-fn sanitize_responses_request(body: Bytes) -> anyhow::Result<Bytes> {
-    let mut req: serde_json::Value =
-        serde_json::from_slice(&body).context("parse OpenAI request body")?;
-    filter_non_function_tools(&mut req);
-    consolidate_responses_instructions(&mut req);
-    Ok(Bytes::from(
-        serde_json::to_vec(&req).context("re-serialize sanitized request")?,
-    ))
+/// Applies both `/v1/responses` request-shape workarounds below, to a
+/// body already parsed by `resolve_openai_request`.
+///
+/// Local targets only, and applied after the target is known rather than
+/// on the way in: both are workarounds for what *llama-server's*
+/// `/v1/responses` cannot accept. A provider that implements the
+/// Responses API natively accepts the request Codex actually sent, and
+/// forwarding a stripped one would silently cost it `web_search` and
+/// every other non-function tool.
+fn sanitize_responses_request(req: &mut serde_json::Value) {
+    filter_non_function_tools(req);
+    consolidate_responses_instructions(req);
+}
+
+/// The routes [`sanitize_responses_request`] applies to.
+fn is_responses_route(llama_path: &str) -> bool {
+    llama_path.starts_with("/v1/responses")
+}
+
+/// Explains a provider's bare 404 on the Responses API.
+///
+/// Being OpenAI-wire-format does not mean implementing every OpenAI
+/// route. `/v1/responses` is the split that matters, because it is the
+/// only one Codex uses: `openai`, `groq` and `openrouter` answer it,
+/// `anthropic` and `mistral` 404. models.dev carries no capability data
+/// to filter on, and a hardcoded list would be wrong the week a provider
+/// shipped it — so this reports the 404 llmman actually received rather
+/// than predicting it, and says which of the two things is missing.
+fn explain_missing_route(target: &Target, route: &str, resp: Response) -> Response {
+    if resp.status() != StatusCode::NOT_FOUND || !is_responses_route(route) {
+        return resp;
+    }
+    // A 404 on any other route means something else entirely — an
+    // unknown model on `/v1/chat/completions`, most often — and claiming
+    // a missing Responses API for it would be a worse answer than the
+    // provider's own.
+    let Target::Remote(remote) = target else {
+        return resp;
+    };
+    let body = serde_json::json!({
+        "error": {
+            "message": format!(
+                "provider {} has no {route} — it is OpenAI-compatible but does not \
+                 implement the Responses API. Use an integration that speaks chat \
+                 completions, or a provider that does (openai, groq, openrouter).",
+                remote.provider
+            ),
+            "type": "invalid_request_error",
+        }
+    });
+    (StatusCode::NOT_IMPLEMENTED, Json(body)).into_response()
 }
 
 /// Strips any entry from the request's top-level `tools` array whose
@@ -4619,23 +5104,23 @@ fn build_anthropic_messages(req: &AnthropicRequest) -> Vec<OAIMessage> {
 
 async fn handle_anthropic_messages(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(req): Json<AnthropicRequest>,
 ) -> Result<Response, AppError> {
     // Backend needs its canonical name (see ensure_model); the response
     // below still echoes req.model back, unchanged from before.
-    let (canonical_model, port, guard) = ensure_model(&state, &req.model).await?;
+    let (canonical_model, target, guard) = ensure_model(&state, &req.model, Some(&headers)).await?;
     // The Anthropic Messages API has no `keep_alive` field of its own —
     // `None` leaves it untouched, same as the OpenAI-compatible surface
     // (see resolve_openai_request's own comment on why).
     let activity = begin_activity(guard, None).await;
-    let url = format!("http://127.0.0.1:{port}/v1/chat/completions");
 
     let messages = build_anthropic_messages(&req);
 
     // See backend_wire_model's own doc comment — usually just
     // canonical_model itself, but a different value for an Engine::Mlx
-    // backend.
-    let wire_model = backend_wire_model(&state, &canonical_model).await;
+    // backend or a remote provider.
+    let wire_model = backend_wire_model(&state, &target, &canonical_model).await;
     let mut oai = OAIChatRequest {
         model: wire_model,
         messages,
@@ -4656,13 +5141,13 @@ async fn handle_anthropic_messages(
     };
 
     if req.stream {
-        stream_anthropic(state.0.client.clone(), url, oai, req.model, activity).await
+        stream_anthropic(state.0.client.clone(), target, oai, req.model, activity).await
     } else {
         // Goes through post_chat like every other typed request (see its
         // own doc comment) rather than posting directly, so this branch
         // also gets repeat_penalty defaulted instead of needing its own
         // copy of that logic.
-        let resp = post_chat(&state.0.client, &url, &mut oai).await?;
+        let resp = post_chat(&state.0.client, &target, &mut oai).await?;
         let body: serde_json::Value = resp.json().await.context("parse llama-server response")?;
         let content = body["choices"][0]["message"]["content"]
             .as_str()
@@ -4987,11 +5472,20 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
 
     // If a model was given on the command line, start loading it immediately
     // so the first request finds it already warm.
-    if let Some(model) = &_args.model {
+    // A provider-routed model has nothing to pre-load — there is no local
+    // weight to warm, and `resolve_ollama_api` below would rewrite its
+    // reference into a registry path it isn't. `cmd::launch` already
+    // declines to pass one; this is the daemon's own guard for anyone
+    // running `llmman serve <ref>` by hand.
+    if let Some(model) = _args
+        .model
+        .as_deref()
+        .filter(|m| !crate::providers::is_remote_ref(m))
+    {
         let model = crate::shortnames::resolve_ollama_api(model);
         let state_clone = state.clone();
         tokio::spawn(async move {
-            match ensure_model(&state_clone, &model).await {
+            match ensure_model(&state_clone, &model, None).await {
                 // ensure_model's own keep_alive (the daemon default, 5
                 // minutes) would otherwise start counting down the
                 // moment this finishes loading, with no request traffic
@@ -5057,6 +5551,334 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- request targets (local backend vs remote provider) -----------------
+
+    fn remote_target(base_url: &str) -> Target {
+        Target::Remote(Arc::new(RemoteTarget {
+            provider: "mockprov".into(),
+            base_url: base_url.into(),
+            model: "mock-model".into(),
+            api_key: "sk-test".into(),
+        }))
+    }
+
+    /// A local target must keep producing byte-for-byte the same loopback
+    /// URLs the `format!("http://127.0.0.1:{port}{path}")` calls this
+    /// replaced did — every existing route depends on it.
+    #[test]
+    fn a_local_target_addresses_loopback_unchanged() {
+        let target = Target::Local(17434);
+        assert_eq!(
+            target.url("/v1/chat/completions"),
+            "http://127.0.0.1:17434/v1/chat/completions"
+        );
+        assert_eq!(
+            target.url("/v1/audio/transcriptions"),
+            "http://127.0.0.1:17434/v1/audio/transcriptions"
+        );
+        assert_eq!(
+            target.url("/v1/responses/input_tokens"),
+            "http://127.0.0.1:17434/v1/responses/input_tokens"
+        );
+        assert!(!target.is_remote());
+    }
+
+    /// A remote target re-bases llmman's internal `/v1/...` route onto
+    /// whatever version segment the provider published, which is often not
+    /// `/v1` and sometimes absent — getting this wrong yields a doubled
+    /// `/v1/v1/` or a dropped path segment.
+    #[test]
+    fn a_remote_target_rebases_routes_onto_the_provider_url() {
+        assert_eq!(
+            remote_target("https://openrouter.ai/api/v1").url("/v1/chat/completions"),
+            "https://openrouter.ai/api/v1/chat/completions"
+        );
+        assert_eq!(
+            remote_target("https://generativelanguage.googleapis.com/v1beta/openai")
+                .url("/v1/chat/completions"),
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        );
+        assert_eq!(
+            remote_target("https://api.perplexity.ai").url("/v1/chat/completions"),
+            "https://api.perplexity.ai/chat/completions"
+        );
+        assert!(remote_target("https://example.invalid/v1").is_remote());
+    }
+
+    /// Both spellings the surfaces here accept, so a provider key reaches
+    /// an already-running daemon whichever integration sent it.
+    #[test]
+    fn client_api_key_reads_bearer_and_x_api_key() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer sk-openai-style".parse().unwrap());
+        assert_eq!(
+            client_api_key(Some(&headers)),
+            Some("sk-openai-style".to_string())
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", "sk-anthropic-style".parse().unwrap());
+        assert_eq!(
+            client_api_key(Some(&headers)),
+            Some("sk-anthropic-style".to_string())
+        );
+
+        // Authorization wins when a client sends both.
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer sk-bearer".parse().unwrap());
+        headers.insert("x-api-key", "sk-other".parse().unwrap());
+        assert_eq!(
+            client_api_key(Some(&headers)),
+            Some("sk-bearer".to_string())
+        );
+    }
+
+    /// `cmd::launch` gives locally-served integrations a placeholder key
+    /// because several refuse to start without one. Treating it as a real
+    /// credential would forward a meaningless token to a real provider
+    /// (which rejects it with an opaque 401) instead of falling back to
+    /// the daemon's own configured key.
+    #[test]
+    fn client_api_key_ignores_the_local_placeholder_and_empty_values() {
+        for header in ["Bearer llmman", "Bearer ", "Bearer    ", ""] {
+            let mut headers = HeaderMap::new();
+            headers.insert("authorization", header.parse().unwrap());
+            assert_eq!(
+                client_api_key(Some(&headers)),
+                None,
+                "{header:?} was treated as a credential"
+            );
+        }
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", PLACEHOLDER_API_KEY.parse().unwrap());
+        assert_eq!(client_api_key(Some(&headers)), None);
+
+        assert_eq!(client_api_key(None), None);
+        assert_eq!(client_api_key(Some(&HeaderMap::new())), None);
+    }
+
+    /// A malformed or non-bearer `Authorization` is not a key — llmman
+    /// must fall through to its own configured one rather than forwarding
+    /// something that was never a bearer token.
+    #[test]
+    fn client_api_key_ignores_non_bearer_authorization() {
+        for header in ["Basic dXNlcjpwYXNz", "sk-no-scheme", "Bearer"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("authorization", header.parse().unwrap());
+            assert_eq!(
+                client_api_key(Some(&headers)),
+                None,
+                "{header:?} was treated as a bearer token"
+            );
+        }
+    }
+
+    /// RFC 7235 makes the scheme case-insensitive and clients do send
+    /// `bearer`. Matching one spelling silently drops a real key, and on
+    /// a daemon that won't use its own there is nothing to fall back to.
+    #[test]
+    fn client_api_key_accepts_any_spelling_of_bearer() {
+        for header in ["Bearer sk-real", "bearer sk-real", "BEARER sk-real"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("authorization", header.parse().unwrap());
+            assert_eq!(
+                client_api_key(Some(&headers)),
+                Some("sk-real".to_string()),
+                "{header:?}"
+            );
+        }
+    }
+
+    /// Each header is judged on its own: an unusable `Authorization` must
+    /// not shadow a real `x-api-key`, which is exactly what a client that
+    /// hardcodes one and configures the other sends.
+    #[test]
+    fn client_api_key_falls_through_an_unusable_authorization() {
+        for header in ["Bearer llmman", "Bearer ", "Basic dXNlcjpwYXNz"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("authorization", header.parse().unwrap());
+            headers.insert("x-api-key", "sk-real".parse().unwrap());
+            assert_eq!(
+                client_api_key(Some(&headers)),
+                Some("sk-real".to_string()),
+                "{header:?} shadowed a real x-api-key"
+            );
+        }
+    }
+
+    /// OpenAI-wire-format does not mean every OpenAI route: `anthropic`
+    /// and `mistral` 404 on `/v1/responses` where `openai`, `groq` and
+    /// `openrouter` answer it. Codex uses only that route, so the bare
+    /// 404 it would otherwise show has to become an explanation.
+    #[tokio::test]
+    async fn a_providers_missing_responses_route_is_explained() {
+        let remote = remote_target("https://example.invalid/v1");
+        let not_found = (StatusCode::NOT_FOUND, "{}").into_response();
+        let explained = explain_missing_route(&remote, "/v1/responses", not_found);
+        assert_eq!(explained.status(), StatusCode::NOT_IMPLEMENTED);
+        let body = axum::body::to_bytes(explained.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("mockprov"), "{body}");
+        assert!(body.contains("Responses API"), "{body}");
+
+        // The token-counting route is the same story.
+        let counted = explain_missing_route(
+            &remote,
+            "/v1/responses/input_tokens",
+            (StatusCode::NOT_FOUND, "{}").into_response(),
+        );
+        assert_eq!(counted.status(), StatusCode::NOT_IMPLEMENTED);
+
+        // Everything else is relayed untouched. A 404 on another route is
+        // an unknown model, not a missing API, and answering it with the
+        // wrong explanation is worse than passing the provider's own.
+        for (target, route, status) in [
+            (&remote, "/v1/chat/completions", StatusCode::NOT_FOUND),
+            (&remote, "/v1/embeddings", StatusCode::NOT_FOUND),
+            (
+                &Target::Local(17434),
+                "/v1/responses",
+                StatusCode::NOT_FOUND,
+            ),
+            (&remote, "/v1/responses", StatusCode::OK),
+            (&remote, "/v1/responses", StatusCode::UNAUTHORIZED),
+        ] {
+            let resp = explain_missing_route(target, route, (status, "{}").into_response());
+            assert_eq!(resp.status(), status, "{route} {status}");
+        }
+    }
+
+    /// A page the user merely visits can POST here — CORS gates reading
+    /// the reply, not sending a "simple" request, and these handlers
+    /// never check `Content-Type`. It must not be able to spend the key
+    /// in the daemon's environment; not seeing the answer is no comfort
+    /// once the money is gone.
+    #[test]
+    fn only_a_browser_acting_for_another_site_is_refused_the_daemons_key() {
+        for site in ["cross-site", "same-site", "Cross-Site", " cross-site "] {
+            let mut headers = HeaderMap::new();
+            headers.insert("sec-fetch-site", site.parse().unwrap());
+            assert!(is_cross_site(Some(&headers)), "{site:?}");
+        }
+        // llmman's own web UI, and a typed URL.
+        for site in ["same-origin", "none"] {
+            let mut headers = HeaderMap::new();
+            headers.insert("sec-fetch-site", site.parse().unwrap());
+            assert!(!is_cross_site(Some(&headers)), "{site:?}");
+        }
+        // A CLI integration sends no such header, which is the whole
+        // reason this can gate on it without breaking them.
+        assert!(!is_cross_site(Some(&HeaderMap::new())));
+        assert!(!is_cross_site(None));
+    }
+
+    /// The key is the one field of a remote target that must never reach
+    /// a log line, so it cannot be reachable through `Debug` either.
+    #[test]
+    fn a_remote_targets_debug_output_omits_the_key() {
+        let rendered = format!("{:?}", remote_target("https://example.invalid/v1"));
+        assert!(!rendered.contains("sk-test"), "{rendered}");
+        assert!(rendered.contains("mockprov"), "{rendered}");
+    }
+
+    /// `repeat_penalty` is a llama.cpp extension. A local backend wants
+    /// llmman's default; a provider rejects the request over it.
+    #[test]
+    fn repeat_penalty_is_local_only() {
+        assert!(repeat_penalty_applies(&Target::Local(17434)));
+        assert!(!repeat_penalty_applies(&remote_target(
+            "https://example.invalid/v1"
+        )));
+    }
+
+    /// A bad provider key must reach the user as the 401 it is. Burying
+    /// it in llmman's blanket 500 is what makes "check your key" look
+    /// like "llmman is broken" — while a local backend, whose failures
+    /// really are llmman's own, keeps the 500 it always returned.
+    #[test]
+    fn a_providers_own_status_is_not_buried_in_a_500() {
+        let remote = remote_target("https://example.invalid/v1");
+        assert_eq!(
+            remote_status(&remote, StatusCode::UNAUTHORIZED),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            remote_status(&remote, StatusCode::TOO_MANY_REQUESTS),
+            StatusCode::TOO_MANY_REQUESTS
+        );
+        // Not the caller's fault, and not llmman's either.
+        assert_eq!(
+            remote_status(&remote, StatusCode::BAD_GATEWAY),
+            StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            remote_status(&remote, StatusCode::INTERNAL_SERVER_ERROR),
+            StatusCode::BAD_GATEWAY
+        );
+
+        let local = Target::Local(17434);
+        for upstream in [StatusCode::UNAUTHORIZED, StatusCode::INTERNAL_SERVER_ERROR] {
+            assert_eq!(
+                remote_status(&local, upstream),
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "a local backend's status changed"
+            );
+        }
+
+        // And the message says which of the two failed, without the key.
+        assert_eq!(local.describe(), "inference backend");
+        assert_eq!(remote.describe(), "provider mockprov");
+    }
+
+    /// What a provider actually receives, checked against a real HTTP
+    /// server rather than inferred from the pieces: the route re-based
+    /// onto its own base URL, the bearer token, the model under the id it
+    /// knows, and no llama.cpp-only field for it to reject.
+    #[tokio::test]
+    async fn a_remote_request_reaches_the_provider_as_plain_openai() {
+        let seen = Arc::new(tokio::sync::Mutex::new(None));
+        let captured = seen.clone();
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|headers: HeaderMap, body: Bytes| async move {
+                let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                let auth = headers["authorization"].to_str().unwrap().to_string();
+                *captured.lock().await = Some((auth, body));
+                ([("content-type", "application/json")], "{}")
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        // `/v1` on the base and `/v1/...` on the route must not double up.
+        let target = remote_target(&format!("http://127.0.0.1:{}/v1", addr.port()));
+        let mut req = OAIChatRequest {
+            model: "mock-model".into(),
+            messages: vec![],
+            stream: false,
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            repeat_penalty: Some(1.1),
+            chat_template_kwargs: None,
+            tools: None,
+            response_format: None,
+        };
+        post_chat(&Client::new(), &target, &mut req).await.unwrap();
+
+        let (auth, body) = seen.lock().await.take().expect("provider was not called");
+        assert_eq!(auth, "Bearer sk-test");
+        assert_eq!(body["model"], "mock-model");
+        assert!(
+            body.get("repeat_penalty").is_none(),
+            "llama.cpp-only field sent to a provider: {body}"
+        );
+    }
 
     // -- keep_alive parsing / resolution (idle-timeout auto-unload) ---------
 
@@ -5662,12 +6484,15 @@ mod tests {
         }
 
         assert_eq!(
-            backend_wire_model(&state, "llama-model").await,
+            backend_wire_model(&state, &Target::Local(0), "llama-model").await,
             "llama-model"
         );
-        assert_eq!(backend_wire_model(&state, "vllm-model").await, "vllm-model");
         assert_eq!(
-            backend_wire_model(&state, "mlx-model").await,
+            backend_wire_model(&state, &Target::Local(0), "vllm-model").await,
+            "vllm-model"
+        );
+        assert_eq!(
+            backend_wire_model(&state, &Target::Local(0), "mlx-model").await,
             "/cache/mlx-model/abcd",
             "an Engine::Mlx backend must be addressed by its real directory path, not its human-readable name"
         );
@@ -5677,8 +6502,22 @@ mod tests {
     async fn backend_wire_model_falls_back_to_the_canonical_name_when_not_running() {
         let state = test_state();
         assert_eq!(
-            backend_wire_model(&state, "not-running").await,
+            backend_wire_model(&state, &Target::Local(0), "not-running").await,
             "not-running"
+        );
+    }
+
+    /// A remote provider knows nothing of `providers::REMOTE_PREFIX` — it
+    /// must receive its own bare model id, with the routing prefix llmman
+    /// added stripped back off, and without consulting `running` at all
+    /// (a provider-routed model is never in it).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn backend_wire_model_strips_the_routing_prefix_for_a_remote_target() {
+        let state = test_state();
+        let target = remote_target("https://example.invalid/v1");
+        assert_eq!(
+            backend_wire_model(&state, &target, "llmman.provider/mockprov/mock-model").await,
+            "mock-model"
         );
     }
 
@@ -7396,7 +8235,7 @@ mod tests {
         let resp = stream_ollama(
             streaming,
             Client::new(),
-            format!("http://{addr}/v1/chat/completions"),
+            Target::Local(addr.port()),
             OAIChatRequest {
                 messages: vec![OAIMessage::text("user", "hi".to_string())],
                 stream: true,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -172,6 +172,44 @@ fn host_is_local() -> bool {
     is_local_host(host)
 }
 
+/// Whether the daemon is reachable *only* from this machine — i.e.
+/// whether a request can have come from anyone else.
+///
+/// Deliberately not [`connects_over_loopback`]: a wildcard bind is
+/// reached over loopback from here, but it is also reached by anyone who
+/// can route to this host, and `0.0.0.0` is exactly that. `cmd::serve`
+/// uses this to decide whether to spend the daemon's own credentials for
+/// a caller it cannot authenticate.
+pub fn reachable_only_locally() -> bool {
+    host_reachable_only_locally(&parsed_host().1)
+}
+
+/// [`reachable_only_locally`] for an explicit host, so it is testable
+/// without the process-wide `PARSED_HOST` already being fixed.
+fn host_reachable_only_locally(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .is_ok_and(|ip| ip.is_loopback())
+}
+
+/// Whether this process reaches the daemon without leaving the machine.
+///
+/// The other side of [`reachable_only_locally`]: a wildcard bind counts,
+/// since `connect_addr` sends us to loopback for it. `cmd::launch` uses
+/// this to decide whether handing an integration a real API key would put
+/// it on the network in cleartext.
+pub fn connects_over_loopback() -> bool {
+    host_connects_over_loopback(&parsed_host().1)
+}
+
+/// [`connects_over_loopback`] for an explicit host. See
+/// [`host_reachable_only_locally`].
+fn host_connects_over_loopback(host: &str) -> bool {
+    is_local_host(connectable_host(host))
+}
+
 /// By value rather than by exact spelling, same as `connectable_host` —
 /// a loopback or unspecified IP (in any form) is local; a bare
 /// "localhost" is too, since it always resolves to one.
@@ -978,6 +1016,31 @@ pub fn get_json<T: serde::de::DeserializeOwned>(path: &str) -> anyhow::Result<T>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two locality questions differ on exactly one host, and it is
+    /// the one that matters: a wildcard bind is reached over loopback
+    /// from here, *and* by anyone who can route to this machine.
+    /// Collapsing them either leaks the daemon's credentials to the
+    /// network or refuses `--provider` on a perfectly local hop.
+    #[test]
+    fn wildcard_binds_are_locally_reachable_but_not_only_locally() {
+        // The host-taking forms the two public predicates delegate to,
+        // since those read a PARSED_HOST fixed once per process.
+        for host in ["127.0.0.1", "::1", "localhost", "LOCALHOST"] {
+            assert!(host_connects_over_loopback(host), "{host}");
+            assert!(host_reachable_only_locally(host), "{host}");
+        }
+        // The one host the two disagree on, and the reason there are two:
+        // we reach it over loopback, but so does the rest of the network.
+        for wildcard in ["0.0.0.0", "::", "0:0:0:0:0:0:0:0"] {
+            assert!(host_connects_over_loopback(wildcard), "{wildcard}");
+            assert!(!host_reachable_only_locally(wildcard), "{wildcard}");
+        }
+        for remote in ["192.168.1.50", "10.0.0.1", "example.com"] {
+            assert!(!host_connects_over_loopback(remote), "{remote}");
+            assert!(!host_reachable_only_locally(remote), "{remote}");
+        }
+    }
 
     /// Unset/blank `LLMMAN_HOST` — the common case — resolves to the
     /// documented default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hostgpu;
 pub mod llama_release;
 pub mod modelpack;
 pub mod oauth;
+pub mod providers;
 pub mod shortnames;
 pub mod storage;
 pub mod thinking;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -1,0 +1,1119 @@
+//! The models.dev provider catalog, fetched at runtime rather than baked
+//! into this binary, so a provider models.dev gains tomorrow works
+//! without an llmman release.
+//!
+//! opencode resolves the same catalog the same way, through its own
+//! mirror of it (`packages/core/src/models-dev.ts` GETs
+//! `models.opencode.ai/api.json`, byte-identical to `models.dev`'s own
+//! today). llmman reads the upstream directly: a mirror is one more
+//! thing that can disagree, and llmman has no say in what opencode's
+//! serves.
+//!
+//! Only a *subset* is exposed as [`Provider`]s, because `llmman serve`
+//! reaches an upstream exactly one way: an HTTPS POST of an OpenAI Chat
+//! Completions body with `Authorization: Bearer <key>` (see
+//! `Target::Remote` in `cmd::serve`). An entry is offered only if llmman
+//! can be *sure* it speaks that:
+//!
+//! * its `npm` driver is one of [`OPENAI_COMPATIBLE_NPM`], as opposed to
+//!   `@ai-sdk/anthropic` (Messages wire format),
+//!   `@ai-sdk/amazon-bedrock` (SigV4 signing), `@ai-sdk/google-vertex`
+//!   (GCP credentials), and the rest;
+//! * it has one concrete `https` base URL. models.dev leaves `api` unset
+//!   where the SDK hardcodes the endpoint — recovered from
+//!   [`BUILTIN_ENDPOINTS`] — and templated (`${VAR}`) where it is
+//!   per-account, which llmman has nothing to interpolate from;
+//! * exactly one of its `env` entries is an API key. Multi-variable auth
+//!   (`CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_KEY`, ...) is not "one
+//!   bearer token".
+//!
+//! Everything filtered out is deliberately *absent* rather than
+//! half-supported: a provider llmman offers is one it can actually reach.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
+
+use anyhow::Context;
+use serde::Deserialize;
+
+/// Where the catalog is fetched from.
+const CATALOG_URL: &str = "https://models.dev/api.json";
+
+/// Cache filename under [`crate::default_cache`].
+const CACHE_FILE: &str = "models-dev.json";
+
+/// How long a cached catalog is served without re-fetching. Long,
+/// deliberately: the provider list moves in days, while a fetch on every
+/// `llmman launch` would put a network round-trip in front of an
+/// otherwise instant command.
+const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Bounded so a hung models.dev can't wedge `llmman launch`; a failed
+/// fetch falls back to any cached copy, however stale.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The AI SDK driver packages that speak the OpenAI wire format — the
+/// only ones `Target::Remote`'s "POST an OpenAI body with a bearer token"
+/// can actually drive. See this module's own doc comment.
+const OPENAI_COMPATIBLE_NPM: &[&str] = &[
+    "@ai-sdk/openai-compatible",
+    "@ai-sdk/openai",
+    "@openrouter/ai-sdk-provider",
+];
+
+/// A provider whose endpoint models.dev leaves unset because its AI SDK
+/// package hardcodes it, plus the one `env` entry that is its API key.
+struct Builtin {
+    /// models.dev provider id.
+    id: &'static str,
+    /// Base URL that `/chat/completions` is appended to.
+    base_url: &'static str,
+    /// The API-key variable, picked out of the provider's `env` list.
+    key_env: &'static str,
+}
+
+/// Endpoints for providers models.dev has no `api` for, restricted to
+/// ones with a published, stable OpenAI-compatible endpoint that was
+/// checked by hand to answer `POST /chat/completions` at the URL below.
+///
+/// Not a second registry: an entry here must still be present in the
+/// fetched catalog to be offered, and supplies only the one field
+/// models.dev omits. The rest (`amazon-bedrock`, `azure`,
+/// `google-vertex`, `watsonx`, ...) are left out because their auth is
+/// not a bearer token, their endpoint is per-account, or their wire
+/// format is not OpenAI's. `v0` is left out for a third reason: nothing
+/// answers at its documented `https://api.v0.dev/v1`, so llmman has no
+/// endpoint it can vouch for.
+const BUILTIN_ENDPOINTS: &[Builtin] = &[
+    Builtin {
+        id: "openai",
+        base_url: "https://api.openai.com/v1",
+        key_env: "OPENAI_API_KEY",
+    },
+    // Anthropic publishes an OpenAI-compatible surface on its normal API
+    // host, keyed by the same ANTHROPIC_API_KEY as a bearer token, so it
+    // is reachable without llmman speaking the Messages wire format.
+    Builtin {
+        id: "anthropic",
+        base_url: "https://api.anthropic.com/v1",
+        key_env: "ANTHROPIC_API_KEY",
+    },
+    // Gemini's OpenAI-compatibility endpoint, not the native
+    // generateContent one. GEMINI_API_KEY of the three variables
+    // models.dev lists, matching what the Gemini docs use.
+    Builtin {
+        id: "google",
+        base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
+        key_env: "GEMINI_API_KEY",
+    },
+    Builtin {
+        id: "groq",
+        base_url: "https://api.groq.com/openai/v1",
+        key_env: "GROQ_API_KEY",
+    },
+    Builtin {
+        id: "mistral",
+        base_url: "https://api.mistral.ai/v1",
+        key_env: "MISTRAL_API_KEY",
+    },
+    Builtin {
+        id: "xai",
+        base_url: "https://api.x.ai/v1",
+        key_env: "XAI_API_KEY",
+    },
+    Builtin {
+        id: "cerebras",
+        base_url: "https://api.cerebras.ai/v1",
+        key_env: "CEREBRAS_API_KEY",
+    },
+    Builtin {
+        id: "togetherai",
+        base_url: "https://api.together.xyz/v1",
+        key_env: "TOGETHER_API_KEY",
+    },
+    Builtin {
+        id: "deepinfra",
+        base_url: "https://api.deepinfra.com/v1/openai",
+        key_env: "DEEPINFRA_API_KEY",
+    },
+    // No `/v1`: Perplexity serves /chat/completions off the bare host.
+    Builtin {
+        id: "perplexity",
+        base_url: "https://api.perplexity.ai",
+        key_env: "PERPLEXITY_API_KEY",
+    },
+    Builtin {
+        id: "cohere",
+        base_url: "https://api.cohere.ai/compatibility/v1",
+        key_env: "COHERE_API_KEY",
+    },
+    Builtin {
+        id: "venice",
+        base_url: "https://api.venice.ai/api/v1",
+        key_env: "VENICE_API_KEY",
+    },
+    Builtin {
+        id: "vercel",
+        base_url: "https://ai-gateway.vercel.sh/v1",
+        key_env: "AI_GATEWAY_API_KEY",
+    },
+];
+
+// ---------------------------------------------------------------------------
+// Remote model references
+// ---------------------------------------------------------------------------
+
+/// Namespace every provider-routed model reference is carried under.
+///
+/// Such a request reaches `llmman serve` through the very same `"model"`
+/// field a local one does — the only field the Ollama, OpenAI, and
+/// Anthropic surfaces have in common, and one the launched integrations
+/// pass through opaquely.
+///
+/// The bare `<provider>/<model>` spelling opencode uses would be
+/// ambiguous here in a way it never is there: llmman also resolves
+/// two-segment names as HuggingFace repositories (see
+/// `shortnames::resolve`), so routing on a bare prefix would silently
+/// capture `google/gemma-3`, `openai/gpt-oss-120b` and every other real
+/// `hf.co/<org>/<repo>` whose org shares a name with a provider. This
+/// prefix cannot collide with one: `shortnames` only treats a first
+/// segment as a registry host when it contains a dot.
+pub const REMOTE_PREFIX: &str = "llmman.provider/";
+
+/// The stand-in `cmd::launch` gives integrations pointed at a
+/// locally-served model, where an API key is meaningless but omitting it
+/// makes several of them refuse to start. It is not a credential, so
+/// `cmd::serve` must never forward it to a real provider.
+pub const PLACEHOLDER_API_KEY: &str = "llmman";
+
+/// Encodes `provider` + `model` into the single reference that travels in
+/// a request's `"model"` field. Inverse of [`split_remote_ref`].
+pub fn format_remote_ref(provider: &str, model: &str) -> String {
+    format!("{REMOTE_PREFIX}{provider}/{model}")
+}
+
+/// Splits a [`REMOTE_PREFIX`]-namespaced reference back into its provider
+/// id and upstream model id, or `None` for any ordinary local reference.
+///
+/// Purely syntactic — it does not consult the catalog, so callers still
+/// have to look the provider id up (and report an unknown one) themselves.
+/// The model id keeps any further slashes: `openrouter`'s ids are
+/// themselves `<vendor>/<model>`.
+pub fn split_remote_ref(reference: &str) -> Option<(&str, &str)> {
+    let rest = reference.strip_prefix(REMOTE_PREFIX)?;
+    let (provider, model) = rest.split_once('/')?;
+    (!provider.is_empty() && !model.is_empty()).then_some((provider, model))
+}
+
+/// Whether `reference` names a provider-routed model rather than a local
+/// one. Cheaper than [`split_remote_ref`] when the parts aren't needed.
+pub fn is_remote_ref(reference: &str) -> bool {
+    split_remote_ref(reference).is_some()
+}
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
+/// One reachable provider: everything `llmman serve` needs to forward a
+/// request upstream, and everything `llmman launch` needs to explain how
+/// to authenticate to it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Provider {
+    /// models.dev provider id, as passed to `--provider`.
+    pub id: String,
+    /// Human-readable name, for listings and error messages.
+    pub name: String,
+    /// OpenAI-compatible base URL that a route (`/chat/completions`, ...)
+    /// is appended to. Never has a trailing slash.
+    pub base_url: String,
+    /// Environment variable holding this provider's API key.
+    pub key_env: String,
+    /// Model ids this provider serves, sorted. Used to validate `--model`
+    /// and to suggest values; never sent upstream verbatim.
+    pub models: Vec<String>,
+}
+
+impl Provider {
+    /// This provider's API key from the environment, or `None` when
+    /// [`Provider::key_env`] is unset or blank.
+    pub fn api_key(&self) -> Option<String> {
+        std::env::var(&self.key_env)
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
+    /// Appends an OpenAI route to this provider's base URL. See
+    /// [`rebase_url`].
+    pub fn url(&self, route: &str) -> String {
+        rebase_url(&self.base_url, route)
+    }
+}
+
+/// Re-bases one of llmman's own internal routes (`/v1/chat/completions`)
+/// onto a provider base URL.
+///
+/// The `/v1` is dropped because a models.dev `api` already includes
+/// whatever version segment the provider uses, which is not always `v1`
+/// (`.../v1beta/openai` for Gemini, `.../compatibility/v1` for Cohere,
+/// none at all for Perplexity).
+pub fn rebase_url(base_url: &str, route: &str) -> String {
+    let suffix = route.trim_start_matches('/');
+    let suffix = suffix.strip_prefix("v1/").unwrap_or(suffix);
+    format!("{base_url}/{suffix}")
+}
+
+/// Every provider llmman can route to, keyed by id.
+#[derive(Debug, Default)]
+pub struct Catalog {
+    providers: BTreeMap<String, Provider>,
+}
+
+impl Catalog {
+    /// The provider `id` names, or `None` if models.dev has no such
+    /// provider or llmman cannot reach it (see the module doc comment).
+    pub fn get(&self, id: &str) -> Option<&Provider> {
+        self.providers.get(id)
+    }
+
+    /// Every routable provider, ordered by id.
+    pub fn iter(&self) -> impl Iterator<Item = &Provider> {
+        self.providers.values()
+    }
+
+    /// Every routable provider id, ordered.
+    pub fn ids(&self) -> impl Iterator<Item = &str> {
+        self.providers.keys().map(String::as_str)
+    }
+
+    pub fn len(&self) -> usize {
+        self.providers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+
+    /// Parses a models.dev `api.json` body, keeping only the entries this
+    /// module's doc comment describes as reachable.
+    ///
+    /// Each entry is deserialized on its own, so one upstream record that
+    /// grows an unexpected shape costs that provider rather than the
+    /// whole catalog — and `--provider` keeps working until llmman
+    /// catches up. Split out from the fetch/cache plumbing so the
+    /// filtering rules are unit-testable with no network or disk at all.
+    pub fn from_json(raw: &[u8]) -> anyhow::Result<Self> {
+        let raw: BTreeMap<String, serde_json::Value> =
+            serde_json::from_slice(raw).context("parse models.dev api.json")?;
+        let providers: BTreeMap<_, _> = raw
+            .into_iter()
+            .filter_map(|(id, provider)| {
+                let provider = serde_json::from_value(provider).ok()?;
+                Some((id.clone(), routable(&id, provider)?))
+            })
+            .collect();
+        // An empty result is a failed load, not a catalog with nothing in
+        // it: `{"error":"temporarily unavailable"}` is valid JSON and a
+        // valid map, and every entry drops out of the filter. Treating it
+        // as success would overwrite a good cache with nothing and
+        // memoize it, so `--provider` would stay broken for a day.
+        anyhow::ensure!(
+            !providers.is_empty(),
+            "models.dev returned no provider llmman can route to"
+        );
+        Ok(Self { providers })
+    }
+}
+
+/// A models.dev catalog entry, narrowed to the fields llmman reads.
+///
+/// `models` deserializes its values into [`serde::de::IgnoredAny`]: only
+/// the ids (the map's keys) are wanted, and `api.json` is megabytes of
+/// per-model cost/limit/modality metadata that would otherwise all be
+/// materialized.
+#[derive(Debug, Deserialize)]
+struct RawProvider {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    api: Option<String>,
+    #[serde(default)]
+    npm: Option<String>,
+    #[serde(default)]
+    env: Vec<String>,
+    #[serde(default)]
+    models: BTreeMap<String, serde::de::IgnoredAny>,
+}
+
+/// Providers that pass every rule below but still cannot be driven with
+/// the variable models.dev names, because the real credential is minted
+/// by an OAuth exchange rather than exported by hand.
+///
+/// `github-copilot` is the case: it advertises `@ai-sdk/openai-compatible`
+/// and `GITHUB_TOKEN`, but `api.githubcopilot.com` 401s a `GITHUB_TOKEN`
+/// bearer — opencode has a whole plugin that trades it through
+/// `login/oauth/access_token` first, and adds `X-GitHub-Api-Version` and
+/// friends. Offering it would mean a user exports the documented variable
+/// and gets an unexplained 401.
+const OAUTH_ONLY: &[&str] = &["github-copilot"];
+
+/// Applies this module's reachability rules to one catalog entry,
+/// returning `None` for anything llmman cannot talk to.
+fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
+    if OAUTH_ONLY.contains(&id) {
+        return None;
+    }
+    let builtin = BUILTIN_ENDPOINTS.iter().find(|b| b.id == id);
+
+    // A builtin's whole purpose is to supply an endpoint models.dev has
+    // no `api` for, so it is trusted over a templated, absent or
+    // plaintext one — but never over a concrete https `api`, which is the
+    // newer of the two and the one that tracks a provider moving hosts.
+    //
+    // https only: this URL is where an API key is sent, and the catalog
+    // is fetched at runtime, so an `http://` entry upstream would be
+    // enough to put a user's key on the wire in the clear. Today that
+    // rule drops exactly the loopback entries (`lmstudio`, `lynkr`,
+    // `privatemode-ai`, `atomic-chat`) — not a loss, since `--provider`
+    // is for models llmman does not serve itself, and a local one is
+    // llmman's own job.
+    let base_url = match raw.api.as_deref().map(str::trim) {
+        Some(api) if api.starts_with("https://") && !api.contains("${") => api,
+        _ => builtin?.base_url,
+    };
+
+    // `npm` is the wire-format signal. A builtin has already been vetted
+    // by hand, so it stands in for a driver package this doesn't know:
+    // `anthropic`'s entry names `@ai-sdk/anthropic` even though the
+    // endpoint used here is its OpenAI-compatible one.
+    let openai_compatible = raw
+        .npm
+        .as_deref()
+        .is_some_and(|npm| OPENAI_COMPATIBLE_NPM.contains(&npm));
+    if !openai_compatible && builtin.is_none() {
+        return None;
+    }
+
+    // One bearer token, and llmman must know which variable holds it. A
+    // builtin names it explicitly (`google` lists three aliases); for
+    // everything else a single-entry `env` is the only unambiguous case.
+    let key_env = match builtin {
+        Some(b) => b.key_env.to_string(),
+        None => match raw.env.as_slice() {
+            [only] if !only.trim().is_empty() => only.trim().to_string(),
+            _ => return None,
+        },
+    };
+
+    Some(Provider {
+        id: id.to_string(),
+        name: raw.name,
+        base_url: base_url_of(base_url),
+        key_env,
+        models: raw.models.into_keys().collect(),
+    })
+}
+
+/// Normalizes a models.dev `api` into a base URL that a route can be
+/// appended to.
+///
+/// Some entries give the full chat route rather than the base it hangs
+/// off (`bailing` is `.../v1/chat/completions` today). Appending to that
+/// yields `.../chat/completions/chat/completions`, which fails as a
+/// confusing 404 from the provider rather than anything llmman reports.
+/// Trailing slashes go for the same reason — `url` adds its own.
+fn base_url_of(api: &str) -> String {
+    let api = api.trim_end_matches('/');
+    api.strip_suffix("/chat/completions")
+        .unwrap_or(api)
+        .trim_end_matches('/')
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Fetch + cache
+// ---------------------------------------------------------------------------
+
+/// How long a failed load is remembered before the next call retries.
+/// Short, because `llmman serve` outlives the transient failure that
+/// produced it — but not zero, or every request on a machine that cannot
+/// reach models.dev would pay [`FETCH_TIMEOUT`] again.
+const RETRY_COOLDOWN: Duration = Duration::from_secs(60);
+
+/// The last [`load`], when it happened, and how long it is good for. The
+/// error is kept as a message rather than an `anyhow::Error`, which is
+/// not cloneable.
+type Cached = (Instant, Duration, Result<Arc<Catalog>, String>);
+static CATALOG: Mutex<Option<Cached>> = Mutex::new(None);
+
+/// The routable provider catalog, fetched from models.dev on first use.
+///
+/// Memoized, but not for the life of the process: `llmman serve` runs for
+/// days, so a success is re-checked after [`CACHE_TTL`] and a failure
+/// after [`RETRY_COOLDOWN`] — otherwise one blip at startup would leave a
+/// daemon with no providers until someone restarted it.
+///
+/// The lock is held across the fetch, so concurrent callers wait for one
+/// load rather than racing several. Blocking: callers on an async runtime
+/// (`cmd::serve`) must go through `spawn_blocking`.
+pub fn catalog() -> anyhow::Result<Arc<Catalog>> {
+    let mut cached = CATALOG.lock().unwrap_or_else(|e| e.into_inner());
+    let live = cached
+        .as_ref()
+        .is_some_and(|(at, good_for, _)| at.elapsed() < *good_for);
+    if !live {
+        // A stale catalog is held only as long as a failure: what
+        // produced it was a failed refresh, whatever it managed to
+        // return. See Loaded.
+        *cached = Some(match load() {
+            Ok(loaded) => (
+                Instant::now(),
+                loaded.good_for(),
+                Ok(Arc::new(loaded.into_catalog())),
+            ),
+            Err(e) => (Instant::now(), RETRY_COOLDOWN, Err(format!("{e:#}"))),
+        });
+    }
+    match &cached.as_ref().expect("just populated").2 {
+        Ok(catalog) => Ok(catalog.clone()),
+        Err(e) => Err(anyhow::anyhow!(e.clone())),
+    }
+}
+
+fn cache_path() -> Option<PathBuf> {
+    crate::default_cache().ok().map(|d| d.join(CACHE_FILE))
+}
+
+/// Whether `path` was written within [`CACHE_TTL`]. An mtime that can't
+/// be read, or is in the future on a machine whose clock moved, counts as
+/// stale: re-fetching is cheap, serving something unbounded is not.
+fn is_fresh(path: &std::path::Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|m| SystemTime::now().duration_since(m).ok())
+        .is_some_and(|age| age < CACHE_TTL)
+}
+
+/// A loaded catalog, and whether it is the result llmman wanted.
+///
+/// [`Loaded::Stale`] is a success the caller should not settle into: the
+/// refresh behind it failed, so [`catalog`] re-tries it on
+/// [`RETRY_COOLDOWN`] rather than the full [`CACHE_TTL`] it gives a real
+/// one. Without the distinction, going offline once for a second would
+/// pin an out-of-date provider list for a day.
+enum Loaded {
+    Fresh(Catalog),
+    Stale(Catalog),
+}
+
+impl Loaded {
+    /// How long [`catalog`] may serve this without loading again.
+    fn good_for(&self) -> Duration {
+        match self {
+            Self::Fresh(_) => CACHE_TTL,
+            Self::Stale(_) => RETRY_COOLDOWN,
+        }
+    }
+
+    fn into_catalog(self) -> Catalog {
+        match self {
+            Self::Fresh(c) | Self::Stale(c) => c,
+        }
+    }
+}
+
+/// Cache-first catalog load: a fresh cache is used as-is, otherwise
+/// models.dev is fetched and the result cached. If that refresh fails,
+/// falls back to a stale cache — an out-of-date provider list beats no
+/// provider list on a machine that is merely offline.
+fn load() -> anyhow::Result<Loaded> {
+    let path = cache_path();
+
+    if let Some(path) = path.as_deref().filter(|p| is_fresh(p)) {
+        if let Ok(raw) = std::fs::read(path) {
+            if let Ok(catalog) = Catalog::from_json(&raw) {
+                crate::debug_log!("provider catalog: {} cached", path.display());
+                return Ok(Loaded::Fresh(catalog));
+            }
+        }
+    }
+
+    crate::debug_log!("provider catalog: fetching {CATALOG_URL}");
+    // Parse is part of the refresh, not a separate step after it: a 200
+    // carrying a truncated body or a captive portal's HTML is a failed
+    // refresh, and must reach the stale cache below like any other.
+    let refreshed = fetch(CATALOG_URL).and_then(|raw| {
+        let catalog = Catalog::from_json(&raw)?;
+        Ok((catalog, raw))
+    });
+
+    match refreshed {
+        Ok((catalog, raw)) => {
+            // Best-effort: an unwritable cache costs a fetch next time,
+            // nothing more, so it must not fail the load.
+            if let Some(path) = &path {
+                let _ = write_cache(path, &raw);
+            }
+            Ok(Loaded::Fresh(catalog))
+        }
+        Err(err) => {
+            let stale = path
+                .as_deref()
+                .and_then(|p| std::fs::read(p).ok())
+                .and_then(|raw| Catalog::from_json(&raw).ok());
+            match stale {
+                Some(catalog) => {
+                    eprintln!("[llmman] using cached provider list ({err:#})");
+                    Ok(Loaded::Stale(catalog))
+                }
+                None => Err(err.context(format!(
+                    "could not fetch the provider list from {CATALOG_URL}, and no cached \
+                     copy is available"
+                ))),
+            }
+        }
+    }
+}
+
+/// Writes the cache through a temp file and a rename, as opencode does
+/// for its own copy: `llmman launch` and `llmman serve` refresh it
+/// independently and do overlap, and a plain write leaves a window in
+/// which the other reads a half-written file. Rename is atomic, so a
+/// reader sees the old copy or the new one. The temp name carries the pid
+/// so two writers can't share one.
+fn write_cache(path: &std::path::Path, raw: &[u8]) -> std::io::Result<()> {
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir)?;
+    }
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    std::fs::write(&tmp, raw)?;
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
+}
+
+fn fetch(url: &str) -> anyhow::Result<Vec<u8>> {
+    let resp = reqwest::blocking::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .context("build HTTP client")?
+        .get(url)
+        .send()
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    anyhow::ensure!(status.is_success(), "GET {url} returned {status}");
+    Ok(resp.bytes().context("read models.dev response")?.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every builtin must name a plausible HTTPS endpoint and a key
+    /// variable — a typo here would surface only as a confusing runtime
+    /// failure against a real provider.
+    #[test]
+    fn builtin_endpoints_are_well_formed_and_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for b in BUILTIN_ENDPOINTS {
+            assert!(seen.insert(b.id), "duplicate builtin {}", b.id);
+            assert!(
+                b.base_url.starts_with("https://"),
+                "{} base_url is not https",
+                b.id
+            );
+            assert!(
+                !b.base_url.ends_with('/'),
+                "{} base_url has a trailing slash",
+                b.id
+            );
+            assert!(!b.key_env.is_empty(), "{} has no key_env", b.id);
+        }
+    }
+
+    #[test]
+    fn format_and_split_remote_ref_round_trip() {
+        let reference = format_remote_ref("openrouter", "qwen/qwen3-coder");
+        assert_eq!(reference, "llmman.provider/openrouter/qwen/qwen3-coder");
+        assert_eq!(
+            split_remote_ref(&reference),
+            Some(("openrouter", "qwen/qwen3-coder"))
+        );
+        assert_eq!(
+            split_remote_ref("llmman.provider/groq/llama-3.3-70b"),
+            Some(("groq", "llama-3.3-70b"))
+        );
+    }
+
+    /// The whole reason [`REMOTE_PREFIX`] exists: a bare `<org>/<repo>`
+    /// is a HuggingFace reference (`shortnames::resolve` turns it into
+    /// `hf.co/<org>/<repo>`), and must never be mistaken for a
+    /// provider-routed one just because the org shares a provider's name.
+    #[test]
+    fn split_remote_ref_ignores_local_and_huggingface_references() {
+        for local in [
+            "google/gemma-3",
+            "openai/gpt-oss-120b",
+            "qwen3.5:0.8b",
+            "docker.io/ai/gemma4",
+            "hf.co/unsloth/Qwen3.5-0.8B-GGUF",
+            "",
+        ] {
+            assert_eq!(split_remote_ref(local), None, "{local} routed as remote");
+            assert!(!is_remote_ref(local));
+        }
+    }
+
+    /// A truncated reference is not a remote one — better to fall through
+    /// to the normal local path (which reports "model not found") than to
+    /// route to an empty provider or an empty model.
+    #[test]
+    fn split_remote_ref_rejects_incomplete_references() {
+        assert_eq!(split_remote_ref("llmman.provider/"), None);
+        assert_eq!(split_remote_ref("llmman.provider/openrouter"), None);
+        assert_eq!(split_remote_ref("llmman.provider/openrouter/"), None);
+        assert_eq!(split_remote_ref("llmman.provider//gpt-5"), None);
+    }
+
+    fn catalog_from(json: &str) -> Catalog {
+        Catalog::from_json(json.as_bytes()).expect("fixture parses")
+    }
+
+    /// The base case: an `@ai-sdk/openai-compatible` provider with one
+    /// concrete URL and one key variable is taken straight from
+    /// models.dev, builtins uninvolved.
+    #[test]
+    fn openai_compatible_providers_come_from_the_catalog() {
+        let catalog = catalog_from(
+            r#"{
+                "openrouter": {
+                    "id": "openrouter",
+                    "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider",
+                    "env": ["OPENROUTER_API_KEY"],
+                    "models": { "z-model": {}, "a-model": {} }
+                }
+            }"#,
+        );
+        let p = catalog.get("openrouter").expect("openrouter is routable");
+        assert_eq!(p.name, "OpenRouter");
+        assert_eq!(p.base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(p.key_env, "OPENROUTER_API_KEY");
+        // Sorted, and only the ids — the per-model metadata is dropped.
+        assert_eq!(p.models, vec!["a-model", "z-model"]);
+    }
+
+    /// models.dev leaves `api` unset for providers whose SDK hardcodes
+    /// the endpoint; those are recovered from `BUILTIN_ENDPOINTS`,
+    /// including `anthropic`, whose `npm` is not OpenAI-compatible but
+    /// whose builtin endpoint is.
+    #[test]
+    fn builtins_supply_endpoints_the_catalog_omits() {
+        let catalog = catalog_from(
+            r#"{
+                "anthropic": {
+                    "id": "anthropic", "name": "Anthropic",
+                    "npm": "@ai-sdk/anthropic", "env": ["ANTHROPIC_API_KEY"],
+                    "models": { "claude-sonnet-4": {} }
+                },
+                "google": {
+                    "id": "google", "name": "Google",
+                    "npm": "@ai-sdk/google",
+                    "env": ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+                    "models": { "gemini-2.5-pro": {} }
+                }
+            }"#,
+        );
+        let anthropic = catalog.get("anthropic").expect("anthropic is routable");
+        assert_eq!(anthropic.base_url, "https://api.anthropic.com/v1");
+        assert_eq!(anthropic.key_env, "ANTHROPIC_API_KEY");
+
+        // Three candidate variables in the catalog, one unambiguous
+        // choice from the builtin.
+        let google = catalog.get("google").expect("google is routable");
+        assert_eq!(google.key_env, "GEMINI_API_KEY");
+    }
+
+    /// A concrete `api` tracks a provider moving hosts, so it wins over
+    /// the hand-written fallback rather than the other way round.
+    #[test]
+    fn a_concrete_api_overrides_the_builtin_endpoint() {
+        let catalog = catalog_from(
+            r#"{
+                "openai": {
+                    "id": "openai", "name": "OpenAI",
+                    "api": "https://api.openai.example/v2/",
+                    "npm": "@ai-sdk/openai", "env": ["OPENAI_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        let p = catalog.get("openai").expect("openai is routable");
+        // Trailing slash normalized away so `url()` can't double it.
+        assert_eq!(p.base_url, "https://api.openai.example/v2");
+    }
+
+    /// Everything llmman cannot reach with a bearer-token OpenAI POST
+    /// must be absent rather than half-supported.
+    #[test]
+    fn unreachable_providers_are_dropped() {
+        let catalog = catalog_from(
+            r#"{
+                "minimax": {
+                    "id": "minimax", "name": "MiniMax",
+                    "api": "https://api.minimax.io/anthropic/v1",
+                    "npm": "@ai-sdk/anthropic", "env": ["MINIMAX_API_KEY"],
+                    "models": { "minimax-m2": {} }
+                },
+                "amazon-bedrock": {
+                    "id": "amazon-bedrock", "name": "Amazon Bedrock",
+                    "npm": "@ai-sdk/amazon-bedrock",
+                    "env": ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+                    "models": { "claude": {} }
+                },
+                "snowflake-cortex": {
+                    "id": "snowflake-cortex", "name": "Snowflake Cortex",
+                    "api": "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1",
+                    "npm": "@ai-sdk/openai-compatible",
+                    "env": ["SNOWFLAKE_ACCOUNT", "SNOWFLAKE_CORTEX_PAT"],
+                    "models": { "claude": {} }
+                },
+                "cloudflare-workers-ai": {
+                    "id": "cloudflare-workers-ai", "name": "Cloudflare Workers AI",
+                    "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+                    "npm": "@ai-sdk/openai-compatible",
+                    "env": ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_KEY"],
+                    "models": { "llama": {} }
+                },
+                "github-copilot": {
+                    "id": "github-copilot", "name": "GitHub Copilot",
+                    "api": "https://api.githubcopilot.com",
+                    "npm": "@ai-sdk/openai-compatible", "env": ["GITHUB_TOKEN"],
+                    "models": { "gpt-5": {} }
+                },
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider", "env": ["OPENROUTER_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        // Anthropic wire format, not OpenAI's.
+        assert!(catalog.get("minimax").is_none());
+        // SigV4 signing, and no endpoint at all.
+        assert!(catalog.get("amazon-bedrock").is_none());
+        // Per-account templated endpoint, two-variable auth.
+        assert!(catalog.get("snowflake-cortex").is_none());
+        assert!(catalog.get("cloudflare-workers-ai").is_none());
+        // Advertises a plain bearer variable, but the real credential is
+        // minted by an OAuth exchange. See OAUTH_ONLY.
+        assert!(catalog.get("github-copilot").is_none());
+        // The one entry llmman can actually drive, so the filter is doing
+        // the dropping rather than the catalog being unusable outright.
+        assert_eq!(catalog.len(), 1);
+        assert!(catalog.get("openrouter").is_some());
+    }
+
+    /// A plaintext `api` is where an API key would be sent, so it is no
+    /// more usable than a templated one: a builtin's own https endpoint
+    /// stands in where there is one, and the provider is dropped where
+    /// there isn't. In today's catalog that second case is the loopback
+    /// entries, which `--provider` has no business routing to anyway.
+    #[test]
+    fn plaintext_endpoints_are_never_routed_to() {
+        let catalog = catalog_from(
+            r#"{
+                "openai": {
+                    "id": "openai", "name": "OpenAI",
+                    "api": "http://api.openai.example/v1",
+                    "npm": "@ai-sdk/openai", "env": ["OPENAI_API_KEY"],
+                    "models": { "gpt-5": {} }
+                },
+                "lmstudio": {
+                    "id": "lmstudio", "name": "LM Studio",
+                    "api": "http://127.0.0.1:1234/v1",
+                    "npm": "@ai-sdk/openai-compatible", "env": ["LMSTUDIO_API_KEY"],
+                    "models": { "some-model": {} }
+                }
+            }"#,
+        );
+        assert_eq!(
+            catalog.get("openai").expect("openai is routable").base_url,
+            "https://api.openai.com/v1"
+        );
+        assert!(catalog.get("lmstudio").is_none());
+    }
+
+    /// A real models.dev response, trimmed to the fields llmman reads
+    /// (the per-model metadata is megabytes and none of it is used).
+    /// Hand-written fixtures above pin one rule each; this one is what
+    /// says the rules together produce a usable list from real data.
+    const REAL_CATALOG: &[u8] = include_bytes!("../tests/fixtures/models-dev-providers.json");
+
+    /// The filter has to be selective without being empty: a rule that
+    /// accidentally excluded everything, or admitted a provider llmman
+    /// cannot authenticate to, would pass every fixture above.
+    #[test]
+    fn the_real_catalog_yields_a_usable_provider_list() {
+        let catalog = Catalog::from_json(REAL_CATALOG).expect("real catalog parses");
+        assert!(
+            (150..207).contains(&catalog.len()),
+            "{} of 207 routable — the filter moved a lot",
+            catalog.len()
+        );
+        for p in catalog.iter() {
+            assert!(
+                p.base_url.starts_with("https://"),
+                "{}: {}",
+                p.id,
+                p.base_url
+            );
+            assert!(!p.base_url.ends_with('/'), "{}: {}", p.id, p.base_url);
+            assert!(!p.base_url.contains("${"), "{}: {}", p.id, p.base_url);
+            assert!(!p.key_env.is_empty(), "{} has no key variable", p.id);
+        }
+
+        // The providers someone actually reaches for, at the endpoints
+        // each was verified to answer `POST /chat/completions` on.
+        for (id, base_url) in [
+            ("openai", "https://api.openai.com/v1"),
+            ("anthropic", "https://api.anthropic.com/v1"),
+            (
+                "google",
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+            ),
+            ("groq", "https://api.groq.com/openai/v1"),
+            ("openrouter", "https://openrouter.ai/api/v1"),
+            ("perplexity", "https://api.perplexity.ai"),
+        ] {
+            let p = catalog.get(id).unwrap_or_else(|| panic!("{id} is dropped"));
+            assert_eq!(p.base_url, base_url, "{id}");
+        }
+
+        // And the ones it must not offer, each for a different reason.
+        for id in [
+            "amazon-bedrock", // SigV4 signing
+            "google-vertex",  // GCP service-account credentials
+            "azure",          // per-account endpoint
+            "lmstudio",       // loopback, and llmman's own job anyway
+        ] {
+            assert!(catalog.get(id).is_none(), "{id} is offered");
+        }
+    }
+
+    /// Some entries give the full chat route where a base URL belongs
+    /// (`bailing` does today). Appending to that yields
+    /// `.../chat/completions/chat/completions`, which reaches the user as
+    /// a bare 404 from the provider rather than anything llmman said.
+    #[test]
+    fn a_route_specific_api_is_normalized_back_to_its_base() {
+        let catalog = catalog_from(
+            r#"{
+                "bailing": {
+                    "id": "bailing", "name": "Bailing",
+                    "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
+                    "npm": "@ai-sdk/openai-compatible", "env": ["BAILING_API_KEY"],
+                    "models": { "ling-1t": {} }
+                }
+            }"#,
+        );
+        let p = catalog.get("bailing").expect("bailing is routable");
+        assert_eq!(p.base_url, "https://api.tbox.cn/api/llm/v1");
+        assert_eq!(
+            p.url("/v1/chat/completions"),
+            "https://api.tbox.cn/api/llm/v1/chat/completions"
+        );
+
+        // A trailing slash on the route form too, and a base that merely
+        // ends in something similar must be left alone.
+        assert_eq!(
+            base_url_of("https://x.example/v1/chat/completions/"),
+            "https://x.example/v1"
+        );
+        assert_eq!(
+            base_url_of("https://x.example/completions"),
+            "https://x.example/completions"
+        );
+    }
+
+    /// No provider may produce a doubled route, whatever shape its `api`
+    /// arrives in — the fixture is where such an entry actually shows up.
+    #[test]
+    fn no_real_provider_builds_a_doubled_route() {
+        for p in Catalog::from_json(REAL_CATALOG).unwrap().iter() {
+            let url = p.url("/v1/chat/completions");
+            assert_eq!(
+                url.matches("/chat/completions").count(),
+                1,
+                "{}: {url}",
+                p.id
+            );
+        }
+    }
+
+    /// A body that parses but yields nothing routable is a failed
+    /// refresh, not an empty catalog. `{"error":"..."}` is the shape that
+    /// matters: accepting it would overwrite a good cache with nothing
+    /// and memoize that, breaking `--provider` until the TTL expired.
+    #[test]
+    fn a_body_with_nothing_routable_is_an_error_not_an_empty_catalog() {
+        for body in [
+            r#"{"error":"temporarily unavailable"}"#,
+            r#"{"message":"rate limited","retry_after":30}"#,
+            "{}",
+        ] {
+            assert!(
+                Catalog::from_json(body.as_bytes()).is_err(),
+                "{body} was accepted as a catalog"
+            );
+        }
+    }
+
+    /// A stale catalog is a *failed* refresh that happened to have
+    /// something to fall back on, so it must expire on the retry cooldown
+    /// like any other failure. Holding it for the full TTL is how one
+    /// second offline pins an out-of-date provider list for a day.
+    #[test]
+    fn a_stale_catalog_is_held_no_longer_than_a_failure() {
+        assert_eq!(Loaded::Fresh(Catalog::default()).good_for(), CACHE_TTL);
+        assert_eq!(Loaded::Stale(Catalog::default()).good_for(), RETRY_COOLDOWN);
+        assert!(
+            RETRY_COOLDOWN < CACHE_TTL,
+            "a failed refresh outlives a good one"
+        );
+    }
+
+    /// A builtin only ever supplies the endpoint models.dev omits, so one
+    /// naming a provider that already has a concrete `api` upstream is
+    /// dead weight nobody would notice — the entry is silently unused.
+    #[test]
+    fn every_builtin_is_for_a_provider_the_catalog_leaves_without_an_api() {
+        let raw: BTreeMap<String, serde_json::Value> =
+            serde_json::from_slice(REAL_CATALOG).expect("fixture parses");
+        for b in BUILTIN_ENDPOINTS {
+            let entry = raw
+                .get(b.id)
+                .unwrap_or_else(|| panic!("builtin {} is not in the catalog at all", b.id));
+            let api = entry.get("api").and_then(|v| v.as_str()).unwrap_or("");
+            assert!(
+                !api.starts_with("https://"),
+                "builtin {} is unused: the catalog already gives it {api}",
+                b.id
+            );
+            let env: Vec<&str> = entry["env"]
+                .as_array()
+                .map(|e| e.iter().filter_map(|v| v.as_str()).collect())
+                .unwrap_or_default();
+            assert!(
+                env.contains(&b.key_env),
+                "builtin {} names {}, which is not one of the catalog's {env:?}",
+                b.id,
+                b.key_env
+            );
+        }
+    }
+
+    /// One upstream entry that grows an unexpected shape must cost that
+    /// provider, not the catalog — `--provider` keeps working on today's
+    /// llmman against tomorrow's api.json.
+    #[test]
+    fn a_malformed_entry_does_not_reject_the_whole_catalog() {
+        let catalog = catalog_from(
+            r#"{
+                "broken": { "id": "broken", "name": ["not", "a", "string"] },
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider",
+                    "env": ["OPENROUTER_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        assert!(catalog.get("broken").is_none());
+        assert!(catalog.get("openrouter").is_some());
+    }
+
+    /// An OpenAI-compatible provider is still dropped when llmman can't
+    /// tell which of its variables is the API key.
+    #[test]
+    fn multi_variable_auth_is_dropped_without_a_builtin() {
+        let catalog = catalog_from(
+            r#"{
+                "databricks": {
+                    "id": "databricks", "name": "Databricks",
+                    "api": "https://example.cloud.databricks.com/ai-gateway/mlflow/v1",
+                    "npm": "@ai-sdk/openai-compatible",
+                    "env": ["DATABRICKS_HOST", "DATABRICKS_TOKEN"],
+                    "models": { "dbrx": {} }
+                },
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider", "env": ["OPENROUTER_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        assert!(catalog.get("databricks").is_none());
+        assert!(catalog.get("openrouter").is_some());
+    }
+
+    /// `url()` has to append to whatever version segment the provider
+    /// already published, since that is not always `/v1`.
+    #[test]
+    fn url_appends_routes_to_the_published_base() {
+        let p = Provider {
+            id: "groq".into(),
+            name: "Groq".into(),
+            base_url: "https://api.groq.com/openai/v1".into(),
+            key_env: "GROQ_API_KEY".into(),
+            models: vec![],
+        };
+        assert_eq!(
+            p.url("/v1/chat/completions"),
+            "https://api.groq.com/openai/v1/chat/completions"
+        );
+        assert_eq!(
+            p.url("/v1/embeddings"),
+            "https://api.groq.com/openai/v1/embeddings"
+        );
+
+        // A base with a non-`v1` version segment, and one with none at
+        // all, must both come out with exactly one `/chat/completions`.
+        let gemini = Provider {
+            base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
+            ..p.clone()
+        };
+        assert_eq!(
+            gemini.url("/v1/chat/completions"),
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        );
+        let perplexity = Provider {
+            base_url: "https://api.perplexity.ai".into(),
+            ..p
+        };
+        assert_eq!(
+            perplexity.url("/v1/chat/completions"),
+            "https://api.perplexity.ai/chat/completions"
+        );
+    }
+
+    #[test]
+    fn api_key_reads_the_providers_own_variable() {
+        let p = Provider {
+            id: "test".into(),
+            name: "Test".into(),
+            base_url: "https://example.invalid/v1".into(),
+            key_env: "LLMMAN_TEST_PROVIDER_KEY_UNSET".into(),
+            models: vec![],
+        };
+        assert_eq!(p.api_key(), None);
+    }
+}

--- a/tests/fixtures/models-dev-providers.json
+++ b/tests/fixtures/models-dev-providers.json
@@ -1,0 +1,2675 @@
+{
+ "302ai": {
+  "api": "https://api.302.ai/v1",
+  "env": [
+   "302AI_API_KEY"
+  ],
+  "id": "302ai",
+  "models": {
+   "MiniMax-M1": {},
+   "MiniMax-M2": {}
+  },
+  "name": "302.AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "abacus": {
+  "api": "https://routellm.abacus.ai/v1",
+  "env": [
+   "ABACUS_API_KEY"
+  ],
+  "id": "abacus",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.7": {},
+   "MiniMaxAI/MiniMax-M3": {}
+  },
+  "name": "Abacus",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "abliteration-ai": {
+  "api": "https://api.abliteration.ai/v1",
+  "env": [
+   "ABLIT_KEY"
+  ],
+  "id": "abliteration-ai",
+  "models": {
+   "abliterated-model": {},
+   "abliterated-model-large": {}
+  },
+  "name": "abliteration.ai",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "agentrouter": {
+  "api": "https://agentrouter.org/v1",
+  "env": [
+   "AGENTROUTER_API_KEY"
+  ],
+  "id": "agentrouter",
+  "models": {
+   "claude-opus-4-8": {},
+   "claude-opus-5": {}
+  },
+  "name": "AgentRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "agnes": {
+  "api": "https://apihub.agnes-ai.com/v1",
+  "env": [
+   "AGNES_API_KEY"
+  ],
+  "id": "agnes",
+  "models": {
+   "agnes-2.0-flash": {},
+   "agnes-2.5-flash": {}
+  },
+  "name": "Agnes AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "ai-router": {
+  "api": "https://api.ai-router.dev/v1",
+  "env": [
+   "AI_ROUTER_API_KEY"
+  ],
+  "id": "ai-router",
+  "models": {
+   "gpt-5.4": {},
+   "gpt-5.5": {}
+  },
+  "name": "AI-ROUTER",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "aiand": {
+  "api": "https://api.aiand.com/v1",
+  "env": [
+   "AIAND_API_KEY"
+  ],
+  "id": "aiand",
+  "models": {
+   "deepseek-ai/deepseek-v4-flash": {},
+   "deepseek-ai/deepseek-v4-pro": {}
+  },
+  "name": "ai&",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "aihubmix": {
+  "env": [
+   "AIHUBMIX_API_KEY"
+  ],
+  "id": "aihubmix",
+  "models": {
+   "alicloud-deepseek-v4-flash": {},
+   "alicloud-deepseek-v4-pro": {}
+  },
+  "name": "AIHubMix",
+  "npm": "@aihubmix/ai-sdk-provider"
+ },
+ "aixy": {
+  "api": "https://api.aixy-gateway.com/v1",
+  "env": [
+   "AIXY_API_KEY"
+  ],
+  "id": "aixy",
+  "models": {
+   "openai/gpt-4.1-mini": {}
+  },
+  "name": "Aixy",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "aki-io": {
+  "api": "https://aki.io/v1",
+  "env": [
+   "AKI_IO_API_KEY"
+  ],
+  "id": "aki-io",
+  "models": {
+   "deepseek-v4-flash-0731-284b": {},
+   "gemma4-26b": {}
+  },
+  "name": "AKI.IO",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba": {
+  "api": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  "env": [
+   "DASHSCOPE_API_KEY"
+  ],
+  "id": "alibaba",
+  "models": {
+   "deepseek-v4-flash-0731": {},
+   "glm-5.2": {}
+  },
+  "name": "Alibaba",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba-cn": {
+  "api": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+  "env": [
+   "DASHSCOPE_API_KEY"
+  ],
+  "id": "alibaba-cn",
+  "models": {
+   "MiniMax-M2.5": {},
+   "MiniMax/MiniMax-M2.7": {}
+  },
+  "name": "Alibaba (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba-coding-plan": {
+  "api": "https://coding-intl.dashscope.aliyuncs.com/v1",
+  "env": [
+   "ALIBABA_CODING_PLAN_API_KEY"
+  ],
+  "id": "alibaba-coding-plan",
+  "models": {
+   "MiniMax-M2.5": {},
+   "glm-4.7": {}
+  },
+  "name": "Alibaba Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba-coding-plan-cn": {
+  "api": "https://coding.dashscope.aliyuncs.com/v1",
+  "env": [
+   "ALIBABA_CODING_PLAN_API_KEY"
+  ],
+  "id": "alibaba-coding-plan-cn",
+  "models": {
+   "MiniMax-M2.5": {},
+   "glm-4.7": {}
+  },
+  "name": "Alibaba Coding Plan (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba-token-plan": {
+  "api": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+  "env": [
+   "ALIBABA_TOKEN_PLAN_API_KEY"
+  ],
+  "id": "alibaba-token-plan",
+  "models": {
+   "MiniMax-M2.5": {},
+   "deepseek-v3.2": {}
+  },
+  "name": "Alibaba Token Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "alibaba-token-plan-cn": {
+  "api": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+  "env": [
+   "ALIBABA_TOKEN_PLAN_API_KEY"
+  ],
+  "id": "alibaba-token-plan-cn",
+  "models": {
+   "MiniMax-M2.5": {},
+   "deepseek-v3.2": {}
+  },
+  "name": "Alibaba Token Plan (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "amazon-bedrock": {
+  "env": [
+   "AWS_ACCESS_KEY_ID",
+   "AWS_SECRET_ACCESS_KEY",
+   "AWS_REGION",
+   "AWS_BEARER_TOKEN_BEDROCK"
+  ],
+  "id": "amazon-bedrock",
+  "models": {
+   "amazon.nova-2-lite-v1:0": {},
+   "amazon.nova-lite-v1:0": {}
+  },
+  "name": "Amazon Bedrock",
+  "npm": "@ai-sdk/amazon-bedrock"
+ },
+ "ambient": {
+  "api": "https://api.ambient.xyz/v1",
+  "env": [
+   "AMBIENT_API_KEY"
+  ],
+  "id": "ambient",
+  "models": {
+   "ambient/large": {},
+   "deepseek/deepseek-v4-flash": {}
+  },
+  "name": "Ambient",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "amd": {
+  "api": "https://developer.amd.com.cn/radeon/api/v1",
+  "env": [
+   "AMD_API_KEY"
+  ],
+  "id": "amd",
+  "models": {
+   "DeepSeek-V4-Flash": {},
+   "Qwen3.8-Flash-Next": {}
+  },
+  "name": "AMD",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "anthropic": {
+  "env": [
+   "ANTHROPIC_API_KEY"
+  ],
+  "id": "anthropic",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Anthropic",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "anyapi": {
+  "api": "https://api.anyapi.ai/v1",
+  "env": [
+   "ANYAPI_API_KEY"
+  ],
+  "id": "anyapi",
+  "models": {
+   "anthropic/claude-haiku-4-5": {},
+   "anthropic/claude-opus-4-6": {}
+  },
+  "name": "AnyAPI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "arcee": {
+  "api": "https://api.arcee.ai/api/v1",
+  "env": [
+   "ARCEE_API_KEY"
+  ],
+  "id": "arcee",
+  "models": {
+   "deepseek/deepseek-v4-flash-latest": {},
+   "deepseek/deepseek-v4-pro": {}
+  },
+  "name": "Arcee",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "atomic-chat": {
+  "api": "http://127.0.0.1:1337/v1",
+  "env": [
+   "ATOMIC_CHAT_API_KEY"
+  ],
+  "id": "atomic-chat",
+  "models": {
+   "Meta-Llama-3_1-8B-Instruct-GGUF": {},
+   "Qwen3_5-9B-MLX-4bit": {}
+  },
+  "name": "Atomic Chat",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "auriko": {
+  "api": "https://api.auriko.ai/v1",
+  "env": [
+   "AURIKO_API_KEY"
+  ],
+  "id": "auriko",
+  "models": {
+   "claude-opus-4-6": {},
+   "claude-opus-4-7": {}
+  },
+  "name": "Auriko",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "azure": {
+  "env": [
+   "AZURE_RESOURCE_NAME",
+   "AZURE_API_KEY"
+  ],
+  "id": "azure",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Azure",
+  "npm": "@ai-sdk/azure"
+ },
+ "azure-cognitive-services": {
+  "env": [
+   "AZURE_COGNITIVE_SERVICES_RESOURCE_NAME",
+   "AZURE_COGNITIVE_SERVICES_API_KEY"
+  ],
+  "id": "azure-cognitive-services",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Azure Cognitive Services",
+  "npm": "@ai-sdk/azure"
+ },
+ "bailing": {
+  "api": "https://api.tbox.cn/api/llm/v1/chat/completions",
+  "env": [
+   "BAILING_API_TOKEN"
+  ],
+  "id": "bailing",
+  "models": {
+   "Ling-1T": {},
+   "Ring-1T": {}
+  },
+  "name": "Bailing",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "baseten": {
+  "api": "https://inference.baseten.co/v1",
+  "env": [
+   "BASETEN_API_KEY"
+  ],
+  "id": "baseten",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.5": {},
+   "deepseek-ai/DeepSeek-V3.1": {}
+  },
+  "name": "Baseten",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "berget": {
+  "api": "https://api.berget.ai/v1",
+  "env": [
+   "BERGET_API_KEY"
+  ],
+  "id": "berget",
+  "models": {
+   "google/gemma-4-31B-it": {},
+   "meta-llama/Llama-3.3-70B-Instruct": {}
+  },
+  "name": "Berget.AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "blueclaw": {
+  "api": "https://openai.blueclaw.network/v1",
+  "env": [
+   "BLUECLAW_API_KEY"
+  ],
+  "id": "blueclaw",
+  "models": {
+   "Qwen/Qwen3.6-35B-A3B-FP8": {},
+   "Qwen3.6-27B": {}
+  },
+  "name": "Blue Claw",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cerebras": {
+  "env": [
+   "CEREBRAS_API_KEY"
+  ],
+  "id": "cerebras",
+  "models": {
+   "gemma-4-31b": {},
+   "gpt-oss-120b": {}
+  },
+  "name": "Cerebras",
+  "npm": "@ai-sdk/cerebras"
+ },
+ "chutes": {
+  "api": "https://llm.chutes.ai/v1",
+  "env": [
+   "CHUTES_API_KEY"
+  ],
+  "id": "chutes",
+  "models": {
+   "Nemotron-3-Nano-Omni-30B-TEE": {},
+   "Qwen/Qwen3-235B-A22B-Thinking-2507-TEE": {}
+  },
+  "name": "Chutes",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "clarifai": {
+  "api": "https://api.clarifai.com/v2/ext/openai/v1",
+  "env": [
+   "CLARIFAI_PAT"
+  ],
+  "id": "clarifai",
+  "models": {
+   "arcee_ai/AFM/models/trinity-mini": {},
+   "clarifai/main/models/mm-poly-8b": {}
+  },
+  "name": "Clarifai",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "claudinio": {
+  "api": "https://api.claudin.io/v1",
+  "env": [
+   "CLAUDINIO_API_KEY"
+  ],
+  "id": "claudinio",
+  "models": {
+   "claudinio": {},
+   "claudius": {}
+  },
+  "name": "Claudinio",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cline-pass": {
+  "api": "https://api.cline.bot/api/v1",
+  "env": [
+   "CLINE_API_KEY"
+  ],
+  "id": "cline-pass",
+  "models": {
+   "cline-pass/deepseek-v4-flash": {},
+   "cline-pass/deepseek-v4-pro": {}
+  },
+  "name": "ClinePass",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cloudferro-sherlock": {
+  "api": "https://api-sherlock.cloudferro.com/openai/v1/",
+  "env": [
+   "CLOUDFERRO_SHERLOCK_API_KEY"
+  ],
+  "id": "cloudferro-sherlock",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.5": {},
+   "meta-llama/Llama-3.3-70B-Instruct": {}
+  },
+  "name": "CloudFerro Sherlock",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cloudflare-ai-gateway": {
+  "env": [
+   "CLOUDFLARE_API_TOKEN",
+   "CLOUDFLARE_ACCOUNT_ID",
+   "CLOUDFLARE_GATEWAY_ID"
+  ],
+  "id": "cloudflare-ai-gateway",
+  "models": {
+   "alibaba/qwen3-max": {},
+   "alibaba/qwen3.5-397b-a17b": {}
+  },
+  "name": "Cloudflare AI Gateway",
+  "npm": "ai-gateway-provider"
+ },
+ "cloudflare-workers-ai": {
+  "api": "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/ai/v1",
+  "env": [
+   "CLOUDFLARE_ACCOUNT_ID",
+   "CLOUDFLARE_API_KEY"
+  ],
+  "id": "cloudflare-workers-ai",
+  "models": {
+   "@cf/aisingapore/gemma-sea-lion-v4-27b-it": {},
+   "@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {}
+  },
+  "name": "Cloudflare Workers AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cohere": {
+  "env": [
+   "COHERE_API_KEY"
+  ],
+  "id": "cohere",
+  "models": {
+   "c4ai-aya-expanse-32b": {},
+   "c4ai-aya-expanse-8b": {}
+  },
+  "name": "Cohere",
+  "npm": "@ai-sdk/cohere"
+ },
+ "coralbricks": {
+  "api": "https://inference.coralbricks.ai/v1",
+  "env": [
+   "CORAL_API_KEY"
+  ],
+  "id": "coralbricks",
+  "models": {
+   "glm-5.2-fp4": {},
+   "gpt-oss-120b": {}
+  },
+  "name": "CoralBricks",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "cortecs": {
+  "api": "https://api.cortecs.ai/v1",
+  "env": [
+   "CORTECS_API_KEY"
+  ],
+  "id": "cortecs",
+  "models": {
+   "apertus-70b": {},
+   "claude-4-5-sonnet": {}
+  },
+  "name": "Cortecs",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "crof": {
+  "api": "https://crof.ai/v1",
+  "env": [
+   "CROF_API_KEY"
+  ],
+  "id": "crof",
+  "models": {
+   "deepseek-v3.2": {},
+   "deepseek-v4-flash": {}
+  },
+  "name": "CrofAI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "crossmodel": {
+  "api": "https://api.crossmodel.ai/v1",
+  "env": [
+   "CROSSMODEL_API_KEY"
+  ],
+  "id": "crossmodel",
+  "models": {
+   "anthropic/claude-fable-5": {},
+   "anthropic/claude-haiku-4-5": {}
+  },
+  "name": "CrossModel",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "crusoe": {
+  "api": "https://api.inference.crusoecloud.com/v1",
+  "env": [
+   "CRUSOE_API_KEY"
+  ],
+  "id": "crusoe",
+  "models": {
+   "deepseek-ai/DeepSeek-V3-0324": {},
+   "google/gemma-4-31b-it": {}
+  },
+  "name": "Crusoe",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "daoxe": {
+  "api": "https://daoxe.com/v1",
+  "env": [
+   "DAOXE_API_KEY"
+  ],
+  "id": "daoxe",
+  "models": {
+   "claude-haiku-4-5-20251001": {},
+   "claude-opus-4-8": {}
+  },
+  "name": "DaoXE",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "databricks": {
+  "api": "https://${DATABRICKS_HOST}/ai-gateway/mlflow/v1",
+  "env": [
+   "DATABRICKS_HOST",
+   "DATABRICKS_TOKEN"
+  ],
+  "id": "databricks",
+  "models": {
+   "databricks-claude-haiku-4-5": {},
+   "databricks-claude-opus-4-1": {}
+  },
+  "name": "Databricks",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "deepinfra": {
+  "env": [
+   "DEEPINFRA_API_KEY"
+  ],
+  "id": "deepinfra",
+  "models": {
+   "ByteDance/Seed-2.0-code": {},
+   "ByteDance/Seed-2.0-mini": {}
+  },
+  "name": "Deep Infra",
+  "npm": "@ai-sdk/deepinfra"
+ },
+ "deepseek": {
+  "api": "https://api.deepseek.com",
+  "env": [
+   "DEEPSEEK_API_KEY"
+  ],
+  "id": "deepseek",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-flash-vision-exp": {}
+  },
+  "name": "DeepSeek",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "digitalocean": {
+  "api": "https://inference.do-ai.run/v1",
+  "env": [
+   "DIGITALOCEAN_ACCESS_TOKEN"
+  ],
+  "id": "digitalocean",
+  "models": {
+   "alibaba-qwen3-32b": {},
+   "all-mini-lm-l6-v2": {}
+  },
+  "name": "DigitalOcean",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "dinference": {
+  "api": "https://api.dinference.com/v1",
+  "env": [
+   "DINFERENCE_API_KEY"
+  ],
+  "id": "dinference",
+  "models": {
+   "glm-4.7": {},
+   "glm-5": {}
+  },
+  "name": "DInference",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "drun": {
+  "api": "https://chat.d.run/v1",
+  "env": [
+   "DRUN_API_KEY"
+  ],
+  "id": "drun",
+  "models": {
+   "public/deepseek-r1": {},
+   "public/deepseek-v3": {}
+  },
+  "name": "D.Run (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "ebcloud": {
+  "api": "https://maas-api.ebcloud.com/v1",
+  "env": [
+   "EBCLOUD_API_KEY"
+  ],
+  "id": "ebcloud",
+  "models": {
+   "DeepSeek-V4-Flash": {},
+   "DeepSeek-V4-Pro": {}
+  },
+  "name": "EBCloud",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "echo": {
+  "api": "https://echo.tracerml.ai/v1",
+  "env": [
+   "ECHO_API_KEY"
+  ],
+  "id": "echo",
+  "models": {
+   "echo": {}
+  },
+  "name": "Echo",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "edenai": {
+  "api": "https://api.edenai.run/v3",
+  "env": [
+   "EDENAI_API_KEY"
+  ],
+  "id": "edenai",
+  "models": {
+   "amazon/moonshot.kimi-k2-thinking": {},
+   "amazon/moonshotai.kimi-k2.5": {}
+  },
+  "name": "Eden AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "empiriolabs": {
+  "api": "https://api.empiriolabs.ai/v1",
+  "env": [
+   "EMPIRIOLABS_API_KEY"
+  ],
+  "id": "empiriolabs",
+  "models": {
+   "deepseek-v3-2": {},
+   "deepseek-v4-flash": {}
+  },
+  "name": "EmpirioLabs AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "evroc": {
+  "api": "https://models.think.evroc.com/v1",
+  "env": [
+   "EVROC_API_KEY"
+  ],
+  "id": "evroc",
+  "models": {
+   "KBLab/kb-whisper-large": {},
+   "Qwen/Qwen3-Embedding-8B": {}
+  },
+  "name": "evroc",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "fastrouter": {
+  "api": "https://go.fastrouter.ai/api/v1",
+  "env": [
+   "FASTROUTER_API_KEY"
+  ],
+  "id": "fastrouter",
+  "models": {
+   "anthropic/claude-opus-4.1": {},
+   "anthropic/claude-opus-4.8": {}
+  },
+  "name": "FastRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "fireworks-ai": {
+  "api": "https://api.fireworks.ai/inference/v1/",
+  "env": [
+   "FIREWORKS_API_KEY"
+  ],
+  "id": "fireworks-ai",
+  "models": {
+   "accounts/fireworks/models/deepseek-v4-flash-0731": {},
+   "accounts/fireworks/models/deepseek-v4-pro-0813": {}
+  },
+  "name": "Fireworks AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "freemodel": {
+  "api": "https://cc.freemodel.dev/v1",
+  "env": [
+   "FREEMODEL_API_KEY"
+  ],
+  "id": "freemodel",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5-20251001": {}
+  },
+  "name": "FreeModel",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "friendli": {
+  "api": "https://api.friendli.ai/serverless/v1",
+  "env": [
+   "FRIENDLI_TOKEN"
+  ],
+  "id": "friendli",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.5": {},
+   "deepseek-ai/DeepSeek-V3.2": {}
+  },
+  "name": "Friendli",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "frogbot": {
+  "api": "https://app.frogbot.ai/api/v1",
+  "env": [
+   "FROGBOT_API_KEY"
+  ],
+  "id": "frogbot",
+  "models": {
+   "claude-haiku-4-5": {},
+   "claude-opus-4-6": {}
+  },
+  "name": "FrogBot",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "github-copilot": {
+  "api": "https://api.githubcopilot.com",
+  "env": [
+   "GITHUB_TOKEN"
+  ],
+  "id": "github-copilot",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4.5": {}
+  },
+  "name": "GitHub Copilot",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "gitlab": {
+  "env": [
+   "GITLAB_TOKEN"
+  ],
+  "id": "gitlab",
+  "models": {
+   "duo-chat-fable-5": {},
+   "duo-chat-gpt-5-1": {}
+  },
+  "name": "GitLab Duo",
+  "npm": "gitlab-ai-provider"
+ },
+ "gmicloud": {
+  "api": "https://api.gmi-serving.com/v1",
+  "env": [
+   "GMICLOUD_API_KEY"
+  ],
+  "id": "gmicloud",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.7": {},
+   "MiniMaxAI/MiniMax-M3": {}
+  },
+  "name": "GMI Cloud",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "google": {
+  "env": [
+   "GOOGLE_API_KEY",
+   "GOOGLE_GENERATIVE_AI_API_KEY",
+   "GEMINI_API_KEY"
+  ],
+  "id": "google",
+  "models": {
+   "deep-research-max-preview-04-2026": {},
+   "deep-research-preview-04-2026": {}
+  },
+  "name": "Google",
+  "npm": "@ai-sdk/google"
+ },
+ "google-vertex": {
+  "env": [
+   "GOOGLE_VERTEX_PROJECT",
+   "GOOGLE_VERTEX_LOCATION",
+   "GOOGLE_APPLICATION_CREDENTIALS"
+  ],
+  "id": "google-vertex",
+  "models": {
+   "claude-fable-5@default": {},
+   "claude-haiku-4-5@20251001": {}
+  },
+  "name": "Vertex",
+  "npm": "@ai-sdk/google-vertex"
+ },
+ "google-vertex-anthropic": {
+  "env": [
+   "GOOGLE_VERTEX_PROJECT",
+   "GOOGLE_VERTEX_LOCATION",
+   "GOOGLE_APPLICATION_CREDENTIALS"
+  ],
+  "id": "google-vertex-anthropic",
+  "models": {
+   "claude-fable-5@default": {},
+   "claude-haiku-4-5@20251001": {}
+  },
+  "name": "Vertex (Anthropic)",
+  "npm": "@ai-sdk/google-vertex/anthropic"
+ },
+ "greenpt": {
+  "api": "https://api.greenpt.ai/v1",
+  "env": [
+   "GREENPT_API_KEY"
+  ],
+  "id": "greenpt",
+  "models": {
+   "deepseek-v4-flash-0731": {},
+   "devstral-2-123b-instruct-2512": {}
+  },
+  "name": "GreenPT",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "groq": {
+  "env": [
+   "GROQ_API_KEY"
+  ],
+  "id": "groq",
+  "models": {
+   "allam-2-7b": {},
+   "canopylabs/orpheus-arabic-saudi": {}
+  },
+  "name": "Groq",
+  "npm": "@ai-sdk/groq"
+ },
+ "helicone": {
+  "api": "https://ai-gateway.helicone.ai/v1",
+  "env": [
+   "HELICONE_API_KEY"
+  ],
+  "id": "helicone",
+  "models": {
+   "chatgpt-4o-latest": {},
+   "claude-3-haiku-20240307": {}
+  },
+  "name": "Helicone",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "hetzner": {
+  "api": "https://inference.hetzner.com/api/v1",
+  "env": [
+   "HETZNER_API_KEY"
+  ],
+  "id": "hetzner",
+  "models": {
+   "Qwen/Qwen3.6-35B-A3B-FP8": {},
+   "Qwen3.8-27B": {}
+  },
+  "name": "Hetzner",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "hpc-ai": {
+  "api": "https://api.hpc-ai.com/inference/v1",
+  "env": [
+   "HPC_AI_API_KEY"
+  ],
+  "id": "hpc-ai",
+  "models": {
+   "anthropic/claude-opus-4.7": {},
+   "deepseek/deepseek-v4-flash": {}
+  },
+  "name": "HPC-AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "huggingface": {
+  "api": "https://router.huggingface.co/v1",
+  "env": [
+   "HF_TOKEN"
+  ],
+  "id": "huggingface",
+  "models": {
+   "MiniMaxAI/MiniMax-M2": {},
+   "MiniMaxAI/MiniMax-M2.1": {}
+  },
+  "name": "Hugging Face",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "hyper": {
+  "api": "https://hyper.charm.land/v1",
+  "env": [
+   "HYPER_API_KEY"
+  ],
+  "id": "hyper",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-flash-0731": {}
+  },
+  "name": "Charm Hyper",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "iflowcn": {
+  "api": "https://apis.iflow.cn/v1",
+  "env": [
+   "IFLOW_API_KEY"
+  ],
+  "id": "iflowcn",
+  "models": {
+   "deepseek-r1": {},
+   "deepseek-v3": {}
+  },
+  "name": "iFlow",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "impossibl": {
+  "api": "https://api.impossibl.com/v1",
+  "env": [
+   "IMPOSSIBL_API_KEY"
+  ],
+  "id": "impossibl",
+  "models": {
+   "anthropic/claude-fable-5": {},
+   "anthropic/claude-haiku-4-5": {}
+  },
+  "name": "Impossibl",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "inception": {
+  "api": "https://api.inceptionlabs.ai/v1/",
+  "env": [
+   "INCEPTION_API_KEY"
+  ],
+  "id": "inception",
+  "models": {
+   "mercury-2": {},
+   "mercury-edit-2": {}
+  },
+  "name": "Inception",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "inceptron": {
+  "api": "https://api.inceptron.io/v1",
+  "env": [
+   "INCEPTRON_API_KEY"
+  ],
+  "id": "inceptron",
+  "models": {
+   "deepseek-ai/DeepSeek-V4-Flash-0731": {},
+   "moonshotai/Kimi-K2.6": {}
+  },
+  "name": "Inceptron",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "inference": {
+  "api": "https://inference.net/v1",
+  "env": [
+   "INFERENCE_API_KEY"
+  ],
+  "id": "inference",
+  "models": {
+   "google/gemma-3": {},
+   "meta/llama-3.1-8b-instruct": {}
+  },
+  "name": "Inference",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "inferx": {
+  "api": "https://model.inferx.net/endpoints/v1",
+  "env": [
+   "INFERX_API_KEY"
+  ],
+  "id": "inferx",
+  "models": {
+   "Agents-A1": {},
+   "Devstral-2-123B-Instruct-2512-int4-AutoRound": {}
+  },
+  "name": "InferX",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "infomaniak": {
+  "api": "https://api.infomaniak.com/2/ai/${INFOMANIAK_PRODUCT_ID}/openai/v1",
+  "env": [
+   "INFOMANIAK_API_KEY",
+   "INFOMANIAK_PRODUCT_ID"
+  ],
+  "id": "infomaniak",
+  "models": {
+   "Qwen/Qwen3.5-122B-A10B-FP8": {},
+   "Qwen/Qwen3.5-397B-A17B-FP8": {}
+  },
+  "name": "Infomaniak",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "io-net": {
+  "api": "https://api.intelligence.io.solutions/api/v1",
+  "env": [
+   "IOINTELLIGENCE_API_KEY"
+  ],
+  "id": "io-net",
+  "models": {
+   "Intel/Qwen3-Coder-480B-A35B-Instruct-int4-mixed-ar": {},
+   "Qwen/Qwen2.5-VL-32B-Instruct": {}
+  },
+  "name": "IO.NET",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "iteracompute": {
+  "api": "https://api.iteracompute.com/v1",
+  "env": [
+   "ITERACOMPUTE_API_KEY"
+  ],
+  "id": "iteracompute",
+  "models": {
+   "iteracompute/qwen3.8-27b": {}
+  },
+  "name": "IteraCompute",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "jalapeno": {
+  "api": "https://api.jalapeno-cloud.ai/v1",
+  "env": [
+   "JALAPENO_API_KEY"
+  ],
+  "id": "jalapeno",
+  "models": {
+   "DeepSeek-V4-Flash": {},
+   "DeepSeek-V4-Pro": {}
+  },
+  "name": "Jalapeno Cloud",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "jiekou": {
+  "api": "https://api.jiekou.ai/openai",
+  "env": [
+   "JIEKOU_API_KEY"
+  ],
+  "id": "jiekou",
+  "models": {
+   "baidu/ernie-4.5-300b-a47b-paddle": {},
+   "baidu/ernie-4.5-vl-424b-a47b": {}
+  },
+  "name": "Jiekou.AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "kenari": {
+  "api": "https://kenari.id/v1",
+  "env": [
+   "KENARI_API_KEY"
+  ],
+  "id": "kenari",
+  "models": {
+   "claude-fable-5": {},
+   "claude-opus-4-7": {}
+  },
+  "name": "Kenari",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "kilo": {
+  "api": "https://api.kilo.ai/api/gateway",
+  "env": [
+   "KILO_API_KEY"
+  ],
+  "id": "kilo",
+  "models": {
+   "aion-labs/aion-2.0": {},
+   "aion-labs/aion-3.0": {}
+  },
+  "name": "Kilo Gateway",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "kimi-for-coding": {
+  "api": "https://api.kimi.com/coding/v1",
+  "env": [
+   "KIMI_API_KEY"
+  ],
+  "id": "kimi-for-coding",
+  "models": {
+   "k3": {},
+   "k3-256k": {}
+  },
+  "name": "Kimi For Coding",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "kosmik": {
+  "api": "https://api.koscompute.com/v1",
+  "env": [
+   "KOSMIK_API_KEY"
+  ],
+  "id": "kosmik",
+  "models": {
+   "qwen/qwen3.8-27b": {}
+  },
+  "name": "Kosmik Compute",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "kuae-cloud-coding-plan": {
+  "api": "https://coding-plan-endpoint.kuaecloud.net/v1",
+  "env": [
+   "KUAE_API_KEY"
+  ],
+  "id": "kuae-cloud-coding-plan",
+  "models": {
+   "GLM-4.7": {}
+  },
+  "name": "KUAE Cloud Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "lilac": {
+  "api": "https://api.getlilac.com/v1",
+  "env": [
+   "LILAC_API_KEY"
+  ],
+  "id": "lilac",
+  "models": {
+   "google/gemma-4-31b-it": {},
+   "minimaxai/minimax-m3": {}
+  },
+  "name": "Lilac",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llama": {
+  "api": "https://api.llama.com/compat/v1/",
+  "env": [
+   "LLAMA_API_KEY"
+  ],
+  "id": "llama",
+  "models": {
+   "cerebras-llama-4-maverick-17b-128e-instruct": {},
+   "cerebras-llama-4-scout-17b-16e-instruct": {}
+  },
+  "name": "Llama",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmgateway": {
+  "api": "https://api.llmgateway.io/v1",
+  "env": [
+   "LLMGATEWAY_API_KEY"
+  ],
+  "id": "llmgateway",
+  "models": {
+   "auto": {},
+   "claude-fable-5": {}
+  },
+  "name": "DevPass (LLM Gateway)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmgateway-providers": {
+  "api": "https://api.llmgateway.io/v1",
+  "env": [
+   "LLMGATEWAY_API_KEY"
+  ],
+  "id": "llmgateway-providers",
+  "models": {
+   "alibaba/deepseek-v4-flash": {},
+   "alibaba/deepseek-v4-pro": {}
+  },
+  "name": "LLM Gateway",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmtech": {
+  "api": "https://api.llmtech.eu/v1",
+  "env": [
+   "LLMTECH_API_KEY"
+  ],
+  "id": "llmtech",
+  "models": {
+   "unsloth/Qwen3.8-27B-NVFP4": {}
+  },
+  "name": "LLM Tech",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "llmtr": {
+  "api": "https://llmtr.com/v1",
+  "env": [
+   "LLMTR_API_KEY"
+  ],
+  "id": "llmtr",
+  "models": {
+   "gemma-4": {},
+   "google/gemini-2.5-flash-lite": {}
+  },
+  "name": "LLMTR",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "lmstudio": {
+  "api": "http://127.0.0.1:1234/v1",
+  "env": [
+   "LMSTUDIO_API_KEY"
+  ],
+  "id": "lmstudio",
+  "models": {
+   "openai/gpt-oss-20b": {},
+   "qwen/qwen3-30b-a3b-2507": {}
+  },
+  "name": "LMStudio",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "longcat": {
+  "api": "https://api.longcat.chat/openai",
+  "env": [
+   "LONGCAT_API_KEY"
+  ],
+  "id": "longcat",
+  "models": {
+   "LongCat-2.0": {}
+  },
+  "name": "LongCat",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "lucidquery": {
+  "api": "https://api.lucidquery.com/v1",
+  "env": [
+   "LUCIDQUERY_API_KEY"
+  ],
+  "id": "lucidquery",
+  "models": {
+   "lucidnova-rf1-100b": {},
+   "lucidquery-agi-01-frontier": {}
+  },
+  "name": "LucidQuery",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "lynkr": {
+  "api": "http://127.0.0.1:8081/v1",
+  "env": [
+   "LYNKR_API_KEY"
+  ],
+  "id": "lynkr",
+  "models": {
+   "lynkr-auto": {}
+  },
+  "name": "Lynkr",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "meganova": {
+  "api": "https://api.meganova.ai/v1",
+  "env": [
+   "MEGANOVA_API_KEY"
+  ],
+  "id": "meganova",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.1": {},
+   "MiniMaxAI/MiniMax-M2.5": {}
+  },
+  "name": "Meganova",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "merge-gateway": {
+  "api": "https://api-gateway.merge.dev/v1/ai-sdk",
+  "env": [
+   "MERGE_GATEWAY_API_KEY"
+  ],
+  "id": "merge-gateway",
+  "models": {
+   "anthropic/claude-3-7-sonnet-20250219": {},
+   "anthropic/claude-fable-5": {}
+  },
+  "name": "Merge Gateway",
+  "npm": "merge-gateway-ai-sdk-provider"
+ },
+ "meta": {
+  "api": "https://api.meta.ai/v1",
+  "env": [
+   "META_MODEL_API_KEY"
+  ],
+  "id": "meta",
+  "models": {
+   "muse-spark-1.1": {},
+   "muse-spark-1.2": {}
+  },
+  "name": "Meta",
+  "npm": "@ai-sdk/openai"
+ },
+ "minimax": {
+  "api": "https://api.minimax.io/anthropic/v1",
+  "env": [
+   "MINIMAX_API_KEY"
+  ],
+  "id": "minimax",
+  "models": {
+   "MiniMax-M2": {},
+   "MiniMax-M2.1": {}
+  },
+  "name": "MiniMax (minimax.io)",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "minimax-cn": {
+  "api": "https://api.minimaxi.com/anthropic/v1",
+  "env": [
+   "MINIMAX_API_KEY"
+  ],
+  "id": "minimax-cn",
+  "models": {
+   "MiniMax-M2": {},
+   "MiniMax-M2.1": {}
+  },
+  "name": "MiniMax (minimaxi.com)",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "minimax-cn-coding-plan": {
+  "api": "https://api.minimaxi.com/anthropic/v1",
+  "env": [
+   "MINIMAX_API_KEY"
+  ],
+  "id": "minimax-cn-coding-plan",
+  "models": {
+   "MiniMax-M2": {},
+   "MiniMax-M2.1": {}
+  },
+  "name": "MiniMax Token Plan (minimaxi.com)",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "minimax-coding-plan": {
+  "api": "https://api.minimax.io/anthropic/v1",
+  "env": [
+   "MINIMAX_API_KEY"
+  ],
+  "id": "minimax-coding-plan",
+  "models": {
+   "MiniMax-M2": {},
+   "MiniMax-M2.1": {}
+  },
+  "name": "MiniMax Token Plan (minimax.io)",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "mistral": {
+  "env": [
+   "MISTRAL_API_KEY"
+  ],
+  "id": "mistral",
+  "models": {
+   "codestral-latest": {},
+   "devstral-2512": {}
+  },
+  "name": "Mistral",
+  "npm": "@ai-sdk/mistral"
+ },
+ "mixlayer": {
+  "api": "https://models.mixlayer.ai/v1",
+  "env": [
+   "MIXLAYER_API_KEY"
+  ],
+  "id": "mixlayer",
+  "models": {
+   "qwen/qwen3.5-122b-a10b": {},
+   "qwen/qwen3.5-27b": {}
+  },
+  "name": "Mixlayer",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "moark": {
+  "api": "https://moark.com/v1",
+  "env": [
+   "MOARK_API_KEY"
+  ],
+  "id": "moark",
+  "models": {
+   "GLM-4.7": {},
+   "MiniMax-M2.1": {}
+  },
+  "name": "Moark",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "modal": {
+  "api": "https://inference.us-west.modal.direct/v1",
+  "env": [
+   "MODAL_PROXY_TOKEN"
+  ],
+  "id": "modal",
+  "models": {
+   "Qwen/Qwen3.8-2.4T-A95B": {},
+   "moonshotai/Kimi-K3": {}
+  },
+  "name": "Modal",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "model-oracle-ai": {
+  "api": "https://api.modeloracle.com/api/v1",
+  "env": [
+   "MODEL_ORACLE_API_KEY"
+  ],
+  "id": "model-oracle-ai",
+  "models": {
+   "auto": {},
+   "claude-fable-5": {}
+  },
+  "name": "Model Oracle AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "modelis": {
+  "api": "https://modelishub.com/v1",
+  "env": [
+   "MODELIS_API_KEY"
+  ],
+  "id": "modelis",
+  "models": {
+   "claude-fable-5": {},
+   "claude-opus-4-8": {}
+  },
+  "name": "Modelis",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "modelscope": {
+  "api": "https://api-inference.modelscope.cn/v1",
+  "env": [
+   "MODELSCOPE_API_KEY"
+  ],
+  "id": "modelscope",
+  "models": {
+   "Qwen/Qwen3-235B-A22B-Instruct-2507": {},
+   "Qwen/Qwen3-235B-A22B-Thinking-2507": {}
+  },
+  "name": "ModelScope",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "moonshotai": {
+  "api": "https://api.moonshot.ai/v1",
+  "env": [
+   "MOONSHOT_API_KEY"
+  ],
+  "id": "moonshotai",
+  "models": {
+   "kimi-k2-0711-preview": {},
+   "kimi-k2-0905-preview": {}
+  },
+  "name": "Moonshot AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "moonshotai-cn": {
+  "api": "https://api.moonshot.cn/v1",
+  "env": [
+   "MOONSHOT_API_KEY"
+  ],
+  "id": "moonshotai-cn",
+  "models": {
+   "kimi-k2-0711-preview": {},
+   "kimi-k2-0905-preview": {}
+  },
+  "name": "Moonshot AI (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "morph": {
+  "api": "https://api.morphllm.com/v1",
+  "env": [
+   "MORPH_API_KEY"
+  ],
+  "id": "morph",
+  "models": {
+   "auto": {},
+   "morph-v3-fast": {}
+  },
+  "name": "Morph",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "nano-gpt": {
+  "api": "https://nano-gpt.com/api/v1",
+  "env": [
+   "NANO_GPT_API_KEY"
+  ],
+  "id": "nano-gpt",
+  "models": {
+   "Baichuan4-Air": {},
+   "Baichuan4-Turbo": {}
+  },
+  "name": "NanoGPT",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "nearai": {
+  "api": "https://cloud-api.near.ai/v1",
+  "env": [
+   "NEARAI_API_KEY"
+  ],
+  "id": "nearai",
+  "models": {
+   "Qwen/Qwen3-30B-A3B-Instruct-2507": {},
+   "Qwen/Qwen3-Embedding-0.6B": {}
+  },
+  "name": "NEAR AI Cloud",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "nebius": {
+  "api": "https://api.tokenfactory.nebius.com/v1",
+  "env": [
+   "NEBIUS_API_KEY"
+  ],
+  "id": "nebius",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.5": {},
+   "MiniMaxAI/MiniMax-M2.5-fast": {}
+  },
+  "name": "Nebius Token Factory",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "neon": {
+  "api": "${NEON_AI_GATEWAY_BASE_URL}/v1",
+  "env": [
+   "NEON_AI_GATEWAY_BASE_URL",
+   "NEON_AI_GATEWAY_TOKEN"
+  ],
+  "id": "neon",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Neon",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "neosmith": {
+  "api": "https://router.neosmith.ai/v1",
+  "env": [
+   "NEOSMITH_API_KEY"
+  ],
+  "id": "neosmith",
+  "models": {
+   "neosmith.intelligent-basic": {},
+   "neosmith.intelligent-maestro": {}
+  },
+  "name": "NeoSmith",
+  "npm": "@ai-sdk/openai"
+ },
+ "neuralwatt": {
+  "api": "https://api.neuralwatt.com/v1",
+  "env": [
+   "NEURALWATT_API_KEY"
+  ],
+  "id": "neuralwatt",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-flash-flex": {}
+  },
+  "name": "Neuralwatt",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "nova": {
+  "api": "https://api.nova.amazon.com/v1",
+  "env": [
+   "NOVA_API_KEY"
+  ],
+  "id": "nova",
+  "models": {
+   "nova-2-lite-v1": {},
+   "nova-2-pro-v1": {}
+  },
+  "name": "Nova",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "novita-ai": {
+  "api": "https://api.novita.ai/openai",
+  "env": [
+   "NOVITA_API_KEY"
+  ],
+  "id": "novita-ai",
+  "models": {
+   "baichuan/baichuan-m2-32b": {},
+   "baidu/ernie-4.5-21B-a3b": {}
+  },
+  "name": "NovitaAI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "nvidia": {
+  "api": "https://integrate.api.nvidia.com/v1",
+  "env": [
+   "NVIDIA_API_KEY"
+  ],
+  "id": "nvidia",
+  "models": {
+   "abacusai/dracarys-llama-3.1-70b-instruct": {},
+   "baai/bge-m3": {}
+  },
+  "name": "Nvidia",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "ofox": {
+  "api": "https://api.ofox.ai/v1",
+  "env": [
+   "OFOX_API_KEY"
+  ],
+  "id": "ofox",
+  "models": {
+   "anthropic/claude-fable-5": {},
+   "anthropic/claude-haiku-4.5": {}
+  },
+  "name": "Ofox",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "ollama-cloud": {
+  "api": "https://ollama.com/v1",
+  "env": [
+   "OLLAMA_API_KEY"
+  ],
+  "id": "ollama-cloud",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-flash:0731": {}
+  },
+  "name": "Ollama Cloud",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "openai": {
+  "env": [
+   "OPENAI_API_KEY"
+  ],
+  "id": "openai",
+  "models": {
+   "chatgpt-image-latest": {},
+   "gpt-3.5-turbo": {}
+  },
+  "name": "OpenAI",
+  "npm": "@ai-sdk/openai"
+ },
+ "opencode": {
+  "api": "https://opencode.ai/zen/v1",
+  "env": [
+   "OPENCODE_API_KEY"
+  ],
+  "id": "opencode",
+  "models": {
+   "big-pickle": {},
+   "claude-3-5-haiku": {}
+  },
+  "name": "OpenCode Zen",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "opencode-go": {
+  "api": "https://opencode.ai/zen/go/v1",
+  "env": [
+   "OPENCODE_API_KEY"
+  ],
+  "id": "opencode-go",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-flash-vision-exp": {}
+  },
+  "name": "OpenCode Go",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "openreason": {
+  "api": "https://api.openreason.app/v1",
+  "env": [
+   "OPENREASON_API_KEY"
+  ],
+  "id": "openreason",
+  "models": {
+   "deepseek-ai/deepseek-v4-flash-0731": {},
+   "moonshotai/kimi-k2.7-code": {}
+  },
+  "name": "OpenReason",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "openrouter": {
+  "api": "https://openrouter.ai/api/v1",
+  "env": [
+   "OPENROUTER_API_KEY"
+  ],
+  "id": "openrouter",
+  "models": {
+   "aion-labs/aion-2.0": {},
+   "aion-labs/aion-3.0": {}
+  },
+  "name": "OpenRouter",
+  "npm": "@openrouter/ai-sdk-provider"
+ },
+ "opper": {
+  "api": "https://api.opper.ai/v3/compat",
+  "env": [
+   "OPPER_API_KEY"
+  ],
+  "id": "opper",
+  "models": {
+   "anthropic/claude-fable-5": {},
+   "anthropic/claude-haiku-4-5": {}
+  },
+  "name": "Opper",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "orcarouter": {
+  "api": "https://api.orcarouter.ai/v1",
+  "env": [
+   "ORCAROUTER_API_KEY"
+  ],
+  "id": "orcarouter",
+  "models": {
+   "anthropic/claude-fable-5": {},
+   "anthropic/claude-haiku-4.5": {}
+  },
+  "name": "OrcaRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "ovhcloud": {
+  "api": "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1",
+  "env": [
+   "OVHCLOUD_API_KEY"
+  ],
+  "id": "ovhcloud",
+  "models": {
+   "gpt-oss-120b": {},
+   "gpt-oss-20b": {}
+  },
+  "name": "OVHcloud AI Endpoints",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "pendra": {
+  "api": "https://api.pendra.ai/api/v1",
+  "env": [
+   "PENDRA_API_KEY"
+  ],
+  "id": "pendra",
+  "models": {
+   "deepseek-v4-flash": {},
+   "glm-4.7-flash": {}
+  },
+  "name": "Pendra",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "perplexity": {
+  "env": [
+   "PERPLEXITY_API_KEY"
+  ],
+  "id": "perplexity",
+  "models": {
+   "sonar": {},
+   "sonar-deep-research": {}
+  },
+  "name": "Perplexity",
+  "npm": "@ai-sdk/perplexity"
+ },
+ "perplexity-agent": {
+  "api": "https://api.perplexity.ai/v1",
+  "env": [
+   "PERPLEXITY_API_KEY"
+  ],
+  "id": "perplexity-agent",
+  "models": {
+   "anthropic/claude-haiku-4-5": {},
+   "anthropic/claude-opus-4-5": {}
+  },
+  "name": "Perplexity Agent",
+  "npm": "@ai-sdk/openai"
+ },
+ "pioneer": {
+  "api": "https://api.pioneer.ai/v1",
+  "env": [
+   "PIONEER_API_KEY"
+  ],
+  "id": "pioneer",
+  "models": {
+   "HuggingFaceTB/SmolLM3-3B-Base": {},
+   "LiquidAI/LFM2-24B-A2B": {}
+  },
+  "name": "Pioneer",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "poe": {
+  "api": "https://api.poe.com/v1",
+  "env": [
+   "POE_API_KEY"
+  ],
+  "id": "poe",
+  "models": {
+   "anthropic/claude-haiku-3": {},
+   "anthropic/claude-haiku-3.5": {}
+  },
+  "name": "Poe",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "poolside": {
+  "api": "https://inference.poolside.ai/v1",
+  "env": [
+   "POOLSIDE_API_KEY"
+  ],
+  "id": "poolside",
+  "models": {
+   "poolside/laguna-m.1": {},
+   "poolside/laguna-s-2.1": {}
+  },
+  "name": "Poolside",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "privatemode-ai": {
+  "api": "http://localhost:8080/v1",
+  "env": [
+   "PRIVATEMODE_API_KEY",
+   "PRIVATEMODE_ENDPOINT"
+  ],
+  "id": "privatemode-ai",
+  "models": {
+   "deepseek-ocr-2": {},
+   "gpt-oss-120b": {}
+  },
+  "name": "Privatemode AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "qihang-ai": {
+  "api": "https://api.qhaigc.net/v1",
+  "env": [
+   "QIHANG_API_KEY"
+  ],
+  "id": "qihang-ai",
+  "models": {
+   "claude-haiku-4-5-20251001": {},
+   "claude-opus-4-5-20251101": {}
+  },
+  "name": "QiHang",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "qiniu-ai": {
+  "api": "https://api.qnaigc.com/v1",
+  "env": [
+   "QINIU_API_KEY"
+  ],
+  "id": "qiniu-ai",
+  "models": {
+   "MiniMax-M1": {},
+   "claude-3.5-haiku": {}
+  },
+  "name": "Qiniu",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "qvac": {
+  "env": [
+   "QVAC_API_KEY"
+  ],
+  "id": "qvac",
+  "models": {
+   "gemma4-31b": {},
+   "gpt-oss-120b": {}
+  },
+  "name": "QVAC",
+  "npm": "@qvac/ai-sdk-provider"
+ },
+ "regolo-ai": {
+  "api": "https://api.regolo.ai/v1",
+  "env": [
+   "REGOLO_API_KEY"
+  ],
+  "id": "regolo-ai",
+  "models": {
+   "apertus-70b": {},
+   "brick-complexity-pro": {}
+  },
+  "name": "Regolo AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "requesty": {
+  "api": "https://router.requesty.ai/v1",
+  "env": [
+   "REQUESTY_API_KEY"
+  ],
+  "id": "requesty",
+  "models": {
+   "claude-fable-5": {},
+   "claude-fable-5@eu": {}
+  },
+  "name": "Requesty",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "routing-run": {
+  "api": "https://api.routing.run/v1",
+  "env": [
+   "ROUTING_RUN_API_KEY"
+  ],
+  "id": "routing-run",
+  "models": {
+   "claude-opus-4-8": {},
+   "claude-sonnet-4-6": {}
+  },
+  "name": "routing.run",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "runinfra": {
+  "api": "https://api.runinfra.ai/v1",
+  "env": [
+   "RUNINFRA_GATEWAY_KEY"
+  ],
+  "id": "runinfra",
+  "models": {
+   "Inferact/Qwen3.8-2.4T-A95B-NVFP4": {},
+   "Qwen/Qwen3.8-27B": {}
+  },
+  "name": "RunInfra",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "sakana": {
+  "api": "https://api.sakana.ai/v1",
+  "env": [
+   "SAKANA_API_KEY"
+  ],
+  "id": "sakana",
+  "models": {
+   "fugu": {},
+   "fugu-ultra": {}
+  },
+  "name": "Sakana AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "salad-cloud": {
+  "env": [
+   "SALAD_CLOUD_API_KEY"
+  ],
+  "id": "salad-cloud",
+  "models": {
+   "qwen3.6-35b-a3b": {}
+  },
+  "name": "SaladCloud AI Gateway",
+  "npm": "@saladtechnologies-oss/ai-sdk-provider"
+ },
+ "sap-ai-core": {
+  "env": [
+   "AICORE_SERVICE_KEY"
+  ],
+  "id": "sap-ai-core",
+  "models": {
+   "amazon--nova-lite": {},
+   "amazon--nova-micro": {}
+  },
+  "name": "SAP AI Core",
+  "npm": "@jerome-benoit/sap-ai-provider-v2"
+ },
+ "sarvam": {
+  "api": "https://api.sarvam.ai/v1",
+  "env": [
+   "SARVAM_API_KEY"
+  ],
+  "id": "sarvam",
+  "models": {
+   "sarvam-105b": {},
+   "sarvam-30b": {}
+  },
+  "name": "Sarvam AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "scaleway": {
+  "api": "https://api.scaleway.ai/v1",
+  "env": [
+   "SCALEWAY_API_KEY"
+  ],
+  "id": "scaleway",
+  "models": {
+   "bge-multilingual-gemma2": {},
+   "deepseek-v4-flash-0731": {}
+  },
+  "name": "Scaleway",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "scnet-token-plan": {
+  "api": "https://api.scnet.cn/api/llm/v1",
+  "env": [
+   "SCNET_API_KEY"
+  ],
+  "id": "scnet-token-plan",
+  "models": {
+   "DeepSeek-V3.2": {},
+   "DeepSeek-V4-Flash": {}
+  },
+  "name": "SCNet Token Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "scx-ai": {
+  "api": "https://api.scx.ai/v1",
+  "env": [
+   "SCX_API_KEY"
+  ],
+  "id": "scx-ai",
+  "models": {
+   "GLM-5.2": {},
+   "MiniMax-M2.7": {}
+  },
+  "name": "SCX.ai",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "siliconflow": {
+  "api": "https://api.siliconflow.com/v1",
+  "env": [
+   "SILICONFLOW_API_KEY"
+  ],
+  "id": "siliconflow",
+  "models": {
+   "ByteDance-Seed/Seed-OSS-36B-Instruct": {},
+   "MiniMaxAI/MiniMax-M2.5": {}
+  },
+  "name": "SiliconFlow",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "siliconflow-cn": {
+  "api": "https://api.siliconflow.cn/v1",
+  "env": [
+   "SILICONFLOW_CN_API_KEY"
+  ],
+  "id": "siliconflow-cn",
+  "models": {
+   "ByteDance-Seed/Seed-OSS-36B-Instruct": {},
+   "PaddlePaddle/PaddleOCR-VL-1.5": {}
+  },
+  "name": "SiliconFlow (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "snowflake-cortex": {
+  "api": "https://${SNOWFLAKE_ACCOUNT}.snowflakecomputing.com/api/v2/cortex/v1",
+  "env": [
+   "SNOWFLAKE_ACCOUNT",
+   "SNOWFLAKE_CORTEX_PAT"
+  ],
+  "id": "snowflake-cortex",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Snowflake Cortex",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "stackit": {
+  "api": "https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1",
+  "env": [
+   "STACKIT_API_KEY"
+  ],
+  "id": "stackit",
+  "models": {
+   "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8": {},
+   "Qwen/Qwen3-VL-Embedding-8B": {}
+  },
+  "name": "STACKIT",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "standardcompute": {
+  "api": "https://api.stdcmpt.com/v1",
+  "env": [
+   "STANDARDCOMPUTE_API_KEY"
+  ],
+  "id": "standardcompute",
+  "models": {
+   "standardcompute": {}
+  },
+  "name": "Standard Compute",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "stepfun": {
+  "api": "https://api.stepfun.com/v1",
+  "env": [
+   "STEPFUN_API_KEY"
+  ],
+  "id": "stepfun",
+  "models": {
+   "step-1-32k": {},
+   "step-2-16k": {}
+  },
+  "name": "StepFun (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "stepfun-ai": {
+  "api": "https://api.stepfun.ai/v1",
+  "env": [
+   "STEPFUN_API_KEY"
+  ],
+  "id": "stepfun-ai",
+  "models": {
+   "step-1-32k": {},
+   "step-2-16k": {}
+  },
+  "name": "StepFun (Global)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "stepfun-ai-step-plan": {
+  "api": "https://api.stepfun.ai/step_plan/v1",
+  "env": [
+   "STEPFUN_API_KEY"
+  ],
+  "id": "stepfun-ai-step-plan",
+  "models": {
+   "step-3.5-flash": {},
+   "step-3.5-flash-2603": {}
+  },
+  "name": "StepFun Step Plan (Global)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "stepfun-step-plan": {
+  "api": "https://api.stepfun.com/step_plan/v1",
+  "env": [
+   "STEPFUN_API_KEY"
+  ],
+  "id": "stepfun-step-plan",
+  "models": {
+   "step-3.5-flash": {},
+   "step-3.5-flash-2603": {}
+  },
+  "name": "StepFun Step Plan (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "subconscious": {
+  "api": "https://api.subconscious.dev/v1",
+  "env": [
+   "SUBCONSCIOUS_API_KEY"
+  ],
+  "id": "subconscious",
+  "models": {
+   "subconscious/glm-5.2": {},
+   "subconscious/tim-qwen3.6-27b": {}
+  },
+  "name": "Subconscious",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "submodel": {
+  "api": "https://llm.submodel.ai/v1",
+  "env": [
+   "SUBMODEL_INSTAGEN_ACCESS_KEY"
+  ],
+  "id": "submodel",
+  "models": {
+   "Qwen/Qwen3-235B-A22B-Instruct-2507": {},
+   "Qwen/Qwen3-235B-A22B-Thinking-2507": {}
+  },
+  "name": "submodel",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "synthetic": {
+  "api": "https://api.synthetic.new/openai/v1",
+  "env": [
+   "SYNTHETIC_API_KEY"
+  ],
+  "id": "synthetic",
+  "models": {
+   "hf:MiniMaxAI/MiniMax-M3": {},
+   "hf:Qwen/Qwen3.6-27B": {}
+  },
+  "name": "Synthetic",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "tencent-coding-plan": {
+  "api": "https://api.lkeap.cloud.tencent.com/coding/v3",
+  "env": [
+   "TENCENT_CODING_PLAN_API_KEY"
+  ],
+  "id": "tencent-coding-plan",
+  "models": {
+   "glm-5": {},
+   "hunyuan-2.0-instruct": {}
+  },
+  "name": "Tencent Coding Plan (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "tencent-token-plan": {
+  "api": "https://api.lkeap.cloud.tencent.com/plan/v3",
+  "env": [
+   "TENCENT_TOKEN_PLAN_API_KEY"
+  ],
+  "id": "tencent-token-plan",
+  "models": {
+   "hy3": {},
+   "hy4-preview": {}
+  },
+  "name": "Tencent Token Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "tencent-tokenhub": {
+  "api": "https://tokenhub.tencentmaas.com/v1",
+  "env": [
+   "TENCENT_TOKENHUB_API_KEY"
+  ],
+  "id": "tencent-tokenhub",
+  "models": {
+   "hy3": {},
+   "hy3-preview": {}
+  },
+  "name": "Tencent TokenHub",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "tensorx": {
+  "api": "https://api.tensorx.ai/v1",
+  "env": [
+   "TENSORX_API_KEY"
+  ],
+  "id": "tensorx",
+  "models": {
+   "deepseek/deepseek-chat-v3.1": {},
+   "deepseek/deepseek-r1-0528": {}
+  },
+  "name": "TensorX",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "the-grid-ai": {
+  "api": "https://api.thegrid.ai/v1",
+  "env": [
+   "THEGRID_API_KEY"
+  ],
+  "id": "the-grid-ai",
+  "models": {
+   "agent-max": {},
+   "agent-prime": {}
+  },
+  "name": "The Grid AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "thinkingmachines": {
+  "api": "https://tinker.thinkingmachines.dev/services/tinker-prod/anthropic/api/v1",
+  "env": [
+   "TINKER_API_KEY"
+  ],
+  "id": "thinkingmachines",
+  "models": {
+   "thinkingmachines/Inkling": {},
+   "thinkingmachines/Inkling:peft:262144": {}
+  },
+  "name": "Thinking Machines",
+  "npm": "@ai-sdk/anthropic"
+ },
+ "tinfoil": {
+  "api": "https://inference.tinfoil.sh/v1",
+  "env": [
+   "TINFOIL_API_KEY"
+  ],
+  "id": "tinfoil",
+  "models": {
+   "deepseek-v4-flash": {},
+   "gemma4-31b": {}
+  },
+  "name": "Tinfoil",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "togetherai": {
+  "env": [
+   "TOGETHER_API_KEY"
+  ],
+  "id": "togetherai",
+  "models": {
+   "LiquidAI/LFM2-24B-A2B": {},
+   "MiniMaxAI/MiniMax-M2.5": {}
+  },
+  "name": "Together AI",
+  "npm": "@ai-sdk/togetherai"
+ },
+ "tokengo": {
+  "api": "https://api.tokengo.com/v1",
+  "env": [
+   "TOKENGO_API_KEY"
+  ],
+  "id": "tokengo",
+  "models": {
+   "deepseek/deepseek-v3.1": {},
+   "deepseek/deepseek-v3.2": {}
+  },
+  "name": "TokenGo",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "trustedrouter": {
+  "api": "https://api.trustedrouter.com/v1",
+  "env": [
+   "TRUSTEDROUTER_API_KEY"
+  ],
+  "id": "trustedrouter",
+  "models": {
+   "auto": {},
+   "cheap": {}
+  },
+  "name": "TrustedRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "umans-ai": {
+  "api": "https://api.code.umans.ai/v1",
+  "env": [
+   "UMANS_AI_API_KEY"
+  ],
+  "id": "umans-ai",
+  "models": {
+   "umans-coder": {},
+   "umans-deepseek-v4-flash-0731": {}
+  },
+  "name": "Umans AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "umans-ai-coding-plan": {
+  "api": "https://api.code.umans.ai/v1",
+  "env": [
+   "UMANS_AI_CODING_PLAN_API_KEY"
+  ],
+  "id": "umans-ai-coding-plan",
+  "models": {
+   "umans-coder": {},
+   "umans-deepseek-v4-flash-0731": {}
+  },
+  "name": "Umans AI Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "unorouter": {
+  "api": "https://api.unorouter.com/v1",
+  "env": [
+   "UNOROUTER_API_KEY"
+  ],
+  "id": "unorouter",
+  "models": {
+   "claude-haiku-4-5-20251001": {},
+   "claude-opus-4-8": {}
+  },
+  "name": "UnoRouter",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "upstage": {
+  "api": "https://api.upstage.ai/v1/solar",
+  "env": [
+   "UPSTAGE_API_KEY"
+  ],
+  "id": "upstage",
+  "models": {
+   "solar-mini": {},
+   "solar-pro2": {}
+  },
+  "name": "Upstage",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "v0": {
+  "env": [
+   "V0_API_KEY"
+  ],
+  "id": "v0",
+  "models": {
+   "v0-1.0-md": {},
+   "v0-1.5-lg": {}
+  },
+  "name": "v0",
+  "npm": "@ai-sdk/vercel"
+ },
+ "vancine": {
+  "api": "https://vancine.com/v1",
+  "env": [
+   "VANCINE_API_KEY"
+  ],
+  "id": "vancine",
+  "models": {
+   "MiniMax-M3": {},
+   "deepseek-v4-flash": {}
+  },
+  "name": "Vancine",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "venice": {
+  "env": [
+   "VENICE_API_KEY"
+  ],
+  "id": "venice",
+  "models": {
+   "aion-labs-aion-3-0": {},
+   "aion-labs-aion-3-0-mini": {}
+  },
+  "name": "Venice AI",
+  "npm": "venice-ai-sdk-provider"
+ },
+ "vercel": {
+  "env": [
+   "AI_GATEWAY_API_KEY"
+  ],
+  "id": "vercel",
+  "models": {
+   "alibaba/qwen-3-14b": {},
+   "alibaba/qwen-3-235b": {}
+  },
+  "name": "Vercel AI Gateway",
+  "npm": "@ai-sdk/gateway"
+ },
+ "vivgrid": {
+  "api": "https://api.vivgrid.com/v1",
+  "env": [
+   "VIVGRID_API_KEY"
+  ],
+  "id": "vivgrid",
+  "models": {
+   "deepseek-v3.2": {},
+   "deepseek-v4-flash": {}
+  },
+  "name": "Vivgrid",
+  "npm": "@ai-sdk/openai"
+ },
+ "volcengine": {
+  "api": "https://ark.cn-beijing.volces.com/api/v3",
+  "env": [
+   "ARK_API_KEY"
+  ],
+  "id": "volcengine",
+  "models": {
+   "deepseek-v4-flash-ga-260731": {},
+   "deepseek-v4-pro-ga-260813": {}
+  },
+  "name": "Volcengine Ark",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "volcengine-coding-plan": {
+  "api": "https://ark.cn-beijing.volces.com/api/coding/v3",
+  "env": [
+   "ARK_CODING_PLAN_API_KEY"
+  ],
+  "id": "volcengine-coding-plan",
+  "models": {
+   "deepseek-v4-flash": {},
+   "deepseek-v4-pro": {}
+  },
+  "name": "Volcengine Ark Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "vultr": {
+  "api": "https://api.vultrinference.com/v1",
+  "env": [
+   "VULTR_API_KEY"
+  ],
+  "id": "vultr",
+  "models": {
+   "MiniMaxAI/MiniMax-M2.7": {},
+   "Qwen/Qwen3.5-397B-A17B": {}
+  },
+  "name": "Vultr",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "wafer.ai": {
+  "api": "https://pass.wafer.ai/v1",
+  "env": [
+   "WAFER_API_KEY"
+  ],
+  "id": "wafer.ai",
+  "models": {
+   "GLM-5.1": {},
+   "GLM-5.2": {}
+  },
+  "name": "Wafer",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "wandb": {
+  "api": "https://api.inference.wandb.ai/v1",
+  "env": [
+   "WANDB_API_KEY"
+  ],
+  "id": "wandb",
+  "models": {
+   "JetBrains/Mellum2-12B-A2.5B-Instruct": {},
+   "MiniMaxAI/MiniMax-M3": {}
+  },
+  "name": "Weights & Biases",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "watsonx": {
+  "env": [
+   "WATSONX_AI_APIKEY",
+   "WATSONX_AI_PROJECT_ID"
+  ],
+  "id": "watsonx",
+  "models": {
+   "ibm/granite-4-h-small": {},
+   "meta-llama/llama-3-3-70b-instruct": {}
+  },
+  "name": "watsonx.ai",
+  "npm": "watsonx-ai-provider"
+ },
+ "xai": {
+  "env": [
+   "XAI_API_KEY"
+  ],
+  "id": "xai",
+  "models": {
+   "grok-4.20-0309-non-reasoning": {},
+   "grok-4.20-0309-reasoning": {}
+  },
+  "name": "xAI",
+  "npm": "@ai-sdk/xai"
+ },
+ "xiaomi": {
+  "api": "https://api.xiaomimimo.com/v1",
+  "env": [
+   "XIAOMI_API_KEY"
+  ],
+  "id": "xiaomi",
+  "models": {
+   "mimo-v2-flash": {},
+   "mimo-v2-omni": {}
+  },
+  "name": "Xiaomi",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "xiaomi-token-plan-ams": {
+  "api": "https://token-plan-ams.xiaomimimo.com/v1",
+  "env": [
+   "XIAOMI_API_KEY"
+  ],
+  "id": "xiaomi-token-plan-ams",
+  "models": {
+   "mimo-v2-pro": {},
+   "mimo-v2-tts": {}
+  },
+  "name": "Xiaomi Token Plan (Europe)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "xiaomi-token-plan-cn": {
+  "api": "https://token-plan-cn.xiaomimimo.com/v1",
+  "env": [
+   "XIAOMI_API_KEY"
+  ],
+  "id": "xiaomi-token-plan-cn",
+  "models": {
+   "mimo-v2-pro": {},
+   "mimo-v2-tts": {}
+  },
+  "name": "Xiaomi Token Plan (China)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "xiaomi-token-plan-sgp": {
+  "api": "https://token-plan-sgp.xiaomimimo.com/v1",
+  "env": [
+   "XIAOMI_API_KEY"
+  ],
+  "id": "xiaomi-token-plan-sgp",
+  "models": {
+   "mimo-v2-pro": {},
+   "mimo-v2-tts": {}
+  },
+  "name": "Xiaomi Token Plan (Singapore)",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "xpersona": {
+  "api": "https://www.xpersona.co/v1",
+  "env": [
+   "XPERSONA_API_KEY"
+  ],
+  "id": "xpersona",
+  "models": {
+   "claude-fable-5": {},
+   "claude-haiku-4-5": {}
+  },
+  "name": "Xpersona",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zai": {
+  "api": "https://api.z.ai/api/paas/v4",
+  "env": [
+   "ZHIPU_API_KEY"
+  ],
+  "id": "zai",
+  "models": {
+   "glm-4.5": {},
+   "glm-4.5-air": {}
+  },
+  "name": "Z.AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zai-coding-plan": {
+  "api": "https://api.z.ai/api/coding/paas/v4",
+  "env": [
+   "ZHIPU_API_KEY"
+  ],
+  "id": "zai-coding-plan",
+  "models": {
+   "glm-4.7": {},
+   "glm-5-turbo": {}
+  },
+  "name": "Z.AI Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zeldoc": {
+  "api": "https://api.zeldoc.ai/v1",
+  "env": [
+   "ZELDOC_API_KEY"
+  ],
+  "id": "zeldoc",
+  "models": {
+   "zdev": {}
+  },
+  "name": "Zeldoc",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zenifra": {
+  "api": "https://ai.zenifra.com/v1",
+  "env": [
+   "ZENIFRA_AI_KEY"
+  ],
+  "id": "zenifra",
+  "models": {
+   "alibaba/qwen3.6-35b-a3b": {}
+  },
+  "name": "Zenifra",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zenmux": {
+  "api": "https://zenmux.ai/api/v1",
+  "env": [
+   "ZENMUX_API_KEY"
+  ],
+  "id": "zenmux",
+  "models": {
+   "anthropic/claude-3.5-haiku": {},
+   "anthropic/claude-3.7-sonnet": {}
+  },
+  "name": "ZenMux",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zhipuai": {
+  "api": "https://open.bigmodel.cn/api/paas/v4",
+  "env": [
+   "ZHIPU_API_KEY"
+  ],
+  "id": "zhipuai",
+  "models": {
+   "glm-4.5": {},
+   "glm-4.5-air": {}
+  },
+  "name": "Zhipu AI",
+  "npm": "@ai-sdk/openai-compatible"
+ },
+ "zhipuai-coding-plan": {
+  "api": "https://open.bigmodel.cn/api/coding/paas/v4",
+  "env": [
+   "ZHIPU_API_KEY"
+  ],
+  "id": "zhipuai-coding-plan",
+  "models": {
+   "glm-4.6v": {},
+   "glm-4.7": {}
+  },
+  "name": "Zhipu AI Coding Plan",
+  "npm": "@ai-sdk/openai-compatible"
+ }
+}


### PR DESCRIPTION
## What

`llmman launch` could only point an integration at a model llmman serves itself. `--provider` extends it to hosted models, resolved from the same [models.dev](https://models.dev) catalog `opencode` uses:

```
export OPENROUTER_API_KEY=...
llmman launch opencode --provider openrouter --model qwen/qwen3-coder
```

`llmman launch --list-providers` prints what's available, with each provider's API-key variable and whether it's set.

## Design decisions

**The catalog is fetched at runtime, not hardcoded.** opencode doesn't hardcode its providers either — it GETs `api.json` and caches it. Same here, so a provider models.dev gains tomorrow works without an llmman release. Cached 24h (written through a temp file and a rename, since `launch` and `serve` refresh it independently), with a stale copy used if the fetch fails, so being offline degrades to an out-of-date list rather than a broken command. There is deliberately no URL override: the catalog has one source, and an override is a way to point llmman at a list that disagrees with the rules its routing was written against.

**Requests still go through `llmman serve`.** `--provider` changes where the daemon forwards them, not who the integration talks to. One endpoint and one place integrations are configured whether a model is local or hosted, and both usable from the same session.

**Only providers llmman can be sure it reaches are offered.** The daemon speaks one thing upstream: an OpenAI Chat Completions POST with `Authorization: Bearer`. An entry qualifies only if its `npm` driver is OpenAI-wire-format, it has one concrete `https` base URL, and one API-key variable — **175 of today's 207**. The rest (Bedrock's SigV4, Vertex's GCP credentials, Azure's per-account endpoints, the `@ai-sdk/anthropic` gateways, GitHub Copilot's OAuth token exchange, and the loopback entries llmman serves itself anyway) are absent rather than half-supported. A small `BUILTIN_ENDPOINTS` table supplies the endpoint for the 13 majors models.dev leaves `api` unset for; it is not a second registry, since an entry still has to be in the fetched catalog to be offered.

**Provider-routed references are namespaced under `llmman.provider/`.** The bare `<provider>/<model>` spelling opencode uses is ambiguous here: llmman also resolves two-segment names as HuggingFace repos, so routing on a bare prefix would silently capture `google/gemma-3`, `openai/gpt-oss-120b` and every other real `hf.co/<org>/<repo>` whose org shares a provider's name. Covered by a regression test.

**The API key travels per request**, in the integration's own `Authorization`/`x-api-key` header, falling back to the daemon's environment. That's what makes this work against an *already-running* daemon — the common case, since `ensure_server` reuses a live one — and means the key is never persisted. The `llmman` placeholder locally-served integrations get is explicitly not a credential, so it's never forwarded to a real provider.

## Implementation

- **`src/providers.rs`** (new) — catalog fetch, cache, and the reachability filter, plus the reference encoding.
- **`src/cmd/serve.rs`** — what was a bare `u16` loopback port is now a `Target`: that same local backend, or a remote provider. The four functions that actually send a request build their URL and attach credentials through it. `/api/show` answers for provider-routed refs so `ensure_model_pulled` doesn't try to pull one, and preload skips them.
- **`src/cmd/launch.rs`** — the flag, the resolved key handed to the integration, and validation that fails in llmman's own output (naming the missing variable, suggesting near-miss provider ids, listing example models) before the integration takes over the terminal.

## Behavior without `--provider` is unchanged

`Target::Local` produces byte-for-byte the same loopback URLs, models resolve exactly as before, no credential is attached, a local backend's failures keep the status they always returned, and the llama-server request fixups (`repeat_penalty`, `/v1/responses` tool filtering) still apply exactly as before. Covered by tests.

## Testing

- Lib tests, `cargo fmt --check`, and `--features podman --no-default-features` all clean; `launch_e2e` still compiles.
- **54 new unit tests.** The filter rules are pinned one fixture each, then run together against a real trimmed `api.json` (`tests/fixtures/`) — that last one asserts the majors come out at the right endpoints, the unreachable categories stay out, and every offered provider has an https, non-templated, non-trailing-slash URL and a key variable. Also URL re-basing for `/v1`, `/v1beta/openai` and bare-host providers, header key extraction and its placeholder/non-bearer guards, prefix round-tripping, the HuggingFace-collision regression, and a real HTTP round trip asserting what a provider actually receives.
- **Manually verified** every `BUILTIN_ENDPOINTS` URL answers `POST /chat/completions` with a bearer token (13/13 return 401/400, i.e. the route exists and parsed the request), and each error path (`--list-providers`, unknown provider, missing `--model`, missing key, unlisted model) in llmman's own output.

I did not add a `launch_e2e` case, since that suite drives real integration binaries against real models — happy to add one if you'd like it there.

## Since review

Two rounds. The first addressed the CodeRabbit/Copilot comments plus a self-review against opencode's own `models-dev.ts`; the second addressed Copilot's re-review.

**Round 1**
- Provider endpoints must be `https` — the catalog is fetched at runtime, so an `http://` entry upstream would have been enough to put a key on the wire in the clear.
- The catalog is parsed per entry, so one malformed upstream record costs that provider rather than the whole list.
- No longer memoized for the life of the process: a success is re-checked after 24h and a failure retried after 60s.
- Cache writes go through a temp file and a rename, as opencode's do — `launch` and `serve` refresh it independently and a plain write leaves a torn-read window.
- **Dropped the `v0` builtin**: nothing answers at its documented `https://api.v0.dev/v1` (404, where the other 13 return 401/400), so llmman had no endpoint it could vouch for.
- `repeat_penalty` (a llama.cpp extension) is dropped for remote requests — OpenAI rejects unrecognized arguments outright.
- A provider's own 4xx passes through instead of being buried in llmman's blanket 500, and errors name the provider rather than "llama-server". A bad key reads as 401, not "internal server error".
- The resolved provider key is handed to the integration rather than the `llmman` placeholder, so `--provider` works against an already-running daemon. Integrations configured through a file on disk keep the placeholder rather than persist a credential.
- `/v1/audio/transcriptions` refuses a provider-routed model instead of forwarding a multipart body whose `model` field the provider has never heard of.
- `RemoteTarget`'s `Debug` redacts the key; `client_api_key` filters each header before choosing between them; the URL re-basing rule lives in one place.
- Corrected a factual claim: opencode fetches `models.opencode.ai/api.json`, its own mirror — byte-identical to `models.dev`'s today (I diffed them), but not "the same source".

**Round 2**
- `load()` fell back to a stale cache and reported plain success, so a transient outage was cached for 24h rather than retried after 60s. It now distinguishes `Fresh` from `Stale`, and stale gets a failure's short lifetime.
- Fetch and parse are one refresh step: a 200 carrying a truncated body or a captive portal's HTML now reaches the stale cache instead of failing outright.
- `/v1/responses` sanitization is local-only. `filter_non_function_tools`/`consolidate_responses_instructions` work around what *llama-server* rejects, and ran before the target was known — a provider with native Responses support silently lost `web_search` and every other non-function tool.
- The daemon no longer spends its own key for callers it cannot authenticate: with a non-loopback bind, the environment fallback is not consulted and the 401 says so.
- `--provider` requires a loopback daemon, since with a remote `LLMMAN_HOST` the key would cross the network in cleartext. Two different questions, so two predicates — `connects_over_loopback` (is *our* hop local; a wildcard bind counts) gates launch, `reachable_only_locally` (can anyone *else* reach this daemon; a wildcard bind does not) gates the server-side fallback — with a test on the distinction.
- `--provider` refuses `cline`, `kimi` and `copilot` rather than launching a configuration that cannot work: the first two select their own model, and `copilot` cannot carry a key.


**Round 3**
- `bailing`'s `api` is a full route rather than a base URL (`.../v1/chat/completions`), so every request to it would have gone to `.../chat/completions/chat/completions`. It is the only such entry in the live catalog today; `base_url_of` normalizes the suffix away, and a test walks the whole real fixture asserting no provider can build a doubled route.
- `Bearer` is matched case-insensitively (RFC 7235) — a client sending `bearer` had its key silently dropped, with no fallback on a daemon that won't use its own.
- `--provider` refuses `hermes`/`openclaw` on a wildcard bind: they are configured through a file so they send the placeholder, and the daemon won't spend its own key for a caller anyone could be. That combination used to 401 from inside the integration.
- The three proxy helpers name the actual target instead of blaming `llama-server` for a provider failure.
- The locality predicates delegate to host-taking forms so the test exercises them directly, rather than the private pieces they were built from.
- README fence labelled `sh` (MD040).


**Round 4**
- An empty catalog after filtering counted as a successful refresh. `{"error":"temporarily unavailable"}` is valid JSON and a valid map, so llmman would have overwritten a good cache with nothing and memoized it for 24h. `from_json` now errors when nothing is routable, so the stale copy survives.
- `github-copilot` excluded: it advertises `@ai-sdk/openai-compatible` + `GITHUB_TOKEN`, but that bearer 401s against `api.githubcopilot.com` — opencode trades it through `login/oauth/access_token` first. Providers that only add optional attribution headers (`kilo`, `openrouter`, ...) are unaffected.
- Cross-site requests no longer reach the daemon-environment key: CORS gates reading a reply, not sending a request, and these handlers never check `Content-Type`, so a page the user merely visits could have spent their provider credits. Gated on `Sec-Fetch-Site`, which browsers always send and CLI integrations never do.
- `gemini` refused for `--provider`: its key feeds a native Google client, and being wrong about `GEMINI_BASE_URL` would send a third-party key to Google. The placeholder was harmless either way; a real key is not.
- Declined the Windows `fs::rename` report — `std::fs::rename` is documented to replace an existing destination, via `MoveFileExW`/`SetFileInformationByHandle`.


**Round 5**
- `openclaw` refused for `--provider`: `launch_openclaw` passes `--custom-model-id` only through first-run onboarding, so every later launch would quietly reuse the old model instead of the provider reference.
- The Responses-API gap turned out to be concrete, and I was wrong to wave it off in round 1. Probing it: `anthropic` and `mistral` 404 on `/v1/responses`, `openai`/`groq`/`openrouter` answer it — so `llmman launch codex --provider anthropic` failed on its first request with a bare 404. Rather than hardcode a capability list models.dev cannot back (and that would be wrong the week a provider ships the route), llmman now reports the 404 it actually received as a 501 naming the provider and what it is missing.


**Round 6**
- `explain_missing_route` ignored its `route` argument (a bug from round 5), so any provider 404 — an unknown model on `/v1/chat/completions`, say — would have been rewritten as "lacks the Responses API". Now gated on the route, with tests covering the other routes and statuses passing through untouched.
- `/v1/responses/input_tokens` goes through the other proxy helper and bypassed that handling entirely; both are wired up now.
- The `hermes` key check was the wrong check: requiring the key in the launching shell rejected a good daemon that has it, while having it there guaranteed nothing about the daemon. For integrations that cannot carry a key it is now a warning naming the daemon requirement; ones that can still fail fast.
- Stopped implying the loopback check is authentication. It bounds the blast radius — network-reachable binds and cross-site browser requests get nothing — but any local account on a shared machine can already reach a loopback daemon for everything else it does. Comment and README now say so and point at per-request keys.
