### PR TITLE
fix: clear clippy warnings across the tree

### DIFF
--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -45,7 +45,7 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
     let model = args
         .model
         .as_deref()
-        .map(|m| crate::shortnames::resolve_ollama_api(m))
+        .map(crate::shortnames::resolve_ollama_api)
         .unwrap_or_default();
 
     // Ensure serve is running (start it in background if needed), preloading

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -43,11 +43,10 @@ pub fn run(args: &ListArgs) -> anyhow::Result<()> {
         .max(4);
 
     println!(
-        "{:<name_w$}    {:<16}    {:<10}    {}",
+        "{:<name_w$}    {:<16}    {:<10}    MODIFIED",
         "NAME",
         "ID",
         "SIZE",
-        "MODIFIED",
         name_w = name_w,
     );
 

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -736,8 +736,8 @@ mod unix_readline {
             raw.c_lflag &= !(libc::ECHO | libc::ECHONL | libc::ICANON | libc::ISIG | libc::IEXTEN);
             raw.c_cflag &= !(libc::CSIZE | libc::PARENB);
             raw.c_cflag |= libc::CS8;
-            raw.c_cc[libc::VMIN as usize] = 1;
-            raw.c_cc[libc::VTIME as usize] = 0;
+            raw.c_cc[libc::VMIN] = 1;
+            raw.c_cc[libc::VTIME] = 0;
             raw
         }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2764,7 +2764,7 @@ async fn proxy(
         req = req.header("content-type", ct);
     }
     let resp = req.send().await.context("proxy request to llama-server")?;
-    let status = reqwest::StatusCode::from(resp.status());
+    let status = resp.status();
     let resp_headers = resp.headers().clone();
 
     // Moved into the stream below (see ActivityGuard's doc comment) so it
@@ -2881,7 +2881,7 @@ async fn proxy_rewriting_model(
         req = req.header("content-type", ct);
     }
     let resp = req.send().await.context("proxy request to llama-server")?;
-    let status = reqwest::StatusCode::from(resp.status());
+    let status = resp.status();
     let resp_headers = resp.headers().clone();
     let raw = resp
         .bytes()
@@ -2929,7 +2929,7 @@ async fn stream_rewriting_model(
         req = req.header("content-type", ct);
     }
     let resp = req.send().await.context("proxy request to llama-server")?;
-    let status = reqwest::StatusCode::from(resp.status());
+    let status = resp.status();
     // Only content-type is meaningful to forward for a stream the
     // caller is about to reconstruct line by line — content-length
     // (absent anyway for a real chunked/streamed response) would be

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -818,7 +818,7 @@ mod tests {
         // context; a 1GiB LLMMAN_GPU_OVERHEAD knocks it back under the
         // 47GiB threshold into the capped 32768 tier.
         let vram = 47 * GIB;
-        let overhead = 1 * GIB;
+        let overhead = GIB;
         assert_eq!(default_ctx_size_for(vram), None);
         assert_eq!(
             default_ctx_size_for(vram.saturating_sub(overhead)),

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -228,9 +228,8 @@ pub fn resolve_model(
     }
 
     // ── safetensors → vllm / mlx_lm.server ──────────────────────────────
-    if manifest.layers.iter().any(|l| is_safetensors_layer(l)) {
-        let model_dir =
-            extract_safetensors_dir(&store, store_path, cache_path, &desc.digest, &manifest)?;
+    if manifest.layers.iter().any(is_safetensors_layer) {
+        let model_dir = extract_safetensors_dir(store_path, cache_path, &desc.digest, &manifest)?;
         return Ok(ModelPath::SafeTensors(model_dir));
     }
 
@@ -254,7 +253,6 @@ pub fn resolve_model(
 /// Extract CNCF-format safetensors layers to a cache directory and return the
 /// model directory (parent of `config.json`).
 fn extract_safetensors_dir(
-    store: &OciStore,
     store_path: &Path,
     cache_path: &Path,
     manifest_digest: &str,

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -3,7 +3,6 @@
 /// Each constant holds the raw gzip-compressed bytes for the corresponding
 /// file from the `webui/` directory.  Serve them with the headers
 /// `Content-Encoding: gzip` and the appropriate `Content-Type`.
-
 pub static INDEX_HTML: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/index.html.gz"));
 
 pub static BUNDLE_JS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/bundle.js.gz"));


### PR DESCRIPTION
Clears every clippy warning that had a one line fix: redundant closures, no-op casts and conversions, an unused parameter, a stray blank line, and an empty format literal. No behavior change, and main goes from 15 warnings down to 4.