### PR TITLE
fix: make cargo install work on Windows x86_64 unaided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,14 +75,17 @@ jobs:
             binary: llmman
 
           # ── Windows x86_64 ────────────────────────────────────────────────
-          # lld-link is used instead of MSVC link.exe: it accepts clang's
-          # .pdata format (fixing LNK1223) and GNU ar archives (fixing LNK4003).
+          # No linker override; build.rs repacks the Go archive and strips
+          # its SEH sections so the default MSVC link.exe works (see it for
+          # the LNK1223/LNK4003 detail). Empty deliberately, not as
+          # belt-and-braces: an override would hide a regression in that
+          # path, and this leg is the only thing exercising it.
           - target: x86_64-pc-windows-msvc
             runner: windows-2025
             go-os: windows
             binary: llmman.exe
             msvc-arch: amd64
-            rustflags: "-C linker=lld-link"
+            rustflags: ""
 
           # ── Windows aarch64 ───────────────────────────────────────────────
           # ARM64 uses the MSVC-native link.exe (put first in PATH by
@@ -260,20 +263,19 @@ jobs:
             go-os: darwin
 
           # ── Windows x86_64 ────────────────────────────────────────────────
-          # lld-link, not MSVC link.exe — see the `build` job's own comment
-          # on why (same CGO-produced-object-format issue, native build or
-          # not).
+          # No linker override; build.rs makes the default MSVC link.exe
+          # work — see the `build` job's own comment.
           - target: x86_64-pc-windows-msvc
             runner: windows-2025
             go-os: windows
             msvc-arch: amd64
-            rustflags: "-C linker=lld-link"
+            rustflags: ""
             timeout: 60
 
           # ── Windows aarch64 ───────────────────────────────────────────────
-          # rustflags empty (MSVC-native link.exe, not lld-link) — see the
-          # `build` job's own comment on why this one architecture is the
-          # opposite of the x86_64 Windows entry just above.
+          # rustflags empty like x86_64, but for a simpler reason: ARM64's
+          # unwind encoding was never the problem, so it links with MSVC
+          # link.exe and build.rs leaves its unwind data intact.
           - target: aarch64-pc-windows-msvc
             runner: windows-11-arm
             go-os: windows
@@ -369,11 +371,10 @@ jobs:
 
       # --target: matches the build job's own invocation (every one of
       # these is a native build, but explicit --target keeps the output
-      # path/build-plan identical to that job's). RUSTFLAGS is needed here
-      # too, not just on a separate build step — see the e2e job's own
-      # comment on cargo test compiling its own separate test binary,
-      # which links against the same Go-shim-produced llmman_shim.lib the
-      # main binary does and hit the exact same lld-link requirement.
+      # path/build-plan identical to that job's). RUSTFLAGS no longer
+      # carries a Windows linker choice: build.rs fixes the archive as it
+      # produces it, so the separate test binary compiled here links the
+      # same way the main binary does with nothing repeated per step.
       - name: cargo test --lib --bins
         run: cargo test --release --target ${{ matrix.target }} --lib --bins
         env:
@@ -586,23 +587,20 @@ jobs:
             feature-flags: "--no-default-features --features podman"
 
           # ── Windows x86_64 (docker backend) ──────────────────────────────
-          # lld-link, not MSVC link.exe — see the `build` job's own comment
-          # on why (same CGO-produced-object-format issue, native build or
-          # not). No podman entry: containers/image has no Windows support
-          # (see the `build` job's own comment on its identical exclusion).
+          # No linker override; build.rs makes the default MSVC link.exe
+          # work — see the `build` job's own comment. No podman entry:
+          # containers/image has no Windows support.
           - target: x86_64-pc-windows-msvc
             runner: windows-2025
             go-os: windows
             llama-asset: win-cpu-x64.zip
             msvc-arch: amd64
-            rustflags: "-C linker=lld-link"
+            rustflags: ""
             backend: docker
             feature-flags: ""
 
           # ── Windows aarch64 (docker backend) ─────────────────────────────
-          # rustflags empty (MSVC-native link.exe, not lld-link) — see the
-          # `build` job's own comment on why this one architecture is the
-          # opposite of the x86_64 Windows entry just above.
+          # rustflags empty; ARM64 keeps its unwind data — see `test`.
           - target: aarch64-pc-windows-msvc
             runner: windows-11-arm
             go-os: windows
@@ -1091,15 +1089,12 @@ jobs:
           "$RUNNER_TEMP/mlx-lm-venv/bin/pip" install mlx-lm
           echo "$RUNNER_TEMP/mlx-lm-venv/bin" >> "$GITHUB_PATH"
 
-      # --target: for the same reason as the Build llmman step above —
-      # and RUSTFLAGS needs repeating here too, not just there: this step
-      # compiles its own separate test binary (tests/launch_e2e.rs), which
-      # links against the exact same Go-shim-produced llmman_shim.lib the
-      # main binary does, and hit that same LNK1223 lld-link exists to
-      # avoid (see the `build` job's own comment) the first several times
-      # this job's Windows entry ran — root-caused to exactly this: the
-      # env was present on the Build llmman step above, but this step
-      # never inherits another step's `env:` block, and never had its own.
+      # --target: for the same reason as the Build llmman step above.
+      # RUSTFLAGS no longer carries a Windows linker choice. This step
+      # compiles its own test binary (tests/launch_e2e.rs) against the same
+      # Go-shim archive, and used to hit LNK1223 whenever the flag was
+      # missing here, since a step never inherits another's `env:`.
+      # build.rs now fixes the archive itself, so that is gone.
       # matrix.feature-flags: same reasoning as the Build llmman step —
       # this test binary must link against the same backend the one built
       # above did, or the two podman entries would silently test a docker-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,16 @@ fuzzing = []
 
 [build-dependencies]
 flate2 = "1"
+
+# `cargo binstall llmman` fetches the prebuilt release binary instead of
+# compiling, so it needs neither a Rust nor a Go toolchain.
+#
+# `pkg-fmt = "bin"` because the assets are bare binaries, not archives (see
+# the `release` job's "Rename binaries for release" step). Their names
+# already match binstall's default `{ name }-{ target }{ binary-ext }`
+# layout, so nothing about how releases are published had to change. The URL
+# is spelled out rather than using `{ repo }` so it does not depend on the
+# `repository` field staying put.
+[package.metadata.binstall]
+pkg-url = "https://github.com/llmmanorg/llmman/releases/download/v{ version }/llmman-{ target }{ binary-ext }"
+pkg-fmt = "bin"

--- a/build.rs
+++ b/build.rs
@@ -7,11 +7,64 @@ use std::process::Command;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 
+/// Strip Go's SEH unwind sections from `go.o`, so MSVC `link.exe` accepts
+/// the archive instead of failing with "LNK1223: ... invalid .pdata
+/// contributions".
+///
+/// `go.o` comes from the Go linker, not the clang wrapper below, so no
+/// compiler flag can affect it. `lld-link` tolerates it -- which is what CI
+/// used until now -- but that is not available to `cargo install llmman`:
+/// Cargo reads no config from a downloaded package and a build script
+/// cannot set `-C linker`. The archive is the only lever left.
+///
+/// Cost: Windows can no longer unwind through Go frames, losing Go stack
+/// fidelity in debuggers and crash dumps. Nothing llmman needs -- Go's
+/// panic/recover uses its own stack maps, faults go to the runtime's
+/// vectored handler, and no C++ exception crosses Go. x86_64 only; aarch64
+/// links with this data intact, so it keeps it.
+fn strip_go_unwind_sections(objs: &[PathBuf]) {
+    let mut found = false;
+    for obj in objs {
+        if obj.file_name().and_then(|s| s.to_str()) != Some("go.o") {
+            continue;
+        }
+        found = true;
+        // .xdata too: .pdata entries point into it, so it would otherwise
+        // just be unreferenced bytes.
+        let ok = Command::new("llvm-objcopy")
+            .args(["--remove-section=.pdata", "--remove-section=.xdata"])
+            .arg(obj)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            println!("cargo:warning=Stripped SEH unwind sections from go.o");
+        } else {
+            println!(
+                "cargo:warning=llvm-objcopy failed on go.o; the link will fail with \
+                 LNK1223. Install LLVM, or use RUSTFLAGS=\"-C linker=lld-link\"."
+            );
+        }
+    }
+    // Guards against a future Go release naming this object something else,
+    // which would otherwise silently stop stripping and resurface as a bare
+    // LNK1223.
+    if !found {
+        println!(
+            "cargo:warning=no go.o in the Go archive, so nothing was stripped; \
+             expect LNK1223 unless linking with lld-link."
+        );
+    }
+}
+
 /// Extract every object from a (possibly GNU ar) static archive and repack
-/// it as an MSVC-format LIB using lib.exe.  This is needed on Windows ARM64
-/// because Go uses GNU 'ar' when it can't identify the C compiler as cl.exe,
-/// but MSVC link.exe only accepts its own LIB format.
-fn repack_as_msvc_lib(lib_path: &Path, out_dir: &Path) {
+/// it as an MSVC-format LIB using lib.exe. Go uses GNU 'ar' when it can't
+/// identify the C compiler as cl.exe, and MSVC link.exe rejects that format
+/// with LNK4003.
+///
+/// `strip_unwind` also drops Go's SEH sections -- see
+/// strip_go_unwind_sections.
+fn repack_as_msvc_lib(lib_path: &Path, out_dir: &Path, strip_unwind: bool) {
     let extract_dir = out_dir.join("ar_extract");
     let _ = fs::remove_dir_all(&extract_dir);
     if fs::create_dir_all(&extract_dir).is_err() {
@@ -38,7 +91,11 @@ fn repack_as_msvc_lib(lib_path: &Path, out_dir: &Path) {
         return;
     }
 
-    // lib.exe is the ARM64-native MSVC archiver; it infers machine type from objects
+    if strip_unwind {
+        strip_go_unwind_sections(&objs);
+    }
+
+    // lib.exe is the MSVC archiver; it infers machine type from objects
     let tmp = out_dir.join("_shim_repack.lib");
     let mut cmd = Command::new("lib.exe");
     cmd.arg("/nologo").arg(format!("/out:{}", tmp.display()));
@@ -50,11 +107,43 @@ fn repack_as_msvc_lib(lib_path: &Path, out_dir: &Path) {
 
     if cmd.status().map(|s| s.success()).unwrap_or(false) {
         let _ = fs::rename(&tmp, lib_path);
-        println!("cargo:warning=Repacked Go archive as MSVC LIB (ARM64)");
+        println!("cargo:warning=Repacked Go archive as MSVC LIB");
     } else {
         eprintln!("cargo:warning=lib.exe repack failed; keeping original archive");
     }
     let _ = fs::remove_dir_all(&extract_dir);
+}
+
+/// True if `tool` is on `PATH`. `--version`, not a bare spawn: a stale PATH
+/// entry can leave a name resolvable but not executable.
+fn on_path(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Name missing Windows prerequisites up front, rather than letting them
+/// surface minutes later as a cgo compiler error or a bare LNK1223. Both
+/// ship with LLVM, already required here, so this adds no dependency:
+/// `clang` backs the CC wrapper below, `llvm-objcopy` does the strip.
+fn warn_missing_msvc_tools(target_arch: &str) {
+    if !on_path("clang") {
+        println!(
+            "cargo:warning=clang was not found on PATH. Building llmman for \
+             *-pc-windows-msvc needs it as cgo's C compiler; install LLVM \
+             (https://releases.llvm.org) or `winget install LLVM.LLVM`."
+        );
+    }
+
+    if target_arch == "x86_64" && !on_path("llvm-objcopy") {
+        println!(
+            "cargo:warning=llvm-objcopy was not found on PATH. It is needed to strip \
+             Go's SEH unwind sections for x86_64-pc-windows-msvc, without which \
+             linking fails with LNK1223; it ships with LLVM."
+        );
+    }
 }
 
 /// Emits `LLMMAN_VERSION`: the Cargo package version plus, when built from
@@ -171,6 +260,7 @@ fn main() {
     // command itself; this is unconditional and cannot be filtered out.
     if env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
         let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        warn_missing_msvc_tools(&arch);
         let msvc_triple = match arch.as_str() {
             "x86_64" => "x86_64-pc-windows-msvc",
             "aarch64" => "aarch64-pc-windows-msvc",
@@ -203,20 +293,21 @@ fn main() {
         panic!("Go shim build failed for tags={}", go_tags);
     }
 
-    // On Windows MSVC + aarch64: Go doesn't recognise our clang wrapper as
-    // MSVC (it checks the binary name for "cl.exe"), so it archives the CGO
-    // objects with GNU 'ar' instead of MSVC 'lib.exe'.  GNU ar archives are
-    // rejected by MSVC link.exe with LNK4003.
+    // Go archives the CGO objects with GNU 'ar' on every *-pc-windows-msvc
+    // target (it identifies MSVC by looking for "cl.exe" in the compiler
+    // name, which our clang wrapper is not), and MSVC link.exe rejects that
+    // with LNK4003. Extract with llvm-ar, which reads both formats, and
+    // repack with lib.exe; it infers machine type from the objects.
     //
-    // Fix: extract every object from the archive with llvm-ar (which reads
-    // both GNU ar and MSVC LIB), then repack with the ARM64-native lib.exe
-    // to produce a proper MSVC LIB.  lib.exe infers the machine type from
-    // the objects so this is safe even when run unconditionally.
+    // Previously aarch64-only, because x86_64 got lld-link via RUSTFLAGS in
+    // CI and lld-link accepts GNU ar archives. Now that x86_64 links with
+    // the default toolchain it needs the MSVC-format archive too, plus the
+    // strip -- see strip_go_unwind_sections.
     if env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows")
         && env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc")
-        && env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("aarch64")
     {
-        repack_as_msvc_lib(&lib_path, &out_dir);
+        let strip_unwind = env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok("x86_64");
+        repack_as_msvc_lib(&lib_path, &out_dir, strip_unwind);
     }
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());


### PR DESCRIPTION
Follow-up to #393. `cargo install llmman` and a plain `git clone && cargo build` both failed on Windows x86_64:

```
libllmman-<hash>.rlib(go.o) : fatal error LNK1223: invalid or corrupt file:
file contains invalid .pdata contributions
```

Only CI worked, by injecting `RUSTFLAGS="-C linker=lld-link"`.

## Why the obvious fix isn't one

A `.cargo/config.toml` setting the linker repairs a *clone* but leaves **every crates.io install broken**: Cargo reads no config from a downloaded package, and a build script cannot set `-C linker`. I built that version first and rejected it — it wouldn't have fixed the reported problem. The only lever that reaches a registry install is the archive, which `build.rs` already post-processes.

## The fix

Two halves, both in `build.rs`:

1. **Repack the c-archive as an MSVC LIB on x86_64 too.** Go archives cgo objects with GNU `ar`, which `link.exe` rejects with LNK4003; x86_64 only escaped this because `lld-link` accepts them.
2. **Strip `.pdata`/`.xdata` from Go's `go.o`** — the LNK1223 half.

`go.o` comes from the **Go linker**, not the clang wrapper that builds the cgo glue, so no compiler flag can affect it. **Repacking alone was tried first and is not sufficient.**

## Cost

Windows can no longer unwind through Go frames, losing Go stack fidelity in debuggers and crash dumps. Nothing llmman relies on needs it: `panic`/`recover` walks Go's own stack maps, faults are taken by the runtime's vectored exception handler, and no C++ exception crosses a Go frame. **aarch64 is left alone** — its unwind encoding was never the problem — so it keeps the data and the debuggability.

## Verification

Probed on real `windows-2025` runners with **no RUSTFLAGS**. Linking alone would be weak evidence, since stripping unwind data could yield a binary that links then dies, so all four were checked:

| Check | Result |
|---|---|
| link with default `link.exe` | PASS |
| `llmman --version` | PASS |
| `cargo test --lib --bins` | PASS |
| real `llmman pull` through the Go shim | PASS — clean error, exit 1, no structured exception |

The FFI check matters most; it returns containerd's own error from inside the shim:

```
Error: ... resolve: pull access denied, repository does not exist or may
require authorization: server message: insufficient_scope
---- exit=1 ----
```

Two of my own probes were faulty and are worth recording so they aren't repeated. The first FFI test used a `registry.invalid` reference, which llmman resolves through its **Rust** HuggingFace source and so never entered Go. And an earlier probe ran under `shell: bash`, where rustc resolved `link.exe` to Git for Windows' coreutils `link(1)` — every crate failed with `/usr/bin/link: extra operand` before llmman was reached, including the aarch64 control. Git Bash puts its `/usr/bin` ahead of MSVC on `PATH`; the real `build` job omits `shell:` and defaults to `pwsh`.

This PR's CI then confirms it in the real pipeline: all 5 `Build` and 5 `Unit tests` legs pass, `LNK1223` appears **0 times**, the x86_64 Windows leg ran with `RUSTFLAGS:` empty, and its log shows both `Stripped SEH unwind sections from go.o` and `Repacked Go archive as MSVC LIB`. Confirmed the strip runs on x86_64 only.

The three matrix entries that carried the linker flag are now **empty, deliberately** rather than as belt-and-braces: an override would hide a regression in this `build.rs` path, and those legs are the only thing exercising it.

## Also

`[package.metadata.binstall]`, so `cargo binstall llmman` installs the prebuilt binary with no toolchain at all. Assets already match binstall's default layout, so publishing is unchanged.

No README changes, deliberately — install docs are left to #393. Touches `Cargo.toml`, `build.rs` and `ci.yml` in different regions from #393, so they merge cleanly in either order.

**Residual gap:** `E2E` only runs on pushes to `main`/tags, so its Windows legs aren't exercised here.
