### PR TITLE
fix: release docker-backend binaries; fix podman login/logout segfault

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,16 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
 
+      # Both builds share an output path (same package, same triple, only
+      # feature flags differ), so the podman build below overwrites this
+      # one — which shipped every non-Windows release asset as a podman
+      # binary labelled as docker. Copy it out of reach first.
+      - name: Stage docker binary
+        shell: bash
+        run: |
+          mkdir -p dist-docker
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "dist-docker/${{ matrix.binary }}"
+
       # ── Build (Podman backend) ────────────────────────────────────────────
       # Skipped on Windows: containers/image has no Windows support.
       - name: Build (podman backend)
@@ -143,6 +153,25 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }} --no-default-features --features podman
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
+
+      # Fail rather than ship a mislabelled binary if those paths ever
+      # collide again. Go embeds each function's source path, and the two
+      # backends' build tags are mutually exclusive, so this checks the
+      # artifact itself rather than the flags meant to build it.
+      # grep -a, not strings(1): Git Bash on Windows ships no strings.
+      - name: Verify staged binary is the docker backend
+        shell: bash
+        run: |
+          bin="dist-docker/${{ matrix.binary }}"
+          if ! grep -aq "go-shim/backend_docker.go" "$bin"; then
+            echo "::error::$bin is not a docker-backend build (no backend_docker.go symbols)"
+            exit 1
+          fi
+          if grep -aq "go-shim/backend_podman.go" "$bin"; then
+            echo "::error::$bin contains podman-backend symbols; the podman build clobbered it"
+            exit 1
+          fi
+          echo "OK: $bin is a docker-backend build"
 
       # ── Diagnostics: inspect the Go shim library on Windows ARM64 ───────────
       - name: Inspect shim library (Windows aarch64)
@@ -163,7 +192,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: llmman-docker-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/${{ matrix.binary }}
+          path: dist-docker/${{ matrix.binary }}
           if-no-files-found: error
 
   # --------------------------------------------------------------------------

--- a/go-shim/backend_podman.go
+++ b/go-shim/backend_podman.go
@@ -58,33 +58,54 @@ func insecurePolicy() (*signature.PolicyContext, error) {
 //
 //export llmman_login
 func llmman_login(cServer, cUsername, cPassword *C.char) *C.char {
-	server := C.GoString(cServer)
-	username := C.GoString(cUsername)
-	password := C.GoString(cPassword)
+	if err := podmanLogin(context.Background(), C.GoString(cServer), C.GoString(cUsername), C.GoString(cPassword)); err != nil {
+		return errResp(err)
+	}
+	return okResp("")
+}
 
+// podmanLogin is llmman_login's implementation, factored out so a test
+// can reach it — Go forbids cgo in _test.go files.
+//
+// Stdout must be set: commonauth.Login writes to it unchecked on the
+// success path, so leaving it nil panicked *after* the credentials were
+// already written. io.Discard, not os.Stdout, because the Rust caller
+// (src/cmd/login.rs) prints its own success line.
+func podmanLogin(ctx context.Context, server, username, password string) error {
 	sys := &types.SystemContext{}
 	opts := &commonauth.LoginOptions{
 		Username: username,
 		Password: password,
+		Stdout:   io.Discard,
 	}
-	if err := commonauth.Login(context.Background(), sys, opts, []string{server}); err != nil {
-		return errResp(fmt.Errorf("login: %w", err))
+	if err := commonauth.Login(ctx, sys, opts, []string{server}); err != nil {
+		return fmt.Errorf("login: %w", err)
 	}
-	return okResp("")
+	return nil
 }
 
 // llmman_logout removes credentials for a registry.
 //
 //export llmman_logout
 func llmman_logout(cServer *C.char) *C.char {
-	server := C.GoString(cServer)
-
-	sys := &types.SystemContext{}
-	opts := &commonauth.LogoutOptions{All: false}
-	if err := commonauth.Logout(sys, opts, []string{server}); err != nil {
-		return errResp(fmt.Errorf("logout: %w", err))
+	if err := podmanLogout(C.GoString(cServer)); err != nil {
+		return errResp(err)
 	}
 	return okResp("")
+}
+
+// podmanLogout is llmman_logout's implementation. Factored out, and
+// needing Stdout set, for the same reasons as podmanLogin above.
+func podmanLogout(server string) error {
+	sys := &types.SystemContext{}
+	opts := &commonauth.LogoutOptions{
+		All:    false,
+		Stdout: io.Discard,
+	}
+	if err := commonauth.Logout(sys, opts, []string{server}); err != nil {
+		return fmt.Errorf("logout: %w", err)
+	}
+	return nil
 }
 
 // llmman_push pushes an image from a local OCI layout to a registry.
@@ -743,6 +764,3 @@ func llmman_transfer(cSource, cDestination *C.char) *C.char {
 	}
 	return okResp(transferStatusUnchanged)
 }
-
-// Ensure io is used (imported via shared helpers but referenced here for the build)
-var _ = io.Discard

--- a/go-shim/backend_podman_auth_test.go
+++ b/go-shim/backend_podman_auth_test.go
@@ -1,0 +1,52 @@
+//go:build podman
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPodmanLogoutDoesNotPanicOnSuccess guards the nil-Stdout crash.
+// Logout, not Login, because only its success path is reachable offline:
+// it needs just an auth file holding a credential, whereas Login's needs
+// a real docker.CheckAuth round-trip. Same bug in both.
+func TestPodmanLogoutDoesNotPanicOnSuccess(t *testing.T) {
+	const registry = "registry.example.com"
+	authFile := filepath.Join(t.TempDir(), "auth.json")
+
+	body, err := json.Marshal(map[string]any{
+		"auths": map[string]any{
+			registry: map[string]string{
+				"auth": base64.StdEncoding.EncodeToString([]byte("user:pass")),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal auth file: %v", err)
+	}
+	if err := os.WriteFile(authFile, body, 0o600); err != nil {
+		t.Fatalf("write auth file: %v", err)
+	}
+	// The only way to aim podmanLogout, which builds its own empty
+	// SystemContext, at a throwaway file rather than the real one.
+	t.Setenv("REGISTRY_AUTH_FILE", authFile)
+
+	// Before the fix this did not return: the test binary aborted with a
+	// nil-pointer dereference inside auth.Logout.
+	if err := podmanLogout(registry); err != nil {
+		t.Fatalf("podmanLogout(%q): %v", registry, err)
+	}
+
+	after, err := os.ReadFile(authFile)
+	if err != nil {
+		t.Fatalf("read auth file back: %v", err)
+	}
+	if strings.Contains(string(after), registry) {
+		t.Fatalf("credentials for %s still present after logout: %s", registry, after)
+	}
+}

--- a/go-shim/hf_range_get_test.go
+++ b/go-shim/hf_range_get_test.go
@@ -1,3 +1,8 @@
+// hfGetBytes lives in transfer_docker.go, which is itself !podman —
+// without a matching tag this package's tests fail to compile under
+// -tags podman ("undefined: hfGetBytes").
+//go:build !podman
+
 package main
 
 import (


### PR DESCRIPTION
Two fixes: the released Linux/macOS binaries are podman builds labelled as docker, and podman-backend `login`/`logout` segfault.

## 1. The podman build clobbers the released docker binary

`Build (docker backend)` and `Build (podman backend)` are the same package and target triple, differing only in feature flags, so cargo writes both to `target/<triple>/release/<binary>`. The podman step runs second and replaces the docker binary; the upload step then publishes that as `llmman-docker-<triple>`, which the release job attaches as `llmman-<triple>`.

So every released non-Windows asset — what `install.sh` serves — is a **podman binary labelled as docker**. Go embeds each function's source path in the binary, so this is checkable against the current release:

| asset | `backend_podman.go` | `backend_docker.go` |
|---|---|---|
| `llmman-x86_64-unknown-linux-gnu` | 1 | 0 |
| `llmman-aarch64-unknown-linux-gnu` | 1 | 0 |
| `llmman-aarch64-apple-darwin` | 1 | 0 |
| `llmman-x86_64-pc-windows-msvc.exe` | 0 | 2 |

Windows is the exception and the tell: the only platform that skips the podman build, and the only one whose asset genuinely contains the docker backend.

**Fix:** stage the docker binary to `dist-docker/` between the two builds and upload from there, plus a step that fails the build if the staged binary carries the wrong backend's symbols — checking the artifact itself, not the flags meant to produce it. Tested against the real assets above and against locally built binaries of both backends: rejects podman, accepts docker.

## 2. `login`/`logout` segfault on the podman backend

`commonauth.Login` and `Logout` both write their success message to `opts.Stdout` with no nil check (`pkg/auth/auth.go:214` and `:370`). `backend_podman.go` never set it:

```
$ llmman login <registry> --username u --password p
panic: runtime error: invalid memory address or nil pointer dereference
fmt.Fprintln({0x0, 0x0}, ...)
go.podman.io/common/pkg/auth.Login(...)   pkg/auth/auth.go:214
main.llmman_login(...)                    go-shim/backend_podman.go:70
```

It fires on the **success** path, which made it misleading: the credentials were already checked against the registry and written to the auth file, so a working login presented as a login failure (exit 134).

**Fix:** set `Stdout` to `io.Discard` on both — the Rust caller (`src/cmd/login.rs`) already prints its own success line, and `backend_docker.go` is likewise silent.

### Testing

The bodies move into `podmanLogin`/`podmanLogout` so a test can reach them (Go forbids cgo in `_test.go` files). The test covers **logout**, the only one of the two whose success path is reachable offline — it needs just an auth file holding a credential, whereas `Login`'s needs a real `docker.CheckAuth` round-trip. Same bug in both.

Verified it catches the regression: reverting only the `Stdout` line reproduces the panic. End-to-end, `llmman logout` goes from `exit=134` + panic to `Logged out of registry.example.com`. `go test`/`go vet` pass under both build tags; `cargo build` passes for both backends.

## Drive-by

`hf_range_get_test.go` gains a `!podman` tag to match `transfer_docker.go`, where the `hfGetBytes` it tests lives. Without it the package's tests did not compile *at all* under `-tags podman`.

Separately: CI has no `go test` step, so every `go-shim/*_test.go` is dead weight there. Out of scope, but it is why a whole build tag's test suite could sit broken unnoticed — and why the new test won't run in CI either.
