### PR TITLE
Remove unsupported vLLM plugin store override

### DIFF
--- a/vllm-plugin/src/vllm_llmman/_llmman_cli.py
+++ b/vllm-plugin/src/vllm_llmman/_llmman_cli.py
@@ -39,7 +39,6 @@ def llmman_binary() -> str:
 def resolve(
     reference: str,
     *,
-    store: str | None = None,
     cache: str | None = None,
     binary: str | None = None,
 ) -> dict:
@@ -55,8 +54,6 @@ def resolve(
     isn't the expected single line of JSON.
     """
     cmd = [binary or llmman_binary(), "resolve", reference]
-    if store:
-        cmd += ["--store", store]
     if cache:
         cmd += ["--cache", cache]
 

--- a/vllm-plugin/tests/test_llmman_cli.py
+++ b/vllm-plugin/tests/test_llmman_cli.py
@@ -38,8 +38,7 @@ def test_resolve_parses_successful_json_output(tmp_path):
         tmp_path / "llmman",
         """
 import sys, json
-assert sys.argv[1] == "resolve"
-assert sys.argv[2] == "ghcr.io/org/model:tag"
+assert sys.argv[1:] == ["resolve", "ghcr.io/org/model:tag"]
 print(json.dumps({"reference": sys.argv[2], "path": "/local/dir", "format": "safetensors"}))
 """,
     )
@@ -51,16 +50,16 @@ print(json.dumps({"reference": sys.argv[2], "path": "/local/dir", "format": "saf
     }
 
 
-def test_resolve_passes_store_and_cache_flags(tmp_path):
+def test_resolve_passes_cache_flag(tmp_path):
     fake = _write_fake_llmman(
         tmp_path / "llmman",
         """
 import sys, json
-assert "--store" in sys.argv and "--cache" in sys.argv
-print(json.dumps({"reference": sys.argv[-1], "path": "/x", "format": "gguf"}))
+assert sys.argv[1:] == ["resolve", "m", "--cache", "/cache"]
+print(json.dumps({"reference": "m", "path": "/x", "format": "gguf"}))
 """,
     )
-    result = resolve("m", store="/store", cache="/cache", binary=fake)
+    result = resolve("m", cache="/cache", binary=fake)
     assert result["format"] == "gguf"
 
 


### PR DESCRIPTION
This PR is:

- To remove a stale `store=` wrapper option that forwarded an unsupported `--store` flag.
- To align the vLLM plugin resolver with llmman’s `LLMMAN_MODELS` store override.
- To delete obsolete `--store` test coverage while retaining `--cache` coverage.

The wrapper accepted a private `store=` argument and translated it into a CLI flag that does not exist:

```text
llmman resolve <reference> --store <path>
```

That fails with:

```text
error: unexpected argument '--store' found
```

The normal vLLM plugin path does not pass `store=`, so this is a small contract cleanup rather than a broad runtime bug.

`llmman resolve` supports `--cache`, but not `--store`; the store override is `LLMMAN_MODELS`.
