### PR TITLE
fix: default-tag unload references and gate unload on a request keep_alive

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2131,6 +2131,25 @@ fn canonical_ref(store_path: &std::path::Path, model_ref: &str) -> String {
         .unwrap_or_else(|| model_ref.to_owned())
 }
 
+/// The `mgr.running` key an unload request names, resolved through the
+/// same three steps `ensure_model` uses to build the key it inserts
+/// under: `resolve_ollama_api`, then `default_tag`, then `canonical_ref`.
+///
+/// `default_tag` is the step the unload paths used to skip, on the
+/// assumption that `canonical_ref` would supply the tag from the store
+/// index. It only does so while the model is still *in* the store: once
+/// `find` misses — the model was removed after it was loaded, the index
+/// is unreadable — `canonical_ref` returns the reference untouched, so a
+/// tagless unload looked for `docker.io/ai/m` while the model ran under
+/// `docker.io/ai/m:latest`. `remove` missed, and the reply still said
+/// `"unload"`, leaving the caller believing a model it can still see in
+/// `llmman ps` had been evicted.
+fn unload_key(state: &AppState, model: &str) -> String {
+    let resolved = crate::shortnames::resolve_ollama_api(model);
+    let tagged = crate::storage::default_tag(&resolved);
+    canonical_ref(&state.0.store_path, &tagged)
+}
+
 /// Is `model_ref` already running and alive? See `ModelProcess::is_alive`.
 /// If so, claims it (`in_flight += 1`, under the same lock as the
 /// liveness check) and returns the same [`ActivityGuard`] `ensure_model`
@@ -4378,8 +4397,7 @@ async fn handle_ollama_chat(
     // empty message, and a `keep_alive: 0` never unloads anything.
     if req.messages.is_empty() {
         if resolve_keep_alive(&req.keep_alive) == Some(Duration::ZERO) {
-            let resolved = crate::shortnames::resolve_ollama_api(&req.model);
-            let canonical = canonical_ref(&state.0.store_path, &resolved);
+            let canonical = unload_key(&state, &req.model);
             let _guard = acquire_load_lock(&canonical).await;
             state.0.manager.lock().await.running.remove(&canonical);
             return Ok(Json(empty_chat_chunk(req.model, "unload")).into_response());
@@ -4468,8 +4486,7 @@ async fn handle_ollama_generate(
     let is_unload =
         req.prompt.is_empty() && resolve_keep_alive(&req.keep_alive) == Some(Duration::ZERO);
     if is_unload {
-        let resolved = crate::shortnames::resolve_ollama_api(&req.model);
-        let canonical = canonical_ref(&state.0.store_path, &resolved);
+        let canonical = unload_key(&state, &req.model);
         // Wait for an in-flight load of this model to publish itself first,
         // so it can't race ahead of this remove.
         let _guard = acquire_load_lock(&canonical).await;
@@ -7237,6 +7254,48 @@ mod tests {
                 .running
                 .contains_key("docker.io/ai/m:latest"),
             "keep_alive: 0 with no messages must actually unload the model"
+        );
+    }
+
+    /// `test_state`'s store path is an empty temp dir, so `canonical_ref`
+    /// finds nothing and returns the reference untouched — the same
+    /// position a real daemon is in once the model has been removed from
+    /// the store while still running. `default_tag` has to supply the
+    /// `:latest` on its own, or the remove looks up `docker.io/ai/m` and
+    /// misses the entry entirely while still reporting `"unload"`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_tagless_unload_still_finds_a_model_running_under_latest() {
+        let state = test_state();
+        {
+            let mut mgr = state.0.manager.lock().await;
+            mgr.running.insert(
+                "docker.io/ai/m:latest".into(),
+                running_model_fixture(Some(DEFAULT_KEEP_ALIVE), Duration::ZERO, 0),
+            );
+        }
+
+        let resp = handle_ollama_chat(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(chat_request(serde_json::json!({
+                "model": "docker.io/ai/m",
+                "messages": [],
+                "keep_alive": 0,
+            }))),
+        )
+        .await
+        .expect("unload must not error");
+
+        assert_eq!(chat_response_json(resp).await["done_reason"], "unload");
+        assert!(
+            !state
+                .0
+                .manager
+                .lock()
+                .await
+                .running
+                .contains_key("docker.io/ai/m:latest"),
+            "a tagless unload must reach the model stored under :latest"
         );
     }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1373,6 +1373,19 @@ fn resolve_keep_alive(value: &Option<serde_json::Value>) -> Option<Duration> {
         .unwrap_or_else(default_keep_alive)
 }
 
+/// True only when the request itself spells `keep_alive: 0` — Ollama's
+/// unload sentinel, in any of the zero forms `parse_keep_alive_value`
+/// accepts. Deliberately not [`resolve_keep_alive`], which falls back to
+/// [`default_keep_alive`] when the field is absent: under
+/// `LLMMAN_KEEP_ALIVE=0` that fallback made every message-less preload
+/// resolve to zero and answer `"unload"`, so a caller asking to warm a
+/// model got it evicted instead. An unparseable value stays a non-unload
+/// here for the same reason it stays one in `resolve_keep_alive` — the
+/// daemon default decides how long to keep it, not whether to keep it.
+fn is_explicit_unload(keep_alive: &Option<serde_json::Value>) -> bool {
+    keep_alive.as_ref().and_then(parse_keep_alive_value) == Some(Some(Duration::ZERO))
+}
+
 /// `None` = couldn't parse `v` as a keep_alive value at all (caller falls
 /// back to the daemon default). `Some(None)` = "never unload" (a negative
 /// number). `Some(Some(d))` = "unload after `d` of inactivity".
@@ -4396,7 +4409,7 @@ async fn handle_ollama_chat(
     // generation and `done_reason: "stop"` where ollama answers with an
     // empty message, and a `keep_alive: 0` never unloads anything.
     if req.messages.is_empty() {
-        if resolve_keep_alive(&req.keep_alive) == Some(Duration::ZERO) {
+        if is_explicit_unload(&req.keep_alive) {
             let canonical = unload_key(&state, &req.model);
             let _guard = acquire_load_lock(&canonical).await;
             state.0.manager.lock().await.running.remove(&canonical);
@@ -4479,12 +4492,11 @@ async fn handle_ollama_generate(
     );
 
     // Empty prompt + keep_alive:0 = unload request (ollama server/routes.go:354).
-    // resolve_keep_alive (not a bare `.as_i64() == Some(0)` check) so every
-    // zero form it accepts — the JSON number 0, but also "0"/"0s"/etc as a
-    // string — is treated as the unload sentinel, matching how the very
-    // same value is interpreted everywhere else keep_alive is read.
-    let is_unload =
-        req.prompt.is_empty() && resolve_keep_alive(&req.keep_alive) == Some(Duration::ZERO);
+    // is_explicit_unload, not resolve_keep_alive: it still accepts every
+    // zero form — the JSON number 0, but also "0"/"0s"/etc as a string —
+    // without treating an absent field as one, which under
+    // `LLMMAN_KEEP_ALIVE=0` turned a plain preload into an eviction.
+    let is_unload = req.prompt.is_empty() && is_explicit_unload(&req.keep_alive);
     if is_unload {
         let canonical = unload_key(&state, &req.model);
         // Wait for an in-flight load of this model to publish itself first,
@@ -7296,6 +7308,36 @@ mod tests {
                 .running
                 .contains_key("docker.io/ai/m:latest"),
             "a tagless unload must reach the model stored under :latest"
+        );
+    }
+
+    /// Pins which requests name the unload sentinel: every zero form
+    /// `parse_keep_alive_value` accepts, and nothing else — an absent
+    /// field least of all, since that is what a message-less preload
+    /// sends and what `LLMMAN_KEEP_ALIVE=0` used to turn into an eviction.
+    ///
+    /// This pins the contract, not the regression. The old and new
+    /// predicates differ only in whether they consult
+    /// `default_keep_alive`, which reads a process-wide environment
+    /// variable the `resolve_keep_alive` tests in this module read too;
+    /// telling them apart in-process would mean mutating it underneath
+    /// those tests. The regression itself was reproduced against a real
+    /// daemon started with `LLMMAN_KEEP_ALIVE=0`.
+    #[test]
+    fn only_a_keep_alive_the_request_actually_carries_means_unload() {
+        assert!(
+            !is_explicit_unload(&None),
+            "an absent field is not an unload"
+        );
+        assert!(is_explicit_unload(&Some(serde_json::json!(0))));
+        assert!(is_explicit_unload(&Some(serde_json::json!("0"))));
+        assert!(is_explicit_unload(&Some(serde_json::json!("0s"))));
+        assert!(!is_explicit_unload(&Some(serde_json::json!(300))));
+        assert!(!is_explicit_unload(&Some(serde_json::json!(-1))));
+        assert!(
+            !is_explicit_unload(&Some(serde_json::json!("garbage"))),
+            "an unparseable value leaves the daemon default deciding how long \
+             to keep the model, not whether to keep it"
         );
     }
 

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -1377,9 +1377,10 @@ fn resolve_keep_alive(value: &Option<serde_json::Value>) -> Option<Duration> {
 /// unload sentinel, in any of the zero forms `parse_keep_alive_value`
 /// accepts. Deliberately not [`resolve_keep_alive`], which falls back to
 /// [`default_keep_alive`] when the field is absent: under
-/// `LLMMAN_KEEP_ALIVE=0` that fallback made every message-less preload
-/// resolve to zero and answer `"unload"`, so a caller asking to warm a
-/// model got it evicted instead. An unparseable value stays a non-unload
+/// `LLMMAN_KEEP_ALIVE=0` that fallback made a message-less preload
+/// naming no `keep_alive` of its own resolve to zero and answer
+/// `"unload"`, so a caller asking to warm a model got it evicted
+/// instead. An unparseable value stays a non-unload
 /// here for the same reason it stays one in `resolve_keep_alive` — the
 /// daemon default decides how long to keep it, not whether to keep it.
 fn is_explicit_unload(keep_alive: &Option<serde_json::Value>) -> bool {

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -33,12 +33,12 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
     }
 
     // default_tag as well as resolve_ollama_api: `/api/ps` reports the
-    // key the model is running under, which `ensure_model` always tags,
-    // so comparing a caller's bare `smollm2` or `docker.io/ai/smollm2`
-    // against `docker.io/ai/smollm2:latest` never matched and every
-    // tagless `llmman stop` failed with "couldn't find model to stop"
-    // while the model kept running. Same omission the unload handlers in
-    // cmd::serve had.
+    // keys of `mgr.running`, and `ensure_model` tags a reference before
+    // inserting one, so comparing a caller's bare `smollm2` or
+    // `docker.io/ai/smollm2` against the `docker.io/ai/smollm2:latest`
+    // sitting there never matched, and a tagless `llmman stop` failed
+    // with "couldn't find model to stop" while the model kept running.
+    // Same omission the unload handlers in cmd::serve had.
     let reference =
         crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(&args.model));
 

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -32,15 +32,7 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
         anyhow::bail!("llmman serve is not running (nothing is loaded) — nothing to stop");
     }
 
-    // default_tag as well as resolve_ollama_api: `/api/ps` reports the
-    // keys of `mgr.running`, and `ensure_model` tags a reference before
-    // inserting one, so comparing a caller's bare `smollm2` or
-    // `docker.io/ai/smollm2` against the `docker.io/ai/smollm2:latest`
-    // sitting there never matched, and a tagless `llmman stop` failed
-    // with "couldn't find model to stop" while the model kept running.
-    // Same omission the unload handlers in cmd::serve had.
-    let reference =
-        crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(&args.model));
+    let reference = crate::shortnames::resolve_ollama_api(&args.model);
 
     // The unload endpoint itself always reports success even when
     // nothing by that name was running (canonical_ref falls back
@@ -48,12 +40,29 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
     // model actually loaded" is checked here, against a `ps` snapshot,
     // purely to give the same "couldn't find model to stop" error
     // `ollama stop` gives instead of a silent, meaningless success.
+    //
+    // Both sides are compared through `default_tag` rather than as raw
+    // strings. A `ps` name is a `mgr.running` key, which `canonical_ref`
+    // took from the store's own `org.opencontainers.image.ref.name`, and
+    // `OciStore::tag` records whatever reference it was handed: `llmman
+    // cp x y` stores a tagless `y`, while a pulled model stores
+    // `y:latest`. Either spelling can therefore be the key, and the
+    // caller may type either, so an exact comparison fails one direction
+    // or the other depending on which. Normalising both is what
+    // `ref_matches_precise` already does inside the store.
     let running: PsResponse = crate::daemon::get_json("/api/ps")?;
-    if !running.models.iter().any(|m| m.name == reference) {
+    let tagged = crate::storage::default_tag(&reference);
+    let Some(found) = running
+        .models
+        .iter()
+        .find(|m| crate::storage::default_tag(&m.name) == tagged)
+    else {
         anyhow::bail!("couldn't find model \"{}\" to stop", args.model);
-    }
+    };
 
-    crate::daemon::unload(&reference)?;
-    println!("Stopped {}", reference);
+    // The `ps` name, not our own spelling of it: it is the key the daemon
+    // actually holds, so there is nothing left for the unload to resolve.
+    crate::daemon::unload(&found.name)?;
+    println!("Stopped {}", found.name);
     Ok(())
 }

--- a/src/cmd/stop.rs
+++ b/src/cmd/stop.rs
@@ -32,7 +32,15 @@ pub fn run(args: &StopArgs) -> anyhow::Result<()> {
         anyhow::bail!("llmman serve is not running (nothing is loaded) — nothing to stop");
     }
 
-    let reference = crate::shortnames::resolve_ollama_api(&args.model);
+    // default_tag as well as resolve_ollama_api: `/api/ps` reports the
+    // key the model is running under, which `ensure_model` always tags,
+    // so comparing a caller's bare `smollm2` or `docker.io/ai/smollm2`
+    // against `docker.io/ai/smollm2:latest` never matched and every
+    // tagless `llmman stop` failed with "couldn't find model to stop"
+    // while the model kept running. Same omission the unload handlers in
+    // cmd::serve had.
+    let reference =
+        crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(&args.model));
 
     // The unload endpoint itself always reports success even when
     // nothing by that name was running (canonical_ref falls back


### PR DESCRIPTION
Follow-up to #326

The unload paths never ran `default_tag`, while the load path gets it from `ensure_model`. `canonical_ref` supplies the tag only while the model is still in the store, so once it is not, a tagless unload looked for `docker.io/ai/m` while the model ran under `docker.io/ai/m:latest`, and the remove missed while the reply still said "unload". The gate also tested the resolved `keep_alive`, which falls back to the daemon default, so under `LLMMAN_KEEP_ALIVE=0` a plain preload evicted the model it was asking to warm. Both handlers now go through `unload_key` and `is_explicit_unload` so they cannot drift apart again.
