### PR TITLE
feat: add llmman live, a voice and camera session at /llmman/live

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The server listens on `127.0.0.1:17434` by default, overridable via `LLMMAN_HOST
 | Ollama | `/api/generate`, `/api/chat`, `/api/tags`, `/api/show`, `/api/pull`, `/api/ps`, `/api/delete` |
 | OpenAI | `/v1/chat/completions`, `/v1/completions`, `/v1/embeddings`, `/v1/models`, `/v1/responses`, `/v1/responses/input_tokens` |
 | Anthropic | `/v1/messages` |
-| llmman | `/llmman/providers`, `/llmman/providers/{id}` |
+| llmman | `/llmman/providers`, `/llmman/providers/{id}`, `/llmman/live` |
 
 `/llmman/...` is llmman's own API, not a compatibility surface: no
 upstream API has a notion of a [models.dev](https://models.dev) provider
@@ -131,6 +131,8 @@ Codex](https://github.com/openai/codex) requires), including streaming SSE
 and function-tool-call re-mapping. This is a plain pass-through to
 `llama-server`'s own native `/v1/responses` support, so a recent enough
 `llama-server` build is required for it to work.
+
+`/llmman/live` is described under [llmman live](#llmman-live) below.
 
 Use it as an Ollama-compatible server:
 
@@ -155,6 +157,58 @@ An idle, unused model is automatically unloaded after `keep_alive`
 Daemon-wide settings (bind address, context length, keep-alive, GPU backend
 selection and the rest) are environment variables, set before `llmman serve`
 starts. They're documented in [docs/configuration.md](docs/configuration.md).
+
+## llmman live
+
+A hands-free voice-and-camera conversation with a local model, in the
+browser. Start the server and open it:
+
+```
+llmman serve
+open http://127.0.0.1:17434/llmman/live
+```
+
+Grant microphone and camera access and just talk. Your browser
+recognizes the speech; llmman attaches the most recent frames from your
+camera, streams the reply back token by token and reads it aloud —
+stopping the moment you start talking again.
+
+There is one model to choose, and it is the model you want to talk to.
+Speech-to-text is the browser's own (the [Web Speech
+API](https://developer.mozilla.org/docs/Web/API/Web_Speech_API), which
+recent Chrome runs on-device), so there is no transcription model to
+pull, none held in memory alongside the one you picked, and no second
+dropdown to guess at. llmman asks for on-device recognition wherever the
+browser offers it, so the audio stays on this machine; where it doesn't,
+the browser recognizes speech through its vendor's service.
+
+Any model works. By the time a turn reaches the model it is text, so a
+small text-only model like `qwen3.5:0.8b` is a first-class choice, not a
+degraded one. Camera frames are attached only to a model that reports
+vision support (a GGUF loaded with an `--mmproj` projector), and the page
+says so when they aren't. Models load on demand and unload on the usual
+`keep_alive` timer, like any other request.
+
+Under the hood the page POSTs one JSON request per turn to
+`/llmman/live/turn` — `model`, `text`, `system`, `history` and up to
+eight base64 JPEG `frames` — and reads the reply as server-sent events
+(`context`, `delta`, `thinking`, `error`, `done`). Frames are downscaled
+to a 512 px long edge and captured continuously, so the ones sent are the
+ones from the moment you spoke. Conversation history is replayed as text
+only: a stale frame is worse than no frame when the question is about
+what the camera sees now.
+
+Replies are spoken with the browser's speech synthesis. Without
+headphones the recognizer would hear them and answer itself, so results
+arriving while llmman is speaking are ignored by default; tick **Allow
+interrupting** to talk over it.
+
+Firefox has no speech recognition — there the camera and the text box
+still work.
+
+Browsers only grant microphone and camera access to a secure context, so
+use `http://127.0.0.1:17434` or `http://localhost:17434` rather than a
+LAN address.
 
 ## Launch an integration
 

--- a/build.rs
+++ b/build.rs
@@ -255,7 +255,17 @@ fn main() {
     let webui_out = out_dir.join("webui_gz");
     fs::create_dir_all(&webui_out).expect("create webui_gz dir");
 
-    for name in &["index.html", "bundle.js", "bundle.css", "loading.html"] {
+    for name in &[
+        "index.html",
+        "bundle.js",
+        "bundle.css",
+        "loading.html",
+        // llmman live (webui/live.*) — hand-written source, not part of
+        // the generated bundle above, but embedded the same way.
+        "live.html",
+        "live.js",
+        "live.css",
+    ] {
         let src = webui_src.join(name);
         let dst = webui_out.join(format!("{name}.gz"));
         let data = fs::read(&src).unwrap_or_else(|e| panic!("read webui/{name}: {e}"));

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -4257,6 +4257,435 @@ async fn handle_llmman_provider(
     Ok(Json(ProviderResponse::from(provider)))
 }
 
+// -- llmman live (/llmman/live) ----------------------------------------------
+//
+// A hands-free voice-and-camera conversation surface: the browser listens
+// to the microphone and watches the camera, and each time the speaker
+// finishes a sentence it sends what was said plus the most recent frames
+// here; llmman attaches the frames if the chosen model can actually see,
+// and streams the reply back token by token for the page to render and
+// speak.
+//
+// Speech recognition is the browser's own, not a model llmman loads.
+// Every browser that can grant microphone access already ships a
+// recognizer (the Web Speech API — on-device, in recent Chrome), so
+// asking the user to pull a whisper-family model, keep it in the store,
+// hold a second model in memory for every session, and *choose* it from
+// a list they have no basis to choose from would be three costs and a
+// decision in exchange for nothing. It also means the page has the
+// transcript as it is being spoken, which is what makes live captions and
+// interrupting mid-reply possible at all — a server round trip per
+// utterance could only produce text after the fact.
+//
+// So a turn arrives here as text, which is also what makes *any* model a
+// first-class choice: by the time `post_chat` is reached nothing about a
+// turn is model-specific. A small text-only model such as `qwen3.5:0.8b`
+// works exactly as well as a vision one, which only additionally gets to
+// see the camera.
+//
+// Deliberately not a bidirectional socket: with recognition happening in
+// the page, a turn is one short JSON request and one streamed reply. That
+// keeps this on exactly the plumbing every other route here already uses
+// (`ensure_model`, `ActivityGuard`, `post_chat`, `bytes_to_lines`) rather
+// than adding a second connection lifecycle to keep in step with a
+// model's keep-alive, and an upgrade path CORS (see `cors_layer`) does
+// not cover.
+
+/// Frames one turn may carry. The page sends two by default; the cap
+/// exists so a malformed or hostile client cannot make a single turn
+/// expand into a prompt large enough to evict every other loaded model to
+/// fit.
+const MAX_LIVE_FRAMES: usize = 8;
+
+/// A turn is a sentence of text plus a few downscaled JPEG stills,
+/// base64-encoded — a few hundred kilobytes at the page's own settings,
+/// but enough headroom here that raising the frame count or resolution
+/// doesn't turn into a confusing 413. Still far below
+/// `TRANSCRIPTION_BODY_LIMIT_BYTES`, since no audio is ever uploaded.
+const LIVE_TURN_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
+
+/// One turn of a live session, as the page sends it.
+///
+/// Every field defaults, so a turn from an older page against a newer
+/// daemon (or the reverse) is a 400 naming what is actually missing
+/// rather than a parse error naming a field the sender never heard of.
+#[derive(Debug, Default, Deserialize, PartialEq)]
+struct LiveTurn {
+    #[serde(default)]
+    model: String,
+    /// The sentence the browser's speech recognizer produced, or what the
+    /// user typed instead.
+    #[serde(default)]
+    text: String,
+    #[serde(default)]
+    system: Option<String>,
+    #[serde(default)]
+    history: Vec<LiveMessage>,
+    /// Camera stills, base64-encoded, oldest first — the same wire shape
+    /// as Ollama's own `images` (see `OllamaMessage::images`), for the
+    /// same reason: it is the one encoding a JSON body can carry an image
+    /// in.
+    #[serde(default)]
+    frames: Vec<String>,
+}
+
+/// One prior turn, replayed by the page. Text only, and no tool roles:
+/// the page never renders anything else, and a `role: "tool"` message
+/// with no matching call would break a chat template rather than add
+/// context.
+#[derive(Debug, Deserialize, PartialEq)]
+struct LiveMessage {
+    role: String,
+    content: String,
+}
+
+/// One server-sent event on `/llmman/live/turn`.
+///
+/// `Context` always comes first, before any of the model's own output:
+/// the page needs to know whether the frames it just uploaded were
+/// actually used, and only the daemon can answer that, since only it
+/// knows what the resolved backend supports.
+///
+/// There is deliberately no event echoing the user's own turn back — the
+/// page recognized the speech itself and already has the text.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum LiveEvent {
+    /// What llmman did with this turn.
+    Context {
+        model: String,
+        vision: bool,
+        frames: usize,
+    },
+    /// A chunk of the reply.
+    Delta {
+        text: String,
+    },
+    /// A chunk of the model's reasoning. A separate event so the page can
+    /// show it as status without reading it aloud or keeping it in the
+    /// conversation history.
+    Thinking {
+        text: String,
+    },
+    /// A failure that only became apparent after the response headers
+    /// were already on the wire, where a status code is no longer
+    /// available to carry it.
+    Error {
+        message: String,
+    },
+    Done,
+}
+
+/// Whether a backend can accept image content parts, read from the same
+/// llama.cpp `/props` document `query_context_length` uses.
+fn vision_from_props(props: &serde_json::Value) -> bool {
+    props
+        .get("modalities")
+        .and_then(|m| m.get("vision"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Whether this turn's camera frames should be attached at all.
+///
+/// A local backend is asked: a GGUF loaded without an `--mmproj`
+/// projector cannot see, and handing it images produces a confusing
+/// backend error instead of a reply. Anything unanswerable — a timeout, a
+/// `vllm`/`mlx` backend with no `/props` at all — counts as no vision,
+/// since text still works and images would not.
+///
+/// A provider is assumed to have vision, because it cannot be asked: it
+/// publishes no capability document llmman reads, and a hosted model
+/// picked for a camera-facing session is overwhelmingly likely to be one
+/// that can see. If it isn't, the provider's own 4xx saying so is passed
+/// through by `post_chat` — an actionable answer, unlike silently
+/// dropping the video from every hosted model.
+async fn target_supports_vision(client: &Client, target: &Target) -> bool {
+    let Target::Local(port) = target else {
+        return true;
+    };
+    let Ok(resp) = client
+        .get(format!("http://127.0.0.1:{port}/props"))
+        .timeout(Duration::from_millis(500))
+        .send()
+        .await
+    else {
+        return false;
+    };
+    match resp.json::<serde_json::Value>().await {
+        Ok(props) => vision_from_props(&props),
+        Err(_) => false,
+    }
+}
+
+/// Wraps one captured camera frame as an `image_url` content part value.
+///
+/// Not `image_data_uri`: that one labels everything `image/png` and
+/// relies on llama.cpp sniffing the real format from the bytes, which a
+/// remote provider does not do. The page encodes frames as JPEG and says
+/// so here, so a provider-routed live session works too. A value that
+/// already looks like a data URI is passed through, same as there.
+fn frame_data_uri(frame: &str) -> String {
+    if frame.starts_with("data:") {
+        frame.to_string()
+    } else {
+        format!("data:image/jpeg;base64,{frame}")
+    }
+}
+
+/// Assembles the messages for one live turn.
+///
+/// `history` is replayed as plain text: frames are never re-sent, both
+/// because they are large and because a stale frame is worse than no
+/// frame when the whole point of the current one is to show what the
+/// camera sees *now*. Only the roles the page itself produces survive —
+/// a `role` it never writes came from somewhere else and has no place in
+/// a chat template.
+fn build_live_messages(
+    system: Option<&str>,
+    history: &[LiveMessage],
+    user_text: &str,
+    frames: &[String],
+) -> Vec<OAIMessage> {
+    let mut messages = Vec::with_capacity(history.len() + 2);
+    if let Some(system) = system.filter(|s| !s.trim().is_empty()) {
+        messages.push(OAIMessage::text("system", system));
+    }
+    for message in history {
+        if message.content.is_empty() || !matches!(message.role.as_str(), "user" | "assistant") {
+            continue;
+        }
+        messages.push(OAIMessage::text(&message.role, &message.content));
+    }
+    let content = if frames.is_empty() {
+        serde_json::Value::String(user_text.to_string())
+    } else {
+        // Text first, then oldest frame to newest — the ordering the
+        // OpenAI vision convention llama-server's multimodal templates
+        // follow expects, and the one `ollama_message_to_oai` already
+        // produces for `/api/chat`'s own images.
+        let mut parts = Vec::with_capacity(frames.len() + 1);
+        parts.push(serde_json::json!({ "type": "text", "text": user_text }));
+        for frame in frames {
+            parts.push(serde_json::json!({
+                "type": "image_url",
+                "image_url": { "url": frame_data_uri(frame) }
+            }));
+        }
+        serde_json::Value::Array(parts)
+    };
+    messages.push(OAIMessage {
+        role: "user".to_string(),
+        content,
+        tool_calls: None,
+        name: None,
+    });
+    messages
+}
+
+/// One event as a server-sent-event frame.
+///
+/// Every `LiveEvent` serializes to a single line — `serde_json` escapes
+/// any newline inside a string — so one `data:` line per event is always
+/// enough, and the page's reader (see `readEvents` in webui/live.js) can
+/// stay line-oriented.
+fn live_sse_frame(event: &LiveEvent) -> Bytes {
+    let json = serde_json::to_string(event).unwrap_or_else(|_| {
+        r#"{"type":"error","message":"llmman could not serialize this event"}"#.to_string()
+    });
+    Bytes::from(format!("data: {json}\n\n"))
+}
+
+/// The events for one line of the backend's SSE stream, in the order they
+/// should reach the page. Split out from the streaming plumbing below so
+/// the mapping itself is directly testable.
+///
+/// `extractor` carries the `<think>`/harmony tag state across lines for a
+/// backend that emits reasoning as raw text inside `content` instead of a
+/// structured field — the same treatment `/api/chat` gets, so a live
+/// session never reads a model's inner monologue aloud (see
+/// [`RawContentExtractor`]).
+fn live_events_for_line(extractor: &mut RawContentExtractor, line: &str) -> Vec<LiveEvent> {
+    let Some(payload) = line.strip_prefix("data: ") else {
+        return Vec::new();
+    };
+    let Some((content, thinking, done)) = oai_chunk_to_content(payload) else {
+        return Vec::new();
+    };
+    let (mut content, thinking) = extractor.process(content, thinking);
+    if done {
+        content.push_str(&extractor.flush());
+    }
+    let mut events = Vec::new();
+    if let Some(text) = thinking.filter(|t| !t.is_empty()) {
+        events.push(LiveEvent::Thinking { text });
+    }
+    if !content.is_empty() {
+        events.push(LiveEvent::Delta { text: content });
+    }
+    if done {
+        events.push(LiveEvent::Done);
+    }
+    events
+}
+
+fn live_sse_response(
+    stream: impl futures::Stream<Item = Result<Bytes, std::convert::Infallible>> + Send + 'static,
+) -> Response {
+    Response::builder()
+        .header("content-type", "text/event-stream")
+        .header("cache-control", "no-cache")
+        // The page renders and speaks each delta as it lands, so any
+        // proxy between it and the daemon buffering the body would defeat
+        // the whole endpoint.
+        .header("x-accel-buffering", "no")
+        .body(Body::from_stream(stream))
+        .unwrap()
+}
+
+/// Sends the turn to the model and relays the reply as `LiveEvent`s,
+/// after `preamble` (what llmman did with the turn, which the page needs
+/// before the first token arrives).
+async fn stream_live(
+    client: Client,
+    target: Target,
+    mut oai_req: OAIChatRequest,
+    activity: ActivityGuard,
+    preamble: LiveEvent,
+) -> Result<Response, AppError> {
+    let resp = post_chat(&client, &target, &mut oai_req).await?;
+
+    let head = futures::stream::once(async move { Ok(live_sse_frame(&preamble)) });
+
+    // llama-server signals "done" twice — the chunk carrying a real
+    // finish_reason, then the trailing literal "[DONE]" line — and the
+    // trailer below needs to know whether either was seen at all, so both
+    // it and the mapping share one flag.
+    let finished = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let seen = finished.clone();
+    let mut extractor = RawContentExtractor::new();
+    let body = bytes_to_lines(resp.bytes_stream()).map(move |line| {
+        // Moved into this closure purely to keep it alive — see
+        // ActivityGuard's doc comment — for as long as the reply is still
+        // streaming.
+        let _activity = &activity;
+        let mut out = Vec::new();
+        for event in live_events_for_line(&mut extractor, &line) {
+            if matches!(event, LiveEvent::Done)
+                && seen.swap(true, std::sync::atomic::Ordering::SeqCst)
+            {
+                continue;
+            }
+            out.extend_from_slice(&live_sse_frame(&event));
+        }
+        Ok::<_, std::convert::Infallible>(Bytes::from(out))
+    });
+
+    // `bytes_to_lines` reports a mid-response read failure as a clean end
+    // of stream (see `stream_ollama`'s own note), so a stream that ends
+    // having never signalled "done" is the only evidence the backend
+    // died. Saying so in band beats letting the page read out a truncated
+    // reply as if the model had simply stopped talking; the status line is
+    // long gone by now.
+    let trailer = futures::stream::once(async move {
+        let mut out = Vec::new();
+        if !finished.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            out.extend_from_slice(&live_sse_frame(&LiveEvent::Error {
+                message: "inference backend closed the connection before finishing".to_string(),
+            }));
+            out.extend_from_slice(&live_sse_frame(&LiveEvent::Done));
+        }
+        Ok::<_, std::convert::Infallible>(Bytes::from(out))
+    });
+
+    Ok(live_sse_response(head.chain(body).chain(trailer)))
+}
+
+/// A malformed turn is the request's own fault, so it gets a 400 in
+/// llmman's usual error shape rather than `AppError`'s blanket 500 — the
+/// same split `handle_pull` and `handle_openai_transcriptions` make for
+/// their own missing-field cases.
+fn live_bad_request(message: impl Into<String>) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": message.into() })),
+    )
+        .into_response()
+}
+
+/// `GET /llmman/live` — the live session page itself.
+async fn handle_live_page() -> impl IntoResponse {
+    gzipped(webui::LIVE_HTML, "text/html; charset=utf-8")
+}
+
+async fn handle_live_js() -> impl IntoResponse {
+    gzipped(webui::LIVE_JS, "application/javascript; charset=utf-8")
+}
+
+async fn handle_live_css() -> impl IntoResponse {
+    gzipped(webui::LIVE_CSS, "text/css; charset=utf-8")
+}
+
+/// `POST /llmman/live/turn` — one spoken (or typed) turn in, one streamed
+/// reply out.
+async fn handle_live_turn(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response, AppError> {
+    let turn: LiveTurn = match serde_json::from_slice(&body) {
+        Ok(turn) => turn,
+        Err(e) => {
+            return Ok(live_bad_request(format!(
+                "a live turn is not a JSON object llmman understands: {e}"
+            )))
+        }
+    };
+    if turn.model.trim().is_empty() {
+        return Ok(live_bad_request(
+            "a live turn is missing its required \"model\" field",
+        ));
+    }
+    // The page only sends a turn once its recognizer has produced a whole
+    // sentence, so this is a client bug rather than a cough — a cough
+    // never gets this far, and answering it with a reply to nothing would
+    // be worse than saying so.
+    if turn.text.trim().is_empty() {
+        return Ok(live_bad_request(
+            "a live turn is missing the \"text\" that was said",
+        ));
+    }
+    if turn.frames.len() > MAX_LIVE_FRAMES {
+        return Ok(live_bad_request(format!(
+            "a live turn carries at most {MAX_LIVE_FRAMES} camera frames, not {}",
+            turn.frames.len()
+        )));
+    }
+
+    let (canonical, target, guard) = ensure_model(&state, &turn.model, Some(&headers)).await?;
+    // No `keep_alive` of its own on this surface either — see
+    // `resolve_openai_request`'s comment on the same choice.
+    let activity = begin_activity(guard, None).await;
+
+    let vision = target_supports_vision(&state.0.client, &target).await;
+    let frames: &[String] = if vision { &turn.frames } else { &[] };
+    let oai_req = OAIChatRequest {
+        model: backend_wire_model(&state, &target, &canonical).await,
+        messages: build_live_messages(turn.system.as_deref(), &turn.history, &turn.text, frames),
+        // Always streamed: a live session's whole point is that the reply
+        // starts being read out before it has finished being generated.
+        stream: true,
+        ..Default::default()
+    };
+    let preamble = LiveEvent::Context {
+        model: canonical,
+        vision,
+        frames: frames.len(),
+    };
+    stream_live(state.0.client.clone(), target, oai_req, activity, preamble).await
+}
+
 /// Ollama's GET /api/version, extended with this daemon's own identity —
 /// executable path (canonicalized at startup) and pid — so a client can
 /// tell whether a daemon it found listening still belongs to a live
@@ -5826,6 +6255,18 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         // llmman's own API — see handle_llmman_providers
         .route("/llmman/providers", get(handle_llmman_providers))
         .route("/llmman/providers/:id", get(handle_llmman_provider))
+        // llmman live — see the /llmman/live section's own header comment.
+        // Both spellings of the page's own path are served: the assets and
+        // the turn endpoint are addressed absolutely from live.html, so a
+        // trailing slash changes nothing but the URL a user typed.
+        .route("/llmman/live", get(handle_live_page))
+        .route("/llmman/live/", get(handle_live_page))
+        .route("/llmman/live/live.js", get(handle_live_js))
+        .route("/llmman/live/live.css", get(handle_live_css))
+        .route(
+            "/llmman/live/turn",
+            post(handle_live_turn).layer(DefaultBodyLimit::max(LIVE_TURN_BODY_LIMIT_BYTES)),
+        )
         // Ollama API
         .route("/api/version", get(handle_version))
         .route("/api/tags", get(handle_tags))
@@ -5866,6 +6307,9 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
         .await
         .with_context(|| format!("bind {addr}"))?;
     eprintln!("llmman serve listening on {addr}");
+    // Worth one line: a voice-and-camera session is not something a
+    // client discovers by probing the Ollama or OpenAI surfaces.
+    eprintln!("llmman live at {}/llmman/live", crate::daemon::server());
 
     // Background idle-unload reaper — see reap_idle_models's doc comment.
     tokio::spawn(reap_idle_models(state.clone()));
@@ -9236,5 +9680,540 @@ mod tests {
             .collect();
         assert_eq!(joined, "Hello, world");
         assert_eq!(chunks.last().unwrap()["done"], true);
+    }
+
+    // -- llmman live -------------------------------------------------------
+
+    fn live_turn_body(turn: serde_json::Value) -> Bytes {
+        Bytes::from(serde_json::to_vec(&turn).unwrap())
+    }
+
+    /// Every field defaults, so a page and a daemon of different vintages
+    /// still complete a turn instead of failing over a field one of them
+    /// has never heard of.
+    #[test]
+    fn a_live_turn_parses_with_only_the_fields_a_sender_actually_set() {
+        let turn: LiveTurn =
+            serde_json::from_value(serde_json::json!({ "model": "qwen3.5:0.8b", "text": "hi" }))
+                .expect("parses");
+        assert_eq!(
+            turn,
+            LiveTurn {
+                model: "qwen3.5:0.8b".into(),
+                text: "hi".into(),
+                system: None,
+                history: vec![],
+                frames: vec![],
+            }
+        );
+
+        let turn: LiveTurn = serde_json::from_value(serde_json::json!({
+            "model": "qwen3.5:0.8b",
+            "text": "what is that",
+            "system": "be brief",
+            "history": [{ "role": "user", "content": "hi" }],
+            "frames": ["Zm9v"],
+            "something_new": "ignored",
+        }))
+        .expect("parses");
+        assert_eq!(turn.system.as_deref(), Some("be brief"));
+        assert_eq!(
+            turn.history,
+            vec![LiveMessage {
+                role: "user".into(),
+                content: "hi".into()
+            }]
+        );
+        assert_eq!(turn.frames, vec!["Zm9v".to_string()]);
+    }
+
+    #[test]
+    fn vision_from_props_reads_the_modalities_llama_server_publishes() {
+        assert!(vision_from_props(
+            &serde_json::json!({ "modalities": { "vision": true, "audio": false } })
+        ));
+        assert!(!vision_from_props(
+            &serde_json::json!({ "modalities": { "vision": false } })
+        ));
+        // A backend whose /props says nothing about modalities at all
+        // counts as no vision: text still works, images would not.
+        assert!(!vision_from_props(&serde_json::json!({ "role": "router" })));
+    }
+
+    /// A provider publishes no capability document llmman reads, so it
+    /// cannot be asked — see `target_supports_vision`'s own doc comment
+    /// for why the answer is nonetheless yes.
+    #[tokio::test]
+    async fn target_supports_vision_assumes_a_provider_can_see() {
+        let target = Target::Remote(Arc::new(RemoteTarget {
+            provider: "openrouter".into(),
+            base_url: "https://openrouter.ai/api/v1".into(),
+            model: "some/vision-model".into(),
+            api_key: "k".into(),
+        }));
+        assert!(target_supports_vision(&Client::new(), &target).await);
+    }
+
+    #[tokio::test]
+    async fn target_supports_vision_reads_a_local_backends_own_props() {
+        let app = Router::new().route(
+            "/props",
+            get(|| async { Json(serde_json::json!({ "modalities": { "vision": true } })) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        assert!(target_supports_vision(&Client::new(), &Target::Local(port)).await);
+        // An unreachable backend answers nothing, which is not vision.
+        let dead = Target::Local(find_free_port().unwrap());
+        assert!(!target_supports_vision(&Client::new(), &dead).await);
+    }
+
+    /// A provider does not sniff the real format out of the bytes the way
+    /// llama.cpp does, so the label has to be the truth.
+    #[test]
+    fn frame_data_uri_labels_a_captured_frame_as_the_jpeg_it_is() {
+        assert_eq!(frame_data_uri("Zm9v"), "data:image/jpeg;base64,Zm9v");
+        assert_eq!(
+            frame_data_uri("data:image/webp;base64,Zm9v"),
+            "data:image/webp;base64,Zm9v"
+        );
+    }
+
+    #[test]
+    fn build_live_messages_sends_plain_text_when_no_frames_are_attached() {
+        let messages = build_live_messages(Some("be brief"), &[], "what is that", &[]);
+        assert_eq!(
+            messages,
+            vec![
+                OAIMessage::text("system", "be brief"),
+                OAIMessage::text("user", "what is that"),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_live_messages_puts_frames_after_the_text_oldest_first() {
+        let frames = ["Zm9v".to_string(), "YmFy".to_string()];
+        let messages = build_live_messages(None, &[], "what is that", &frames);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].content,
+            serde_json::json!([
+                { "type": "text", "text": "what is that" },
+                { "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,Zm9v" } },
+                { "type": "image_url", "image_url": { "url": "data:image/jpeg;base64,YmFy" } },
+            ])
+        );
+    }
+
+    /// History is replayed verbatim for the two roles the page writes, and
+    /// only those: an empty message adds nothing, and a role it never
+    /// writes (a bare `tool` result with no matching call, say) would
+    /// break a chat template rather than add context.
+    #[test]
+    fn build_live_messages_replays_only_the_history_roles_the_page_writes() {
+        let history = [
+            LiveMessage {
+                role: "user".into(),
+                content: "hi".into(),
+            },
+            LiveMessage {
+                role: "assistant".into(),
+                content: "hello".into(),
+            },
+            LiveMessage {
+                role: "tool".into(),
+                content: "{}".into(),
+            },
+            LiveMessage {
+                role: "user".into(),
+                content: String::new(),
+            },
+        ];
+        let messages = build_live_messages(None, &history, "still there?", &[]);
+        assert_eq!(
+            messages,
+            vec![
+                OAIMessage::text("user", "hi"),
+                OAIMessage::text("assistant", "hello"),
+                OAIMessage::text("user", "still there?"),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_live_messages_omits_a_blank_system_prompt_entirely() {
+        let messages = build_live_messages(Some("   "), &[], "hi", &[]);
+        assert_eq!(messages, vec![OAIMessage::text("user", "hi")]);
+    }
+
+    #[test]
+    fn live_sse_frame_is_one_data_line_per_event() {
+        let frame = live_sse_frame(&LiveEvent::Delta {
+            text: "two\nlines".into(),
+        });
+        let frame = String::from_utf8(frame.to_vec()).unwrap();
+        assert_eq!(
+            frame,
+            "data: {\"type\":\"delta\",\"text\":\"two\\nlines\"}\n\n"
+        );
+        assert_eq!(
+            String::from_utf8(live_sse_frame(&LiveEvent::Done).to_vec()).unwrap(),
+            "data: {\"type\":\"done\"}\n\n"
+        );
+    }
+
+    #[test]
+    fn live_events_for_line_maps_a_chunk_to_the_events_the_page_reads() {
+        let mut extractor = RawContentExtractor::new();
+        assert_eq!(
+            live_events_for_line(
+                &mut extractor,
+                r#"data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}"#
+            ),
+            vec![LiveEvent::Delta {
+                text: "Hello".into()
+            }]
+        );
+        assert_eq!(
+            live_events_for_line(
+                &mut extractor,
+                r#"data: {"choices":[{"delta":{"content":"!"},"finish_reason":"stop"}]}"#
+            ),
+            vec![LiveEvent::Delta { text: "!".into() }, LiveEvent::Done]
+        );
+        assert_eq!(
+            live_events_for_line(&mut extractor, "data: [DONE]"),
+            vec![LiveEvent::Done]
+        );
+        // Neither an SSE comment, a blank separator line, nor a payload
+        // this daemon didn't write is an event.
+        assert!(live_events_for_line(&mut extractor, "").is_empty());
+        assert!(live_events_for_line(&mut extractor, ": keep-alive").is_empty());
+        assert!(live_events_for_line(&mut extractor, "data: not json").is_empty());
+    }
+
+    /// A backend that hands back raw `<think>` tags instead of a
+    /// structured reasoning field must still not have its inner monologue
+    /// read aloud — see `RawContentExtractor`, which this shares with
+    /// `/api/chat`.
+    #[test]
+    fn live_events_for_line_keeps_raw_think_tags_out_of_the_spoken_reply() {
+        let mut extractor = RawContentExtractor::new();
+        let mut thinking = String::new();
+        let mut spoken = String::new();
+        for chunk in [
+            r#"{"choices":[{"delta":{"content":"<think>"},"finish_reason":null}]}"#,
+            r#"{"choices":[{"delta":{"content":"hmm"},"finish_reason":null}]}"#,
+            r#"{"choices":[{"delta":{"content":"</think>"},"finish_reason":null}]}"#,
+            r#"{"choices":[{"delta":{"content":"Hi."},"finish_reason":"stop"}]}"#,
+        ] {
+            for event in live_events_for_line(&mut extractor, &format!("data: {chunk}")) {
+                match event {
+                    LiveEvent::Thinking { text } => thinking.push_str(&text),
+                    LiveEvent::Delta { text } => spoken.push_str(&text),
+                    _ => {}
+                }
+            }
+        }
+        assert_eq!(spoken, "Hi.");
+        assert_eq!(thinking, "hmm");
+    }
+
+    /// Reads a live response back into the JSON payload of each event, in
+    /// order.
+    async fn live_events_of(resp: Response) -> Vec<serde_json::Value> {
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(body.to_vec())
+            .unwrap()
+            .lines()
+            .filter_map(|l| l.strip_prefix("data: "))
+            .map(|p| serde_json::from_str(p).expect("each payload is one JSON object"))
+            .collect()
+    }
+
+    /// Runs one turn through `stream_live` against a real HTTP backend
+    /// serving `sse`.
+    async fn run_stream_live(sse: &'static str) -> Vec<serde_json::Value> {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(move || async move { ([("content-type", "text/event-stream")], sse) }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let state = test_state();
+        let resp = stream_live(
+            Client::new(),
+            Target::Local(addr.port()),
+            OAIChatRequest {
+                model: "qwen3.5:0.8b".into(),
+                messages: vec![OAIMessage::text("user", "hi")],
+                stream: true,
+                ..Default::default()
+            },
+            ActivityGuard::new(&state, "qwen3.5:0.8b"),
+            LiveEvent::Context {
+                model: "qwen3.5:0.8b".into(),
+                vision: false,
+                frames: 0,
+            },
+        )
+        .await
+        .expect("the mock backend answers 200");
+
+        assert_eq!(
+            resp.headers()["content-type"],
+            "text/event-stream",
+            "the page reads this as SSE"
+        );
+        live_events_of(resp).await
+    }
+
+    /// What llmman did with the turn has to reach the page before the
+    /// first token, since only the daemon knows it.
+    #[tokio::test]
+    async fn stream_live_sends_the_context_then_deltas_then_exactly_one_done() {
+        let events = run_stream_live(MOCK_SSE).await;
+        assert_eq!(events[0]["type"], "context");
+        assert_eq!(events[0]["vision"], false);
+
+        let spoken: String = events
+            .iter()
+            .filter(|e| e["type"] == "delta")
+            .map(|e| e["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(spoken, "Hello, world");
+
+        // llama-server signals done twice — a real finish_reason, then the
+        // trailing "[DONE]" — and the page must not see two ends of one
+        // reply.
+        assert_eq!(events.iter().filter(|e| e["type"] == "done").count(), 1);
+        assert_eq!(events.last().unwrap()["type"], "done");
+        assert!(!events.iter().any(|e| e["type"] == "error"));
+    }
+
+    /// A backend that dies mid-reply looks exactly like a clean end of
+    /// stream to `bytes_to_lines`, and the status line is long gone — so
+    /// the truncation has to be reported in band rather than left looking
+    /// like a model that simply stopped talking.
+    #[tokio::test]
+    async fn stream_live_reports_a_truncated_backend_stream_in_band() {
+        const TRUNCATED: &str =
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hel\"},\"finish_reason\":null}]}\n";
+        let events = run_stream_live(TRUNCATED).await;
+        assert_eq!(events.iter().filter(|e| e["type"] == "delta").count(), 1);
+        let error = events
+            .iter()
+            .find(|e| e["type"] == "error")
+            .expect("the truncation is reported");
+        assert!(
+            error["message"]
+                .as_str()
+                .unwrap()
+                .contains("closed the connection"),
+            "{error}"
+        );
+        assert_eq!(events.last().unwrap()["type"], "done");
+    }
+
+    /// What `ensure_model` will resolve `model_ref` to in a test whose
+    /// store holds nothing — the key a mock backend has to be registered
+    /// under for `check_running` to find it (see `ensure_model`: shortname
+    /// aliasing, then `default_tag`, then a `canonical_ref` that no-ops on
+    /// an empty store).
+    fn live_canonical(model_ref: &str) -> String {
+        crate::storage::default_tag(&crate::shortnames::resolve_ollama_api(model_ref).unwrap())
+    }
+
+    /// Registers `model_ref` as already loaded on `port`, so a live turn
+    /// reaches a mock backend instead of trying to pull anything.
+    async fn register_live_backend(state: &AppState, model_ref: &str, port: u16) {
+        state.0.manager.lock().await.running.insert(
+            live_canonical(model_ref),
+            RunningModel {
+                process: ModelProcess::Local(
+                    Engine::LlamaServer,
+                    spawn_placeholder_process(),
+                    None,
+                ),
+                port,
+                digest: String::new(),
+                size: 0,
+                started_at: now_rfc3339(),
+                last_active: Instant::now(),
+                last_active_wall: chrono::Utc::now(),
+                backend_model_path: None,
+                keep_alive: None,
+                in_flight: 0,
+            },
+        );
+    }
+
+    /// A mock llama-server that reports `vision` on `/props`, answers the
+    /// chat completion with `MOCK_SSE`, and remembers what it was asked.
+    async fn mock_live_backend(
+        vision: bool,
+    ) -> (u16, Arc<tokio::sync::Mutex<Option<serde_json::Value>>>) {
+        let chat = Arc::new(tokio::sync::Mutex::new(None));
+        let chatted = chat.clone();
+        let app = Router::new()
+            .route(
+                "/props",
+                get(move || async move {
+                    Json(serde_json::json!({ "modalities": { "vision": vision } }))
+                }),
+            )
+            .route(
+                "/v1/chat/completions",
+                post(move |body: Bytes| async move {
+                    *chatted.lock().await = Some(serde_json::from_slice(&body).unwrap());
+                    ([("content-type", "text/event-stream")], MOCK_SSE)
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (port, chat)
+    }
+
+    /// The whole pipeline against a real HTTP backend: the sentence the
+    /// browser recognized reaches the model, the frames ride along as
+    /// image parts because this backend says it can see, and the reply
+    /// comes back as deltas.
+    #[tokio::test]
+    async fn a_live_turn_shows_the_frames_to_a_model_that_can_see() {
+        let (port, chat) = mock_live_backend(true).await;
+        let state = test_state();
+        register_live_backend(&state, "qwen3.5:0.8b", port).await;
+
+        let resp = handle_live_turn(
+            State(state),
+            HeaderMap::new(),
+            live_turn_body(serde_json::json!({
+                "model": "qwen3.5:0.8b",
+                "text": "what is on the table",
+                "system": "be brief",
+                "frames": ["Zm9v"],
+            })),
+        )
+        .await
+        .expect("the mock backend answers");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let events = live_events_of(resp).await;
+
+        assert_eq!(
+            events[0],
+            serde_json::json!({
+                "type": "context",
+                "model": live_canonical("qwen3.5:0.8b"),
+                "vision": true,
+                "frames": 1,
+            })
+        );
+        let spoken: String = events
+            .iter()
+            .filter(|e| e["type"] == "delta")
+            .map(|e| e["text"].as_str().unwrap())
+            .collect();
+        assert_eq!(spoken, "Hello, world");
+        assert_eq!(events.last().unwrap()["type"], "done");
+
+        let chat = chat.lock().await;
+        let chat = chat.as_ref().expect("the model was prompted");
+        assert_eq!(chat["model"], live_canonical("qwen3.5:0.8b"));
+        assert_eq!(chat["stream"], true);
+        assert_eq!(
+            chat["messages"],
+            serde_json::json!([
+                { "role": "system", "content": "be brief" },
+                { "role": "user", "content": [
+                    { "type": "text", "text": "what is on the table" },
+                    { "type": "image_url",
+                      "image_url": { "url": "data:image/jpeg;base64,Zm9v" } },
+                ] },
+            ])
+        );
+    }
+
+    /// A text-only model — `qwen3.5:0.8b`, say — is a first-class choice,
+    /// not a broken one. Speech recognition happened in the browser, so
+    /// the turn is already text; only the frames are dropped, rather than
+    /// sent to a backend that would fail on them.
+    #[tokio::test]
+    async fn a_live_turn_to_a_model_that_cannot_see_still_works_without_the_frames() {
+        let (port, chat) = mock_live_backend(false).await;
+        let state = test_state();
+        register_live_backend(&state, "qwen3.5:0.8b", port).await;
+
+        let resp = handle_live_turn(
+            State(state),
+            HeaderMap::new(),
+            live_turn_body(serde_json::json!({
+                "model": "qwen3.5:0.8b",
+                "text": "hello there",
+                "frames": ["Zm9v", "YmFy"],
+            })),
+        )
+        .await
+        .expect("a text-only model is not an error");
+        let events = live_events_of(resp).await;
+
+        assert_eq!(events[0]["vision"], false);
+        // Reported, so the page can say why the camera is being ignored.
+        assert_eq!(events[0]["frames"], 0);
+        assert!(events.iter().any(|e| e["type"] == "delta"));
+
+        // Plain text content, not a parts array with an image in it.
+        assert_eq!(
+            chat.lock().await.as_ref().unwrap()["messages"],
+            serde_json::json!([{ "role": "user", "content": "hello there" }])
+        );
+    }
+
+    /// Every way a turn can be malformed is the request's own fault, and
+    /// says which one it was — none of them is llmman failing.
+    #[tokio::test]
+    async fn a_malformed_live_turn_is_a_400_that_names_what_is_wrong() {
+        for (body, expected) in [
+            (Bytes::from_static(b"not json"), "JSON object"),
+            (live_turn_body(serde_json::json!({ "text": "hi" })), "model"),
+            (
+                live_turn_body(serde_json::json!({ "model": "qwen3.5:0.8b" })),
+                "text",
+            ),
+            (
+                live_turn_body(serde_json::json!({
+                    "model": "qwen3.5:0.8b", "text": "  ",
+                })),
+                "text",
+            ),
+            (
+                live_turn_body(serde_json::json!({
+                    "model": "qwen3.5:0.8b",
+                    "text": "hi",
+                    "frames": vec!["Zm9v"; MAX_LIVE_FRAMES + 1],
+                })),
+                "at most",
+            ),
+        ] {
+            let resp = handle_live_turn(State(test_state()), HeaderMap::new(), body)
+                .await
+                .expect("a malformed turn is a 400, not a 500");
+            assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+            let reported = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let reported = String::from_utf8_lossy(&reported);
+            assert!(
+                reported.contains(expected),
+                "{expected:?} not in {reported}"
+            );
+        }
     }
 }

--- a/src/webui.rs
+++ b/src/webui.rs
@@ -11,3 +11,13 @@ pub static BUNDLE_CSS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_g
 
 pub static LOADING_HTML: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/loading.html.gz"));
+
+/// llmman live's own page, script and stylesheet — see the
+/// `/llmman/live` handlers in `cmd::serve`. Unlike the bundle above these
+/// three are hand-written source files, not build output, so they are
+/// edited in `webui/` directly.
+pub static LIVE_HTML: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/live.html.gz"));
+
+pub static LIVE_JS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/live.js.gz"));
+
+pub static LIVE_CSS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/webui_gz/live.css.gz"));

--- a/webui/live.css
+++ b/webui/live.css
@@ -1,0 +1,298 @@
+/* llmman live — hand-written, no build step. See webui/live.js. */
+
+:root {
+  color-scheme: dark;
+  --bg: #0d1117;
+  --panel: #161b22;
+  --panel-2: #1c2430;
+  --line: #2a3341;
+  --text: #e6edf3;
+  --muted: #8b98a5;
+  --accent: #4c8dff;
+  --accent-dim: #1f3a66;
+  --danger: #f2555a;
+  --ok: #3fb950;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--line);
+  background: var(--panel);
+}
+
+.bar h1 {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  margin: 0;
+}
+
+.bar h1 span {
+  color: var(--accent);
+}
+
+main {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  gap: 16px;
+  padding: 16px 20px 20px;
+}
+
+@media (max-width: 900px) {
+  main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.stage {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.camera {
+  position: relative;
+  flex: 1;
+  min-height: 220px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #05070a;
+  overflow: hidden;
+}
+
+.camera video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  /* Mirrored preview only: the frames actually sent to the model are
+     drawn from the unmirrored source. */
+  transform: scaleX(-1);
+}
+
+.camera-off {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 13px;
+  background: #05070a;
+}
+
+.camera-off[hidden] {
+  display: none;
+}
+
+/* Live transcript of what is being said right now — the page's only
+   feedback that the microphone is working, and worth more than a level
+   meter because it shows what was actually understood. */
+.caption {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  padding: 7px 11px;
+  border-radius: 8px;
+  background: #000000a6;
+  backdrop-filter: blur(4px);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.35;
+  max-height: 5.4em;
+  overflow: hidden;
+}
+
+.caption[hidden] {
+  display: none;
+}
+
+.stage-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  font: inherit;
+  border-radius: 8px;
+  padding: 8px 14px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  color: var(--text);
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: #3a465a;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+button[hidden] {
+  display: none;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #06121f;
+  font-weight: 600;
+}
+
+button.toggle[aria-pressed="false"] {
+  color: var(--muted);
+  background: transparent;
+}
+
+.hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12.5px;
+}
+
+.hint.error {
+  color: var(--danger);
+}
+
+.side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+}
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.settings label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.settings .row {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.settings .check {
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+  font-size: 13px;
+}
+
+.settings .narrow input {
+  width: 90px;
+}
+
+select,
+input[type="text"],
+input[type="number"],
+textarea {
+  font: inherit;
+  color: var(--text);
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 7px 9px;
+  resize: vertical;
+}
+
+.log {
+  flex: 1;
+  min-height: 160px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+}
+
+.turn {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.turn b {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.turn p {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.turn.user p {
+  color: #b9c6d3;
+}
+
+.turn.note p,
+.turn.note b {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.turn.failed b,
+.turn.failed p {
+  color: var(--danger);
+}
+
+.compose {
+  display: flex;
+  gap: 8px;
+}
+
+.compose input {
+  flex: 1;
+}

--- a/webui/live.html
+++ b/webui/live.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>llmman live</title>
+    <!--
+      Absolute asset paths, not relative ones: this page answers both
+      /llmman/live and /llmman/live/, and a relative "live.js" would
+      resolve to a different URL under each.
+    -->
+    <link rel="stylesheet" href="/llmman/live/live.css" />
+  </head>
+  <body>
+    <header class="bar">
+      <h1>llmman <span>live</span></h1>
+    </header>
+
+    <main>
+      <section class="stage">
+        <div class="camera">
+          <video id="preview" playsinline muted autoplay></video>
+          <div id="camera-off" class="camera-off">camera off</div>
+          <div id="caption" class="caption" hidden></div>
+        </div>
+
+        <div class="stage-controls">
+          <button id="start" class="primary">Start session</button>
+          <button id="stop" class="ghost" hidden>End session</button>
+          <button id="mic" class="toggle" aria-pressed="true" hidden>
+            Mic on
+          </button>
+          <button id="cam" class="toggle" aria-pressed="true" hidden>
+            Camera on
+          </button>
+        </div>
+
+        <p id="hint" class="hint">
+          Grant microphone and camera access, then just talk. Your browser
+          recognizes the speech, llmman attaches the most recent video frames
+          and streams the reply back — spoken aloud, and interruptible.
+        </p>
+      </section>
+
+      <section class="side">
+        <div class="settings">
+          <label>
+            Model
+            <select id="model"></select>
+          </label>
+          <label>
+            System prompt
+            <!-- Shown rather than applied behind the page's back: a spoken
+                 conversation needs short replies, and the reason it gets
+                 them should be visible and editable. -->
+            <textarea id="system" rows="4" spellcheck="false">
+You are in a live spoken conversation and may be shown frames from the user's camera. Reply in one or two short, natural sentences unless asked for more detail. Never use markdown, lists or emoji: everything you say is read aloud.</textarea
+            >
+          </label>
+          <div class="row">
+            <label class="check">
+              <input id="send-video" type="checkbox" checked />
+              Send video frames
+            </label>
+            <label class="check">
+              <input id="speak" type="checkbox" checked />
+              Speak replies
+            </label>
+          </div>
+          <div class="row">
+            <label class="check">
+              <input id="barge-in" type="checkbox" />
+              Allow interrupting (headphones)
+            </label>
+          </div>
+          <label class="narrow">
+            Frames per turn
+            <input id="frames" type="number" min="0" max="8" value="2" />
+          </label>
+        </div>
+
+        <div id="log" class="log" aria-live="polite"></div>
+
+        <form id="compose" class="compose">
+          <input
+            id="text"
+            type="text"
+            placeholder="…or type instead of talking"
+            autocomplete="off"
+          />
+          <button type="submit">Send</button>
+        </form>
+      </section>
+    </main>
+
+    <script type="module" src="/llmman/live/live.js"></script>
+  </body>
+</html>

--- a/webui/live.js
+++ b/webui/live.js
@@ -1,0 +1,619 @@
+// llmman live — a hands-free voice + video conversation UI over the
+// daemon's own /llmman/live/turn endpoint.
+//
+// Hand-written ES module served verbatim (gzipped) by `handle_live_js`;
+// unlike webui/bundle.js this file is source, not a build artifact, so
+// edit it directly.
+//
+// The shape of a turn:
+//
+//   microphone → the browser's own speech recognizer → a sentence
+//   + the last N JPEG frames from the camera → POST /llmman/live/turn
+//   → SSE back → the reply, streamed, rendered and spoken.
+//
+// Speech recognition is the browser's (the Web Speech API), not a model
+// llmman loads — see the /llmman/live section of src/cmd/serve.rs for
+// why. Recent Chrome can run it entirely on-device; `setUpRecognition`
+// below asks for that first and says which one is in use, because "your
+// audio left this machine" is not something a local-inference tool should
+// let happen quietly.
+
+const TURN_URL = "/llmman/live/turn";
+const MODELS_URL = "/v1/models";
+
+// --- turn taking ---------------------------------------------------------
+
+/** Quiet time after the recognizer's last result before the sentences it
+ *  produced are sent as one turn. Long enough to keep "Hi. What's on the
+ *  table?" together as a single turn rather than firing twice, short
+ *  enough not to feel like waiting. */
+const COMMIT_DELAY_MS = 700;
+/** Floor between recognition restarts. The Web Speech API ends a session
+ *  on its own schedule (and immediately, on some errors), so restarting
+ *  is normal — but it has to be rate-limited or a permanently failing
+ *  recognizer becomes a busy loop. */
+const RESTART_DELAY_MS = 250;
+
+// --- video ---------------------------------------------------------------
+
+/** How often a frame is grabbed into the ring buffer. The model only ever
+ *  sees the last few, so this is really "how stale the oldest one is". */
+const FRAME_INTERVAL_MS = 700;
+const FRAME_RING = 8;
+/** Must not exceed the daemon's own `MAX_LIVE_FRAMES`. */
+const MAX_FRAMES_PER_TURN = 8;
+/** Long edge of a captured frame. Vision encoders tile at roughly this
+ *  scale anyway, and it keeps a turn's upload in the tens of kilobytes. */
+const FRAME_EDGE = 512;
+const FRAME_QUALITY = 0.6;
+
+// --- history -------------------------------------------------------------
+
+/** Messages of text-only history replayed to the model. Frames are never
+ *  replayed: they are large, and a stale one actively misleads a model
+ *  being asked about what the camera sees *now*. */
+const HISTORY_MESSAGES = 12;
+
+const $ = (id) => document.getElementById(id);
+const el = {
+  preview: $("preview"),
+  cameraOff: $("camera-off"),
+  caption: $("caption"),
+  start: $("start"),
+  stop: $("stop"),
+  mic: $("mic"),
+  cam: $("cam"),
+  hint: $("hint"),
+  model: $("model"),
+  system: $("system"),
+  sendVideo: $("send-video"),
+  speak: $("speak"),
+  bargeIn: $("barge-in"),
+  frames: $("frames"),
+  log: $("log"),
+  compose: $("compose"),
+  text: $("text"),
+};
+
+const session = {
+  stream: null,
+  micOn: true,
+  camOn: true,
+  frames: [],
+  frameTimer: null,
+  inFlight: null,
+  history: [],
+};
+
+const speech = {
+  /** The `SpeechRecognition` constructor, or null where there is none. */
+  Recognition: null,
+  /** True once the recognizer is confirmed to run without sending audio
+   *  anywhere. */
+  onDevice: false,
+  recognition: null,
+  running: false,
+  /** Set while deliberately stopping, so `onend` doesn't restart. */
+  stopping: false,
+  /** Finalized sentences not yet sent as a turn. */
+  pending: "",
+  commitTimer: null,
+  /** When the last turn was handed to `sendTurn` — see the interrupt
+   *  guard in `onRecognitionResult`. */
+  lastCommitAt: 0,
+};
+
+// ---------------------------------------------------------------------------
+// Transcript rendering
+// ---------------------------------------------------------------------------
+
+function setHint(text, isError) {
+  el.hint.textContent = text;
+  el.hint.classList.toggle("error", !!isError);
+}
+
+function setCaption(text) {
+  el.caption.textContent = text;
+  el.caption.hidden = !text;
+}
+
+function addTurn(kind, who) {
+  const wrap = document.createElement("div");
+  wrap.className = `turn ${kind}`;
+  const label = document.createElement("b");
+  label.textContent = who;
+  const body = document.createElement("p");
+  wrap.append(label, body);
+  el.log.append(wrap);
+  el.log.scrollTop = el.log.scrollHeight;
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Model list
+// ---------------------------------------------------------------------------
+
+async function loadModels() {
+  let ids = [];
+  try {
+    const resp = await fetch(MODELS_URL);
+    if (!resp.ok) throw new Error(`${resp.status} ${resp.statusText}`);
+    ids = ((await resp.json()).data || []).map((m) => m.id).sort();
+  } catch (err) {
+    setHint(`Could not list models: ${err.message}`, true);
+    return;
+  }
+
+  el.model.replaceChildren();
+  el.model.append(new Option(ids.length ? "select a model" : "no models", ""));
+  for (const id of ids) el.model.append(new Option(id, id));
+  if (ids.length) {
+    el.model.value = ids[0];
+  } else {
+    setHint("No models in the store yet — pull one with `llmman pull`.", true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Speech recognition (the browser's own)
+// ---------------------------------------------------------------------------
+
+const RECOGNITION_LANG = navigator.language || "en-US";
+
+/** Picks the recognizer, preferring one that keeps the audio here.
+ *
+ *  Chrome 138+ can run recognition on-device and exposes `available()`
+ *  to ask whether it currently can; everything else has only the
+ *  original API, whose implementation may send audio to a vendor
+ *  service. Asking costs one call and is the difference between the
+ *  microphone staying on this machine and not. */
+async function setUpRecognition() {
+  const Recognition =
+    window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!Recognition) {
+    el.mic.hidden = true;
+    setHint(
+      "This browser has no speech recognition, so llmman live can't listen — " +
+        "the camera and the text box below still work. Chrome, Edge and " +
+        "Safari can listen.",
+      true,
+    );
+    return;
+  }
+  speech.Recognition = Recognition;
+
+  // The original API only: no way to ask where the audio goes, and no
+  // way to ask for it to stay put either.
+  if (typeof Recognition.available !== "function") return;
+  const status = await Recognition.available({
+    langs: [RECOGNITION_LANG],
+    processLocally: true,
+  }).catch(() => "unavailable");
+  speech.onDevice = status === "available";
+}
+
+function startRecognition() {
+  if (!speech.Recognition || speech.running || !session.stream) return;
+  const recognition = new speech.Recognition();
+  recognition.lang = RECOGNITION_LANG;
+  // Keep listening across sentences instead of stopping at the first one,
+  // and surface partial results so the caption tracks the speaker and
+  // barge-in can fire on the first syllable rather than the last.
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.maxAlternatives = 1;
+  if (speech.onDevice) recognition.processLocally = true;
+
+  recognition.onresult = onRecognitionResult;
+  recognition.onerror = onRecognitionError;
+  recognition.onend = () => {
+    speech.running = false;
+    if (!speech.stopping && session.stream && session.micOn) {
+      setTimeout(startRecognition, RESTART_DELAY_MS);
+    }
+  };
+
+  try {
+    recognition.start();
+    speech.running = true;
+    speech.stopping = false;
+    speech.recognition = recognition;
+  } catch {
+    // start() throws if one is somehow already running; onend will
+    // schedule the next attempt.
+  }
+}
+
+function stopRecognition() {
+  speech.stopping = true;
+  clearTimeout(speech.commitTimer);
+  speech.pending = "";
+  setCaption("");
+  if (speech.recognition) speech.recognition.abort();
+  speech.recognition = null;
+  speech.running = false;
+}
+
+function restartRecognition() {
+  stopRecognition();
+  speech.stopping = false;
+  startRecognition();
+}
+
+function onRecognitionResult(event) {
+  // Without headphones the recognizer hears the reply being spoken and
+  // answers it, which is a conversation with itself. Dropping results
+  // while speaking is the only reliable defence, so interrupting is
+  // opt-in for people who can't be overheard by their own microphone.
+  if (tts.speaking && !el.bargeIn.checked) return;
+
+  let interim = "";
+  let final = "";
+  for (let i = event.resultIndex; i < event.results.length; i++) {
+    const result = event.results[i];
+    if (result.isFinal) final += result[0].transcript;
+    else interim += result[0].transcript;
+  }
+  if (!interim && !final) return;
+
+  // The user is talking, so whatever the assistant was saying (or about
+  // to say) stops. Matching how a person interrupts is most of what makes
+  // this feel live rather than turn-based.
+  //
+  // Except just after a turn was sent: the recognizer can deliver a
+  // trailing result for speech that has *already* been committed, and
+  // aborting on that would cancel the very turn it produced. Nothing
+  // reaches the speakers that fast, so a window as short as the commit
+  // delay separates the two cases.
+  if (Date.now() - speech.lastCommitAt > COMMIT_DELAY_MS) interrupt();
+
+  speech.pending = (speech.pending + final).replace(/\s+/g, " ");
+  setCaption((speech.pending + " " + interim).trim());
+
+  // Restarted on every result, final or not: the turn is sent once the
+  // speaker has actually stopped, not at the first sentence boundary.
+  clearTimeout(speech.commitTimer);
+  speech.commitTimer = setTimeout(commitSpokenTurn, COMMIT_DELAY_MS);
+}
+
+function commitSpokenTurn() {
+  const text = speech.pending.trim();
+  speech.pending = "";
+  setCaption("");
+  if (!text) return;
+  speech.lastCommitAt = Date.now();
+  sendTurn(text);
+}
+
+function onRecognitionError(event) {
+  switch (event.error) {
+    case "no-speech":
+    case "aborted":
+      return; // ordinary; onend restarts
+    case "not-allowed":
+    case "service-not-allowed":
+      speech.stopping = true;
+      setHint(
+        "Microphone access was refused, so llmman live can't listen. You can " +
+          "still type below.",
+        true,
+      );
+      return;
+    case "audio-capture":
+      setHint("No microphone was found. You can still type below.", true);
+      return;
+    case "network":
+      setHint(
+        "This browser's speech recognition needs a network connection — it " +
+          "is not running on this machine. Type below instead.",
+        true,
+      );
+      return;
+    default:
+      setHint(`Speech recognition failed: ${event.error}`, true);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Video: ring buffer of recent JPEG stills
+// ---------------------------------------------------------------------------
+
+const canvas = document.createElement("canvas");
+
+/** Base64 (no data-URI prefix) of the current video frame, which is the
+ *  wire shape /llmman/live/turn wants. */
+async function grabFrame() {
+  const video = el.preview;
+  if (!session.camOn || !video.videoWidth) return;
+  const scale = Math.min(
+    1,
+    FRAME_EDGE / Math.max(video.videoWidth, video.videoHeight),
+  );
+  canvas.width = Math.round(video.videoWidth * scale);
+  canvas.height = Math.round(video.videoHeight * scale);
+  // Drawn from the unmirrored source: the preview is flipped for the
+  // person looking at it, but the model should see text the right way
+  // round.
+  canvas.getContext("2d").drawImage(video, 0, 0, canvas.width, canvas.height);
+  const dataUri = canvas.toDataURL("image/jpeg", FRAME_QUALITY);
+  session.frames.push(dataUri.slice(dataUri.indexOf(",") + 1));
+  while (session.frames.length > FRAME_RING) session.frames.shift();
+}
+
+// ---------------------------------------------------------------------------
+// Speech output
+// ---------------------------------------------------------------------------
+
+const tts = { queue: "", speaking: false, outstanding: 0 };
+
+/** End of a sentence: terminal punctuation, the closing quote or bracket
+ *  that may follow it, then whitespace. Requiring the whitespace is what
+ *  keeps "3.5" or "qwen3.5:0.8b" from being read as two sentences. */
+const SENTENCE_END = /[.!?…]["')\]]?\s/;
+
+/** Speaks whole sentences as they finish streaming, rather than waiting
+ *  for the full reply — the same reason the reply itself is streamed.
+ *  `flush` speaks whatever is left at the end of a turn, boundary or
+ *  not. */
+function speakStreaming(text, flush) {
+  if (!el.speak.checked || !window.speechSynthesis) return;
+  tts.queue += text;
+  for (;;) {
+    const end = SENTENCE_END.exec(tts.queue);
+    if (!end && !flush) return;
+    const cut = end ? end.index + end[0].length : tts.queue.length;
+    const say = tts.queue.slice(0, cut).trim();
+    tts.queue = tts.queue.slice(cut);
+    if (say) speakOne(say);
+    if (!tts.queue) return;
+  }
+}
+
+function speakOne(text) {
+  const utterance = new SpeechSynthesisUtterance(text);
+  tts.outstanding++;
+  tts.speaking = true;
+  const finished = () => {
+    // `speechSynthesis.speaking` lags its own events, and the recognizer
+    // gate above has to be exact — one stale frame of "not speaking" is
+    // enough for the assistant to hear itself and reply to it.
+    if (--tts.outstanding <= 0) {
+      tts.outstanding = 0;
+      tts.speaking = false;
+    }
+  };
+  utterance.onend = finished;
+  utterance.onerror = finished;
+  window.speechSynthesis.speak(utterance);
+}
+
+/** Stops the reply, whether it is still being generated or only still
+ *  being spoken. */
+function interrupt() {
+  tts.queue = "";
+  tts.outstanding = 0;
+  tts.speaking = false;
+  if (window.speechSynthesis) window.speechSynthesis.cancel();
+  if (session.inFlight) {
+    session.inFlight.abort();
+    session.inFlight = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// One turn: POST the sentence and frames, read the SSE reply
+// ---------------------------------------------------------------------------
+
+/** Splits an SSE byte stream into the JSON payload of each `data:` line.
+ *  Every event this endpoint sends is a single-line JSON object (see
+ *  `LiveEvent` in src/cmd/serve.rs), so no multi-line reassembly is
+ *  needed — only buffering across chunk boundaries. */
+async function* readEvents(body) {
+  const reader = body.pipeThrough(new TextDecoderStream()).getReader();
+  let buf = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) return;
+    buf += value;
+    let nl;
+    while ((nl = buf.indexOf("\n")) >= 0) {
+      const line = buf.slice(0, nl).trimEnd();
+      buf = buf.slice(nl + 1);
+      if (!line.startsWith("data: ")) continue;
+      try {
+        yield JSON.parse(line.slice(6));
+      } catch {
+        // A payload llmman didn't write; nothing useful to do with it.
+      }
+    }
+  }
+}
+
+function framesForTurn() {
+  // `slice(-0)` is `slice(0)` — the whole buffer — so zero has to be its
+  // own case rather than falling out of the arithmetic. Clamped to what
+  // the daemon accepts (MAX_LIVE_FRAMES) so a hand-edited input makes a
+  // smaller turn rather than a 400.
+  if (!el.sendVideo.checked) return [];
+  const wanted = Math.max(
+    0,
+    Math.min(MAX_FRAMES_PER_TURN, Number(el.frames.value) || 0),
+  );
+  return wanted ? session.frames.slice(-wanted) : [];
+}
+
+async function sendTurn(text) {
+  const model = el.model.value;
+  if (!model) {
+    setHint("Pick a model first.", true);
+    return;
+  }
+
+  interrupt();
+  addTurn("user", "you").textContent = text;
+  const frames = framesForTurn();
+
+  const controller = new AbortController();
+  session.inFlight = controller;
+
+  let replyBody = null;
+  let reply = "";
+
+  try {
+    const resp = await fetch(TURN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        model,
+        text,
+        system: el.system.value.trim() || null,
+        history: session.history.slice(-HISTORY_MESSAGES),
+        frames,
+      }),
+    });
+    if (!resp.ok) {
+      const detail = await resp.json().catch(() => ({}));
+      throw new Error(detail.error || `${resp.status} ${resp.statusText}`);
+    }
+    for await (const event of readEvents(resp.body)) {
+      switch (event.type) {
+        case "context":
+          if (!event.vision && frames.length) {
+            setHint(
+              `${event.model} has no vision support, so the camera frames ` +
+                "were not sent. Pick a vision model to be seen.",
+            );
+          } else if (event.frames) {
+            setHint(`Sent ${event.frames} camera frame(s) with this turn.`);
+          }
+          break;
+        case "delta":
+          replyBody = replyBody || addTurn("assistant", "llmman");
+          reply += event.text;
+          replyBody.textContent = reply;
+          el.log.scrollTop = el.log.scrollHeight;
+          speakStreaming(event.text, false);
+          break;
+        case "thinking":
+          // Reasoning is deliberately neither rendered as the reply nor
+          // spoken: it isn't addressed to the user.
+          break;
+        case "error":
+          throw new Error(event.message);
+        default:
+          break;
+      }
+    }
+    speakStreaming("", true);
+    session.history.push({ role: "user", content: text });
+    if (reply) session.history.push({ role: "assistant", content: reply });
+  } catch (err) {
+    if (err.name === "AbortError") return; // interrupted on purpose
+    addTurn("failed", "error").textContent = err.message;
+    return;
+  } finally {
+    if (session.inFlight === controller) session.inFlight = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+async function startSession() {
+  el.start.disabled = true;
+  try {
+    // Video only: the recognizer opens the microphone itself, and asking
+    // for it here too would capture the same input twice for nothing.
+    session.stream = await navigator.mediaDevices.getUserMedia({
+      video: { width: { ideal: 1280 }, height: { ideal: 720 } },
+    });
+  } catch (err) {
+    el.start.disabled = false;
+    setHint(
+      `Camera access was refused (${err.name}). A browser only grants it ` +
+        "over http://127.0.0.1, http://localhost or HTTPS.",
+      true,
+    );
+    return;
+  }
+
+  el.preview.srcObject = session.stream;
+  el.cameraOff.hidden = true;
+  session.frameTimer = setInterval(grabFrame, FRAME_INTERVAL_MS);
+
+  el.start.hidden = true;
+  el.stop.hidden = false;
+  el.cam.hidden = false;
+  if (speech.Recognition) {
+    el.mic.hidden = false;
+    speech.stopping = false;
+    startRecognition();
+    setHint("Listening. Just talk — llmman replies when you stop.");
+  } else {
+    setHint("Camera on. Type below to talk to the model.");
+  }
+}
+
+function stopSession() {
+  interrupt();
+  stopRecognition();
+  clearInterval(session.frameTimer);
+  session.frameTimer = null;
+  if (session.stream) for (const t of session.stream.getTracks()) t.stop();
+  session.stream = null;
+  session.frames = [];
+  el.preview.srcObject = null;
+  el.cameraOff.hidden = false;
+  el.start.hidden = false;
+  el.start.disabled = false;
+  el.stop.hidden = true;
+  el.mic.hidden = true;
+  el.cam.hidden = true;
+  setHint("Session ended.");
+}
+
+function toggle(button, on, onLabel, offLabel) {
+  button.setAttribute("aria-pressed", String(on));
+  button.textContent = on ? onLabel : offLabel;
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+el.start.addEventListener("click", startSession);
+el.stop.addEventListener("click", stopSession);
+
+el.mic.addEventListener("click", () => {
+  session.micOn = !session.micOn;
+  if (session.micOn) restartRecognition();
+  else stopRecognition();
+  toggle(el.mic, session.micOn, "Mic on", "Mic off");
+});
+
+el.cam.addEventListener("click", () => {
+  session.camOn = !session.camOn;
+  for (const track of session.stream.getVideoTracks()) {
+    track.enabled = session.camOn;
+  }
+  if (!session.camOn) session.frames = [];
+  el.cameraOff.hidden = session.camOn;
+  toggle(el.cam, session.camOn, "Camera on", "Camera off");
+});
+
+el.compose.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const text = el.text.value.trim();
+  if (!text) return;
+  el.text.value = "";
+  sendTurn(text);
+});
+
+window.addEventListener("pagehide", () => {
+  if (session.stream) stopSession();
+});
+
+loadModels();
+setUpRecognition();


### PR DESCRIPTION
A hands-free conversation with a local model in the browser, at
`http://127.0.0.1:17434/llmman/live`. It listens, watches the camera, and
streams the reply back token by token — read aloud, and interruptible.

```
llmman serve
open http://127.0.0.1:17434/llmman/live
```

## Speech-to-text is the browser's, not a model

Every browser that can grant microphone access already ships a recognizer
(the Web Speech API — on-device, in recent Chrome). Requiring a
whisper-family model would have meant one more pull, a second model
resident in memory for every session, and a dropdown the user has no basis
to fill in.

It is also what makes the rest work: the page holds the transcript *as it
is spoken*, which is what live captions and interrupting mid-reply need. A
server round trip per utterance could only produce text after the fact.

Recognition is asked to run on-device (`available({processLocally: true})`)
wherever the browser offers it, so the audio stays on the machine the model
is already on.

Because a turn is already text by the time `post_chat` is reached, **any
model works** — `qwen3.5:0.8b` is a first-class choice, not a degraded
one. Camera frames are attached only to a backend whose `/props` reports
vision support, so a model that cannot see is never handed images it would
only fail on, and the page says why the camera was ignored.

## Surface

| Route | |
|---|---|
| `GET /llmman/live` (and `/`) | the page |
| `GET /llmman/live/live.js`, `live.css` | assets, gzipped and embedded like the existing bundle |
| `POST /llmman/live/turn` | one turn in, SSE out |

A turn is JSON — `model`, `text`, `system`, `history`, up to 8 base64 JPEG
`frames` — answered as `context`, `delta`, `thinking`, `error`, `done`.

Deliberately **not** a WebSocket. With recognition in the page a turn is
one short request and one streamed reply, so this stays on the plumbing
every other route already uses (`ensure_model`, `ActivityGuard`,
`post_chat`, `bytes_to_lines`) rather than adding a second connection
lifecycle to keep in step with `keep_alive`, and an upgrade path
`cors_layer` does not cover.

## Self-hearing

Without headphones the recognizer hears the spoken reply and answers it —
the assistant talking to itself. Results arriving while speaking are
dropped by default, with an opt-in **Allow interrupting** checkbox.
`speechSynthesis.speaking` lags its own events, so the gate counts
outstanding utterances instead.

Reasoning goes through the existing `RawContentExtractor`, so a model
emitting raw `<think>` tags never has its monologue read aloud. History is
replayed as text only: a stale frame is worse than none when the question
is about what the camera sees *now*.

## Verification

- 460 lib tests (26 new for live), `clippy --all-targets -D warnings`
  clean, `fmt --check` clean.
- Against a live daemon: all malformed-turn paths return 400s naming the
  problem; all four asset routes 200; assets byte-identical to source
  after the gzip round-trip.
- 30 checks driving the real `live.js` under a stub DOM (checkbox defaults
  read from the real markup, `SpeechRecognition.results` emulated with its
  accumulating-array / `resultIndex` semantics): interim results don't
  send, two sentences coalesce into one turn, frames sent as bare base64,
  and both halves of the self-hearing gate.
- A pristine `git archive` of this branch builds, confirming the three new
  `webui/live.*` assets `build.rs` reads are tracked.

## Notes for review

- `webui/live.{html,js,css}` are hand-written **source**, not bundle
  output — unlike `bundle.js` they are edited directly.
- Firefox has no speech recognition. The page detects that, says so, hides
  the mic button; camera and the text box still work.
- Browsers only grant capture to a secure context, so this needs
  `127.0.0.1`/`localhost`, not a LAN address.