### PR TITLE
Double the VRAM-tiered default context size to 65536

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -418,7 +418,7 @@ const MIN_CTX_SIZE_FOR_RETRY: u32 = 16384;
 /// halve). Matches the top VRAM tier's own default (see
 /// `hostgpu::default_ctx_size_for`) rather than starting below
 /// `MIN_CTX_SIZE_FOR_RETRY`.
-const STARTING_CTX_SIZE_FOR_UNBOUNDED_RETRY: u32 = 32768;
+const STARTING_CTX_SIZE_FOR_UNBOUNDED_RETRY: u32 = 65536;
 
 /// Next `--ctx-size` to retry an OOM'd load with, or `None` if shrinking
 /// further wouldn't help (at/under the floor already).
@@ -8123,6 +8123,7 @@ mod tests {
     #[test]
     fn next_ctx_size_after_oom_halves_from_the_vram_tiered_default_down_to_the_floor() {
         // The default_ctx_size_for(<=46GiB) tier — see hostgpu.rs.
+        assert_eq!(next_ctx_size_after_oom(Some(65536)), Some(32768));
         assert_eq!(next_ctx_size_after_oom(Some(32768)), Some(16384));
         // At (or below) the floor, no further shrink is offered.
         assert_eq!(next_ctx_size_after_oom(Some(16384)), None);
@@ -8134,7 +8135,7 @@ mod tests {
         // ctx_size: None means "defer to the model's own trained
         // context" (see hostgpu::default_ctx_size) — nothing to halve,
         // so the first retry pins an explicit starting point instead.
-        assert_eq!(next_ctx_size_after_oom(None), Some(32768));
+        assert_eq!(next_ctx_size_after_oom(None), Some(65536));
     }
 
     #[test]

--- a/src/hostgpu.rs
+++ b/src/hostgpu.rs
@@ -131,7 +131,7 @@ fn parse_igpu_enabled(value: Option<&str>) -> bool {
 
 /// VRAM-tiered context-size default (used by `cmd::serve` when
 /// `LLMMAN_CONTEXT_LENGTH` isn't set). Below a 47GiB VRAM threshold,
-/// defaults to 32768 tokens instead of a model's full trained context:
+/// defaults to 65536 tokens instead of a model's full trained context:
 /// llmman forwards requests to llama-server as-is rather than
 /// truncating oversized prompts, and real agentic CLIs routinely send
 /// 7-8k-token prompts before any reply — a smaller floor would be too
@@ -142,7 +142,7 @@ pub fn default_ctx_size_for(vram_bytes: u64) -> Option<u32> {
     if vram_bytes >= 47 * GIB {
         None
     } else {
-        Some(32768)
+        Some(65536)
     }
 }
 
@@ -359,10 +359,10 @@ mod tests {
 
     #[test]
     fn default_ctx_size_for_defers_above_the_top_vram_tier() {
-        assert_eq!(default_ctx_size_for(0), Some(32768));
-        assert_eq!(default_ctx_size_for(8 * GIB), Some(32768));
-        assert_eq!(default_ctx_size_for(23 * GIB), Some(32768));
-        assert_eq!(default_ctx_size_for(46 * GIB), Some(32768));
+        assert_eq!(default_ctx_size_for(0), Some(65536));
+        assert_eq!(default_ctx_size_for(8 * GIB), Some(65536));
+        assert_eq!(default_ctx_size_for(23 * GIB), Some(65536));
+        assert_eq!(default_ctx_size_for(46 * GIB), Some(65536));
         assert_eq!(default_ctx_size_for(47 * GIB), None);
         assert_eq!(default_ctx_size_for(80 * GIB), None);
     }
@@ -410,13 +410,13 @@ mod tests {
     fn default_ctx_size_for_with_overhead_subtracted_can_drop_a_tier() {
         // A host with 47GiB VRAM would defer to the model's own trained
         // context; a 1GiB LLMMAN_GPU_OVERHEAD knocks it back under the
-        // 47GiB threshold into the capped 32768 tier.
+        // 47GiB threshold into the capped 65536 tier.
         let vram = 47 * GIB;
         let overhead = GIB;
         assert_eq!(default_ctx_size_for(vram), None);
         assert_eq!(
             default_ctx_size_for(vram.saturating_sub(overhead)),
-            Some(32768)
+            Some(65536)
         );
     }
 


### PR DESCRIPTION
## What

Doubles the `32768` default context size to `65536` in the two places it is defined:

- `hostgpu::default_ctx_size_for` (src/hostgpu.rs:141) — the VRAM-tiered `--ctx-size` default used when `LLMMAN_CONTEXT_LENGTH` is unset and the host has under 47GiB of VRAM.
- `STARTING_CTX_SIZE_FOR_UNBOUNDED_RETRY` (src/cmd/serve.rs:421) — the first retry value the OOM auto-shrink path uses when `ctx_size` started as `None`. Its doc comment already says it matches the tiered default, so it moves with it.

## Why

llmman forwards requests to llama-server as-is rather than truncating oversized prompts. Agentic CLIs routinely push past 32k tokens once tool output and file contents accumulate in a conversation, so the old ceiling truncates real sessions rather than just capping pathological ones.

## Notes

- `MIN_CTX_SIZE_FOR_RETRY` (16384) is unchanged, so the OOM shrink path just gains one extra halving step (65536 -> 32768 -> 16384), still well within `MAX_CTX_SHRINK_ATTEMPTS` (4).
- The `47 * GIB` tier boundary is unchanged; hosts at or above it still defer to the model's own trained context.
- No README change needed — the env-var table describes the default as "a VRAM-tiered value" without quoting the number.

## Testing

- `cargo test` — 443 lib tests pass. The 2 `launch_e2e` failures (`launch_claude_with_model`, `launch_qwen_with_model`) are pre-existing on `main` and unrelated to this change.
- `cargo fmt --check` and `cargo clippy --all-targets` clean.