### PR TITLE
feat(launch): add Qwen Code integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ jobs:
         run: go test -tags podman,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
 
   # --------------------------------------------------------------------------
-  # E2E: `llmman launch <claude|opencode|codex|hermes|openclaw> --model
+  # E2E: `llmman launch <claude|opencode|codex|qwen|hermes|openclaw> --model
   # qwen3.5:0.8b` (tests/launch_e2e.rs) against a real `llmman serve`, a
   # real pulled model, a real llama-server, and the real third-party CLIs
   # — not mocks. Mirrors the `build` job's own 5-target matrix exactly
@@ -450,7 +450,7 @@ jobs:
   # non-Apple-Silicon build to test against).
   # --------------------------------------------------------------------------
   e2e:
-    name: E2E (launch claude/opencode/codex/hermes/openclaw, vllm-plugin, mlx) — ${{ matrix.target }} (${{ matrix.backend }})
+    name: E2E (launch claude/opencode/codex/qwen/hermes/openclaw, vllm-plugin, mlx) — ${{ matrix.target }} (${{ matrix.backend }})
     runs-on: ${{ matrix.runner }}
     # These take a long time (see the timeout-minutes comment below), so
     # they're skipped on pull_request entirely and only run on the two
@@ -460,30 +460,30 @@ jobs:
     # which now includes this job for exactly that reason, and its own
     # identical two-channel `if:` condition below.
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    # 5 tests run serialized (--test-threads=1 + lock_serial()), so the
-    # worst case sums all 5's own retry budgets: MAX_ATTEMPTS * TIMEOUT
+    # 6 tests run serialized (--test-threads=1 + lock_serial()), so the
+    # worst case sums all 6's own retry budgets: MAX_ATTEMPTS * TIMEOUT
     # (3 * 600s = 30 min) each — a timeout itself never retries (see
     # launch_and_assert's own doc comment), so 30 min/test is only hit if
     # every attempt fails via a missing "pong" instead. Plus warm_model()'s
     # own separate TIMEOUT budget (10 min), paid at most once across all
-    # tests (guarded by WARM's own Once). 5*30 + 10 = 160 min; 180 leaves
+    # tests (guarded by WARM's own Once). 6*30 + 10 = 190 min; 210 leaves
     # headroom on top of that for setup/build overhead (5-8 min on
     # Windows). Exhausting every attempt doesn't fail this job either way
     # (see launch_and_assert's own doc comment) — a run can still
     # legitimately take this long in wall-clock time before giving up.
     #
-    # +90 on top of that 180 (270 total) for the vllm-plugin steps'
+    # +90 on top of that 210 (300 total) for the vllm-plugin steps'
     # own per-step budgets below: up to 60 min for "Install vLLM (e2e)"
     # (wheel downloads, but a slow/retried one on a bad connection) plus
     # up to 30 min for "pytest -m e2e (vllm-plugin)".
     #
-    # +10 more (280 total) for `serve_mlx_safetensors_model`'s own single
+    # +10 more (310 total) for `serve_mlx_safetensors_model`'s own single
     # TIMEOUT budget (10 min, same 600s as warm_model's) — it doesn't go
     # through launch_and_assert's retry loop at all (a real failure there
     # is always a deterministic llmman bug worth failing loudly on, not
-    # small-model sampling variance), so unlike the 5 launch tests above
+    # small-model sampling variance), so unlike the 6 launch tests above
     # it never multiplies by MAX_ATTEMPTS.
-    timeout-minutes: 280
+    timeout-minutes: 310
     strategy:
       fail-fast: false
       matrix:
@@ -631,7 +631,7 @@ jobs:
       # multi-line/array syntax; ubuntu/macOS already default to bash.
       #
       # Unlike hermes/mlx_lm.server (legitimately missing on some
-      # platforms), these four are plain npm packages expected to work
+      # platforms), these five are plain npm packages expected to work
       # everywhere — so install_cli fails the job, rather than letting
       # tests/launch_e2e.rs's on_path check silently skip, when one never
       # becomes a working binary.
@@ -644,7 +644,7 @@ jobs:
       # designed (npm tolerates one failed platform-tarball fetch, here
       # a registry blip, instead of failing the install), just not
       # detectable by a mere on_path/PATH check. Retrying rides that out.
-      - name: Install integration CLIs (claude, opencode, codex, openclaw)
+      - name: Install integration CLIs (claude, opencode, codex, qwen, openclaw)
         shell: bash
         run: |
           failed_clis=()
@@ -679,6 +679,11 @@ jobs:
           install_cli "@anthropic-ai/claude-code" "@anthropic-ai/claude-code" "claude"
           install_cli "opencode-ai" "opencode-ai" "opencode"
           install_cli "@openai/codex" "@openai/codex" "codex"
+          # Pinned (not @latest): tests/launch_e2e.rs's qwen test relies on
+          # this release's tool set under --safe-mode and on the
+          # report_findings schema it excludes by name; a newer release can
+          # change either. Bump deliberately, re-running that test.
+          install_cli "@qwen-code/qwen-code@0.22.3" "@qwen-code/qwen-code" "qwen"
           # Pinned (not @latest): tests/launch_e2e.rs's own openclaw
           # invocation was verified against this exact release — its
           # docs describe CLI commands/flags this build doesn't actually

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -337,6 +337,11 @@ const INTEGRATIONS: &[Integration] = &[
         description: "OpenClaw",
         binary: "openclaw",
     },
+    Integration {
+        name: "qwen",
+        description: "Qwen Code",
+        binary: "qwen",
+    },
 ];
 
 fn print_integrations() {
@@ -413,6 +418,7 @@ fn launch(name: &str, model: &str, api_key: &str, extra_args: &[String]) -> anyh
         "gemini" => launch_gemini(model, api_key, extra_args),
         "hermes" => launch_hermes(model, extra_args),
         "openclaw" => launch_openclaw(model, extra_args),
+        "qwen" => launch_qwen(model, api_key, extra_args),
         other => anyhow::bail!(
             "unknown integration {:?}\nRun 'llmman launch' without arguments to list supported integrations.",
             other
@@ -802,6 +808,74 @@ fn launch_openclaw(model: &str, extra_args: &[String]) -> anyhow::Result<()> {
     exec_with_env(&bin, extra_args, &[])
 }
 
+/// qwen: Qwen Code's OpenAI-compatible mode, pointed at our /v1.
+///
+/// The auth type and model go on the command line, not only in the
+/// environment. Qwen Code resolves both as `argv`, then its own
+/// `~/.qwen/settings.json`, then the `OPENAI_*` variables, and it writes
+/// that file itself whenever a user picks a provider or model with
+/// `/auth` or `/model`. For anyone who has used it before, variables alone
+/// lose: the session went to the cloud provider recorded there, with that
+/// provider's real key, and reported success. Ollama's own
+/// `cmd/launch/qwen.go` prepends the same two flags.
+///
+/// The base URL and key stay in the environment even though Qwen Code
+/// has `--openai-base-url` and `--openai-api-key`: a key on the command
+/// line is visible in `ps` to anyone on the host, and for these two
+/// Qwen Code reads the variables ahead of its settings file, so the flags
+/// buy nothing. The one thing that still precedes them is a
+/// `modelProviders` entry whose id equals the launched model, which the
+/// `docker.io/…` and `hf.co/…` references llmman hands over do not
+/// collide with.
+///
+/// `--model` is required. Qwen Code has no notion of a missing model:
+/// given none it sends its own built-in default (`qwen3.7-max` in
+/// 0.22.3), which the daemon would then try to pull as
+/// `docker.io/ai/qwen3.7-max` and fail on, minutes later, naming a model
+/// the caller did not ask for. Refusing here names the flag instead.
+fn launch_qwen(model: &str, api_key: &str, extra_args: &[String]) -> anyhow::Result<()> {
+    let bin = find_on_path("qwen").ok_or_else(|| anyhow::anyhow!("qwen is not installed"))?;
+    if model.is_empty() {
+        anyhow::bail!("qwen needs a model: llmman launch qwen --model <model>");
+    }
+
+    let base_url = format!("{}/v1", daemon::server());
+    exec_with_env(
+        &bin,
+        &qwen_args(model, extra_args),
+        &[
+            ("OPENAI_BASE_URL", base_url.as_str()),
+            ("OPENAI_API_KEY", api_key),
+            ("OPENAI_MODEL", model),
+        ],
+    )
+}
+
+/// `--auth-type openai --model <model>` ahead of the caller's own
+/// arguments, each dropped when the caller already passed it after `--`:
+/// Qwen Code 0.22.3 crashes on either flag repeated (a `toLowerCase`
+/// TypeError) rather than taking the last one, and a caller who spelled
+/// out an auth type meant it. `--authType` is checked too — yargs accepts
+/// a flag's camelCase spelling as well.
+fn qwen_args(model: &str, extra_args: &[String]) -> Vec<String> {
+    let has = |long: &str, short: Option<&str>| {
+        extra_args.iter().any(|a| {
+            a == long
+                || a.starts_with(&format!("{long}="))
+                || short.is_some_and(|s| a == s || a.starts_with(&format!("{s}=")))
+        })
+    };
+    let mut args = Vec::with_capacity(extra_args.len() + 4);
+    if !has("--auth-type", Some("--authType")) {
+        args.extend(["--auth-type".to_string(), "openai".to_string()]);
+    }
+    if !has("--model", Some("-m")) {
+        args.extend(["--model".to_string(), model.to_string()]);
+    }
+    args.extend_from_slice(extra_args);
+    args
+}
+
 // ---------------------------------------------------------------------------
 // Process execution helper
 // ---------------------------------------------------------------------------
@@ -920,6 +994,45 @@ mod tests {
         );
         assert_eq!(openclaw_model_id(""), "default");
         assert_eq!(openclaw_model_id("docker.io/ai/"), "default");
+    }
+
+    /// The two flags `launch_qwen` relies on to beat a persisted
+    /// `~/.qwen/settings.json` (see its doc comment) go first, and each
+    /// yields to the caller's own spelling of it — a repeated `--model`
+    /// crashes Qwen Code.
+    #[test]
+    fn qwen_args_prefix_auth_type_and_model_unless_the_caller_passed_them() {
+        let none: Vec<String> = vec![];
+        assert_eq!(
+            qwen_args("m:latest", &none),
+            ["--auth-type", "openai", "--model", "m:latest"]
+        );
+
+        let user_model = vec![
+            "--model".to_string(),
+            "theirs".to_string(),
+            "-p".to_string(),
+        ];
+        assert_eq!(
+            qwen_args("m:latest", &user_model),
+            ["--auth-type", "openai", "--model", "theirs", "-p"]
+        );
+        let user_short = vec!["-m=theirs".to_string()];
+        assert_eq!(
+            qwen_args("m:latest", &user_short),
+            ["--auth-type", "openai", "-m=theirs"]
+        );
+
+        let user_auth = vec!["--auth-type=qwen-oauth".to_string()];
+        assert_eq!(
+            qwen_args("m:latest", &user_auth),
+            ["--model", "m:latest", "--auth-type=qwen-oauth"]
+        );
+        let user_camel = vec!["--authType".to_string(), "openai".to_string()];
+        assert_eq!(
+            qwen_args("m:latest", &user_camel),
+            ["--model", "m:latest", "--authType", "openai"]
+        );
     }
 
     /// Regression test for the codex config bug described on

--- a/tests/launch_e2e.rs
+++ b/tests/launch_e2e.rs
@@ -5,7 +5,7 @@
 //! from the bare short name the same way `llmman launch`/`pull` always
 //! resolve one — see `shortnames::resolve_ollama_api`), a real
 //! `llama-server` backing it, and the real third-party CLI under test
-//! (`claude`, `opencode`, `codex`, `hermes`, `openclaw`) — not mocks.
+//! (`claude`, `opencode`, `codex`, `qwen`, `hermes`, `openclaw`) — not mocks.
 //! That's the only way this actually verifies anything: every one of the
 //! three bugs this file's tests were written to catch (see below) only
 //! ever showed up against the real binaries, never in isolation.
@@ -852,6 +852,41 @@ fn launch_openclaw_with_model() {
         &["agent", "--local", "--message", PROMPT, "--agent", "main"],
         openclaw_pull_registry_flake,
     );
+}
+
+#[test]
+fn launch_qwen_with_model() {
+    eprintln!("[test] launch_qwen_with_model: acquiring SERIAL");
+    let _guard = lock_serial();
+    eprintln!("[test] launch_qwen_with_model: acquired SERIAL");
+
+    // No on_path skips: ci.yml's install_cli already fails the job when
+    // qwen did not become a working binary, and a skip here would hide
+    // exactly that (the ask on #332).
+    //
+    // Positional prompt, and first: `-p` is deprecated in 0.22.3, and
+    // `--exclude-tools` is an array option that would swallow a prompt
+    // placed after it. `--safe-mode` trims Qwen Code's eager tool set from
+    // 23 to 10, but its `tool_search` can add the rest back on a later
+    // turn, so `report_findings` is excluded by name as well: that tool's
+    // `summary` field carries `maxLength: 2000`, which llama.cpp's
+    // json-schema-to-grammar renders as `char{0,2000}` and its grammar
+    // parser refuses at exactly that repetition count, for any model whose
+    // template constrains tool calls with a grammar — MODEL's does. The
+    // request then fails with a 400 before generating (issue #352).
+    launch_and_assert_tolerating(
+        "qwen",
+        &[PROMPT, "--safe-mode", "--exclude-tools", "report_findings"],
+        qwen_loop_detection,
+    );
+}
+
+/// Qwen Code's own loop detector stops a run and exits 1 when a small
+/// model repeats a tool call — a property of MODEL's sampling, not of
+/// llmman, so tolerated the same way a timeout or a missing "pong" already
+/// are (see `openclaw_pull_registry_flake` for the same shape).
+fn qwen_loop_detection(stderr: &str) -> bool {
+    stderr.contains("Loop detection halted the run")
 }
 
 /// Verifies `daemon::ensure_server`'s fast-fail path end to end: when the


### PR DESCRIPTION
Qwen Code has an OpenAI-compatible mode, so this points `OPENAI_BASE_URL` at the daemon's `/v1`, passes the key in `OPENAI_API_KEY`, and execs. Auth type and model also go on the command line as `--auth-type openai --model <model>`, because Qwen Code reads its arguments, then `~/.qwen/settings.json`, then the environment, and writes that file itself when a user picks a provider with `/auth` or `/model`. With such a file present, a launch through the variables alone went to the cloud provider it named, with that provider's key, and reported success.

Ollama's `cmd/launch/qwen.go` prepends the same two flags. Each yields to the caller's own after `--`, since a repeated flag crashes Qwen Code 0.22.3. The key stays in the environment because on the command line it shows in `ps`. `--model` is required: with none, Qwen Code sends its built-in default `qwen3.7-max`, which the daemon would then try to pull and fail on, so the launcher refuses first and names the flag.

Closes #352.