### PR TITLE
ci: bound the build and release jobs with timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,14 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    # Every leg finishes in 2-7 min warm, so 60 is pure headroom — it
+    # exists only to bound a wedged runner. CI 33613527281's
+    # ubuntu-24.04-arm leg lost communication with the server mid-build
+    # and, with no timeout here, stalled 46 min before GitHub's own
+    # infrastructure gave up, blocking `release` (which `needs:` this)
+    # the whole time. A timeout can't keep a runner alive, just stop a
+    # dead one from stalling until the 6-hour default.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -1252,6 +1260,10 @@ jobs:
     # other event (e.g. a PR).
     needs: [build, test, lint, e2e]
     runs-on: ubuntu-24.04
+    # Downloads, renames and uploads artefacts in under a minute; 60 is
+    # the same runner-wedge bound as the `build` job above, not an
+    # estimate of this job's own runtime.
+    timeout-minutes: 60
     # Two release channels, both attaching one binary per matrix.target
     # (see the build job above — this is where "all the platforms
     # llama.app does" is actually decided, not here):


### PR DESCRIPTION
Adds `timeout-minutes: 60` to the two jobs in `.github/workflows/ci.yml` that didn't have one: `build` and `release`. Both were inheriting GitHub's 6-hour default.

## Why

On the a9fa279 push to main ([CI 33613527281](https://github.com/llmmanorg/llmman/actions/runs/33613527281)), the `ubuntu-24.04-arm` runner for `Build (aarch64-unknown-linux-gnu)` reported *"the hosted runner lost communication with the server"* mid-`cargo build` and sat there **46 minutes** — against a 2-4 minute norm — before GitHub's infrastructure gave up. It blocked `release` (which `needs:` it) the whole time and left main red with `b299` never cut.

## It was a flake, not a code failure

- The same commit's `Unit tests (aarch64-unknown-linux-gnu)` leg ran the strictly larger `cargo clippy --release --all-targets` plus `cargo test --release`, same runner image and target, in 3m57s.
- This failure mode appears exactly once in the last 120 CI runs.
- Re-running the failed job alone turned the run green and cut the missing `b299`. Already done — main is no longer red.

## On "de-flaking"

A dead hosted runner can't be prevented from inside a workflow, so this doesn't claim to stop a recurrence. It bounds the damage: a silent multi-hour stall becomes a fast, clearly labelled timeout. 60 min is pure headroom on both jobs, not an estimate of their runtime.

Job bounds after this change: `build` 60, `test` 15, `lint` 10, `e2e` 310, `release` 60.