### PR TITLE
ci: budget the unit-test timeout for a cold Rust cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
   test:
     name: Unit tests (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 15
+    timeout-minutes: ${{ matrix.timeout || 60 }}
     strategy:
       fail-fast: false
       matrix:
@@ -268,6 +268,7 @@ jobs:
             go-os: windows
             msvc-arch: amd64
             rustflags: "-C linker=lld-link"
+            timeout: 60
 
           # ── Windows aarch64 ───────────────────────────────────────────────
           # rustflags empty (MSVC-native link.exe, not lld-link) — see the
@@ -278,6 +279,7 @@ jobs:
             go-os: windows
             msvc-arch: arm64
             rustflags: ""
+            timeout: 60
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
`Unit tests (x86_64-pc-windows-msvc)` was cancelled at the job's flat 15-minute limit on main ([run 33773787305](https://github.com/llmmanorg/llmman/actions/runs/33773787305)), still linking, having never run a test.

## Root cause

Not a random flake — a scheduled one. `rust-cache` puts the exact rustc commit hash in its key:

```
Cache Key: v0-rust-test-x86_64-pc-windows-msvc-test-Windows_NT-x64-07261475-f7c06c71
  - Rust Versions:
    - 1.98.1 x86_64-pc-windows-msvc 48a229ceaefd...
... Restoring cache ...
No cache found.
```

The toolchain step in that same job logs `stable-x86_64-pc-windows-msvc updated - rustc 1.98.1 (from rustc 1.98.0)`. A stable release — patch releases included — discards every leg's cache at once, and the next push rebuilds the entire dependency graph. Warm, this job runs 4-5 minutes; the flat 15 was set against that number. Cold, `cargo clippy --release --all-targets` alone took 4 minutes and `cargo test` was 9m37s in and still linking when the runner killed it.

It also does not clear on its own: a timed-out job is cancelled *before* rust-cache's post step, so the artefacts it just rebuilt are discarded and the following push starts cold too.

## Fix

Raise the bound to 60 on every leg. Cold times in the failing run:

| leg | cold | new ceiling |
| --- | --- | --- |
| `aarch64-unknown-linux-gnu` | 5m02s | 60 |
| `aarch64-apple-darwin` | 8m59s | 60 |
| `x86_64-unknown-linux-gnu` | 9m36s | 60 |
| `aarch64-pc-windows-msvc` | 13m48s | 60 |
| `x86_64-pc-windows-msvc` | killed at 15m07s | 60 |

Fitting each leg to its last observed cold number only invites re-tuning whenever a dependency or a runner image moves. 60 stays a ceiling for catching a genuine hang rather than an expected runtime — the warm path is unchanged.

## Alternatives considered

- **`cache-on-failure`.** Does not help. The post step is skipped on *cancellation*, not just failure, so nothing gets saved either way.
- **Dropping rustc from the cache key.** Not configurable in `Swatinem/rust-cache`, and unsound anyway — stale artefacts across a rustc bump.
