### PR TITLE
fix(ci): run the unit tests that the bin target no longer holds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
           if-no-files-found: error
 
   # --------------------------------------------------------------------------
-  # Unit tests: every #[cfg(test)] module under src/ (`cargo test --bin`,
-  # since this crate has no lib target — see Cargo.toml). These are pure-
+  # Unit tests: every #[cfg(test)] module under src/, which live in the
+  # lib target and the llmman-bench binary. These are pure-
   # Rust logic tests with no OS-specific behavior, but the crate itself
   # still links the Go shim via CGO, so a target-specific toolchain issue
   # (the exact kind the `build`/`e2e` jobs' own git history is full of —
@@ -288,8 +288,8 @@ jobs:
       # comment on cargo test compiling its own separate test binary,
       # which links against the same Go-shim-produced llmman_shim.lib the
       # main binary does and hit the exact same lld-link requirement.
-      - name: cargo test --bin llmman
-        run: cargo test --release --target ${{ matrix.target }} --bin llmman
+      - name: cargo test --lib --bins
+        run: cargo test --release --target ${{ matrix.target }} --lib --bins
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
 

--- a/src/llama_release.rs
+++ b/src/llama_release.rs
@@ -459,7 +459,12 @@ impl DownloadMarker {
     /// download from a crashed one whose Drop never ran.
     fn touch(&self) {
         if let Some(path) = &self.0 {
+            // Windows keeps the old mtime when a write is zero bytes,
+            // so set it explicitly.
             let _ = std::fs::write(path, b"");
+            if let Ok(file) = std::fs::File::options().write(true).open(path) {
+                let _ = file.set_modified(std::time::SystemTime::now());
+            }
         }
     }
 }


### PR DESCRIPTION
The unit test job ran `cargo test --bin llmman`, which has run 0 tests since the lib target was added: every `#[cfg(test)]` module moved into the lib, so the bin target has none left. `--lib --bins` runs all 341 of them again.

With the tests running, the Windows legs failed on the download marker: `touch` writes zero bytes, and a zero byte write does not move the mtime on Windows, so a long download looked stale and got stopped part way through. It now sets the mtime explicitly.

The daemon process group fix that was here before is dropped, #317 covers it.
