### PR TITLE
docs: trim Gemini CLI references and two hosted-provider paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,6 @@ used with `--provider` at all: the first two pick their own model rather
 than taking llmman's, `copilot` has no way to send a key, and `openclaw`
 only takes a model during first-run onboarding.
 
-Being OpenAI-compatible doesn't mean implementing every OpenAI route.
-`codex` uses `/v1/responses`, which `openai`, `groq` and `openrouter`
-answer but `anthropic` and `mistral` don't; models.dev carries no
-capability data to filter on, so llmman turns that provider's bare 404
-into an explanation naming what's missing rather than guessing up front.
-
 `--provider` needs a local `llmman serve`. The daemon talks plain HTTP
 and has no authentication, so neither `run` nor `launch` will send a real
 key to a remote `LLMMAN_HOST`, and a daemon bound to anything but

--- a/README.md
+++ b/README.md
@@ -224,12 +224,6 @@ that didn't present one. (`llmman providers` and `llmman list
 --provider` read the catalog only, no key involved, and work against any
 daemon.)
 
-Providers llmman cannot reach with a single bearer token over an
-OpenAI-compatible https endpoint are deliberately absent rather than
-half-supported: Amazon Bedrock (SigV4 request signing), Google Vertex
-(GCP service-account credentials), Azure, and the others whose endpoint
-is per-account or whose wire format isn't OpenAI's.
-
 ## Use with vLLM directly
 
 `llmman serve` already spawns `vllm` itself as a backend for safetensors

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><b>Run any coding agent on any model.</b></p>
 
 <p align="center">
-Claude Code, Codex, OpenCode, Gemini CLI and friends, pointed at a model
+Claude Code, Codex, OpenCode and friends, pointed at a model
 running on your own machine, or at any hosted provider, in one command.
 No subscription, no rewiring, no vendor's idea of which model you should use.
 </p>
@@ -205,11 +205,10 @@ configures it through a file on disk, so it can't carry a key and
 fallback is only used for a daemon bound to loopback, and never for a
 browser request from another site. It bounds the blast radius rather
 than authenticating anyone, so on a shared machine prefer an integration
-that sends its own key. `cline`, `kimi`, `copilot`, `gemini` and `openclaw` can't be
+that sends its own key. `cline`, `kimi`, `copilot` and `openclaw` can't be
 used with `--provider` at all: the first two pick their own model rather
-than taking llmman's, `copilot` has no way to send a key, `gemini` feeds
-its key to a native Google client llmman can't confirm it has redirected,
-and `openclaw` only takes a model during first-run onboarding.
+than taking llmman's, `copilot` has no way to send a key, and `openclaw`
+only takes a model during first-run onboarding.
 
 Being OpenAI-compatible doesn't mean implementing every OpenAI route.
 `codex` uses `/v1/responses`, which `openai`, `groq` and `openrouter`


### PR DESCRIPTION
## What

Three README-only changes:

1. **Remove Gemini CLI references.** Dropped from the tagline's list of supported agents, and dropped the clause explaining why `--provider gemini` is refused.
2. **Remove the unreachable-providers paragraph** (Bedrock/Vertex/Azure and why they are absent).
3. **Remove the OpenAI-route-coverage paragraph** (`codex` needing `/v1/responses`, and the 404 some providers return).

## Why

Requested doc trim. The hosted-providers section reads shorter without the two paragraphs, both of which explained behaviour the CLI already reports at the point of use.

## Note

No code changed. `gemini` is still a `launch` target in `src/cmd/launch.rs`, still listed by `llmman launch` with no arguments, and `--provider gemini` is still refused with its reason in `PROVIDER_UNSUPPORTED`. The README is now silent on that integration rather than contradicting the code.