### PR TITLE
feat(ci): publish llmman to crates.io, Homebrew and Scoop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1282,6 +1282,14 @@ jobs:
     permissions:
       contents: write
 
+    # Consumed by the three package-manager publish jobs below
+    # (publish-crate/publish-homebrew/publish-scoop), so the tag is
+    # computed once, here, rather than each of them re-deriving it from
+    # github.ref and `git rev-list` and risking drift from this job's own
+    # "Determine release tag" step.
+    outputs:
+      tag_name: ${{ steps.tag.outputs.tag_name }}
+
     steps:
       # fetch-depth: 0 — the b<N> tag below is the full commit count,
       # which a shallow default clone can't compute. Checkout comes
@@ -1349,3 +1357,89 @@ jobs:
           target_commitish: ${{ github.sha }}
           prerelease: false
           files: dist/llmman-*
+
+  # --------------------------------------------------------------------------
+  # crates.io (issue #389). Publishes the `llmman` crate.
+  #
+  # Stable `v*` tags only, unlike every other job here that also fires on
+  # each push to main: crates.io versions are immutable and permanent (a
+  # bad one can only be yanked, never replaced or deleted), and the
+  # version published comes from Cargo.toml, which does not change
+  # per-commit. Publishing the b<N> channel here would therefore mean
+  # either hundreds of throwaway versions or a hard failure on the second
+  # commit — so the per-commit channel stays with install.sh/install.ps1
+  # and the `llmman-dev` brew/scoop packages below, which are all
+  # overwrite-in-place by design.
+  #
+  # `needs: [release]` rather than repeating release's own
+  # [build, test, lint, e2e]: that job already gates on all four, so this
+  # additionally guarantees the GitHub release itself succeeded before a
+  # permanent, unrevocable crates.io version exists for it.
+  # --------------------------------------------------------------------------
+  publish-crate:
+    name: Publish to crates.io
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Go, gcc: `cargo publish` runs a full verification build of the
+      # packaged crate by default, and build.rs compiles the go-shim
+      # c-archive via CGO. Same toolchain the `build` job sets up, for the
+      # same reason.
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: go-shim/go.sum
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y gcc
+
+      # The tag is the release's identity but Cargo.toml's `version` is
+      # what actually gets published, and nothing otherwise ties them
+      # together — a `v0.2.0` tag cut without bumping Cargo.toml would
+      # silently publish 0.1.0 again (or fail deep inside `cargo publish`
+      # with an "already uploaded" error that names neither the tag nor
+      # the mismatch). Fail here instead, before anything is uploaded.
+      - name: Verify tag matches Cargo.toml version
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.release.outputs.tag_name }}"
+          manifest="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          if [ "${tag#v}" != "$manifest" ]; then
+            echo "::error::tag $tag does not match Cargo.toml version $manifest — bump the version before tagging"
+            exit 1
+          fi
+          echo "OK: $tag matches Cargo.toml version $manifest"
+          echo "CRATE_VERSION=$manifest" >> "$GITHUB_ENV"
+
+      # Makes a re-run of a partially-failed workflow safe. crates.io
+      # rejects a duplicate version outright, which would turn any re-run
+      # (e.g. to retry a failed publish-homebrew below) into a red X on an
+      # already-correctly-published crate.
+      - name: Skip if this version is already on crates.io
+        id: exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          if curl -fsS -H "User-Agent: llmman-ci (github.com/llmmanorg/llmman)" \
+              "https://crates.io/api/v1/crates/llmman/$CRATE_VERSION" >/dev/null 2>&1; then
+            echo "::notice::llmman $CRATE_VERSION is already published; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: cargo publish
+        if: steps.exists.outputs.skip != 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,6 +459,189 @@ jobs:
         run: go test -tags podman,containers_image_openpgp,exclude_graphdriver_btrfs,exclude_graphdriver_devicemapper ./...
 
   # --------------------------------------------------------------------------
+  # Packaging: renders the Homebrew formula and Scoop manifest from
+  # packaging/ and checks the *output* parses, on every PR.
+  #
+  # Without this, the only thing that ever exercises those templates is
+  # the publish-homebrew/publish-scoop jobs at the very end of a release —
+  # by which point a one-character typo has already been pushed to
+  # llmmanorg/homebrew-tap, where it doesn't break this repo's CI at all,
+  # it breaks `brew install` for everyone (a formula that raises during
+  # load takes out the whole tap, not just llmman).
+  #
+  # Synthetic checksums, not a real release's: this validates the
+  # rendering and the templates' syntax, which are independent of what
+  # the hashes actually are. render.sh's own placeholder-leak and
+  # hash-shape guards (see that script) are exercised for free.
+  # --------------------------------------------------------------------------
+  packaging:
+    name: Packaging (brew/scoop templates)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: shellcheck packaging/render.sh
+        run: shellcheck packaging/render.sh
+
+      # Both channels: they take different branches through render.sh
+      # (different package name, version derivation and formula class), so
+      # checking one proves nothing about the other.
+      #
+      # The stable tag has to be the *real* crate version rather than a
+      # made-up one: render.sh deliberately refuses a stable tag that
+      # disagrees with Cargo.toml (see its own comment on why), so a
+      # hardcoded "v9.9.9" here would only ever exercise that rejection.
+      - name: Render both channels
+        id: render
+        run: |
+          set -euo pipefail
+          for asset in \
+            llmman-aarch64-apple-darwin \
+            llmman-x86_64-unknown-linux-gnu \
+            llmman-aarch64-unknown-linux-gnu \
+            llmman-x86_64-pc-windows-msvc.exe \
+            llmman-aarch64-pc-windows-msvc.exe; do
+            printf '%s  %s\n' "$(printf '%s' "$asset" | sha256sum | cut -d' ' -f1)" "$asset"
+          done > fake-checksums.txt
+
+          crate_version="$(cargo metadata --no-deps --format-version 1 \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+          echo "crate_version=$crate_version" >> "$GITHUB_OUTPUT"
+          echo "Crate version: $crate_version"
+
+          packaging/render.sh --tag "v$crate_version" --checksums fake-checksums.txt --out-dir out-stable
+          packaging/render.sh --tag b99999 --checksums fake-checksums.txt --out-dir out-dev
+
+      # The formula's `test do` block asserts `llmman --version` contains
+      # this string, so if render.sh ever stops sourcing it from
+      # Cargo.toml the formulae still install fine and only fail later,
+      # under `brew test`, on a machine nobody is watching.
+      - name: Check both channels assert the crate version
+        env:
+          CRATE_VERSION: ${{ steps.render.outputs.crate_version }}
+        run: |
+          set -euo pipefail
+          for f in out-stable/Formula/llmman.rb out-dev/Formula/llmman-dev.rb; do
+            grep -q "assert_match \"$CRATE_VERSION\", shell_output" "$f" \
+              || { echo "::error::$f does not assert the crate version $CRATE_VERSION"; exit 1; }
+          done
+          echo "OK: both formulae assert $CRATE_VERSION"
+
+      # ruby -c, not `brew audit`: this catches the failure mode that
+      # actually matters (a formula that cannot be parsed, and so breaks
+      # the entire tap) without making the whole job depend on installing
+      # Homebrew on a Linux runner.
+      - name: Check formulae parse
+        run: |
+          set -euo pipefail
+          for f in out-stable/Formula/*.rb out-dev/Formula/*.rb; do
+            echo "== $f"
+            ruby -c "$f"
+          done
+
+      # Structural, not just well-formed. Scoop's own schema sets
+      # "additionalProperties": false, so a typo'd or invented key makes a
+      # manifest Scoop rejects while `json.tool` still calls it valid
+      # JSON. The key allowlist below is the schema's own top-level
+      # property set (ScoopInstaller/Scoop's schema.json), checked
+      # offline rather than by fetching that schema at CI time so this
+      # job cannot start failing because of someone else's outage.
+      - name: Check manifests
+        run: |
+          set -euo pipefail
+          python3 - out-stable/bucket/*.json out-dev/bucket/*.json <<'PY'
+          import json, sys
+
+          ALLOWED = {
+              "##", "$schema", "_comment", "architecture", "autoupdate", "bin",
+              "checkver", "cookie", "depends", "description", "env_add_path",
+              "env_set", "extract_dir", "extract_to", "hash", "homepage",
+              "innosetup", "installer", "license", "notes", "persist",
+              "post_install", "post_uninstall", "pre_install", "pre_uninstall",
+              "psmodule", "shortcuts", "suggest", "uninstaller", "url", "version",
+          }
+          REQUIRED = {"version", "homepage", "license"}
+          ARCHES = {"64bit", "arm64"}
+
+          failed = False
+          for path in sys.argv[1:]:
+              with open(path) as fh:
+                  m = json.load(fh)
+
+              def bad(msg):
+                  global failed
+                  print(f"::error::{path}: {msg}")
+                  failed = True
+
+              unknown = sorted(set(m) - ALLOWED)
+              if unknown:
+                  bad(f"unknown top-level key(s) {unknown}; Scoop's schema forbids extras")
+              missing = sorted(REQUIRED - set(m))
+              if missing:
+                  bad(f"missing required key(s) {missing}")
+
+              arch = m.get("architecture", {})
+              if set(arch) != ARCHES:
+                  bad(f"architecture keys are {sorted(arch)}, expected {sorted(ARCHES)}")
+              for name, spec in arch.items():
+                  if not spec.get("url"):
+                      bad(f"architecture.{name} has no url")
+                  if len(spec.get("hash", "")) != 64:
+                      bad(f"architecture.{name}.hash is not a 64-char sha256")
+                  # Scoop renames a bare .exe download via this fragment;
+                  # without it the installed file keeps the release asset's
+                  # own llmman-<triple>.exe name and "bin" never resolves.
+                  if not spec.get("url", "").endswith("#/llmman.exe"):
+                      bad(f"architecture.{name}.url lacks the '#/llmman.exe' rename fragment")
+
+              if m.get("bin") != "llmman.exe":
+                  bad(f"bin is {m.get('bin')!r}, expected 'llmman.exe'")
+
+              if not failed:
+                  print(f"OK {path} (version {m['version']})")
+
+          sys.exit(1 if failed else 0)
+          PY
+
+      # Homebrew derives a formula's class name from its filename and
+      # refuses to load the file if they disagree, so the two must be
+      # checked against each other rather than just individually parsing.
+      # Same for the package name render.sh picks per channel.
+      - name: Check filenames, class names and versions
+        run: |
+          set -euo pipefail
+          check() {
+            local rb="$1" want_class="$2" want_version="$3" json="$4"
+            test -f "$rb" || { echo "::error::missing $rb"; exit 1; }
+            grep -q "^class $want_class < Formula$" "$rb" \
+              || { echo "::error::$rb does not declare 'class $want_class'"; exit 1; }
+            grep -q "^  version \"$want_version\"$" "$rb" \
+              || { echo "::error::$rb does not declare version $want_version"; exit 1; }
+            local got
+            got="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" "$json")"
+            [ "$got" = "$want_version" ] \
+              || { echo "::error::$json has version $got, expected $want_version"; exit 1; }
+          }
+          check out-stable/Formula/llmman.rb  Llmman    "${{ steps.render.outputs.crate_version }}" out-stable/bucket/llmman.json
+          check out-dev/Formula/llmman-dev.rb LlmmanDev 99999 out-dev/bucket/llmman-dev.json
+          echo "OK"
+
+      # A rejected tag must stay rejected: render.sh keying the channel off
+      # the tag prefix is what keeps the stable and dev package versions
+      # from ever being compared against each other, so a tag shape it
+      # does not recognise has to fail loudly rather than default to one.
+      - name: Check an unrecognised tag is rejected
+        run: |
+          if packaging/render.sh --tag 1.2.3 --checksums fake-checksums.txt --out-dir out-bad 2>/dev/null; then
+            echo "::error::render.sh accepted a tag with neither a v nor b prefix"
+            exit 1
+          fi
+          echo "OK: unrecognised tag rejected"
+
+  # --------------------------------------------------------------------------
   # E2E: `llmman launch <claude|opencode|codex|qwen|hermes|openclaw> --model
   # qwen3.5:0.8b` (tests/launch_e2e.rs) against a real `llmman serve`, a
   # real pulled model, a real llama-server, and the real third-party CLIs
@@ -1258,7 +1441,12 @@ jobs:
     # lines up with both the main-push and v*-tag release channels without
     # ever blocking on an e2e run that was never going to happen for some
     # other event (e.g. a PR).
-    needs: [build, test, lint, e2e]
+    #
+    # `packaging` is in here too: the publish-homebrew/publish-scoop jobs
+    # below run off this job, and a formula/manifest that fails to render
+    # should stop the release rather than be discovered only once it has
+    # been pushed to the tap.
+    needs: [build, test, lint, e2e, packaging]
     runs-on: ubuntu-24.04
     # Downloads, renames and uploads artefacts in under a minute; 60 is
     # the same runner-wedge bound as the `build` job above, not an
@@ -1329,6 +1517,42 @@ jobs:
             echo "tag_name=b$(git rev-list --count HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
+      # SHA256 of every published binary, attached to the release as
+      # checksums.txt. Two consumers:
+      #
+      #   - users, who can verify a `curl`-ed binary by hand;
+      #   - the publish-homebrew/publish-scoop jobs below, whose formula
+      #     and manifest must each embed a hash per asset. They read this
+      #     file (via the artifact uploaded below) rather than hashing the
+      #     binaries themselves, so the hash a user's `brew install`
+      #     enforces provably belongs to the same byte stream that got
+      #     uploaded here — not to a separately-recomputed copy.
+      #
+      # Run from inside dist/ so the names in the file are bare basenames
+      # (what packaging/render.sh's own lookup expects) rather than
+      # "dist/"-prefixed. The llmman-docker-*/ artifact subdirectories the
+      # previous step copied out of are excluded by -maxdepth 1 -type f.
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          find . -maxdepth 1 -type f -name 'llmman-*' -printf '%f\0' \
+            | sort -z \
+            | xargs -0 sha256sum > checksums.txt
+          cat checksums.txt
+
+      # Also an artifact, not just a release asset: the publish jobs below
+      # `needs: [release]` but cannot read the release's own assets
+      # without another authenticated round trip, and an artifact is the
+      # same bytes with none of that.
+      - name: Upload checksums artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-checksums
+          path: dist/checksums.txt
+          if-no-files-found: error
+
       - name: Build release notes
         id: notes
         shell: bash
@@ -1356,7 +1580,9 @@ jobs:
           body_path: release-notes.md
           target_commitish: ${{ github.sha }}
           prerelease: false
-          files: dist/llmman-*
+          files: |
+            dist/llmman-*
+            dist/checksums.txt
 
   # --------------------------------------------------------------------------
   # crates.io (issue #389). Publishes the `llmman` crate.
@@ -1443,3 +1669,216 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --locked
+
+  # --------------------------------------------------------------------------
+  # Homebrew (issue #385) and Scoop (issue #390).
+  #
+  # Both push a generated formula/manifest into a repo outside this one
+  # (llmmanorg/homebrew-tap, llmmanorg/scoop-bucket), which the workflow's
+  # own GITHUB_TOKEN cannot write to — hence secrets.TAP_GITHUB_TOKEN.
+  #
+  # Both fire on the same two channels the `release` job itself publishes,
+  # and packaging/render.sh turns the tag into the right package name:
+  # a `v*` tag updates `llmman`, a push to main updates `llmman-dev`. See
+  # that script's own header for why these must be two packages and not
+  # one.
+  #
+  # Two jobs rather than one so a failure to reach one of the two
+  # repos does not also withhold an already-rendered, already-correct
+  # update from the other.
+  # --------------------------------------------------------------------------
+  publish-homebrew:
+    name: Publish Homebrew formula
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    # Serialize every run of this job across the whole repo, so two
+    # commits landing on main close together can't have their tap pushes
+    # interleave. Without this the second run's `git push` is rejected as
+    # a non-fast-forward — recoverable, but it would make the common case
+    # (llmman merges several times an hour) depend on the retry loop
+    # below rather than never racing in the first place.
+    #
+    # cancel-in-progress: false — these must queue, not cancel. Cancelling
+    # the in-flight one would abandon a formula update for a release that
+    # has already been published.
+    concurrency:
+      group: publish-homebrew
+      cancel-in-progress: false
+    steps:
+      # persist-credentials: false — this checkout only supplies
+      # packaging/; the tap checkout below is the one that needs a token,
+      # and leaving this one's in .git/config would put a GITHUB_TOKEN
+      # next to a script this job then runs.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-checksums
+
+      - name: Render formula
+        run: |
+          packaging/render.sh \
+            --tag "${{ needs.release.outputs.tag_name }}" \
+            --checksums checksums.txt \
+            --out-dir rendered
+
+      - name: Check out the tap
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: llmmanorg/homebrew-tap
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: tap
+
+      - name: Commit and push
+        working-directory: tap
+        env:
+          TAG: ${{ needs.release.outputs.tag_name }}
+          SRC: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "llmman-ci"
+          git config user.email "llmman-ci@users.noreply.github.com"
+          # symbolic-ref, not rev-parse --abbrev-ref: the latter prints
+          # the literal string "HEAD" on a detached checkout instead of
+          # failing, which would then be pushed as a branch named HEAD.
+          branch="$(git symbolic-ref --quiet --short HEAD || true)"
+          if [ -z "$branch" ]; then
+            branch="$(git remote show origin | sed -n 's/.*HEAD branch: //p')"
+          fi
+          echo "Target branch: $branch"
+
+          # Re-sync, re-copy and re-commit from scratch on each attempt
+          # rather than rebasing: the file being written is generated
+          # output, so a concurrent update to it is not a conflict to
+          # resolve but simply a base to regenerate on top of. `reset
+          # --hard` is safe for the same reason -- nothing here is
+          # authored in this checkout.
+          #
+          # The `concurrency` group above should already make a second
+          # attempt unnecessary; this exists for transient network/5xx
+          # failures and for the tag-push and main-push runs of the same
+          # commit, which are in different concurrency groups only by
+          # virtue of being the same group name at different times.
+          for attempt in 1 2 3 4 5; do
+            # FETCH_HEAD, not origin/$branch: actions/checkout clones
+            # shallow with a narrow refspec, so a remote-tracking ref for
+            # the branch is not guaranteed to exist here. `git fetch`
+            # always writes FETCH_HEAD.
+            git fetch --quiet origin "$branch"
+            git reset --quiet --hard FETCH_HEAD
+
+            mkdir -p Formula
+            cp ../rendered/Formula/*.rb Formula/
+            git add Formula
+
+            # A re-run for an unchanged release would otherwise fail on
+            # `git commit`'s own "nothing to commit" exit status, turning
+            # a genuine no-op into a red X.
+            if git diff --cached --quiet; then
+              echo "::notice::tap already up to date for $TAG"
+              exit 0
+            fi
+
+            git commit --quiet -m "llmman $TAG" \
+              -m "Generated from llmmanorg/llmman@$SRC by packaging/render.sh."
+
+            if git push --quiet origin "HEAD:$branch"; then
+              echo "Pushed llmman $TAG to the tap"
+              exit 0
+            fi
+            echo "::warning::push to homebrew-tap rejected (attempt $attempt/5); re-syncing"
+            sleep "$((attempt * 3))"
+          done
+          echo "::error::could not push llmman $TAG to homebrew-tap after 5 attempts"
+          exit 1
+
+  publish-scoop:
+    name: Publish Scoop manifest
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && github.event_name == 'push')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    # See publish-homebrew's own comment. A separate group from that job:
+    # these two write to different repos and have no reason to block each
+    # other, only their own successive runs.
+    concurrency:
+      group: publish-scoop
+      cancel-in-progress: false
+    steps:
+      # persist-credentials: false — same reasoning as publish-homebrew.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-checksums
+
+      - name: Render manifest
+        run: |
+          packaging/render.sh \
+            --tag "${{ needs.release.outputs.tag_name }}" \
+            --checksums checksums.txt \
+            --out-dir rendered
+
+      - name: Check out the bucket
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: llmmanorg/scoop-bucket
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          path: bucket-repo
+
+      # Same regenerate-and-retry structure as publish-homebrew's own
+      # push step; see its comments for why this resets rather than
+      # rebases.
+      - name: Commit and push
+        working-directory: bucket-repo
+        env:
+          TAG: ${{ needs.release.outputs.tag_name }}
+          SRC: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "llmman-ci"
+          git config user.email "llmman-ci@users.noreply.github.com"
+          # symbolic-ref, not rev-parse --abbrev-ref: the latter prints
+          # the literal string "HEAD" on a detached checkout instead of
+          # failing, which would then be pushed as a branch named HEAD.
+          branch="$(git symbolic-ref --quiet --short HEAD || true)"
+          if [ -z "$branch" ]; then
+            branch="$(git remote show origin | sed -n 's/.*HEAD branch: //p')"
+          fi
+          echo "Target branch: $branch"
+
+          for attempt in 1 2 3 4 5; do
+            # FETCH_HEAD, not origin/$branch: actions/checkout clones
+            # shallow with a narrow refspec, so a remote-tracking ref for
+            # the branch is not guaranteed to exist here. `git fetch`
+            # always writes FETCH_HEAD.
+            git fetch --quiet origin "$branch"
+            git reset --quiet --hard FETCH_HEAD
+
+            mkdir -p bucket
+            cp ../rendered/bucket/*.json bucket/
+            git add bucket
+
+            if git diff --cached --quiet; then
+              echo "::notice::bucket already up to date for $TAG"
+              exit 0
+            fi
+
+            git commit --quiet -m "llmman $TAG" \
+              -m "Generated from llmmanorg/llmman@$SRC by packaging/render.sh."
+
+            if git push --quiet origin "HEAD:$branch"; then
+              echo "Pushed llmman $TAG to the bucket"
+              exit 0
+            fi
+            echo "::warning::push to scoop-bucket rejected (attempt $attempt/5); re-syncing"
+            sleep "$((attempt * 3))"
+          done
+          echo "::error::could not push llmman $TAG to scoop-bucket after 5 attempts"
+          exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,58 @@ version = "0.1.0"
 edition = "2021"
 description = "llmman manages OCI models"
 license = "Apache-2.0"
+repository = "https://github.com/llmmanorg/llmman"
+homepage = "https://github.com/llmmanorg/llmman"
+documentation = "https://docs.rs/llmman"
+readme = "README.md"
+keywords = ["llm", "oci", "inference", "gguf", "ai"]
+categories = ["command-line-utilities", "science"]
+# Not a policy choice — this is the floor the dependency graph already
+# imposes, and is the highest `rust-version` declared by anything in it
+# (the aws-* crates behind the `s3://` source, as of the pinned
+# versions). Declaring it here is what turns "cargo install llmman" on an
+# older toolchain into Cargo's own "requires rustc 1.94.1" message
+# instead of a pile of confusing syntax errors from inside a dependency.
+#
+# CI itself tracks `stable` (see the dtolnay/rust-toolchain steps in
+# .github/workflows/ci.yml), so this exact version is not built there;
+# re-derive it with
+#   cargo metadata --format-version 1 | jq -r '.packages[].rust_version'
+# after a dependency bump rather than assuming it still holds.
+rust-version = "1.94.1"
+
+# What NOT to ship in the .crate. Everything build.rs actually reads must
+# stay: `go-shim/` (the c-archive it compiles and statically links) and
+# `webui/` (gzipped and `include_bytes!`d — see src/webui.rs). What's left
+# is developer/CI-only and is pure dead weight to a `cargo install`:
+#
+#   vllm-plugin/  a separately-published Python package, not Rust
+#   fuzz/         its own cargo-fuzz crate, nightly-only
+#   docs/, .github/, install.sh, install.ps1
+#                 repo-level material with no bearing on building
+#
+# tests/ is deliberately NOT excluded despite launch_e2e.rs being
+# unrunnable from an unpacked .crate (it drives real agent CLIs against a
+# real llama-server). It is 108K, and excluding it makes `cargo package`
+# warn "ignoring test `launch_e2e`" on every run, which reads like a
+# problem and isn't. Suppressing that warning properly would need
+# `autotests = false`, which would in turn stop Cargo discovering the
+# target at all and break the e2e job's own `cargo test --test
+# launch_e2e` invocation.
+#
+# This is deliberately an `exclude` rather than an `include`: an
+# `include` list silently drops any *new* path a future build.rs starts
+# depending on, which would only surface as a broken published crate.
+exclude = [
+	"vllm-plugin/",
+	"fuzz/",
+	"docs/",
+	".github/",
+	".ruff_cache/",
+	"install.sh",
+	"install.ps1",
+	"packaging/",
+]
 
 [lib]
 name = "llmman"

--- a/README.md
+++ b/README.md
@@ -36,10 +36,34 @@ curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | 
 irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
 ```
 
-### From source
+### Package managers
 
-`llmman` is published to crates.io, which also covers platforms with no
-prebuilt binary (Intel macOS, for instance):
+If you'd rather have llmman upgraded and removed by something that keeps
+track of it, all three of these are published automatically from the same
+CI run as the binaries above:
+
+**Homebrew** (macOS Apple Silicon, Linux x86_64/aarch64):
+
+```sh
+brew tap llmmanorg/tap
+brew trust llmmanorg/tap
+brew install llmman
+```
+
+The `brew trust` step is required because current Homebrew refuses to load
+formulae from third-party taps until you explicitly trust them; without
+it, `brew install` stops with `Refusing to load formula ... from untrusted
+tap`.
+
+**Scoop** (Windows x86_64/aarch64):
+
+```powershell
+scoop bucket add llmman https://github.com/llmmanorg/scoop-bucket
+scoop install llmman
+```
+
+**Cargo** — builds from source, so it also covers platforms with no
+published binary (Intel macOS, for instance):
 
 ```sh
 cargo install llmman
@@ -47,8 +71,13 @@ cargo install llmman
 
 > `cargo install` needs a **Go 1.25+ toolchain on `PATH`** in addition to
 > Rust: llmman links a Go static archive for its OCI registry transport
-> (see `build.rs` and `go-shim/`). The `curl`/`irm` scripts above ship a
+> (see `build.rs` and `go-shim/`). The other three install methods ship a
 > prebuilt binary and need neither.
+
+The `curl`/`irm` scripts above install the newest commit that passed CI;
+`brew`, `scoop` and `cargo install` follow tagged releases. To track
+individual commits through Homebrew or Scoop instead, install
+`llmman-dev` rather than `llmman`.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | 
 irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
 ```
 
+### From source
+
+`llmman` is published to crates.io, which also covers platforms with no
+prebuilt binary (Intel macOS, for instance):
+
+```sh
+cargo install llmman
+```
+
+> `cargo install` needs a **Go 1.25+ toolchain on `PATH`** in addition to
+> Rust: llmman links a Go static archive for its OCI registry transport
+> (see `build.rs` and `go-shim/`). The `curl`/`irm` scripts above ship a
+> prebuilt binary and need neither.
+
 ## Quick start
 
 Three commands cover most of it:

--- a/build.rs
+++ b/build.rs
@@ -105,6 +105,25 @@ fn git_path(path: &str) -> Option<PathBuf> {
         .map(|s| PathBuf::from(s.trim()))
 }
 
+/// True when running inside docs.rs's builder, which sets `DOCS_RS` for
+/// exactly this purpose.
+///
+/// docs.rs runs `cargo doc` in a network-isolated sandbox with no Go
+/// toolchain, so the `go mod download` / `go build -buildmode=c-archive`
+/// below cannot possibly succeed there — without this the crate's
+/// documentation build fails outright the moment it's published to
+/// crates.io (see the `publish-crate` job in .github/workflows/ci.yml),
+/// leaving a permanently broken docs.rs page for every release.
+///
+/// Skipping the shim is safe *specifically* because rustdoc never links:
+/// it type-checks and documents, so the `#[link(kind = "static")]` items
+/// in src/ffi.rs are resolved as declarations only and the archive they
+/// name is never opened. A real `cargo build` still goes down the normal
+/// path below and still hard-fails if Go is missing.
+fn is_docs_rs() -> bool {
+    env::var_os("DOCS_RS").is_some()
+}
+
 fn main() {
     emit_version();
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -112,6 +131,16 @@ fn main() {
     let shim_dir = manifest_dir.join("go-shim");
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+
+    // See is_docs_rs(). The webui gzipping at the bottom of this function
+    // still has to run even here: src/webui.rs `include_bytes!`s its
+    // output, so skipping it would break the very `cargo doc` this is
+    // meant to rescue. Only the Go/CGO half is skipped.
+    if is_docs_rs() {
+        println!("cargo:warning=DOCS_RS set: skipping the Go shim build (rustdoc does not link)");
+        gzip_webui(&manifest_dir, &out_dir);
+        return;
+    }
 
     // Determine backend build tags from Cargo features.
     // For the podman backend we add two extra tags to avoid pulling in C library
@@ -250,7 +279,13 @@ fn main() {
     println!("cargo:rerun-if-changed=go-shim/");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PODMAN");
 
-    // ── Gzip web UI assets for embedding ──────────────────────────────────
+    gzip_webui(&manifest_dir, &out_dir);
+}
+
+/// Gzip the web UI assets into `$OUT_DIR/webui_gz/` for src/webui.rs to
+/// `include_bytes!`. Split out of `main` so the docs.rs early return
+/// above can still produce them — see is_docs_rs().
+fn gzip_webui(manifest_dir: &Path, out_dir: &Path) {
     let webui_src = manifest_dir.join("webui");
     let webui_out = out_dir.join("webui_gz");
     fs::create_dir_all(&webui_out).expect("create webui_gz dir");

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,10 @@ main() {
 	(Darwin)
 		[ "$ARCH" = "aarch64" ] || die \
 			"Intel (x86_64) macOS is not supported by llmman's published builds — only" \
-			"Apple Silicon (arm64) is. Build from source instead: see README.md."
+			"Apple Silicon (arm64) is. Build it from source instead, with Rust and a" \
+			"Go 1.25+ toolchain on PATH:" \
+			"" \
+			"  cargo install llmman"
 		TARGET="aarch64-apple-darwin"
 		;;
 	(*) die "OS not supported: $(uname -s). On Windows, use install.ps1 instead." ;;

--- a/packaging/homebrew/llmman.rb.in
+++ b/packaging/homebrew/llmman.rb.in
@@ -1,0 +1,80 @@
+# GENERATED FILE -- DO NOT EDIT.
+#
+# Rendered by packaging/render.sh in github.com/llmmanorg/llmman from
+# packaging/homebrew/llmman.rb.in, and pushed here by that repo's
+# `publish-homebrew` CI job. Every release overwrites this file
+# wholesale, so edit the template upstream instead.
+#
+# This installs the prebuilt release binary rather than building from
+# source. Building from source would mean making Go *and* Rust build
+# dependencies and recompiling the whole tree (plus the CGO shim) on every
+# user's machine, for a binary CI has already built, tested end-to-end and
+# published for these exact three platforms.
+class @CLASS@ < Formula
+  desc "Run any coding agent on any model"
+  homepage "https://github.com/llmmanorg/llmman"
+  version "@VERSION@"
+  license "Apache-2.0"
+
+  # One bare binary per platform, not a tarball — that is the shape
+  # .github/workflows/ci.yml's `release` job publishes (see its "Rename
+  # binaries for release" step). Homebrew cannot infer a version from such
+  # a URL, hence the explicit `version` above.
+  on_macos do
+    # llmman publishes no x86_64-apple-darwin build (see the `build` job's
+    # matrix in .github/workflows/ci.yml — Apple Silicon only). Declaring
+    # the requirement gives Intel users Homebrew's own clear "requires an
+    # arm64 architecture" error instead of a download 404.
+    depends_on arch: :arm64
+
+    url "@BASE_URL@/llmman-aarch64-apple-darwin"
+    sha256 "@SHA_MACOS_ARM64@"
+  end
+
+  on_linux do
+    on_intel do
+      url "@BASE_URL@/llmman-x86_64-unknown-linux-gnu"
+      sha256 "@SHA_LINUX_X86_64@"
+    end
+    on_arm do
+      url "@BASE_URL@/llmman-aarch64-unknown-linux-gnu"
+      sha256 "@SHA_LINUX_AARCH64@"
+    end
+  end
+
+  def install
+    # The staged file keeps its release-asset name (llmman-<triple>), which
+    # differs per platform — matched by glob rather than repeating the
+    # triple a third time. `=> "llmman"` is what puts it on PATH under the
+    # name users actually type.
+    bin.install Dir["llmman-*"].first => "llmman"
+  end
+
+  def caveats
+    <<~EOS
+      llmman downloads a llama.cpp build matching your GPU on first use; no
+      extra setup is needed. To get started:
+
+        llmman launch claude --model gemma4
+
+      Models and cached llama.cpp builds live under ~/.llmman.
+    EOS
+  end
+
+  test do
+    # `llmman --version` prints "llmman <crate version> (<git describe>)"
+    # (see emit_version in build.rs). Asserted against the crate version
+    # rather than this formula's own `version`, because on the dev channel
+    # the latter is a bare build number that the line does not contain:
+    # the `git describe` part is a plain commit hash there, since the
+    # b<N> tag does not yet exist when the binary is built.
+    assert_match "@VERSION_MATCH@", shell_output("#{bin}/llmman --version")
+
+    # A second, real command: `--version` is handled by clap before any of
+    # llmman's own code runs, so on its own it would still pass if the
+    # binary could not reach its storage layer at all. `list` against an
+    # empty store exercises that layer and must exit 0 with no rows --
+    # shell_output itself raises on a non-zero exit.
+    assert_empty shell_output("#{bin}/llmman list").strip
+  end
+end

--- a/packaging/render.sh
+++ b/packaging/render.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Render the Homebrew formula and Scoop manifest for one llmman release
+# from the templates next to this script.
+#
+# Used by the `publish-homebrew` and `publish-scoop` jobs in
+# .github/workflows/ci.yml, but deliberately a standalone script rather
+# than inline YAML so the exact bytes that land in the tap/bucket can be
+# reproduced (and diffed) locally:
+#
+#   packaging/render.sh --tag b304 --checksums checksums.txt --out-dir /tmp/out
+#
+# Two release channels, mirroring the two the `release` job itself
+# publishes (see its own comment on the b<N>/v* split):
+#
+#   v<semver>  "stable" -> Formula/llmman.rb, bucket/llmman.json
+#   b<N>       "dev"    -> Formula/llmman-dev.rb, bucket/llmman-dev.json
+#
+# They are separate packages *on purpose*. A single formula cannot serve
+# both: Homebrew and Scoop both order upgrades by comparing version
+# strings, and the two channels' versions are not mutually comparable
+# (b305's "305" sorts above a stable "0.2.0", so one merge to main would
+# permanently shadow every future stable release for anyone tracking it).
+# Keeping them as two names means `llmman` upgrades along semver and
+# `llmman-dev` tracks main, and neither can ever shadow the other.
+
+set -euo pipefail
+
+die() {
+	printf 'render.sh: %s\n' "$@" >&2
+	exit 1
+}
+
+usage() {
+	cat >&2 <<-EOF
+		usage: render.sh --tag <tag> --checksums <file> --out-dir <dir> [--repo <owner/repo>]
+
+		  --tag        release tag to render for: "v1.2.3" (stable) or "b304" (dev)
+		  --checksums  sha256sum-format file covering the release's assets
+		  --out-dir    directory to write Formula/ and bucket/ into
+		  --repo       GitHub repo the download URLs point at
+		               (default: llmmanorg/llmman)
+	EOF
+	exit 2
+}
+
+TAG=""
+CHECKSUMS=""
+OUT_DIR=""
+REPO="llmmanorg/llmman"
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--tag) TAG="${2:-}"; shift 2 ;;
+	--checksums) CHECKSUMS="${2:-}"; shift 2 ;;
+	--out-dir) OUT_DIR="${2:-}"; shift 2 ;;
+	--repo) REPO="${2:-}"; shift 2 ;;
+	-h | --help) usage ;;
+	*) die "unknown argument: $1" ;;
+	esac
+done
+
+[ -n "$TAG" ] || usage
+[ -n "$CHECKSUMS" ] || usage
+[ -n "$OUT_DIR" ] || usage
+[ -f "$CHECKSUMS" ] || die "no such checksums file: $CHECKSUMS"
+
+TEMPLATE_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(dirname -- "$TEMPLATE_DIR")"
+
+# The crate version, read from the same Cargo.toml the binaries were built
+# from. Used as the string the Homebrew formula's `test do` block asserts
+# `llmman --version` contains -- see VERSION_MATCH below. Taken from the
+# first `version = "..."` after [package] so a dependency's own version
+# line can never be picked up instead.
+CARGO_VERSION="$(awk '
+	/^\[package\]/ { in_pkg = 1; next }
+	/^\[/          { in_pkg = 0 }
+	in_pkg && /^[[:space:]]*version[[:space:]]*=/ {
+		gsub(/^[^"]*"|".*$/, "")
+		print
+		exit
+	}
+' "$REPO_ROOT/Cargo.toml")"
+[ -n "$CARGO_VERSION" ] || die "could not read [package] version from $REPO_ROOT/Cargo.toml"
+
+# ── Channel, version and version-assertion string ─────────────────────────
+#
+# VERSION is what the package manager sorts on.
+#
+# VERSION_MATCH is a substring of `llmman --version`'s own output, which
+# the Homebrew formula's `test do` block asserts on. It is the *crate*
+# version for both channels, not the tag: build.rs's emit_version prints
+# "llmman <crate version> (<git describe>)", and on the dev channel that
+# `git describe` is a bare commit hash, not the b<N> tag -- the `build`
+# job checks the commit out before the `release` job has created that tag,
+# so there is no tag for describe to find. (Confirmed against release
+# b304, whose binary reports "llmman 0.1.0 (6cdaadb)".) The crate version
+# is the only part of that line both channels reliably share.
+case "$TAG" in
+v*)
+	CHANNEL="stable"
+	NAME="llmman"
+	VERSION="${TAG#v}"
+	# A stable tag must name the version actually compiled into the
+	# binaries it points at, or the formula would advertise a version
+	# `llmman --version` disagrees with. The publish-crate job enforces
+	# the same equality before uploading to crates.io; this is the same
+	# check for the Homebrew/Scoop side, which does not go through Cargo.
+	[ "$VERSION" = "$CARGO_VERSION" ] || die \
+		"tag \"$TAG\" does not match the Cargo.toml version \"$CARGO_VERSION\"" \
+		"(bump the crate version before tagging a stable release)"
+	;;
+b*)
+	CHANNEL="dev"
+	NAME="llmman-dev"
+	# Bare build number: the `release` job derives b<N> from `git
+	# rev-list --count HEAD`, so this increases monotonically with every
+	# commit and orders correctly within this channel.
+	VERSION="${TAG#b}"
+	;;
+*)
+	die "unrecognised tag \"$TAG\": expected v<semver> (stable) or b<N> (dev)"
+	;;
+esac
+
+VERSION_MATCH="$CARGO_VERSION"
+
+case "$VERSION" in
+'' | *[!0-9.]*) die "tag \"$TAG\" yielded a non-numeric version \"$VERSION\"" ;;
+esac
+
+# Homebrew derives a formula's class name from its filename: llmman.rb ->
+# Llmman, llmman-dev.rb -> LlmmanDev. Getting this wrong makes the tap
+# fail to load rather than merely misbehave.
+case "$CHANNEL" in
+stable) CLASS="Llmman" ;;
+dev) CLASS="LlmmanDev" ;;
+esac
+
+BASE_URL="https://github.com/$REPO/releases/download/$TAG"
+
+# ── Asset checksums ───────────────────────────────────────────────────────
+# Looked up by asset name from the release's own checksums.txt rather than
+# recomputed here, so the formula/manifest and the published binaries can
+# never disagree: both come from the same file the `release` job attached.
+sha_for() {
+	local asset="$1" hash
+	# The `release` job runs sha256sum from inside dist/, so the names in
+	# the file are already bare basenames. The two sub()s tolerate the
+	# other forms a hand-made checksums file can have anyway: a leading
+	# "*" (sha256sum's binary-mode marker) and a directory prefix.
+	hash="$(awk -v want="$asset" '{ n = $NF; sub(/^\*/, "", n); sub(/.*\//, "", n); if (n == want) { print $1; exit } }' "$CHECKSUMS")"
+	[ -n "$hash" ] || die "no sha256 for \"$asset\" in $CHECKSUMS"
+	# 64 lowercase hex chars. A truncated or otherwise malformed hash here
+	# would otherwise only surface as a checksum mismatch on a user's
+	# machine, long after the release was published.
+	case "$hash" in
+	[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+	*) die "malformed sha256 for \"$asset\": \"$hash\"" ;;
+	esac
+	printf '%s' "$hash"
+}
+
+SHA_MACOS_ARM64="$(sha_for llmman-aarch64-apple-darwin)"
+SHA_LINUX_X86_64="$(sha_for llmman-x86_64-unknown-linux-gnu)"
+SHA_LINUX_AARCH64="$(sha_for llmman-aarch64-unknown-linux-gnu)"
+SHA_WINDOWS_X86_64="$(sha_for llmman-x86_64-pc-windows-msvc.exe)"
+SHA_WINDOWS_AARCH64="$(sha_for llmman-aarch64-pc-windows-msvc.exe)"
+
+# ── Render ────────────────────────────────────────────────────────────────
+# sed with a distinct delimiter (|) since several values are URLs. Every
+# placeholder is a fixed @NAME@ token and none of the values can contain
+# one, so ordering between the expressions does not matter.
+render() {
+	sed \
+		-e "s|@CLASS@|$CLASS|g" \
+		-e "s|@VERSION@|$VERSION|g" \
+		-e "s|@VERSION_MATCH@|$VERSION_MATCH|g" \
+		-e "s|@BASE_URL@|$BASE_URL|g" \
+		-e "s|@SHA_MACOS_ARM64@|$SHA_MACOS_ARM64|g" \
+		-e "s|@SHA_LINUX_X86_64@|$SHA_LINUX_X86_64|g" \
+		-e "s|@SHA_LINUX_AARCH64@|$SHA_LINUX_AARCH64|g" \
+		-e "s|@SHA_WINDOWS_X86_64@|$SHA_WINDOWS_X86_64|g" \
+		-e "s|@SHA_WINDOWS_AARCH64@|$SHA_WINDOWS_AARCH64|g" \
+		"$1"
+}
+
+mkdir -p "$OUT_DIR/Formula" "$OUT_DIR/bucket"
+render "$TEMPLATE_DIR/homebrew/llmman.rb.in" >"$OUT_DIR/Formula/$NAME.rb"
+render "$TEMPLATE_DIR/scoop/llmman.json.in" >"$OUT_DIR/bucket/$NAME.json"
+
+# Nothing downstream should ever publish a half-substituted template: a
+# leftover @PLACEHOLDER@ is a rename in a template that this script was
+# not updated for, and would otherwise reach the tap as a formula that
+# fails to load (or, worse, a manifest with a literal "@SHA...@" hash).
+for rendered in "$OUT_DIR/Formula/$NAME.rb" "$OUT_DIR/bucket/$NAME.json"; do
+	if grep -n '@[A-Z_]\{2,\}@' "$rendered"; then
+		die "unsubstituted placeholder(s) left in $rendered (see above)"
+	fi
+done
+
+printf 'rendered %s channel %s (version %s)\n' "$CHANNEL" "$NAME" "$VERSION" >&2
+printf '  %s\n' "$OUT_DIR/Formula/$NAME.rb" "$OUT_DIR/bucket/$NAME.json" >&2

--- a/packaging/scoop/llmman.json.in
+++ b/packaging/scoop/llmman.json.in
@@ -1,0 +1,41 @@
+{
+    "##": [
+        "GENERATED FILE -- DO NOT EDIT.",
+        "",
+        "Rendered by packaging/render.sh in github.com/llmmanorg/llmman from",
+        "packaging/scoop/llmman.json.in, and pushed here by that repo's",
+        "`publish-scoop` CI job. Every release overwrites this file wholesale,",
+        "so edit the template upstream instead.",
+        "",
+        "Scoop rather than Chocolatey (issue #390 asked for whichever works",
+        "better): a plain JSON manifest with first-class 64bit/arm64 keys, no",
+        "human moderation queue between a green build and an installable",
+        "package, and no admin rights required to install.",
+        "",
+        "No checkver/autoupdate block: CI owns this file and rewrites it on",
+        "every release, so a bucket-side version poll would only ever race",
+        "with the push that already updated it."
+    ],
+    "version": "@VERSION@",
+    "description": "Run any coding agent on any model",
+    "homepage": "https://github.com/llmmanorg/llmman",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "@BASE_URL@/llmman-x86_64-pc-windows-msvc.exe#/llmman.exe",
+            "hash": "@SHA_WINDOWS_X86_64@"
+        },
+        "arm64": {
+            "url": "@BASE_URL@/llmman-aarch64-pc-windows-msvc.exe#/llmman.exe",
+            "hash": "@SHA_WINDOWS_AARCH64@"
+        }
+    },
+    "bin": "llmman.exe",
+    "notes": [
+        "llmman downloads a llama.cpp build matching your GPU on first use; no extra setup is needed.",
+        "",
+        "To get started:  llmman launch claude --model gemma4",
+        "",
+        "Models and cached llama.cpp builds live under %USERPROFILE%\\.llmman."
+    ]
+}


### PR DESCRIPTION
Addresses #385 (Homebrew), #389 (crates.io) and #390 (Windows via Scoop).

Installing llmman currently means piping `curl`/`irm` into a shell, which nothing then tracks: no upgrade path, no uninstall, and no record that the binary on `PATH` came from this project. This wires up three package managers, all driven off the same all-green CI gate the GitHub releases already use.

Two commits, each independently valid:

1. **`feat(ci): publish llmman to crates.io on tagged releases`** — #389
2. **`feat(ci): publish a Homebrew formula and Scoop manifest on release`** — #385, #390

## What publishes when

| Trigger | GitHub | crates.io | Homebrew | Scoop |
|---|---|---|---|---|
| push to `main` | `b<N>` | — | `llmman-dev` | `llmman-dev` |
| push `v1.2.3` tag | `v1.2.3` | `1.2.3` | `llmman` | `llmman` |
| pull request | — | — | — | — |
| any build red | — | — | — | — |

The gate has no gaps: `release` requires `[build, test, lint, e2e, packaging]`, and all three publish jobs require `[release]`. None use `always()`, so a failed *or skipped* dependency skips the dependent. A build failure publishes nothing anywhere.

Note the publishes are **not atomic** — the gate protects against build failures, not publish failures. If the GitHub release succeeds and `publish-crate` then fails on a bad token, you get a GitHub release with no crate. All three jobs are idempotent for exactly this reason (crates.io skips an already-published version, brew/scoop no-op when unchanged), so re-running the failed job fixes it with no side effects.

## Key decisions

**Homebrew via a tap, not homebrew-core.** llmman does meet core's notability bar, but core has no co-maintainer concept — which #385 explicitly asked for — and a core formula must build from source, meaning Go + Rust build deps and a full recompile of the tree plus the CGO shim on every user's machine, for a binary CI already built and tested. Covers the three platforms #385 asked for: macOS arm64, Linux x86_64/aarch64.

**Scoop, not Chocolatey** (#390 said "whichever works better"). Plain JSON manifest with first-class `64bit`/`arm64` keys, no human moderation review between a green build and an installable package, no admin rights. Chocolatey's per-version review is measured in days, which doesn't fit releasing on every merge.

**crates.io is `v*`-tags-only, deliberately.** Rate limits are not the reason — crates.io allows a burst of 30 new versions with 1/minute refill, which fits llmman's cadence fine. The reason is that crates.io versions are immutable and permanent, and the published version comes from `Cargo.toml`, which doesn't change per commit. The b`<N>` channel would mean either thousands of unrevocable junk versions or a hard failure on the second commit.

**Two package names per channel, `llmman` and `llmman-dev`.** Not incidental: brew and scoop both order upgrades by comparing version strings, and the two channels' versions aren't mutually comparable. A b`<N>` build's `305` sorts above a stable `0.2.0`, so one merge to main would permanently shadow every future stable release for anyone on a single combined package.

## Verification

Tested the real chain, not just the templates: downloaded release **b304's actual assets**, computed real checksums, rendered, and ran a genuine `brew install` + `brew test` on macOS arm64.

That caught a real bug. I'd assumed the dev formula could assert `b304`, but the `build` job checks the commit out *before* `release` creates that tag, so `git describe` yields a bare hash and the binary reports `llmman 0.1.0 (6cdaadb)`. `render.sh` now sources that assertion from `Cargo.toml`, and the new `packaging` job checks both channels still do.

Also verified:
- Both manifests validate against **ScoopInstaller/Scoop's own `schema.json`**
- `cargo publish --dry-run --locked` passes; `cargo doc` passes under `DOCS_RS=1`
- `actionlint` reports **2 findings, identical to the `main` baseline** (both pre-existing) — zero new
- Release asset URL shapes resolve `200`
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `shellcheck` all clean

The new `packaging` job renders both channels on every PR and checks the output parses. Without it the only thing exercising these templates would be the publish jobs at the end of a release — by which point a typo is already in the tap, where it doesn't break this repo's CI at all, it breaks `brew install` for everyone, since a formula that raises during load takes out the whole tap. The manifest check is structural, not just well-formed JSON: Scoop's schema sets `additionalProperties: false`, so an invented key is something `json.tool` accepts and Scoop rejects.

## Required before this can publish anything

- [ ] Add a **`CARGO_REGISTRY_TOKEN`** secret (doesn't exist yet; only `TAP_GITHUB_TOKEN` and `WINGET_GITHUB_TOKEN` do)
- [ ] Confirm **`TAP_GITHUB_TOKEN` can write to `llmmanorg/homebrew-tap` and `llmmanorg/scoop-bucket`** — I created and seeded both repos, but if that token is a fine-grained PAT scoped to specific repos, they need adding to its scope. Until then those two jobs go red while the GitHub release still succeeds.
- [ ] Cut a **`v0.1.0`** tag for the first stable/crates.io release (there are no `v*` tags today, so `llmman` and the crate stay unpublished until then; `llmman-dev` starts updating on the first green main push)

`brew install` also needs `brew trust llmmanorg/tap` first — current Homebrew refuses third-party taps until explicitly trusted. Documented in the README and the tap's own README.

One caveat worth flagging: `cargo install llmman` requires a **Go 1.25+ toolchain on `PATH`**, since llmman links a Go static archive for its OCI transport. That's inherent to the CGO shim rather than something I could work around, so it's documented rather than fixed.
