### PR TITLE
feat: serve the provider catalog over /llmman, add --provider to run/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Models are packaged as standard OCI artifacts and stored in any compatible regis
 | `launch`  | Launch an integration (Claude Code, OpenCode, …) |
 | `run`     | Run a model interactively or with a one-shot prompt |
 | `pull`    | Pull a model from a registry or HuggingFace |
-| `list`    | List locally stored models |
+| `list`    | List locally stored models, or a hosted provider's (`--provider`) models |
 | `ps`      | List models currently loaded |
+| `providers` | List the hosted providers `--provider` can route to |
 | `stop`    | Stop (unload) a running model |
 | `build`   | Package model files into a local OCI image |
 | `push`    | Push a local image to a registry |
@@ -72,6 +73,18 @@ The server listens on `127.0.0.1:17434` by default, overridable via `LLMMAN_HOST
 | Ollama | `/api/generate`, `/api/chat`, `/api/tags`, `/api/show`, `/api/pull`, `/api/ps`, `/api/delete` |
 | OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/responses/input_tokens` |
 | Anthropic | `/v1/messages` |
+| llmman | `/llmman/providers`, `/llmman/providers/{id}` |
+
+`/llmman/...` is llmman's own API, not a compatibility surface — no
+upstream API has a notion of a [models.dev](https://models.dev) provider
+(see [Hosted providers](#hosted-providers)). `/llmman/providers` lists
+the ones this daemon can route to, each with its API-key variable,
+whether the daemon has that key, and how many models it serves;
+`/llmman/providers/{id}` adds those models and what each costs in US
+dollars per million tokens (absent, not zero, where models.dev publishes
+no price). `llmman providers`, `list --provider`, `run --provider` and
+`launch --provider` are all clients of it, so the catalog is fetched and
+cached in one process: the one that forwards the request upstream.
 
 `/v1/responses` implements the OpenAI Responses API (the dialect [OpenAI
 Codex](https://github.com/openai/codex) requires), including streaming SSE
@@ -147,11 +160,14 @@ Short names work wherever a model reference is accepted.
 
 #### Hosted providers
 
-`--provider` points the same integrations at a model llmman doesn't serve
-itself:
+`--provider` points llmman at a model it doesn't serve itself — from
+`launch`, from `run`, and from `list`:
 
 ```sh
 export OPENROUTER_API_KEY=...
+llmman providers                                    # which providers, and is the key set
+llmman list --provider openrouter                   # its models, and $/Mtok in and out
+llmman run --provider openrouter qwen/qwen3-coder   # chat with one directly
 llmman launch opencode --provider openrouter --model qwen/qwen3-coder
 ```
 
@@ -160,13 +176,16 @@ The provider list is fetched at runtime from
 its own providers from — so a newly added provider works without an
 llmman release. It's cached for 24 hours, and a stale copy is used if the
 fetch fails, so being offline means an out-of-date list rather than a
-broken command. `llmman launch --list-providers` prints the providers
-llmman can route to, with each one's API-key variable and whether it's
-set.
+broken command.
+
+All four commands ask the daemon over [`/llmman/providers`](#serve)
+rather than fetching models.dev themselves, so the cache outlives any
+single command and the key status reported is that of the environment
+whose key actually gets spent.
 
 Requests still go through `llmman serve`; `--provider` changes where the
-daemon forwards them, not who the integration talks to. So one endpoint
-and one place integrations are configured, whether a model is local or
+daemon forwards them, not who the client talks to. So one endpoint and
+one place integrations are configured, whether a model is local or
 hosted, and both usable from the same session.
 
 The API key is read from the variable models.dev names for that provider
@@ -189,10 +208,12 @@ capability data to filter on, so llmman turns that provider's bare 404
 into an explanation naming what's missing rather than guessing up front.
 
 `--provider` needs a local `llmman serve`. The daemon talks plain HTTP
-and has no authentication, so llmman will not hand an integration a real
-key to send to a remote `LLMMAN_HOST`, and a daemon bound to anything but
+and has no authentication, so neither `run` nor `launch` will send a real
+key to a remote `LLMMAN_HOST`, and a daemon bound to anything but
 loopback will not spend its own environment's key on behalf of a caller
-that didn't present one.
+that didn't present one. (`llmman providers` and `llmman list
+--provider` read the catalog only, no key involved, and work against any
+daemon.)
 
 Providers llmman cannot reach with a single bearer token over an
 OpenAI-compatible https endpoint are deliberately absent rather than

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -18,7 +18,7 @@ use anyhow::Context;
 use clap::Args;
 
 use crate::daemon;
-use crate::providers::{self, Provider};
+use crate::providers;
 
 // ---------------------------------------------------------------------------
 // CLI
@@ -36,13 +36,9 @@ pub struct LaunchArgs {
     pub model: Option<String>,
 
     /// Serve --model from this provider (openai, anthropic, openrouter, …)
-    /// instead of locally. Requires --model. See --list-providers.
+    /// instead of locally. Requires --model. See `llmman providers`.
     #[arg(long, short = 'p', value_name = "PROVIDER")]
     pub provider: Option<String>,
-
-    /// List the providers --provider accepts, and exit
-    #[arg(long)]
-    pub list_providers: bool,
 
     /// Extra arguments forwarded to the integration binary (after --)
     #[arg(last = true, value_name = "ARGS")]
@@ -50,15 +46,7 @@ pub struct LaunchArgs {
 }
 
 pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
-    if args.list_providers {
-        return print_providers();
-    }
-
-    let provider = args
-        .provider
-        .as_deref()
-        .map(str::trim)
-        .filter(|p| !p.is_empty());
+    let provider = providers::provider_flag(args.provider.as_deref())?;
 
     let Some(ref name) = args.integration else {
         print_integrations();
@@ -68,48 +56,50 @@ pub fn run(args: &LaunchArgs) -> anyhow::Result<()> {
     let (model, api_key) = match provider {
         Some(provider) => {
             check_provider_supported(name)?;
+            // The daemon first, before --provider is validated: the
+            // catalog belongs to `llmman serve` (see cmd::providers), so
+            // there is nothing to validate against until it runs. Nothing
+            // to preload either — a provider-routed model has nothing
+            // local to warm up — but it still has to be running, since it
+            // is what forwards upstream.
+            crate::daemon::ensure_server("")?;
             let per_request = !PROVIDER_NEEDS_DAEMON_KEY.contains(&name.to_lowercase().as_str());
             resolve_provider_model(provider, args.model.as_deref(), name, per_request)?
         }
-        // resolve_ollama_api, not resolve: every integration this launches
-        // talks to serve's Ollama/OpenAI/Anthropic-compat surfaces, all of
-        // which resolve model names the same way (see ensure_model in
-        // cmd::serve), so a bare name here must match what the daemon
-        // resolves it to at request time. Fallible: it validates the raw
-        // reference first (see shortnames::validate_reference).
-        None => (
-            args.model
+        None => {
+            // resolve_ollama_api, not resolve: every integration this
+            // launches talks to serve's Ollama/OpenAI/Anthropic-compat
+            // surfaces, all of which resolve model names the same way
+            // (see ensure_model in cmd::serve), so a bare name here must
+            // match what the daemon resolves it to at request time.
+            // Fallible: it validates the raw reference first (see
+            // shortnames::validate_reference).
+            let model = args
+                .model
                 .as_deref()
                 .map(crate::shortnames::resolve_ollama_api)
                 .transpose()?
-                .unwrap_or_default(),
-            providers::PLACEHOLDER_API_KEY.to_string(),
-        ),
-    };
+                .unwrap_or_default();
 
-    // Ensure serve is running (start it in background if needed), preloading
-    // the requested model so the integration's first request finds it warm.
-    //
-    // A provider-routed model is never preloaded: there is nothing local to
-    // warm up, and asking the daemon to load one would just fail. The daemon
-    // still has to be running — it is what forwards upstream.
-    let preload = if provider.is_some() {
-        ""
-    } else {
-        model.as_str()
-    };
-    crate::daemon::ensure_server(preload)?;
+            // Ensure serve is running (start it in background if needed),
+            // preloading the requested model so the integration's first
+            // request finds it warm.
+            crate::daemon::ensure_server(&model)?;
 
-    // serve's preload above is fire-and-forget and only fires on a cold
-    // `serve` start (see run() in cmd/serve.rs) — if the daemon was already
-    // running from a previous invocation, a missing model would otherwise
-    // only surface as an opaque failure once the integration made its first
-    // request. Mirror `llmman run`'s behavior and pull it here instead,
-    // synchronously and with progress, before ever handing off to the
-    // integration. Nothing to pull for a provider-routed model.
-    if !preload.is_empty() {
-        crate::daemon::ensure_model_pulled(preload)?;
-    }
+            // serve's preload above is fire-and-forget and only fires on
+            // a cold `serve` start (see run() in cmd/serve.rs) — if the
+            // daemon was already running from a previous invocation, a
+            // missing model would otherwise only surface as an opaque
+            // failure once the integration made its first request. Mirror
+            // `llmman run`'s behavior and pull it here instead,
+            // synchronously and with progress, before ever handing off to
+            // the integration.
+            if !model.is_empty() {
+                crate::daemon::ensure_model_pulled(&model)?;
+            }
+            (model, providers::PLACEHOLDER_API_KEY.to_string())
+        }
+    };
 
     launch(name, &model, &api_key, &args.extra_args)
 }
@@ -202,10 +192,10 @@ fn check_provider_supported(integration: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Validates `--provider`/`--model` against the catalog, returning the
-/// reference the daemon routes on (see
-/// [`crate::providers::REMOTE_PREFIX`]) and the key `integration` should
-/// authenticate with.
+/// Validates `--provider`/`--model` against the running daemon's catalog
+/// (see [`crate::daemon::provider`]), returning the reference the daemon
+/// routes on (see [`crate::providers::REMOTE_PREFIX`]) and the key
+/// `integration` should authenticate with.
 ///
 /// `key_travels_per_request` is false for the integrations in
 /// [`PROVIDER_NEEDS_DAEMON_KEY`], which get the placeholder because they
@@ -225,10 +215,10 @@ fn resolve_provider_model(
     integration: &str,
     key_travels_per_request: bool,
 ) -> anyhow::Result<(String, String)> {
-    let catalog = providers::catalog()?;
-    let entry = catalog
-        .get(provider)
-        .ok_or_else(|| unknown_provider_error(provider, &catalog))?;
+    // Asked of the daemon, not models.dev: it routes the request, so it
+    // is the authority on whether this provider exists — and on whether
+    // *it* has the key, which this shell cannot see.
+    let entry = daemon::provider(provider)?;
 
     let model = model
         .map(str::trim)
@@ -236,40 +226,43 @@ fn resolve_provider_model(
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "--provider {provider} also needs --model\n\n{}",
-                example_models(entry)
+                providers::example_models(&entry.name, &entry.model_ids())
             )
         })?;
 
-    // A warning, not an error: models.dev is a snapshot, and a provider
-    // can serve a model — a brand new release, a fine-tune, a private
-    // deployment — before the catalog lists it. Refusing here would make
-    // llmman the reason a working model can't be used.
-    if !entry.models.iter().any(|m| m == model) {
-        eprintln!(
-            "[llmman] warning: {} does not list model {model:?}\n{}",
-            entry.name,
-            example_models(entry)
-        );
-    }
+    entry.warn_unlisted(model);
 
-    // Read here rather than left to the daemon so a missing key names the
-    // variable to set, in llmman's own output. The key travels to the
-    // daemon per request, in the integration's own Authorization header
-    // (see client_api_key in cmd::serve) — never written to disk or
-    // passed on a command line.
+    // Read here, not left to the daemon, so a missing key names the
+    // variable to set in llmman's own output. It travels per request in
+    // the integration's own Authorization header (see client_api_key in
+    // cmd::serve), never to disk or a command line.
     //
-    // Unless the integration cannot carry one, in which case this shell's
-    // key is not the one that matters and its absence is not an error:
-    // what counts is the daemon's own environment, which llmman cannot
-    // read from here. A warning, because the two are usually the same
-    // shell, and the daemon's 401 already names the variable.
+    // The placeholder goes instead whenever the daemon's key is the one
+    // that matters — an integration that cannot carry one, or a shell
+    // without one where the daemon has it — since that is what makes
+    // serve fall back to its own.
     let key = match (entry.api_key(), key_travels_per_request) {
-        (Some(key), _) => key,
-        (None, false) => {
+        (Some(key), true) => key,
+        (_, false) => {
+            // Fatal, not a warning: this integration cannot carry a key,
+            // so the daemon's is the only one its first request can use,
+            // and `key_usable` is the daemon's own word on whether it
+            // would spend it. Warning and handing off would surface as a
+            // 401 inside someone else's TUI.
+            anyhow::ensure!(
+                entry.key_usable,
+                "{integration} is configured through a file, so it cannot send an API key: \
+                 llmman serve needs {} in its own environment, and must be bound to \
+                 loopback to spend it.\n\
+                 Export it where the daemon runs and restart it.",
+                entry.key_env
+            );
+            providers::PLACEHOLDER_API_KEY.to_string()
+        }
+        (None, true) if entry.daemon_key_usable() => {
             eprintln!(
-                "[llmman] warning: {} is unset here; {} needs it set where \
-                 llmman serve runs",
-                entry.key_env, integration
+                "[llmman] warning: {} is unset here; using the key llmman serve has",
+                entry.key_env
             );
             providers::PLACEHOLDER_API_KEY.to_string()
         }
@@ -281,80 +274,6 @@ fn resolve_provider_model(
     };
 
     Ok((providers::format_remote_ref(provider, model), key))
-}
-
-/// A few real model ids for `provider`, to turn "which models?" into
-/// something answerable without leaving the error message.
-fn example_models(provider: &Provider) -> String {
-    if provider.models.is_empty() {
-        return format!("{} lists no models", provider.name);
-    }
-    let shown: Vec<&str> = provider.models.iter().take(5).map(String::as_str).collect();
-    let more = provider.models.len().saturating_sub(shown.len());
-    let suffix = if more > 0 {
-        format!(", … ({more} more)")
-    } else {
-        String::new()
-    };
-    format!(
-        "{} models include: {}{suffix}",
-        provider.name,
-        shown.join(", ")
-    )
-}
-
-/// Suggests near-matches before falling back to `--list-providers`, so a
-/// typo or a half-remembered id ("together" for `togetherai`) is one line
-/// away from the right answer instead of a 170-entry list.
-fn unknown_provider_error(provider: &str, catalog: &providers::Catalog) -> anyhow::Error {
-    let needle = provider.to_lowercase();
-    let close: Vec<&str> = catalog
-        .ids()
-        .filter(|id| id.contains(&needle) || needle.contains(*id))
-        .take(10)
-        .collect();
-    if close.is_empty() {
-        anyhow::anyhow!(
-            "unknown provider {provider:?}\nRun 'llmman launch --list-providers' for the \
-             {} providers llmman can route to.",
-            catalog.len()
-        )
-    } else {
-        anyhow::anyhow!(
-            "unknown provider {provider:?}\nDid you mean: {}?\nRun 'llmman launch \
-             --list-providers' for all {} of them.",
-            close.join(", "),
-            catalog.len()
-        )
-    }
-}
-
-fn print_providers() -> anyhow::Result<()> {
-    let catalog = providers::catalog()?;
-    let width = catalog.ids().map(str::len).max().unwrap_or(0);
-    for provider in catalog.iter() {
-        // The key variable is the one thing a user has to act on, and
-        // whether it is already set is the question they are really
-        // asking, so mark it rather than making them check.
-        let status = if provider.api_key().is_some() {
-            "set"
-        } else {
-            "unset"
-        };
-        println!(
-            "  {:<width$}  {:<28}  {} ({status})",
-            provider.id,
-            provider.name,
-            provider.key_env,
-            width = width
-        );
-    }
-    println!(
-        "\n{} providers, from models.dev — the same catalog opencode uses.",
-        catalog.len()
-    );
-    println!("Usage: llmman launch <integration> --provider <provider> --model <model>");
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -444,7 +363,7 @@ fn print_integrations() {
         }
     }
     println!("\nUsage: llmman launch <integration> [--model <model>] [--provider <provider>]");
-    println!("       llmman launch --list-providers");
+    println!("       llmman providers   (the providers --provider accepts)");
 }
 
 /// Extensions to try, in order, when resolving a bare command name on
@@ -985,33 +904,6 @@ mod tests {
             yaml_quote(r#"a "quoted" \ value"#),
             r#""a \"quoted\" \\ value""#
         );
-    }
-
-    fn provider(id: &str, models: &[&str]) -> Provider {
-        Provider {
-            id: id.to_string(),
-            name: format!("{id} Inc"),
-            base_url: "https://example.invalid/v1".to_string(),
-            key_env: "EXAMPLE_API_KEY".to_string(),
-            models: models.iter().map(|m| m.to_string()).collect(),
-        }
-    }
-
-    /// The listing has to stay short enough to read in an error message
-    /// while still saying how much was elided.
-    #[test]
-    fn example_models_lists_a_few_and_counts_the_rest() {
-        let few = provider("groq", &["a", "b"]);
-        assert_eq!(example_models(&few), "groq Inc models include: a, b");
-
-        let many = provider("groq", &["a", "b", "c", "d", "e", "f", "g"]);
-        assert_eq!(
-            example_models(&many),
-            "groq Inc models include: a, b, c, d, e, … (2 more)"
-        );
-
-        let none = provider("groq", &[]);
-        assert_eq!(example_models(&none), "groq Inc lists no models");
     }
 
     /// A provider-routed `--model` must come out under

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -1,3 +1,11 @@
+//! `llmman list` — locally stored images, or (with `--provider`) the
+//! models a hosted provider serves.
+//!
+//! One command for both, because "which models can I run" has one
+//! answer; where the weights sit is a detail of how `llmman serve`
+//! reaches them (see `Target` in cmd::serve). `--provider`'s answer comes
+//! from the daemon's catalog — see cmd::providers for why.
+
 use clap::Args;
 
 use crate::fmt::{human_size, relative_time, short_id};
@@ -13,9 +21,22 @@ pub struct ListArgs {
     /// Available fields: .ID, .Digest, .Name, .Repository, .Tag, .Size, .Modified
     #[arg(long, value_name = "TEMPLATE")]
     pub format: Option<String>,
+    /// List the models this hosted provider serves (openai, anthropic,
+    /// openrouter, …) instead of local images. See `llmman providers`.
+    #[arg(
+        long,
+        short = 'p',
+        value_name = "PROVIDER",
+        conflicts_with_all = ["reference", "format"]
+    )]
+    pub provider: Option<String>,
 }
 
 pub fn run(args: &ListArgs) -> anyhow::Result<()> {
+    if let Some(provider) = crate::providers::provider_flag(args.provider.as_deref())? {
+        return list_provider_models(provider);
+    }
+
     let store_root = crate::default_store()?;
     let store = OciStore::open(&store_root)?;
     let mut images = store.list()?;
@@ -65,6 +86,73 @@ pub fn run(args: &ListArgs) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+/// Prints the models a provider serves and what it charges, from the
+/// daemon's catalog (`GET /llmman/providers/:id`). Nothing is downloaded:
+/// these are ids for `llmman run --provider`. Price replaces
+/// SIZE/MODIFIED, which mean nothing for someone else's weights.
+fn list_provider_models(provider: &str) -> anyhow::Result<()> {
+    crate::daemon::ensure_server("")?;
+    let entry = crate::daemon::provider(provider)?;
+    if entry.models.is_empty() {
+        // As for an empty local store: nothing to tabulate. The provider
+        // exists — an unknown one is an error from the daemon.
+        return Ok(());
+    }
+    let name_w = entry
+        .models
+        .iter()
+        .map(|m| m.id.len())
+        .max()
+        .unwrap_or(4)
+        .max(4);
+    // "IN $/Mtok" is the widest thing in its column, so it sizes itself.
+    println!(
+        "{:<name_w$}    {:<9}    OUT $/Mtok",
+        "NAME",
+        "IN $/Mtok",
+        name_w = name_w
+    );
+    for model in &entry.models {
+        let cost = model.cost;
+        println!(
+            "{:<name_w$}    {:<9}    {}",
+            model.id,
+            price(cost.map(|c| c.input)),
+            price(cost.map(|c| c.output)),
+            name_w = name_w,
+        );
+    }
+    Ok(())
+}
+
+/// Renders one dollars-per-million-tokens figure.
+///
+/// `None` (no published price) is `-`, never `0`: showing a paid model as
+/// free is worse than admitting llmman doesn't know. A genuinely free one
+/// — openrouter has plenty — still prints `0`.
+///
+/// Trailing zeros go because the range spans four orders of magnitude
+/// ($0.0023 and $600 are both real), so any fixed precision either loses
+/// the cheap end or pads the expensive one.
+fn price(value: Option<f64>) -> String {
+    let Some(value) = value else {
+        return "-".to_string();
+    };
+    if value == 0.0 {
+        return "0".to_string();
+    }
+    let rendered = if value >= 1.0 {
+        format!("{value:.2}")
+    } else {
+        format!("{value:.5}")
+    };
+    let trimmed = rendered.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "0" {
+        return "<0.00001".to_string();
+    }
+    trimmed.to_string()
 }
 
 /// Splits a stored reference into its repository and *explicit* tag,
@@ -262,5 +350,20 @@ mod tests {
     fn render_format_rejects_unknown_field() {
         let img = sample();
         assert!(render_format("{{.Bogus}}", &img).is_err());
+    }
+
+    /// Telling "free", "cheap" and "unpublished" apart is the point.
+    #[test]
+    fn price_distinguishes_free_from_unpublished() {
+        assert_eq!(price(None), "-");
+        assert_eq!(price(Some(0.0)), "0");
+        assert_eq!(price(Some(2.5)), "2.5");
+        assert_eq!(price(Some(10.0)), "10");
+        assert_eq!(price(Some(600.0)), "600");
+        assert_eq!(price(Some(1.234)), "1.23");
+        // The cheap end keeps its digits instead of rounding to free.
+        assert_eq!(price(Some(0.0023)), "0.0023");
+        assert_eq!(price(Some(0.01618)), "0.01618");
+        assert_eq!(price(Some(0.0000001)), "<0.00001");
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -5,6 +5,7 @@ pub mod launch;
 pub mod list;
 pub mod login;
 pub mod logout;
+pub mod providers;
 pub mod ps;
 pub mod pull;
 pub mod push;

--- a/src/cmd/providers.rs
+++ b/src/cmd/providers.rs
@@ -1,0 +1,150 @@
+//! `llmman providers` — the providers `--provider` accepts.
+//!
+//! Answered by `llmman serve` (`GET /llmman/providers`), not by fetching
+//! models.dev here: the daemon forwards the request, so its catalog
+//! decides whether `--provider x` works and its environment holds the key
+//! that gets spent (see `resolve_remote_target` in cmd::serve).
+
+use clap::Args;
+
+use crate::daemon::{self, ProviderSummary};
+
+#[derive(Args, Debug)]
+pub struct ProvidersArgs {
+    /// Only show providers whose id or name contains this substring
+    #[arg(value_name = "FILTER")]
+    pub filter: Option<String>,
+}
+
+pub fn run(args: &ProvidersArgs) -> anyhow::Result<()> {
+    // Same contract as `run`/`pull`/`launch`: start the daemon rather
+    // than tell the user to. It owns the catalog, and whatever runs next
+    // needs it anyway.
+    daemon::ensure_server("")?;
+
+    let all = daemon::providers()?;
+    let total = all.len();
+    let filter = args
+        .filter
+        .as_deref()
+        .map(str::trim)
+        .filter(|f| !f.is_empty())
+        .map(str::to_lowercase);
+    let shown: Vec<&ProviderSummary> = all
+        .iter()
+        .filter(|p| matches(p, filter.as_deref()))
+        .collect();
+
+    if shown.is_empty() {
+        // A header with no rows would read as "there are none".
+        anyhow::bail!(
+            "no provider matches {:?} — run 'llmman providers' for all {total} of them",
+            args.filter.as_deref().unwrap_or_default()
+        );
+    }
+
+    let id_w = shown.iter().map(|p| p.id.len()).max().unwrap_or(8).max(8);
+    let name_w = shown.iter().map(|p| p.name.len()).max().unwrap_or(4).max(4);
+    let key_w = shown
+        .iter()
+        .map(|p| p.key_env.len())
+        .max()
+        .unwrap_or(7)
+        .max(7);
+
+    println!(
+        "{:<id_w$}    {:<name_w$}    {:<key_w$}    {:<14}    MODELS",
+        "PROVIDER",
+        "NAME",
+        "API KEY",
+        "KEY",
+        id_w = id_w,
+        name_w = name_w,
+        key_w = key_w,
+    );
+    for p in &shown {
+        println!(
+            "{:<id_w$}    {:<name_w$}    {:<key_w$}    {:<14}    {}",
+            p.id,
+            p.name,
+            p.key_env,
+            key_status(p),
+            p.models,
+            id_w = id_w,
+            name_w = name_w,
+            key_w = key_w,
+        );
+    }
+
+    // Nothing after the last row: a trailing count and usage block is
+    // something to skip past every time, and something a pipe into
+    // `grep`/`awk` has to filter out. `--help` is where usage belongs.
+    Ok(())
+}
+
+fn matches(provider: &ProviderSummary, needle: Option<&str>) -> bool {
+    let Some(needle) = needle else { return true };
+    provider.id.to_lowercase().contains(needle) || provider.name.to_lowercase().contains(needle)
+}
+
+/// Where a *usable* key is — the one thing to act on before `--provider`
+/// works.
+///
+/// "shell" is a key only this process has, which travels per request.
+/// "withheld" is one the daemon has but will not spend, because it is
+/// bound where others could reach it (see `resolve_remote_target` in
+/// cmd::serve) — a state of its own, since what needs fixing there is the
+/// bind, not the variable.
+fn key_status(provider: &ProviderSummary) -> &'static str {
+    match (provider.key_usable, provider.key_here(), provider.key_set) {
+        (true, _, _) => "set",
+        (false, true, _) => "set (shell)",
+        (false, false, true) => "set (withheld)",
+        (false, false, false) => "unset",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(id: &str, name: &str) -> ProviderSummary {
+        ProviderSummary {
+            id: id.to_string(),
+            name: name.to_string(),
+            key_env: "LLMMAN_TEST_PROVIDER_KEY_UNSET".to_string(),
+            key_set: false,
+            key_usable: false,
+            models: 0,
+        }
+    }
+
+    /// Findable by the name a user knows, not only by its id.
+    #[test]
+    fn filter_matches_id_or_name_case_insensitively() {
+        let p = summary("togetherai", "Together AI");
+        assert!(matches(&p, None));
+        assert!(matches(&p, Some("together")));
+        assert!(matches(&p, Some("ai")));
+        assert!(!matches(&p, Some("groq")));
+
+        // The needle is lowercased by `run` before it gets here; the
+        // provider's own casing must not matter either way.
+        let p = summary("openai", "OpenAI");
+        assert!(matches(&p, Some("openai")));
+    }
+
+    /// Each way a key can be present is a different thing to do about
+    /// it, so none may collapse into another.
+    #[test]
+    fn key_status_reports_the_key_that_would_actually_be_used() {
+        let mut p = summary("openai", "OpenAI");
+        assert_eq!(key_status(&p), "unset");
+        // Held by the daemon but withheld: the bind needs fixing, not
+        // the variable.
+        p.key_set = true;
+        assert_eq!(key_status(&p), "set (withheld)");
+        p.key_usable = true;
+        assert_eq!(key_status(&p), "set");
+    }
+}

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -46,6 +46,12 @@ use crate::daemon;
 pub struct RunArgs {
     #[arg(value_name = "MODEL")]
     pub model: String,
+    /// Chat with MODEL at this hosted provider (openai, anthropic,
+    /// openrouter, …) instead of locally. The request still goes through
+    /// `llmman serve`, which forwards it upstream; MODEL is the
+    /// provider's own model id. See `llmman providers`.
+    #[arg(long, short = 'p', value_name = "PROVIDER")]
+    pub provider: Option<String>,
     /// Forwarded as Ollama's own top-level `think` field on every request
     /// this sends (see cmd::serve's think_to_chat_template_kwargs) —
     /// `--think false` disables a reasoning model's thinking block
@@ -79,35 +85,51 @@ pub struct RunArgs {
 
 /// Per-request knobs threaded through unchanged from `RunArgs`.
 #[derive(Debug, Clone, Copy)]
-struct ChatOptions {
+struct ChatOptions<'a> {
     think: Option<bool>,
     num_predict: Option<u32>,
     /// Inverse of `RunArgs::nowordwrap`, matching ollama's
     /// `runOptions.WordWrap` (defaults `true`).
     word_wrap: bool,
+    /// Provider key to send with every request under `--provider` (see
+    /// `provider_model`), `None` for a local model. Applied as a default
+    /// header, not a body field — see `chat_client`.
+    api_key: Option<&'a str>,
 }
 
-impl Default for ChatOptions {
+impl Default for ChatOptions<'_> {
     fn default() -> Self {
         Self {
             think: None,
             num_predict: None,
             word_wrap: true,
+            api_key: None,
         }
     }
 }
 
 pub fn run(args: &RunArgs) -> anyhow::Result<()> {
+    let provider = crate::providers::provider_flag(args.provider.as_deref())?;
+    let prompt = args.prompt.join(" ");
+
     // resolve_ollama_api, not resolve: `llmman run` is an /api/chat client
     // (see chat_submit/run_interactive_tty below), so a bare name must
     // resolve the same way it would if requested directly over the Ollama
-    // API — otherwise a name resolved here, then handed to ensure_server as
-    // a --model preload and to every /api/chat request this sends, is no
-    // longer "bare" by the time ensure_model resolves it server-side (it
-    // already has a "/" and a "."), so the docker.io/ai/ default never
-    // fires and this silently falls back to hf.co/<name> instead.
-    let model = crate::shortnames::resolve_ollama_api(&args.model)?;
-    let prompt = args.prompt.join(" ");
+    // API — otherwise a name resolved here, then handed to every /api/chat
+    // request this sends, is no longer "bare" by the time ensure_model
+    // resolves it server-side (it already has a "/" and a "."), so the
+    // docker.io/ai/ default never fires and this silently falls back to
+    // hf.co/<name> instead.
+    //
+    // Not applied under `--provider`: that MODEL names a model on someone
+    // else's servers, so no shortname aliasing, tag defaulting, store
+    // lookup or pull applies — the same call ensure_model makes
+    // server-side. Resolved before the daemon starts, so a malformed
+    // local reference still fails without one.
+    let route = match provider {
+        Some(provider) => Route::Provider(provider),
+        None => Route::Local(crate::shortnames::resolve_ollama_api(&args.model)?),
+    };
 
     // Starts `llmman serve` detached, left running indefinitely, if one
     // isn't already reachable — the same shared helper pull/push/launch
@@ -118,17 +140,27 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
     // is a plain `llmman serve` with no model argument, so it's shared
     // cleanly across every future `run`/`pull`/`push`/`launch` in this
     // session rather than looking like it's dedicated to whatever model
-    // happened to start it first. ensure_model_pulled below still makes
-    // sure the model is on disk before the first /api/chat request.
+    // happened to start it first.
+    //
+    // A provider-routed model has nothing to preload or pull, but needs
+    // the daemon sooner still: it owns the catalog `provider_model`
+    // validates against, and it forwards the chat upstream.
     crate::daemon::ensure_server("")?;
 
-    // Fail fast on a bad/unresolvable reference — mirrors ollama's
-    // RunHandler, which resolves (Show, falling back to Pull) the model
-    // before ever showing its interactive prompt. Without this, an error
-    // like an invalid `hf.co/...` reference wouldn't surface until the
-    // first message was submitted to /api/chat, well after the `> `
-    // prompt had already been shown and read from.
-    crate::daemon::ensure_model_pulled(&model)?;
+    let (model, api_key) = match route {
+        Route::Provider(provider) => provider_model(provider, &args.model)?,
+        Route::Local(model) => {
+            // Fail fast on a bad/unresolvable reference — mirrors ollama's
+            // RunHandler, which resolves (Show, falling back to Pull) the
+            // model before ever showing its interactive prompt. Without
+            // this, an error like an invalid `hf.co/...` reference wouldn't
+            // surface until the first message was submitted to /api/chat,
+            // well after the `> ` prompt had already been shown and read
+            // from.
+            crate::daemon::ensure_model_pulled(&model)?;
+            (model, None)
+        }
+    };
 
     // Mirrors ollama's RunHandler: interactive needs *both* ends of the
     // terminal, not just stdin — otherwise a redirected stdout still gets
@@ -138,6 +170,7 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
         think: args.think,
         num_predict: args.num_predict,
         word_wrap: !args.nowordwrap,
+        api_key: api_key.as_deref(),
     };
 
     if interactive {
@@ -156,11 +189,61 @@ pub fn run(args: &RunArgs) -> anyhow::Result<()> {
             // reqwest::blocking, so Ctrl-C can race the response via
             // `tokio::select!` in `chat_submit` — see that fn's doc comment.
             let rt = tokio::runtime::Runtime::new().context("start tokio runtime")?;
-            let client = chat_client()?;
+            let client = chat_client(opts.api_key)?;
             chat_submit(&rt, &client, &model, &mut Vec::new(), p, opts)?;
         }
         Ok(())
     }
+}
+
+/// Where this chat goes: a local reference, already resolved (see `run`),
+/// or a provider id `provider_model` still has to validate.
+enum Route<'a> {
+    Local(String),
+    Provider(&'a str),
+}
+
+/// Validates `--provider`/MODEL against the daemon's catalog, returning
+/// the reference the daemon routes on (see
+/// [`crate::providers::REMOTE_PREFIX`]) and the key to send with each
+/// request, if this shell has one.
+///
+/// Mirrors `cmd::launch`'s `resolve_provider_model` minus the
+/// integrations: the key travels per request in an `Authorization` header
+/// (see `client_api_key` in cmd::serve), never to disk.
+fn provider_model(provider: &str, model: &str) -> anyhow::Result<(String, Option<String>)> {
+    // Same rule as `launch --provider` (see check_provider_supported in
+    // cmd::launch): the daemon has no TLS, so a key sent to one elsewhere
+    // on the network would cross it in cleartext. A wildcard bind is
+    // fine — that hop is still loopback.
+    anyhow::ensure!(
+        crate::daemon::connects_over_loopback(),
+        "--provider needs a local llmman serve: LLMMAN_HOST points at {}, and the provider \
+         key would cross the network in cleartext.\n\
+         Export the key where that daemon runs, and run llmman there.",
+        crate::daemon::server()
+    );
+
+    let entry = daemon::provider(provider)?;
+    let model = model.trim();
+    anyhow::ensure!(
+        !model.is_empty(),
+        "--provider {provider} also needs a model\n\n{}",
+        crate::providers::example_models(&entry.name, &entry.model_ids())
+    );
+
+    entry.warn_unlisted(model);
+
+    // Naming the missing variable beats a 401 mid-conversation — unless
+    // the daemon has the key, in which case it spends its own.
+    let key = entry.api_key();
+    anyhow::ensure!(
+        key.is_some() || entry.daemon_key_usable(),
+        "no API key for {} — set {} in your environment",
+        entry.name,
+        entry.key_env
+    );
+    Ok((crate::providers::format_remote_ref(provider, model), key))
 }
 
 // ---------------------------------------------------------------------------
@@ -178,8 +261,22 @@ struct Msg {
 /// Async, not `reqwest::blocking`, so a chat turn's response can be raced
 /// against `tokio::signal::ctrl_c()` in `chat_submit` — no `.timeout()`
 /// needed either, unlike the blocking client's own 30s default.
-fn chat_client() -> anyhow::Result<Client> {
-    Client::builder().build().context("build http client")
+///
+/// A `--provider` key (see `provider_model`) rides along as a default
+/// `Authorization` header — this client has one destination, and that
+/// header is what `client_api_key` in cmd::serve reads. Sensitive, so a
+/// `Debug`-formatted client or request cannot print it.
+fn chat_client(api_key: Option<&str>) -> anyhow::Result<Client> {
+    let mut builder = Client::builder();
+    if let Some(key) = api_key {
+        let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {key}"))
+            .context("provider API key is not a valid HTTP header value")?;
+        value.set_sensitive(true);
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::AUTHORIZATION, value);
+        builder = builder.default_headers(headers);
+    }
+    builder.build().context("build http client")
 }
 
 #[derive(Serialize)]
@@ -358,7 +455,7 @@ impl Drop for SpinnerGuard {
 // Interactive — TTY path
 // ---------------------------------------------------------------------------
 
-fn run_interactive_tty(model: &str, opts: ChatOptions) -> anyhow::Result<()> {
+fn run_interactive_tty(model: &str, opts: ChatOptions<'_>) -> anyhow::Result<()> {
     #[cfg(unix)]
     {
         run_interactive_unix(model, opts)
@@ -375,13 +472,13 @@ fn run_interactive_tty(model: &str, opts: ChatOptions) -> anyhow::Result<()> {
 // ---------------------------------------------------------------------------
 
 #[cfg(unix)]
-fn run_interactive_unix(model: &str, opts: ChatOptions) -> anyhow::Result<()> {
+fn run_interactive_unix(model: &str, opts: ChatOptions<'_>) -> anyhow::Result<()> {
     use unix_readline::Readline;
 
     // One tokio runtime, reused across every turn's `block_on` — see
     // `chat_submit`'s doc comment for why this needs async reqwest.
     let rt = tokio::runtime::Runtime::new().context("start tokio runtime")?;
-    let client = chat_client()?;
+    let client = chat_client(opts.api_key)?;
     let mut messages: Vec<Msg> = Vec::new();
     let mut rl = Readline::new()?;
     let mut multiline: Option<String> = None; // Some while inside """
@@ -497,7 +594,7 @@ fn submit_turn(
     rl: &mut unix_readline::Readline,
     messages: &mut Vec<Msg>,
     content: String,
-    opts: ChatOptions,
+    opts: ChatOptions<'_>,
 ) -> anyhow::Result<()> {
     rl.leave_raw();
     let result = chat_submit(rt, client, model, messages, content, opts);
@@ -520,7 +617,7 @@ fn chat_submit(
     model: &str,
     messages: &mut Vec<Msg>,
     content: String,
-    opts: ChatOptions,
+    opts: ChatOptions<'_>,
 ) -> anyhow::Result<()> {
     rt.block_on(chat_submit_async(client, model, messages, content, opts))
 }
@@ -530,7 +627,7 @@ async fn chat_submit_async(
     model: &str,
     messages: &mut Vec<Msg>,
     content: String,
-    opts: ChatOptions,
+    opts: ChatOptions<'_>,
 ) -> anyhow::Result<()> {
     messages.push(Msg {
         role: "user".into(),
@@ -574,8 +671,11 @@ async fn chat_submit_async(
 
     if !resp.status().is_success() {
         spinner.stop();
-        let e = resp.text().await.unwrap_or_default();
-        anyhow::bail!("{e}");
+        let body = resp.text().await.unwrap_or_default();
+        // The daemon's own message, not the JSON envelope around it: a
+        // provider's 401 naming the key it rejected is the whole of what
+        // is needed here.
+        anyhow::bail!("{}", daemon::api_error(&body).unwrap_or(body));
     }
 
     // Stream NDJSON lines as they arrive, async so each read can be
@@ -937,9 +1037,9 @@ mod unix_readline {
 // ---------------------------------------------------------------------------
 
 #[allow(dead_code)]
-fn run_interactive_cooked(model: &str, opts: ChatOptions) -> anyhow::Result<()> {
+fn run_interactive_cooked(model: &str, opts: ChatOptions<'_>) -> anyhow::Result<()> {
     let rt = tokio::runtime::Runtime::new().context("start tokio runtime")?;
-    let client = chat_client()?;
+    let client = chat_client(opts.api_key)?;
     let mut messages: Vec<Msg> = Vec::new();
     use std::io::BufRead;
     let stdin = std::io::stdin();

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 
 use anyhow::{anyhow, Context};
 use axum::body::{Body, Bytes};
-use axum::extract::{DefaultBodyLimit, State};
+use axum::extract::{DefaultBodyLimit, Path as UrlPath, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
@@ -2714,6 +2714,17 @@ fn is_cross_site(headers: Option<&HeaderMap>) -> bool {
         })
 }
 
+/// The models.dev catalog, as everything in this module reaches it: off
+/// the runtime, since the first call fetches (and caches) it while every
+/// later one is memoized, and a 502 when that fetch fails — the failure
+/// is upstream's, not the caller's.
+async fn provider_catalog() -> Result<Arc<crate::providers::Catalog>, AppError> {
+    tokio::task::spawn_blocking(crate::providers::catalog)
+        .await
+        .context("provider catalog task panicked")?
+        .map_err(|e| AppError(e, StatusCode::BAD_GATEWAY))
+}
+
 /// Resolves a [`crate::providers::REMOTE_PREFIX`] reference into a
 /// [`Target::Remote`], or `None` for any ordinary local reference.
 ///
@@ -2731,19 +2742,11 @@ async fn resolve_remote_target(
     };
     let (provider_id, model) = (provider_id.to_string(), model.to_string());
 
-    // Blocking: the first call fetches models.dev (and caches it); every
-    // later one is a memoized lookup.
-    let catalog = tokio::task::spawn_blocking(crate::providers::catalog)
-        .await
-        .context("provider catalog task panicked")?
-        .map_err(|e| AppError(e, StatusCode::BAD_GATEWAY))?;
+    let catalog = provider_catalog().await?;
 
     let provider = catalog.get(&provider_id).ok_or_else(|| {
         AppError(
-            anyhow!(
-                "unknown provider {provider_id:?} — run 'llmman launch --list-providers' \
-                 for the providers llmman can route to"
-            ),
+            crate::providers::unknown_provider_error(&provider_id, &catalog),
             StatusCode::BAD_REQUEST,
         )
     })?;
@@ -4064,6 +4067,142 @@ async fn handle_props() -> impl IntoResponse {
             }
         }
     }))
+}
+
+// -- llmman's own API --------------------------------------------------------
+//
+// `/llmman` is llmman's own, not a compatibility surface: no upstream API
+// has a notion of a models.dev provider. `llmman providers`, `run
+// --provider`, `list --provider` and `launch --provider` are all clients
+// of the two routes below (see `cmd::providers`, and `crate::daemon` for
+// the wire types), so the catalog lives in one process: the one that
+// needs it to route upstream anyway, and whose key is spent for a request
+// that presents none (see `resolve_remote_target`).
+
+/// One entry in `GET /llmman/providers`.
+///
+/// A count, not the model ids: those are megabytes across the catalog,
+/// and a caller wanting one provider's asks for it (`ProviderResponse`).
+#[derive(Serialize)]
+struct ProviderSummary {
+    id: String,
+    name: String,
+    base_url: String,
+    key_env: String,
+    /// Whether *this daemon's* environment holds `key_env`.
+    key_set: bool,
+    /// Whether it would actually spend it for a request that presents no
+    /// key of its own — `key_set` plus this daemon's own bind check, which
+    /// only it can make (see `resolve_remote_target`). A client asking
+    /// "will my keyless request work" has to read this, not `key_set`:
+    /// its own `LLMMAN_HOST` says nothing about how the daemon is bound.
+    key_usable: bool,
+    models: usize,
+}
+
+impl From<&crate::providers::Provider> for ProviderSummary {
+    fn from(p: &crate::providers::Provider) -> Self {
+        Self {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            base_url: p.base_url.clone(),
+            key_env: p.key_env.clone(),
+            key_set: p.api_key().is_some(),
+            key_usable: daemon_key_usable(p),
+            models: p.models.len(),
+        }
+    }
+}
+
+/// Whether this daemon would spend its own key for a request that
+/// presents none — the same two conditions `resolve_remote_target`
+/// applies, minus the per-request cross-site check no CLI can trip.
+fn daemon_key_usable(provider: &crate::providers::Provider) -> bool {
+    provider.api_key().is_some() && crate::daemon::reachable_only_locally()
+}
+
+/// `GET /llmman/providers`.
+#[derive(Serialize)]
+struct ProvidersResponse {
+    providers: Vec<ProviderSummary>,
+}
+
+/// `GET /llmman/providers/:id` — one provider, with its models.
+#[derive(Serialize)]
+struct ProviderResponse {
+    id: String,
+    name: String,
+    base_url: String,
+    key_env: String,
+    key_set: bool,
+    /// See [`ProviderSummary::key_usable`].
+    key_usable: bool,
+    models: Vec<ProviderModelResponse>,
+}
+
+/// One model in a [`ProviderResponse`].
+#[derive(Serialize)]
+struct ProviderModelResponse {
+    id: String,
+    /// Absent, not zero, where models.dev publishes no price: printing
+    /// "unknown" as "free" lies about someone's bill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<ProviderCostResponse>,
+}
+
+/// US dollars per million tokens, models.dev's own unit (see
+/// [`crate::providers::Cost`]).
+#[derive(Serialize)]
+struct ProviderCostResponse {
+    input: f64,
+    output: f64,
+}
+
+impl From<&crate::providers::Provider> for ProviderResponse {
+    fn from(p: &crate::providers::Provider) -> Self {
+        Self {
+            id: p.id.clone(),
+            name: p.name.clone(),
+            base_url: p.base_url.clone(),
+            key_env: p.key_env.clone(),
+            key_set: p.api_key().is_some(),
+            key_usable: daemon_key_usable(p),
+            models: p
+                .models
+                .iter()
+                .map(|m| ProviderModelResponse {
+                    id: m.id.clone(),
+                    cost: m.cost.map(|c| ProviderCostResponse {
+                        input: c.input,
+                        output: c.output,
+                    }),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// `GET /llmman/providers` — every provider `--provider` accepts.
+async fn handle_llmman_providers() -> Result<impl IntoResponse, AppError> {
+    let catalog = provider_catalog().await?;
+    Ok(Json(ProvidersResponse {
+        providers: catalog.iter().map(ProviderSummary::from).collect(),
+    }))
+}
+
+/// `GET /llmman/providers/:id` — one provider, or a 404 naming
+/// near-matches (see [`crate::providers::unknown_provider_error`]).
+async fn handle_llmman_provider(
+    UrlPath(id): UrlPath<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let catalog = provider_catalog().await?;
+    let provider = catalog.get(&id).ok_or_else(|| {
+        AppError(
+            crate::providers::unknown_provider_error(&id, &catalog),
+            StatusCode::NOT_FOUND,
+        )
+    })?;
+    Ok(Json(ProviderResponse::from(provider)))
 }
 
 /// Ollama's GET /api/version, extended with this daemon's own identity —
@@ -5636,6 +5775,9 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         .route("/loading.html", get(handle_loading_html))
         // llama.cpp-compatible props endpoint (router mode)
         .route("/props", get(handle_props))
+        // llmman's own API — see handle_llmman_providers
+        .route("/llmman/providers", get(handle_llmman_providers))
+        .route("/llmman/providers/:id", get(handle_llmman_provider))
         // Ollama API
         .route("/api/version", get(handle_version))
         .route("/api/tags", get(handle_tags))
@@ -6571,6 +6713,78 @@ mod tests {
             r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#
         )
         .is_empty());
+    }
+
+    // -- llmman's own API ----------------------------------------------------
+
+    /// A catalog to serve, without the network. Its key variable is one
+    /// nothing exports, so `key_set` is false even in a shell that has a
+    /// real OpenRouter key.
+    fn fixture_catalog() -> crate::providers::Catalog {
+        crate::providers::Catalog::from_json(
+            br#"{
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider",
+                    "env": ["LLMMAN_TEST_PROVIDER_KEY_UNSET"],
+                    "models": {
+                        "z-model": { "cost": { "input": 2.5, "output": 10 } },
+                        "a-model": {}
+                    }
+                }
+            }"#,
+        )
+        .expect("fixture parses")
+    }
+
+    /// "Which providers are there" gets a count, not every model id.
+    #[test]
+    fn the_provider_listing_reports_model_counts_not_model_ids() {
+        let catalog = fixture_catalog();
+        let summaries: Vec<ProviderSummary> = catalog.iter().map(ProviderSummary::from).collect();
+        let json = serde_json::to_value(&summaries).unwrap();
+        assert_eq!(json[0]["id"], "openrouter");
+        assert_eq!(json[0]["name"], "OpenRouter");
+        assert_eq!(json[0]["key_env"], "LLMMAN_TEST_PROVIDER_KEY_UNSET");
+        assert_eq!(json[0]["models"], 2);
+        assert_eq!(json[0]["key_set"], false);
+        assert_eq!(json[0]["key_usable"], false);
+    }
+
+    /// The per-provider route carries the models themselves, sorted by
+    /// id (`list --provider` prints them straight through) and priced
+    /// where models.dev prices them.
+    #[test]
+    fn a_single_provider_carries_its_models_and_their_prices() {
+        let catalog = fixture_catalog();
+        let provider = catalog.get("openrouter").unwrap();
+        let json = serde_json::to_value(ProviderResponse::from(provider)).unwrap();
+        assert_eq!(json["base_url"], "https://openrouter.ai/api/v1");
+        assert_eq!(
+            json["models"],
+            serde_json::json!([
+                { "id": "a-model" },
+                { "id": "z-model", "cost": { "input": 2.5, "output": 10.0 } },
+            ])
+        );
+    }
+
+    /// `key_set` is the whole of what a client is told about a key.
+    #[test]
+    fn provider_responses_carry_no_api_key() {
+        let catalog = fixture_catalog();
+        let provider = catalog.get("openrouter").unwrap();
+        for json in [
+            serde_json::to_value(ProviderSummary::from(provider)).unwrap(),
+            serde_json::to_value(ProviderResponse::from(provider)).unwrap(),
+        ] {
+            let fields: Vec<&String> = json.as_object().unwrap().keys().collect();
+            assert!(
+                !fields.iter().any(|f| f.contains("api_key")),
+                "{fields:?} carries a key"
+            );
+        }
     }
 
     // -- Idle-timeout auto-unload reaper --------------------------------------

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3,10 +3,11 @@
 //! by default, overridable via `LLMMAN_HOST`.
 //!
 //! Used by any CLI subcommand that acts as a client of that API rather than
-//! calling the FFI/model-management logic directly — currently `pull`,
-//! `push`, and `launch` — so bare model-name resolution (see
-//! `shortnames::resolve_ollama_api`), the local model store, and any
-//! already-loaded models are always the daemon's, never duplicated
+//! calling the FFI/model-management logic directly — `pull`, `push`,
+//! `run`, `ps`, `stop`, `launch`, and `providers` — so bare model-name
+//! resolution (see `shortnames::resolve_ollama_api`), the local model
+//! store, any already-loaded models, and the provider catalog (see
+//! [`providers`]) are always the daemon's, never duplicated
 //! per-invocation.
 
 use std::io::BufRead;
@@ -1007,18 +1008,177 @@ pub fn unload(reference: &str) -> anyhow::Result<()> {
 }
 
 /// A plain `GET {server()}{path}` returning the parsed JSON body — for
-/// callers (currently just `ps`) that don't need `stream_progress`'s
-/// newline-delimited-JSON streaming, just a single request/response.
+/// callers (`ps`, and the provider helpers below) that don't need
+/// `stream_progress`'s newline-delimited-JSON streaming, just a single
+/// request/response.
 pub fn get_json<T: serde::de::DeserializeOwned>(path: &str) -> anyhow::Result<T> {
     let resp = reqwest::blocking::get(format!("{}{path}", server()))
         .with_context(|| format!("request {path}"))?;
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().unwrap_or_default();
-        anyhow::bail!("{path}: server returned {status}: {body}");
+        // The daemon's errors are `{"error": "<message>"}` (see AppError
+        // in cmd::serve), and that message is written for a person — the
+        // "did you mean" suggestions, say. An envelope and a status code
+        // around it bury the part meant to be read.
+        anyhow::bail!(
+            "{}",
+            api_error(&body).unwrap_or(format!("{path}: server returned {status}: {body}"))
+        );
     }
     resp.json()
         .with_context(|| format!("parse response from {path}"))
+}
+
+/// The `error` message out of an `AppError` response body, or `None` for
+/// a body that isn't one (an empty 404 from axum's router, say). Public
+/// for `cmd::run`, the one client that reads a body itself rather than
+/// through `get_json`.
+pub fn api_error(body: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()?
+        .get("error")?
+        .as_str()
+        .map(str::to_string)
+        .filter(|e| !e.is_empty())
+}
+
+// ---------------------------------------------------------------------------
+// Providers — clients of the daemon's own /llmman API
+// ---------------------------------------------------------------------------
+
+/// Wire shape of one entry in `GET /llmman/providers` — see
+/// `ProviderSummary` in `cmd::serve` for the server side these field
+/// names must match.
+#[derive(Debug, Deserialize)]
+pub struct ProviderSummary {
+    pub id: String,
+    pub name: String,
+    pub key_env: String,
+    /// Whether the key is set *where the daemon runs*. This process's own
+    /// environment is [`ProviderSummary::key_here`].
+    pub key_set: bool,
+    /// Whether the daemon would actually spend that key for a request
+    /// presenting none. Only it can tell: that depends on how it is
+    /// bound, which this process's `LLMMAN_HOST` says nothing about.
+    #[serde(default)]
+    pub key_usable: bool,
+    pub models: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProvidersResponse {
+    providers: Vec<ProviderSummary>,
+}
+
+impl ProviderSummary {
+    /// Whether *this* process holds the key — the other way one reaches
+    /// a provider, sent per request (see `client_api_key` in cmd::serve).
+    pub fn key_here(&self) -> bool {
+        crate::providers::key_from_env(&self.key_env).is_some()
+    }
+}
+
+/// Every provider `--provider` accepts, as the running daemon sees them.
+pub fn providers() -> anyhow::Result<Vec<ProviderSummary>> {
+    Ok(get_json::<ProvidersResponse>("/llmman/providers")?.providers)
+}
+
+/// Wire shape of `GET /llmman/providers/:id` — one provider, with the
+/// models it serves. See `ProviderResponse` in `cmd::serve`.
+#[derive(Debug, Deserialize)]
+pub struct ProviderDetail {
+    pub id: String,
+    pub name: String,
+    pub base_url: String,
+    pub key_env: String,
+    /// See [`ProviderSummary::key_set`].
+    pub key_set: bool,
+    /// See [`ProviderSummary::key_usable`].
+    #[serde(default)]
+    pub key_usable: bool,
+    pub models: Vec<ProviderModel>,
+}
+
+/// One model in a [`ProviderDetail`].
+#[derive(Debug, Deserialize)]
+pub struct ProviderModel {
+    pub id: String,
+    /// `None` where models.dev publishes no price, which is not free.
+    #[serde(default)]
+    pub cost: Option<ModelCost>,
+}
+
+/// US dollars per million tokens (see [`crate::providers::Cost`]).
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub struct ModelCost {
+    pub input: f64,
+    pub output: f64,
+}
+
+impl ProviderDetail {
+    /// This provider's key from *this* process's environment, to travel
+    /// with each request (see `client_api_key` in cmd::serve). `None` need
+    /// not be fatal — the daemon may hold it ([`ProviderDetail::key_set`]).
+    ///
+    /// The daemon names the variable, so a process squatting the port
+    /// could name an unrelated secret — inside the trust boundary this
+    /// whole module sits in either way: that daemon is handed every
+    /// prompt, and every key, regardless.
+    pub fn api_key(&self) -> Option<String> {
+        crate::providers::key_from_env(&self.key_env)
+    }
+
+    /// Just the ids, for a caller that only needs to name one (see
+    /// `crate::providers::example_models`).
+    pub fn model_ids(&self) -> Vec<&str> {
+        self.models.iter().map(|m| m.id.as_str()).collect()
+    }
+
+    /// Warns when this provider does not list `model` — a warning, since
+    /// models.dev is a snapshot and a provider can serve a model (a new
+    /// release, a fine-tune, a private deployment) before it lists one.
+    pub fn warn_unlisted(&self, model: &str) {
+        if !self.models.iter().any(|m| m.id == model) {
+            eprintln!(
+                "[llmman] warning: {} does not list model {model:?}\n{}",
+                self.name,
+                crate::providers::example_models(&self.name, &self.model_ids())
+            );
+        }
+    }
+
+    /// Whether the *daemon's* own key gets spent for a request that
+    /// presents none — its own answer (see `resolve_remote_target` in
+    /// cmd::serve), not a guess from this process's `LLMMAN_HOST`, which
+    /// describes the host it dials rather than how that daemon is bound.
+    pub fn daemon_key_usable(&self) -> bool {
+        self.key_usable
+    }
+}
+
+/// Looks one provider up in the daemon's catalog. An unknown id comes
+/// back as the daemon's own error, near-matches included (see
+/// `crate::providers::unknown_provider_error`).
+pub fn provider(id: &str) -> anyhow::Result<ProviderDetail> {
+    get_json(&format!("/llmman/providers/{}", encode_path_segment(id)))
+}
+
+/// Percent-encodes everything outside the unreserved set, so a typo'd id
+/// stays one path segment: `a/b` would otherwise miss the daemon's
+/// single-segment route (an empty 404 from axum's router instead of
+/// llmman's "unknown provider"), and `../` would address another.
+fn encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -1048,6 +1208,59 @@ mod tests {
             assert!(!host_connects_over_loopback(remote), "{remote}");
             assert!(!host_reachable_only_locally(remote), "{remote}");
         }
+    }
+
+    /// A typo'd id has to stay one segment, or the daemon's "unknown
+    /// provider" answer never gets printed.
+    #[test]
+    fn encode_path_segment_keeps_a_typo_inside_one_segment() {
+        assert_eq!(encode_path_segment("openrouter"), "openrouter");
+        assert_eq!(
+            encode_path_segment("together-ai_1.0~x"),
+            "together-ai_1.0~x"
+        );
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+        assert_eq!(encode_path_segment("../api/tags"), "..%2Fapi%2Ftags");
+        assert_eq!(encode_path_segment("open ai"), "open%20ai");
+        assert_eq!(encode_path_segment("a?b#c"), "a%3Fb%23c");
+        // Non-ASCII goes out as its UTF-8 bytes, percent-encoded.
+        assert_eq!(encode_path_segment("é"), "%C3%A9");
+    }
+
+    /// Whether the daemon spends its own key is the daemon's answer, not
+    /// a guess from this process's `LLMMAN_HOST`: a daemon bound to
+    /// `0.0.0.0` withholds it while the client dialing loopback would
+    /// conclude the opposite, and only find out at the first request.
+    #[test]
+    fn daemon_key_usable_is_the_daemons_own_answer() {
+        let body = |extra: &str| {
+            serde_json::from_str::<ProviderDetail>(&format!(
+                r#"{{"id":"openai","name":"OpenAI","base_url":"https://api.openai.com/v1",
+                     "key_env":"LLMMAN_TEST_PROVIDER_KEY_UNSET","models":[]{extra}}}"#
+            ))
+            .expect("parses")
+        };
+        assert!(body(r#","key_set":true,"key_usable":true"#).daemon_key_usable());
+        // Has the key, would withhold it — a wildcard-bound daemon.
+        assert!(!body(r#","key_set":true,"key_usable":false"#).daemon_key_usable());
+        // Says nothing at all: assume the conservative answer.
+        assert!(!body(r#","key_set":true"#).daemon_key_usable());
+    }
+
+    /// The daemon's messages are written to be read; the JSON envelope
+    /// around them is not.
+    #[test]
+    fn api_error_unwraps_the_daemons_own_message() {
+        assert_eq!(
+            api_error(r#"{"error":"unknown provider \"togethr\""}"#).as_deref(),
+            Some("unknown provider \"togethr\"")
+        );
+        // Not an AppError body: nothing to unwrap, and the caller falls
+        // back to reporting the status and the raw body.
+        assert_eq!(api_error(""), None);
+        assert_eq!(api_error("Not Found"), None);
+        assert_eq!(api_error(r#"{"error":""}"#), None);
+        assert_eq!(api_error(r#"{"detail":"nope"}"#), None);
     }
 
     /// Unset/blank `LLMMAN_HOST` — the common case — resolves to the

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,8 @@ enum Commands {
     List(cmd::list::ListArgs),
     /// List models currently loaded by a running `llmman serve`
     Ps(cmd::ps::PsArgs),
+    /// List the hosted providers `--provider` can route to
+    Providers(cmd::providers::ProvidersArgs),
     /// Copy a local image to a new reference
     Cp(cmd::cp::CpArgs),
     /// Remove a local image, freeing its blobs and extracted cache no
@@ -108,6 +110,7 @@ fn main() {
         Commands::Transfer(a) => cmd::transfer::run(a),
         Commands::List(a) => cmd::list::run(a),
         Commands::Ps(a) => cmd::ps::run(a),
+        Commands::Providers(a) => cmd::providers::run(a),
         Commands::Cp(a) => cmd::cp::run(a),
         Commands::Rm(a) => cmd::rm::run(a),
         Commands::Stop(a) => cmd::stop::run(a),

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -220,7 +220,7 @@ pub fn is_remote_ref(reference: &str) -> bool {
 /// One reachable provider: everything `llmman serve` needs to forward a
 /// request upstream, and everything `llmman launch` needs to explain how
 /// to authenticate to it.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Provider {
     /// models.dev provider id, as passed to `--provider`.
     pub id: String,
@@ -231,19 +231,35 @@ pub struct Provider {
     pub base_url: String,
     /// Environment variable holding this provider's API key.
     pub key_env: String,
-    /// Model ids this provider serves, sorted. Used to validate `--model`
-    /// and to suggest values; never sent upstream verbatim.
-    pub models: Vec<String>,
+    /// Models this provider serves, sorted by id. Used to validate
+    /// `--model`, to suggest values, and to answer `llmman list
+    /// --provider`; the id is never sent upstream verbatim.
+    pub models: Vec<Model>,
+}
+
+/// One model a provider serves.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Model {
+    /// The model id as the *provider* knows it.
+    pub id: String,
+    /// `None` where models.dev publishes no price, which is not the same
+    /// as free and must not be rendered as one.
+    pub cost: Option<Cost>,
+}
+
+/// US dollars per million tokens — models.dev's own unit, unconverted so
+/// a printed figure matches the provider's pricing page.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Cost {
+    pub input: f64,
+    pub output: f64,
 }
 
 impl Provider {
     /// This provider's API key from the environment, or `None` when
     /// [`Provider::key_env`] is unset or blank.
     pub fn api_key(&self) -> Option<String> {
-        std::env::var(&self.key_env)
-            .ok()
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
+        key_from_env(&self.key_env)
     }
 
     /// Appends an OpenAI route to this provider's base URL. See
@@ -251,6 +267,128 @@ impl Provider {
     pub fn url(&self, route: &str) -> String {
         rebase_url(&self.base_url, route)
     }
+}
+
+/// An API key read out of `var`, or `None` when it is unset or blank.
+///
+/// Free-standing because a `/llmman/providers` client (see
+/// `cmd::providers`) learns only the variable's *name* from the daemon,
+/// never a whole [`Provider`].
+pub fn key_from_env(var: &str) -> Option<String> {
+    std::env::var(var)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// The provider id `--provider` names: `None` when the flag is absent,
+/// an error when it is present but blank.
+///
+/// Blank is not absent. `--provider "$PROVIDER"` with the variable unset
+/// would otherwise silently run, list or launch *locally* — pulling
+/// weights, or reading the local store — when what was asked for was a
+/// hosted model.
+pub fn provider_flag(value: Option<&str>) -> anyhow::Result<Option<&str>> {
+    match value.map(str::trim) {
+        Some("") => anyhow::bail!(
+            "--provider needs a provider id — run 'llmman providers' for the ones llmman \
+             can route to"
+        ),
+        other => Ok(other),
+    }
+}
+
+/// A few real model ids, to make "which models?" answerable without
+/// leaving the error message. Ids, not a [`Provider`]: callers hold a
+/// wire shape from the daemon (see `cmd::providers`).
+pub fn example_models(name: &str, ids: &[&str]) -> String {
+    if ids.is_empty() {
+        return format!("{name} lists no models");
+    }
+    let shown: Vec<&str> = ids.iter().take(5).copied().collect();
+    let more = ids.len().saturating_sub(shown.len());
+    let suffix = if more > 0 {
+        format!(", … ({more} more)")
+    } else {
+        String::new()
+    };
+    format!("{name} models include: {}{suffix}", shown.join(", "))
+}
+
+/// Suggests near-matches before falling back to `llmman providers`, so a
+/// typo is one line from the right answer rather than a 180-entry
+/// listing. Next to the catalog because `llmman serve` owns it, and so is
+/// what reports an unknown id — to `/llmman/providers/:id` callers and to
+/// a request routed at a provider that does not exist alike.
+pub fn unknown_provider_error(provider: &str, catalog: &Catalog) -> anyhow::Error {
+    let close = suggestions(provider, catalog);
+    if close.is_empty() {
+        anyhow::anyhow!(
+            "unknown provider {provider:?}\nRun 'llmman providers' for the {} providers \
+             llmman can route to.",
+            catalog.len()
+        )
+    } else {
+        anyhow::anyhow!(
+            "unknown provider {provider:?}\nDid you mean: {}?\nRun 'llmman providers' for \
+             all {} of them.",
+            close.join(", "),
+            catalog.len()
+        )
+    }
+}
+
+/// Catalog ids closest to `provider`, or nothing when it is too long to
+/// be one: an id can arrive in a request body (see
+/// `resolve_remote_target` in cmd::serve), and both passes below scan the
+/// whole catalog against it — the second at O(needle × id) a candidate.
+/// Neither could match a needle that long anyway, so the guard costs no
+/// suggestion anyone would have wanted.
+fn suggestions<'a>(provider: &str, catalog: &'a Catalog) -> Vec<&'a str> {
+    let needle = provider.to_lowercase();
+    if needle.len() > MAX_SUGGESTION_LEN {
+        return Vec::new();
+    }
+    // A shortened or padded id first ("together" for `togetherai`), then
+    // — no substring match catches a slip like "togethr" — the nearest
+    // ids, allowing about one edit per three characters.
+    let close: Vec<&str> = catalog
+        .ids()
+        .filter(|id| id.contains(&needle) || needle.contains(*id))
+        .take(10)
+        .collect();
+    if !close.is_empty() {
+        return close;
+    }
+    let mut ranked: Vec<(usize, &str)> = catalog
+        .ids()
+        .map(|id| (edit_distance(&needle, id), id))
+        .filter(|(d, id)| d * 3 <= needle.len().max(id.len()))
+        .collect();
+    ranked.sort_unstable();
+    ranked.into_iter().take(5).map(|(_, id)| id).collect()
+}
+
+/// Longest id [`suggestions`] will look for a near-match to. A real one
+/// is ~30 characters; a request body allows megabytes.
+const MAX_SUGGESTION_LEN: usize = 64;
+
+/// Levenshtein distance, two rows at a time. Run over ~180 short ids,
+/// and only once no substring matched.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            cur[j + 1] = (prev[j] + usize::from(ca != *cb))
+                .min(prev[j + 1] + 1)
+                .min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
 }
 
 /// Re-bases one of llmman's own internal routes (`/v1/chat/completions`)
@@ -328,12 +466,9 @@ impl Catalog {
     }
 }
 
-/// A models.dev catalog entry, narrowed to the fields llmman reads.
-///
-/// `models` deserializes its values into [`serde::de::IgnoredAny`]: only
-/// the ids (the map's keys) are wanted, and `api.json` is megabytes of
-/// per-model cost/limit/modality metadata that would otherwise all be
-/// materialized.
+/// A models.dev catalog entry, narrowed to the fields llmman reads —
+/// `api.json` is megabytes of per-model limit/modality metadata nothing
+/// here reads.
 #[derive(Debug, Deserialize)]
 struct RawProvider {
     #[serde(default)]
@@ -345,7 +480,32 @@ struct RawProvider {
     #[serde(default)]
     env: Vec<String>,
     #[serde(default)]
-    models: BTreeMap<String, serde::de::IgnoredAny>,
+    models: BTreeMap<String, RawModel>,
+}
+
+/// A models.dev model entry — the id is the map key, so only the price
+/// is read out of the value.
+#[derive(Debug, Deserialize)]
+struct RawModel {
+    /// Untyped on purpose: a typed `{input, output}` would let an
+    /// upstream `cost` that grew a new shape drop the whole *provider*,
+    /// and a listing column is not worth `--provider x` breaking over.
+    #[serde(default)]
+    cost: Option<serde_json::Value>,
+}
+
+/// A models.dev `cost` object as a [`Cost`], or `None` unless *both*
+/// figures are there and sane — half a price misleads worse than none.
+fn cost_of(raw: &serde_json::Value) -> Option<Cost> {
+    let field = |name: &str| -> Option<f64> {
+        raw.get(name)?
+            .as_f64()
+            .filter(|v| v.is_finite() && *v >= 0.0)
+    };
+    Some(Cost {
+        input: field("input")?,
+        output: field("output")?,
+    })
 }
 
 /// Providers that pass every rule below but still cannot be driven with
@@ -413,7 +573,15 @@ fn routable(id: &str, raw: RawProvider) -> Option<Provider> {
         name: raw.name,
         base_url: base_url_of(base_url),
         key_env,
-        models: raw.models.into_keys().collect(),
+        // Sorted by id, since `models` came out of a BTreeMap.
+        models: raw
+            .models
+            .into_iter()
+            .map(|(id, model)| Model {
+                id,
+                cost: model.cost.as_ref().and_then(cost_of),
+            })
+            .collect(),
     })
 }
 
@@ -696,7 +864,10 @@ mod tests {
                     "api": "https://openrouter.ai/api/v1",
                     "npm": "@openrouter/ai-sdk-provider",
                     "env": ["OPENROUTER_API_KEY"],
-                    "models": { "z-model": {}, "a-model": {} }
+                    "models": {
+                        "z-model": { "cost": { "input": 2.5, "output": 10 } },
+                        "a-model": {}
+                    }
                 }
             }"#,
         );
@@ -704,8 +875,23 @@ mod tests {
         assert_eq!(p.name, "OpenRouter");
         assert_eq!(p.base_url, "https://openrouter.ai/api/v1");
         assert_eq!(p.key_env, "OPENROUTER_API_KEY");
-        // Sorted, and only the ids — the per-model metadata is dropped.
-        assert_eq!(p.models, vec!["a-model", "z-model"]);
+        // Sorted by id; an unpriced model keeps `None`, not a zero.
+        assert_eq!(
+            p.models,
+            vec![
+                Model {
+                    id: "a-model".into(),
+                    cost: None
+                },
+                Model {
+                    id: "z-model".into(),
+                    cost: Some(Cost {
+                        input: 2.5,
+                        output: 10.0
+                    })
+                },
+            ]
+        );
     }
 
     /// models.dev leaves `api` unset for providers whose SDK hardcodes
@@ -1115,5 +1301,141 @@ mod tests {
             models: vec![],
         };
         assert_eq!(p.api_key(), None);
+    }
+
+    /// The listing has to stay short enough to read in an error message
+    /// while still saying how much was elided.
+    #[test]
+    fn example_models_lists_a_few_and_counts_the_rest() {
+        assert_eq!(
+            example_models("Groq", &["a", "b"]),
+            "Groq models include: a, b"
+        );
+        assert_eq!(
+            example_models("Groq", &["a", "b", "c", "d", "e", "f", "g"]),
+            "Groq models include: a, b, c, d, e, … (2 more)"
+        );
+        assert_eq!(example_models("Groq", &[]), "Groq lists no models");
+    }
+
+    /// An explicitly blank `--provider` asked for a hosted model and gave
+    /// no id; running locally instead would pull weights nobody asked
+    /// for.
+    #[test]
+    fn a_blank_provider_flag_is_an_error_not_an_absent_one() {
+        assert_eq!(provider_flag(None).unwrap(), None);
+        assert_eq!(provider_flag(Some("  openai ")).unwrap(), Some("openai"));
+        assert!(provider_flag(Some("")).is_err());
+        assert!(provider_flag(Some("   ")).is_err());
+    }
+
+    /// A price is carried only when llmman is sure of it; anything else
+    /// is `None`, which `list --provider` prints as unknown, not free.
+    #[test]
+    fn cost_of_takes_both_figures_or_neither() {
+        let cost = |json: &str| cost_of(&serde_json::from_str(json).unwrap());
+        assert_eq!(
+            cost(r#"{"input": 2.5, "output": 10}"#),
+            Some(Cost {
+                input: 2.5,
+                output: 10.0
+            })
+        );
+        // A genuinely free model is a price, not a missing one.
+        assert_eq!(
+            cost(r#"{"input": 0, "output": 0, "cache_read": 1}"#),
+            Some(Cost {
+                input: 0.0,
+                output: 0.0
+            })
+        );
+        // Half a price, no price, and a shape llmman doesn't recognize.
+        assert_eq!(cost(r#"{"input": 2.5}"#), None);
+        assert_eq!(cost(r#"{}"#), None);
+        assert_eq!(cost(r#"{"input": "2.5", "output": "10"}"#), None);
+        assert_eq!(cost(r#"{"input": -1, "output": 10}"#), None);
+        assert_eq!(cost(r#"[]"#), None);
+    }
+
+    /// The reason `cost` is untyped: a shape llmman doesn't know costs
+    /// that model its price, not the provider its routability.
+    #[test]
+    fn an_unrecognized_cost_shape_keeps_the_provider() {
+        let catalog = catalog_from(
+            r#"{
+                "openrouter": {
+                    "id": "openrouter", "name": "OpenRouter",
+                    "api": "https://openrouter.ai/api/v1",
+                    "npm": "@openrouter/ai-sdk-provider", "env": ["OPENROUTER_API_KEY"],
+                    "models": {
+                        "weird": { "cost": "free, actually" },
+                        "fine": { "cost": { "input": 1, "output": 2 } }
+                    }
+                }
+            }"#,
+        );
+        let p = catalog.get("openrouter").expect("openrouter is routable");
+        assert_eq!(p.models.len(), 2);
+        assert_eq!(p.models[0].id, "fine");
+        assert!(p.models[1].cost.is_none());
+    }
+
+    /// A half-remembered or fat-fingered id has to come back with the
+    /// real one, or a 180-entry listing has to be re-read.
+    #[test]
+    fn unknown_provider_error_suggests_near_matches() {
+        let catalog = catalog_from(
+            r#"{
+                "togetherai": {
+                    "id": "togetherai", "name": "Together",
+                    "api": "https://api.together.xyz/v1",
+                    "npm": "@ai-sdk/openai-compatible", "env": ["TOGETHER_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        // A shortened id, caught by the substring pass.
+        let short = unknown_provider_error("together", &catalog).to_string();
+        assert!(short.contains("unknown provider \"together\""), "{short}");
+        assert!(short.contains("Did you mean: togetherai?"), "{short}");
+        assert!(short.contains("llmman providers"), "{short}");
+
+        // A dropped character, which only the distance pass catches.
+        let typo = unknown_provider_error("togethr", &catalog).to_string();
+        assert!(typo.contains("Did you mean: togetherai?"), "{typo}");
+
+        // Nothing close: still name the command that lists them all,
+        // without inventing a suggestion.
+        let far = unknown_provider_error("nope", &catalog).to_string();
+        assert!(!far.contains("Did you mean"), "{far}");
+        assert!(far.contains("llmman providers"), "{far}");
+    }
+
+    /// An id from a request body can be megabytes long (see
+    /// `resolve_remote_target` in cmd::serve). Scanning the catalog
+    /// against it — let alone a distance matrix per entry — buys nothing:
+    /// it cannot match either pass.
+    #[test]
+    fn an_absurdly_long_id_is_reported_without_a_suggestion_pass() {
+        let catalog = catalog_from(
+            r#"{
+                "togetherai": {
+                    "id": "togetherai", "name": "Together",
+                    "api": "https://api.together.xyz/v1",
+                    "npm": "@ai-sdk/openai-compatible", "env": ["TOGETHER_API_KEY"],
+                    "models": { "gpt-5": {} }
+                }
+            }"#,
+        );
+        let huge = "z".repeat(4 * 1024 * 1024);
+        let started = Instant::now();
+        let error = unknown_provider_error(&huge, &catalog).to_string();
+        assert!(!error.contains("Did you mean"), "suggested for a 4MB id");
+        assert!(error.contains("llmman providers"));
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "took {:?}",
+            started.elapsed()
+        );
     }
 }


### PR DESCRIPTION
## What

- `llmman launch --list-providers` → top-level **`llmman providers`**.
- Adds **`llmman run --provider`** and **`llmman list --provider`**.
- Adds llmman's own API on `llmman serve`, which all of those (and `launch --provider`) are clients of:
  - `GET /llmman/providers` — providers the daemon can route to, each with its key variable, whether the daemon has that key *and would spend it*, and a model count.
  - `GET /llmman/providers/{id}` — that provider's models and what each costs per million tokens; an unknown id 404s with llmman's own "did you mean".

## Why

`--list-providers` answered a question belonging to no single subcommand, by fetching models.dev from whichever process asked. Each client then kept its own catalog, cache and idea of whether a key was set — while the daemon, the only process whose environment decides whether a keyless request can be forwarded, was never asked. It now owns the catalog it already needed to route a provider request at all.

## Notes

- `llmman run -p openai gpt-4o "hi"` sends this shell's key per request in a sensitive `Authorization` header (never to disk), skips the shortname/tag/pull path, and streams back through `/api/chat` like a local model.
- `list --provider` prints `IN $/Mtok`/`OUT $/Mtok`; `-` is "no published price", `0` is genuinely free, never conflated.
- `run --provider` refuses a non-loopback `LLMMAN_HOST` (the daemon has no TLS), mirroring `launch`. `providers` and `list --provider` read the catalog only and work against any daemon.
- CLI errors print the daemon's message rather than the `{"error":"..."}` envelope around it.

## Review feedback

- **Client-side bind check was wrong** (Copilot): `daemon_key_usable` asked *this process's* `LLMMAN_HOST` whether the daemon would spend its own key, so a wildcard-bound daemon reached over loopback passed preflight and 401'd on the first request. The daemon now reports `key_usable` (its key plus its own bind check) and clients consume that. Verified both ways against a real `0.0.0.0` daemon; regression test included.
- **`launch` warned where it should fail** (Copilot): an integration configured through a file cannot carry a key, so a daemon without a usable one guarantees a 401 inside someone else's TUI. Now a hard error naming the variable and where to set it.
- **Duplicated provider validation** (CodeRabbit): the shared rules live once, as `ProviderDetail::warn_unlisted`/`daemon_key_usable`.
- **Substring-only suggestions** (Copilot): a ranked edit-distance pass now catches `togethr` → `togetherai`, tested.
- **The daemon names which env var the client reads** (Copilot): real, but inside the trust boundary every client of this daemon already sits in — that daemon is handed every prompt and every provider key regardless, so a port squatter harvests the legitimate key just by answering normally. Documented at `ProviderDetail::api_key`; authenticating the daemon is its own change.
- **Unbounded suggestion work** (CodeRabbit, twice): a provider id arrives in a request body, so the new near-match search could be handed megabytes. Both passes — substring and edit distance — are now behind one length bound, since neither could match a needle that long. Regression test asserts a 4 MB id is answered without them; a 200 KB id over the wire returns immediately.
- **Blank `--provider` ran locally** (Copilot): `--provider "$UNSET"` was treated as if the flag were absent, so `run`/`list`/`launch` quietly fell back to local models (pulling weights, in `run`'s case). One shared `provider_flag` now makes a present-but-blank value an error.
- **"unset" hid a withheld key** (Copilot): a wildcard-bound daemon that *has* the key now reports `set (withheld)`, so the operator fixes the bind rather than re-exporting a variable that is already set.
- Also from self-review: de-flaked a test that asserted `key_set == false` against a fixture named `OPENROUTER_API_KEY`; replaced an `unreachable!()` in `run` with a `Route` enum; kept the request path in non-API error messages so a daemon without these routes stays diagnosable.

## Testing

- `cargo test --lib --bins` (435 pass), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — clean, green on all five CI targets.
- Manually against the live catalog (180 providers): `providers`, `providers <filter>`, `list -p groq/openai/openrouter`, `run -p openai` with the key in the shell and with it only in a loopback daemon (both routed upstream; the provider's own 401 reported verbatim for a bogus key), the same against a `0.0.0.0` daemon, typo'd and `../api/tags` ids, a daemon with no `/llmman` routes, `launch -p` with no key / no model / an unsupported integration, and the unchanged local `list`/`run`/`ps`.