### PR TITLE
feat(config): merge every config file into one llmman.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ llmman push docker.io/myorg/mymodel:v1 --sign-key signing.key
 llmman verify docker.io/myorg/mymodel:v1 --key signing.pub
 ```
 
-A `verify.conf` trust policy turns that into an automatic check on every
+A `[verify]` trust policy turns that into an automatic check on every
 `pull`, warning or refusing outright per repository. Off by default —
 there is nothing to check against until you have said whom you trust.
 See [docs/verification.md](docs/verification.md).
@@ -261,19 +261,31 @@ broken command.
 
 All four commands ask the daemon over [`/llmman/providers`](#serve)
 rather than fetching models.dev themselves, so the cache outlives any
-single command and the key status reported is that of the environment
-whose key actually gets spent.
+single command and the key status reported is that of the process whose
+key actually gets spent.
 
 Requests still go through `llmman serve`; `--provider` changes where the
 daemon forwards them, not who the client talks to. So one endpoint and
 one place integrations are configured, whether a model is local or
 hosted, and both usable from the same session.
 
-The API key is read from the variable models.dev names for that provider
-and travels per request, never to disk. `hermes` is the exception: llmman
-configures it through a file on disk, so it can't carry a key and
-`llmman serve` needs the variable in its own environment instead. That
-fallback is only used for a daemon bound to loopback, and never for a
+The API key comes from the variable models.dev names for that provider,
+or — when that is unset — from `~/.config/llmman/llmman.conf`, keyed by
+provider id:
+
+```toml
+[providers.openrouter]
+api_key = "sk-or-..."
+```
+
+Either way it travels per request; llmman itself never writes a key
+anywhere. A file carrying one must be `chmod 600` or the keys in it are
+ignored with a warning, and an `export` still overrides it. See
+[docs/configuration.md](docs/configuration.md#provider-api-keys).
+
+`hermes` is the exception: llmman configures it through a file on disk,
+so it can't carry a key and `llmman serve` needs one of its own instead.
+That fallback is only used for a daemon bound to loopback, and never for a
 browser request from another site. It bounds the blast radius rather
 than authenticating anyone, so on a shared machine prefer an integration
 that sends its own key. `cline`, `kimi`, `copilot` and `openclaw` can't be
@@ -284,7 +296,7 @@ only takes a model during first-run onboarding.
 `--provider` needs a local `llmman serve`. The daemon talks plain HTTP
 and has no authentication, so neither `run` nor `launch` will send a real
 key to a remote `LLMMAN_HOST`, and a daemon bound to anything but
-loopback will not spend its own environment's key on behalf of a caller
+loopback will not spend its own key on behalf of a caller
 that didn't present one. (`llmman providers` and `llmman list
 --provider` read the catalog only, no key involved, and work against any
 daemon.)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,18 +19,92 @@ store the daemon was started with; set `LLMMAN_MODELS` before
 
 The store uses [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md), readable by `docker` and `podman`.
 
-## Signature trust policy
+## llmman.conf
 
-`verify.conf` decides which references must carry a trusted signature
-before `llmman pull` will accept them, and which keys count as trusted.
-It is read from the same five locations as `shortnames.conf`
-(`/usr/share/llmman/`, `/etc/llmman/`, `<binary>/../share/llmman/`,
-`<binary-dir>/`, `~/.config/llmman/`), with later files overriding
-earlier ones. Absent, nothing is verified; present but unreadable or
-malformed is an error rather than a silent downgrade.
+Everything that needs a file rather than an environment variable lives in
+one place: short-name aliases, provider API keys, and the signature trust
+policy.
 
-See [verification.md](verification.md) for the file format, what is
-checked, and the limitations.
+```toml
+# ~/.config/llmman/llmman.conf
+
+[aliases]
+gemma4 = "docker.io/ai/gemma4"
+
+[providers.openrouter]
+api_key = "sk-or-..."
+
+[verify]
+default = "off"
+
+[[verify.trust]]
+pattern = "docker.io/myorg/**"
+keys    = ["keys/myorg.pub"]   # relative to this file's directory
+mode    = "enforce"
+```
+
+Read from two locations, later overriding earlier:
+
+| Path | Purpose |
+|------|---------|
+| `/etc/llmman/llmman.conf` | system-wide, admin-managed |
+| `~/.config/llmman/llmman.conf` | per-user |
+
+The same two paths on every platform, including macOS and Windows, with no
+llmman-specific variable to move them (`~` is `$HOME` as usual): one
+documented answer to "where does this go" beats a per-OS convention.
+
+Unknown sections and keys are rejected rather than ignored: a misspelled
+`[verify]` or `api_kye` that parsed happily would be a policy or a
+credential that silently never takes effect, and the symptom would show up
+somewhere else entirely.
+
+### Provider API keys
+
+`--provider` reaches a hosted model with a key llmman never generates and
+never writes. It takes one from the variable models.dev names for that
+provider, or — when that is unset — from `[providers.<id>]`. Entries are
+keyed by the provider id `llmman providers` prints, not by the variable,
+which is models.dev's naming rather than llmman's.
+
+The environment wins where both have a key, as it does for `aws` and
+`gh`: the file is the standing answer and an `export` is the deliberate,
+this-session-only override. An id that is not a bare TOML key must be
+quoted — `[providers."wafer.ai"]` — since `[providers.wafer.ai]` is two
+nested tables. Setting `api_key = ""` blanks out a key `/etc` supplied.
+
+On Unix a file carrying a key must not be readable by group or other —
+`chmod 600` it — or llmman ignores the keys in it with a warning, the way
+`ssh` refuses a loose private key. Only the keys: a world-readable
+`/etc/llmman/llmman.conf` still supplies its aliases and trust policy,
+which are not secrets. This is unchecked on Windows, which has no mode
+bits.
+
+Which process reads it matters. A key found by `llmman run`/`launch`
+travels per request in an `Authorization` header. A key found by
+`llmman serve` is the fallback for a request that presents none, and is
+only spent for a daemon bound to loopback. `llmman providers` reports
+which of the two has a usable key.
+
+### Short-name aliases
+
+`[aliases]` maps a short name to a full reference, so `llmman pull gemma4`
+resolves to whatever you point it at. Nothing is compiled into the binary.
+
+### Signature trust policy
+
+`[verify]` decides which references must carry a trusted signature before
+`llmman pull` will accept them, and which keys count as trusted. Absent,
+nothing is verified.
+
+A file that is present but unreadable or malformed is a fatal error for
+verification, rather than a silent downgrade to `off` — even though the
+same failure only costs the other two sections their aliases and keys.
+That asymmetry is deliberate: a trust policy llmman cannot read must not
+be mistaken for one that does not exist.
+
+See [verification.md](verification.md) for the format, what is checked,
+and the limitations.
 
 ## Environment variables
 
@@ -60,7 +134,7 @@ setting may not behave identically.
 | `LLMMAN_IGPU_ENABLE` | Counts integrated GPUs (Vulkan only) when probing for an accelerator. Defaults to disabled, since an integrated GPU is usually a worse choice than the discrete/CPU fallback it would otherwise be skipped in favor of. |
 | `LLMMAN_LOAD_TIMEOUT` | How long to allow a model load to stall before giving up. Zero or negative means wait forever. Defaults to 10 minutes (`vllm` can take several minutes to load a large safetensors model). |
 | `LLMMAN_TMPDIR` | Staging directory for `llama-server` release downloads, overriding the default `tmp` subdirectory of the install root. |
-| `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `verify.conf` selected. Does *not* supply trusted keys — those still come from `verify.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
+| `LLMMAN_VERIFY` | Overrides the signature-verification mode (`off`, `warn`, or `enforce`) for every reference, ignoring what `[verify]` selected. Does *not* supply trusted keys — those still come from `llmman.conf`, so `enforce` with no configured keys fails every check rather than passing them. Intended for CI, which can demand `enforce` without editing config files. See [verification.md](verification.md). |
 | `LLMMAN_SIGN_PASSWORD` | Passphrase for the `--sign-key` private key used by `push`/`transfer`, when it is an encrypted PEM. Falls back to `COSIGN_PASSWORD`. Read from the client's environment and forwarded to the daemon, since the daemon's own environment is generally not the shell you set it in. |
 | `LLMMAN_NOPRUNE` | When set (to anything other than `0`/`false`/`no`/`off`), skips the garbage-collection sweep that `llmman rm` and `llmman serve` startup otherwise run to delete blobs and extracted-cache entries no longer referenced by any local model. Note this is broader than skipping the daemon-startup catch-all: it also stops `llmman rm` itself from ever freeing disk space, so a removed model's (possibly multi-GB) weights stay on disk until a later sweep runs without this set. Useful for a shared/read-mostly store, or scripts that `rm` in a loop and prune once at the end. |
 | `LLAMA_ARG_FIT` / `LLAMA_ARG_FIT_TARGET` | llama.cpp's own env-configurable `--fit`/`--fit-target` options. Not something llmman parses itself, just forwarded through to every `llama-server` (local or `--ociman` container) it spawns, same as `CUDA_VISIBLE_DEVICES`/etc. below. |

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -7,9 +7,10 @@ put them there**.
 
 That gap matters more for llmman than for a registry with a curated
 library, because llmman deliberately has no gatekeeper. A bare
-`llmman pull gemma4` resolves through `shortnames.conf` — five config
-tiers, any of which can repoint it — to some registry you never typed,
-and the GGUF it lands on goes straight into `llama-server`'s parser.
+`llmman pull gemma4` resolves through the `[aliases]` table of
+`llmman.conf` — which either config tier can repoint — to some registry
+you never typed, and the GGUF it lands on goes straight into
+`llama-server`'s parser.
 
 Signatures close that gap, and they do it per-artifact rather than
 per-registry: the check works the same on Docker Hub, GHCR, quay, or your
@@ -67,25 +68,21 @@ full report.
 
 ## Enforcing it on pull
 
-Verification during `pull` is driven by a policy file, `verify.conf`,
-read from the same locations as `shortnames.conf` (later files win):
-
-1. `/usr/share/llmman/verify.conf` — distro / package default
-2. `/etc/llmman/verify.conf` — system-admin policy
-3. `<binary>/../share/llmman/verify.conf` — install-tree relative
-4. `<binary-dir>/verify.conf` — development
-5. `~/.config/llmman/verify.conf` — per-user
+Verification during `pull` is driven by the `[verify]` section of
+`llmman.conf`, read from `/etc/llmman/` then `~/.config/llmman/` (later
+files win — see [configuration.md](configuration.md#llmmanconf)):
 
 ```toml
+[verify]
 # Applies to any reference no rule below matches. Default "off".
 default = "off"
 
-[[trust]]
+[[verify.trust]]
 pattern = "docker.io/myorg/**"
 keys    = ["keys/myorg.pub"]     # relative paths resolve against this file
 mode    = "enforce"
 
-[[trust]]
+[[verify.trust]]
 # Narrower rules written later override broader earlier ones, and
 # *replace* their key set rather than adding to it — so "trust the org
 # key everywhere except here" is expressible.
@@ -93,7 +90,7 @@ pattern = "docker.io/myorg/experimental"
 keys    = ["keys/lab.pub"]
 mode    = "warn"
 
-[[trust]]
+[[verify.trust]]
 pattern = "docker.io/ai/*"
 keys    = ["~/.config/llmman/keys/docker-ai.pub"]
 mode    = "warn"
@@ -105,7 +102,7 @@ mode    = "warn"
 | `warn` | Check, print the outcome, pull anyway. |
 | `enforce` | Refuse to pull unless a trusted key signed that exact manifest. |
 
-A `[[trust]]` rule with no explicit `mode` defaults to `warn`.
+A `[[verify.trust]]` rule with no explicit `mode` defaults to `warn`.
 
 **Patterns** match the *repository* (`host/namespace/name`, no tag), since
 trust is about who publishes a model and tags move. `*` matches within one

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -252,24 +252,24 @@ fn resolve_provider_model(
             anyhow::ensure!(
                 entry.key_usable,
                 "{integration} is configured through a file, so it cannot send an API key: \
-                 llmman serve needs {} in its own environment, and must be bound to \
-                 loopback to spend it.\n\
-                 Export it where the daemon runs and restart it.",
-                entry.key_env
+                 llmman serve needs a key of its own, and must be bound to loopback to \
+                 spend it.\n\
+                 Where the daemon runs, {}, then restart it.",
+                providers::key_hint(&entry.id, &entry.key_env)
             );
             providers::PLACEHOLDER_API_KEY.to_string()
         }
         (None, true) if entry.daemon_key_usable() => {
             eprintln!(
-                "[llmman] warning: {} is unset here; using the key llmman serve has",
-                entry.key_env
+                "[llmman] warning: no API key for {} here; using the key llmman serve has",
+                entry.name
             );
             providers::PLACEHOLDER_API_KEY.to_string()
         }
         (None, true) => anyhow::bail!(
-            "no API key for {} — set {} in your environment",
+            "no API key for {} — {}",
             entry.name,
-            entry.key_env
+            providers::key_hint(&entry.id, &entry.key_env)
         ),
     };
 

--- a/src/cmd/providers.rs
+++ b/src/cmd/providers.rs
@@ -90,15 +90,16 @@ fn matches(provider: &ProviderSummary, needle: Option<&str>) -> bool {
 /// Where a *usable* key is — the one thing to act on before `--provider`
 /// works.
 ///
-/// "shell" is a key only this process has, which travels per request.
-/// "withheld" is one the daemon has but will not spend, because it is
-/// bound where others could reach it (see `resolve_remote_target` in
-/// cmd::serve) — a state of its own, since what needs fixing there is the
-/// bind, not the variable.
+/// "client" is a key only this process has, which travels per request —
+/// from its environment or its own `llmman.conf`, which is why the word
+/// is not "shell". "withheld" is one the daemon has but will not spend,
+/// being bound where others could reach it (see `resolve_remote_target`
+/// in cmd::serve) — a state of its own, since what needs fixing there is
+/// the bind, not the key.
 fn key_status(provider: &ProviderSummary) -> &'static str {
     match (provider.key_usable, provider.key_here(), provider.key_set) {
         (true, _, _) => "set",
-        (false, true, _) => "set (shell)",
+        (false, true, _) => "set (client)",
         (false, false, true) => "set (withheld)",
         (false, false, false) => "unset",
     }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -234,14 +234,14 @@ fn provider_model(provider: &str, model: &str) -> anyhow::Result<(String, Option
 
     entry.warn_unlisted(model);
 
-    // Naming the missing variable beats a 401 mid-conversation — unless
-    // the daemon has the key, in which case it spends its own.
+    // Naming where the missing key goes beats a 401 mid-conversation —
+    // unless the daemon has the key, in which case it spends its own.
     let key = entry.api_key();
     anyhow::ensure!(
         key.is_some() || entry.daemon_key_usable(),
-        "no API key for {} — set {} in your environment",
+        "no API key for {} — {}",
         entry.name,
-        entry.key_env
+        crate::providers::key_hint(&entry.id, &entry.key_env)
     );
     Ok((crate::providers::format_remote_ref(provider, model), key))
 }

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -2292,7 +2292,7 @@ fn pull_serialized(store_path: &std::path::Path, model: &str) -> anyhow::Result<
         let existing = OciStore::open(store_path).and_then(|s| s.find(model)).ok();
         // In the store is not the same as trusted: it may predate the
         // policy, or have come in under `warn`. Classification first so
-        // a malformed verify.conf can't break a cached non-OCI model no
+        // a malformed llmman.conf can't break a cached non-OCI model no
         // policy could apply to; then an in-memory policy lookup, which
         // returns immediately when nothing is configured.
         if let Some(desc) = existing {
@@ -3153,7 +3153,10 @@ async fn resolve_remote_target(
                      environment is deliberately not used"
                         .to_string()
                 } else if crate::daemon::reachable_only_locally() {
-                    format!(", or set {} where llmman serve runs", provider.key_env)
+                    format!(
+                        ", or give llmman serve a key of its own: {}",
+                        crate::providers::key_hint(&provider.id, &provider.key_env)
+                    )
                 } else {
                     ". llmman serve is not bound to loopback, so its own environment is \
                      deliberately not used"
@@ -6476,7 +6479,7 @@ async fn serve_async(_args: &ServeArgs) -> anyhow::Result<()> {
     // up rather than from whenever something first scraped it.
     metrics::mark_process_start();
 
-    // Before the listener: a malformed verify.conf or LLMMAN_VERIFY is
+    // Before the listener: a malformed llmman.conf or LLMMAN_VERIFY is
     // fatal, and failing at exec is far better than booting cleanly and
     // then failing every pull with a config error.
     crate::verify::Policy::load().context("signature trust policy")?;

--- a/src/cmd/verify.rs
+++ b/src/cmd/verify.rs
@@ -10,7 +10,7 @@ pub struct VerifyArgs {
     pub reference: String,
 
     /// PEM public key to trust, repeatable. Overrides whatever
-    /// verify.conf would have selected for this reference.
+    /// the `[verify]` policy would have selected for this reference.
     #[arg(long = "key", value_name = "PATH")]
     pub keys: Vec<String>,
 
@@ -33,7 +33,7 @@ pub struct VerifyArgs {
 /// "why did my policy not fire?" and "who actually signed this?" are
 /// answerable without editing config files. Consequently its exit status
 /// reflects the *signature*, not the policy: unverified is a failure
-/// here even where `verify.conf` would only have warned.
+/// here even where the `[verify]` policy would only have warned.
 pub fn run(args: &VerifyArgs) -> anyhow::Result<()> {
     crate::shortnames::validate_reference(&args.reference)?;
     let reference = crate::shortnames::resolve(&args.reference)?;
@@ -56,7 +56,7 @@ pub fn run(args: &VerifyArgs) -> anyhow::Result<()> {
     if keys.is_empty() {
         bail!(
             "no trusted public keys to check {reference} against — pass --key PATH, \
-             or add a [[trust]] rule to verify.conf"
+             or add a [[verify.trust]] rule to llmman.conf"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,511 @@
+//! `llmman.conf` — one config file, read once, shared by every consumer.
+//!
+//! Two locations, later overriding earlier:
+//!
+//!   1. `/etc/llmman/llmman.conf`        system-wide
+//!   2. `~/.config/llmman/llmman.conf`   per-user
+//!
+//! The same paths on every platform, with no llmman-specific variable
+//! to move them: one documented answer to "where does this go". (`~` is
+//! `$HOME` as usual.)
+//!
+//! ```toml
+//! [aliases]                            # crate::shortnames
+//! gemma4 = "docker.io/ai/gemma4"
+//!
+//! [providers.openrouter]               # crate::providers
+//! api_key = "sk-or-..."
+//!
+//! [verify]                             # crate::verify
+//! default = "off"
+//!
+//! [[verify.trust]]
+//! pattern = "docker.io/myorg/**"
+//! keys    = ["keys/myorg.pub"]         # relative to this file's directory
+//! mode    = "enforce"
+//! ```
+//!
+//! Parsing happens once, in [`files`]; what a *failed* parse means is
+//! left to each consumer, because it differs. [`crate::verify`] refuses
+//! to run, since a trust policy it cannot read must not quietly become
+//! `off`; aliases and keys degrade to none. The error is reported once,
+//! centrally, so one typo is not announced three times.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
+const FILE: &str = "llmman.conf";
+
+/// Everything `llmman.conf` configures.
+///
+/// `deny_unknown_fields` throughout: a misspelling that parsed happily
+/// would be a policy, alias or credential that silently never takes
+/// effect, surfacing somewhere else entirely — an unsigned pull that
+/// passes, a 401 inside someone else's TUI.
+#[derive(Deserialize, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct Conf {
+    /// Short-name aliases — see [`crate::shortnames`].
+    #[serde(default)]
+    pub aliases: HashMap<String, String>,
+    /// Private: a key leaves this module only through
+    /// [`provider_api_key`], which gates it on the file's mode.
+    #[serde(default)]
+    providers: HashMap<String, ProviderConf>,
+    /// Signature trust policy — see [`crate::verify`].
+    #[serde(default)]
+    pub verify: VerifyConf,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProviderConf {
+    #[serde(default)]
+    api_key: Option<String>,
+}
+
+/// Hand-written so the key cannot reach a log through the derived
+/// `Debug` of the public [`Conf`] and [`File`]. Same reasoning as
+/// `RemoteTarget` in `cmd::serve`.
+impl std::fmt::Debug for ProviderConf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderConf")
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+/// The `[verify]` section. [`crate::verify`] owns what these strings
+/// mean; this module only spells out their shape.
+#[derive(Deserialize, Default, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct VerifyConf {
+    /// Mode for references no rule matches.
+    #[serde(default)]
+    pub default: Option<String>,
+    /// `[[verify.trust]]` entries, in the order they appear.
+    #[serde(default)]
+    pub trust: Vec<TrustConf>,
+}
+
+/// One `[[verify.trust]]` entry.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TrustConf {
+    pub pattern: String,
+    #[serde(default)]
+    pub keys: Vec<String>,
+    #[serde(default)]
+    pub mode: Option<String>,
+}
+
+impl Conf {
+    /// Every entry that sets `api_key` at all, trimmed, by provider id.
+    ///
+    /// A blank value is kept here rather than dropped, so a user file can
+    /// blank out a key `/etc` set — otherwise there is no way to opt out
+    /// of a system-wide credential. [`load_provider_keys`] drops blanks
+    /// after merging, since sending `Authorization: Bearer ` upstream
+    /// would turn a clear "no API key" into someone else's 401.
+    fn provider_keys(&self) -> HashMap<String, String> {
+        self.providers
+            .iter()
+            .filter_map(|(id, p)| Some((id.clone(), p.api_key.as_deref()?.trim().to_string())))
+            .collect()
+    }
+}
+
+/// One `llmman.conf` that exists on disk.
+#[derive(Debug)]
+pub struct File {
+    /// Where it was read from.
+    pub path: PathBuf,
+    /// Its own directory — what relative paths inside it resolve
+    /// against, so a trust policy can ship alongside its keys.
+    pub dir: PathBuf,
+    pub conf: Conf,
+}
+
+// ---------------------------------------------------------------------------
+// Search paths
+// ---------------------------------------------------------------------------
+
+/// Every place [`FILE`] may live, in ascending priority order.
+///
+/// Not the `/usr/share/llmman/`, `<binary>/../share/llmman/` and
+/// `<binary-dir>/` tiers earlier versions searched: nothing ever shipped
+/// a file to them, and they are package-managed and world-readable,
+/// which `llmman.conf` cannot be.
+fn search_paths() -> Vec<PathBuf> {
+    let mut paths = vec![system_dir().join(FILE)];
+    paths.extend(user_dir().map(|d| d.join(FILE)));
+    paths
+}
+
+/// `/etc/llmman`.
+#[cfg(not(windows))]
+fn system_dir() -> PathBuf {
+    PathBuf::from("/etc/llmman")
+}
+
+/// `/etc/llmman` anchored to the system drive.
+///
+/// A leading `/` is drive-*relative* on Windows, so a bare `/etc/llmman`
+/// would mean `D:\etc\llmman` for a process launched from `D:` — the
+/// system-wide location would move with the working directory.
+#[cfg(windows)]
+fn system_dir() -> PathBuf {
+    let drive = std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_string());
+    PathBuf::from(format!("{drive}\\etc\\llmman"))
+}
+
+/// `~/.config/llmman`, on every platform. No llmman-specific override;
+/// `~` is `$HOME` as usual.
+fn user_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".config").join("llmman"))
+}
+
+/// Where a user's own config belongs, for a message that has to name
+/// it. `None` only when there is no home directory.
+fn user_path() -> Option<PathBuf> {
+    user_dir().map(|d| d.join(FILE))
+}
+
+/// [`user_path`] for printing, falling back to the bare file name.
+pub fn user_path_display() -> String {
+    user_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| FILE.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/// Every `llmman.conf` that exists, lowest priority first, parsed once
+/// for the process.
+///
+/// `Err` when one is there but unreadable or malformed — see the module
+/// docs for why what to do about that is the caller's call.
+pub fn files() -> Result<&'static [File], &'static str> {
+    cache().as_deref().map_err(String::as_str)
+}
+
+fn cache() -> &'static Result<Vec<File>, String> {
+    static CACHE: OnceLock<Result<Vec<File>, String>> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let loaded = load();
+        // Once, here, rather than by each of the three consumers.
+        if let Err(e) = &loaded {
+            eprintln!("[llmman] warning: {e}");
+        }
+        loaded
+    })
+}
+
+fn load() -> Result<Vec<File>, String> {
+    // No unit test may depend on whoever runs it having an llmman.conf:
+    // their aliases would redirect a fixture reference, and a provider
+    // called `openai` would resolve their real key, flipping the
+    // assertions in `cmd::serve` and `cmd::providers` that prove no key
+    // leaks. `parse`, `provider_keys` and `Policy::parse` are covered
+    // directly instead. The binary the e2e tests spawn is built without
+    // `cfg(test)`, so it reads the real files.
+    if cfg!(test) {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for path in search_paths() {
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            // Absence is the common case: most machines never have one.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("ignoring {}: {e}", path.display())),
+        };
+        let conf = parse(&text).map_err(|e| format!("ignoring {}: {e}", path.display()))?;
+        let dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        files.push(File { path, dir, conf });
+    }
+    Ok(files)
+}
+
+/// Parse one `llmman.conf`. Split out from [`load`] so the format is
+/// testable without a file, a home directory, or a particular umask.
+pub(crate) fn parse(text: &str) -> Result<Conf, String> {
+    toml::from_str(text).map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Provider API keys
+// ---------------------------------------------------------------------------
+
+/// The key `llmman.conf` configures for `provider_id`, or `None`. Keyed
+/// by the id `llmman providers` prints, not by the environment variable,
+/// which is models.dev's naming rather than llmman's.
+///
+/// Borrowed from a process-lifetime cache, so a daemon serving requests
+/// is not stat'ing `/etc` per token.
+pub fn provider_api_key(provider_id: &str) -> Option<&'static str> {
+    static CACHE: OnceLock<HashMap<String, String>> = OnceLock::new();
+    CACHE
+        .get_or_init(load_provider_keys)
+        .get(provider_id)
+        .map(String::as_str)
+}
+
+fn load_provider_keys() -> HashMap<String, String> {
+    let mut accepted = Vec::new();
+    for file in files().unwrap_or_default() {
+        let keys = file.conf.provider_keys();
+        // The mode gate is for a file that holds a secret. One that only
+        // blanks a key out does not.
+        if !keys.values().all(String::is_empty) {
+            if let Err(e) = owner_readable_only(&file.path) {
+                eprintln!(
+                    "[llmman] warning: ignoring the API keys in {}: {e}",
+                    file.path.display()
+                );
+                continue;
+            }
+        }
+        accepted.push(keys);
+    }
+    merge_keys(accepted)
+}
+
+/// Merge per-file key tables, lowest priority first, then drop blanks.
+///
+/// Blanks survive the merge so a user file can shadow a key `/etc` set,
+/// and are dropped only at the end so none is ever spent. Split out to
+/// be testable without a filesystem.
+fn merge_keys(per_file: Vec<HashMap<String, String>>) -> HashMap<String, String> {
+    let mut merged: HashMap<String, String> = HashMap::new();
+    for keys in per_file {
+        merged.extend(keys);
+    }
+    merged.retain(|_, key| !key.is_empty());
+    merged
+}
+
+/// Refuses a file that group or other can read, the way `ssh` refuses a
+/// loose private key.
+///
+/// Gates the keys, not the read: `/etc/llmman/llmman.conf` is
+/// legitimately world-readable for the aliases and trust policy it also
+/// carries, so a loose file still supplies everything but the key.
+#[cfg(unix)]
+fn owner_readable_only(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = std::fs::metadata(path)
+        .map_err(|e| e.to_string())?
+        .permissions()
+        .mode();
+    if mode & 0o077 != 0 {
+        return Err(format!(
+            "mode {:04o} lets other users read it. Run: chmod 600 {}",
+            mode & 0o7777,
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Unchecked on Windows: there are no mode bits, and reading an ACL
+/// needs a `windows` dependency this crate does not have. Defaults are
+/// owner-only under the user's profile, but a file with a widened ACL,
+/// or one under the system directory, is accepted as-is.
+#[cfg(not(unix))]
+fn owner_readable_only(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conf(text: &str) -> Conf {
+        parse(text).expect("valid conf")
+    }
+
+    /// A key must not reach a log through the derived `Debug` of the
+    /// public `Conf`/`File`.
+    #[test]
+    fn debug_output_never_carries_a_key() {
+        let c = conf("[providers.openai]\napi_key = \"sk-secret-value\"");
+        let rendered = format!("{c:?}");
+        assert!(!rendered.contains("sk-secret-value"), "{rendered}");
+        assert!(rendered.contains("redacted"), "{rendered}");
+    }
+
+    /// The documented shape, all three sections in one file.
+    #[test]
+    fn parses_every_section_of_one_file() {
+        let c = conf(
+            r#"
+            [aliases]
+            gemma4 = "docker.io/ai/gemma4"
+
+            [providers.openrouter]
+            api_key = "sk-or-abc"
+
+            [verify]
+            default = "warn"
+
+            [[verify.trust]]
+            pattern = "docker.io/myorg/**"
+            keys    = ["keys/myorg.pub"]
+            mode    = "enforce"
+            "#,
+        );
+        assert_eq!(
+            c.aliases.get("gemma4").map(String::as_str),
+            Some("docker.io/ai/gemma4")
+        );
+        assert_eq!(
+            c.provider_keys().get("openrouter").map(String::as_str),
+            Some("sk-or-abc")
+        );
+        assert_eq!(c.verify.default.as_deref(), Some("warn"));
+        assert_eq!(c.verify.trust.len(), 1);
+        assert_eq!(c.verify.trust[0].mode.as_deref(), Some("enforce"));
+    }
+
+    /// A file that sets one section must not need the other two.
+    #[test]
+    fn every_section_is_optional() {
+        let c = conf("");
+        assert!(c.aliases.is_empty());
+        assert!(c.provider_keys().is_empty());
+        assert!(c.verify.default.is_none());
+        assert!(c.verify.trust.is_empty());
+
+        assert!(!conf("[aliases]\nx = \"y\"").aliases.is_empty());
+        assert!(conf("[verify]\ndefault = \"off\"").aliases.is_empty());
+    }
+
+    /// A key is trimmed; one that sets no `api_key` at all is absent.
+    /// A blank *is* carried this far — see [`merge_keys`].
+    #[test]
+    fn a_key_is_trimmed_and_an_unset_one_is_absent() {
+        let keys = conf(
+            r#"
+            [providers.openai]
+            api_key = "  sk-padded  "
+
+            [providers.groq]
+            api_key = "   "
+
+            [providers.mistral]
+            "#,
+        )
+        .provider_keys();
+        assert_eq!(keys.get("openai").map(String::as_str), Some("sk-padded"));
+        assert_eq!(keys.get("groq").map(String::as_str), Some(""));
+        assert_eq!(keys.get("mistral"), None);
+    }
+
+    /// A user file must be able to blank out a key `/etc` set, or there
+    /// is no way to opt out of a system-wide credential. A blank never
+    /// survives as an empty bearer token either.
+    #[test]
+    fn a_later_blank_shadows_an_earlier_key_and_is_never_spent() {
+        let system = HashMap::from([
+            ("openai".to_string(), "sk-system".to_string()),
+            ("groq".to_string(), "sk-groq".to_string()),
+        ]);
+        let user = HashMap::from([("openai".to_string(), String::new())]);
+
+        let merged = merge_keys(vec![system, user]);
+        assert_eq!(merged.get("openai"), None, "blanked out by the user file");
+        assert_eq!(merged.get("groq").map(String::as_str), Some("sk-groq"));
+
+        // And the ordinary case: a later real key replaces an earlier one.
+        let merged = merge_keys(vec![
+            HashMap::from([("openai".to_string(), "sk-system".to_string())]),
+            HashMap::from([("openai".to_string(), "sk-user".to_string())]),
+        ]);
+        assert_eq!(merged.get("openai").map(String::as_str), Some("sk-user"));
+    }
+
+    /// A misspelling that parsed happily would silently never take
+    /// effect. Every section rejects one.
+    #[test]
+    fn a_misspelled_section_or_field_is_rejected_rather_than_ignored() {
+        assert!(parse("[provider.openai]\napi_key = \"x\"").is_err());
+        assert!(parse("[providers.openai]\napi_kye = \"x\"").is_err());
+        assert!(parse("[alias]\nx = \"y\"").is_err());
+        assert!(parse("[verify]\ndefualt = \"off\"").is_err());
+        assert!(parse("[[verify.trust]]\npattern = \"a/b\"\nkyes = []").is_err());
+        assert!(parse("api_key = \"x\"").is_err());
+    }
+
+    /// A mangled file is reported, not treated as empty.
+    #[test]
+    fn malformed_toml_is_an_error() {
+        assert!(parse("[providers.openai").is_err());
+    }
+
+    // -- search paths --------------------------------------------------------
+
+    /// Two locations, system first so the user's file wins — and none
+    /// of the package-managed ones earlier versions searched.
+    #[test]
+    fn the_search_path_is_etc_then_the_user_directory() {
+        let paths = search_paths();
+        assert_eq!(
+            paths.first().expect("a system path"),
+            &system_dir().join(FILE)
+        );
+        assert!(system_dir().ends_with("etc/llmman"), "{:?}", system_dir());
+        // Rooted, so it cannot resolve against the working directory.
+        assert!(system_dir().is_absolute(), "{:?}", system_dir());
+        assert!(
+            !paths.iter().any(|p| p.starts_with("/usr/share")),
+            "{paths:?}"
+        );
+        if let Some(user) = user_path() {
+            assert_eq!(paths.last(), Some(&user));
+            assert!(user.ends_with("llmman/llmman.conf"), "{}", user.display());
+        }
+    }
+
+    /// One per-user location on every platform, so there is exactly one
+    /// place `user_path` can name in an error.
+    #[test]
+    fn there_is_one_user_directory_on_every_platform() {
+        assert_eq!(search_paths().len(), user_dir().iter().count() + 1);
+        if let Some(dir) = user_dir() {
+            assert!(dir.ends_with(".config/llmman"), "{}", dir.display());
+        }
+    }
+
+    /// A key any account on the box can read is not one worth spending.
+    ///
+    /// Everything here is inlined rather than sharing a helper: a helper
+    /// used only by a `cfg(unix)` test is dead code on Windows, which
+    /// `clippy --all-targets -D warnings` rejects.
+    #[cfg(unix)]
+    #[test]
+    fn a_group_or_world_readable_file_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("llmman-conf-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join(FILE);
+        std::fs::write(&path, "[providers.openai]\napi_key = \"sk-x\"\n").expect("write");
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let err = owner_readable_only(&path).expect_err("0644 is refused");
+        assert!(err.contains("chmod 600"), "{err}");
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        assert!(owner_readable_only(&path).is_ok());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1106,8 +1106,8 @@ pub struct ProviderSummary {
     pub id: String,
     pub name: String,
     pub key_env: String,
-    /// Whether the key is set *where the daemon runs*. This process's own
-    /// environment is [`ProviderSummary::key_here`].
+    /// Whether the key is set *where the daemon runs*. What this process
+    /// itself holds is [`ProviderSummary::key_here`].
     pub key_set: bool,
     /// Whether the daemon would actually spend that key for a request
     /// presenting none. Only it can tell: that depends on how it is
@@ -1126,7 +1126,7 @@ impl ProviderSummary {
     /// Whether *this* process holds the key — the other way one reaches
     /// a provider, sent per request (see `client_api_key` in cmd::serve).
     pub fn key_here(&self) -> bool {
-        crate::providers::key_from_env(&self.key_env).is_some()
+        crate::providers::key_for(&self.id, &self.key_env).is_some()
     }
 }
 
@@ -1168,16 +1168,17 @@ pub struct ModelCost {
 }
 
 impl ProviderDetail {
-    /// This provider's key from *this* process's environment, to travel
-    /// with each request (see `client_api_key` in cmd::serve). `None` need
-    /// not be fatal — the daemon may hold it ([`ProviderDetail::key_set`]).
+    /// This provider's key as *this* process resolves it, to travel with
+    /// each request (see `client_api_key` in cmd::serve). `None` need not
+    /// be fatal — the daemon may hold it ([`ProviderDetail::key_set`]).
     ///
     /// The daemon names the variable, so a process squatting the port
     /// could name an unrelated secret — inside the trust boundary this
     /// whole module sits in either way: that daemon is handed every
-    /// prompt, and every key, regardless.
+    /// prompt, and every key, regardless. It does not name the
+    /// `llmman.conf` entry, which is keyed by the provider id.
     pub fn api_key(&self) -> Option<String> {
-        crate::providers::key_from_env(&self.key_env)
+        crate::providers::key_for(&self.id, &self.key_env)
     }
 
     /// Just the ids, for a caller that only needs to name one (see

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
 pub mod cmd;
+pub mod config;
 pub mod container;
 pub mod daemon;
 pub mod ffi;

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -256,10 +256,10 @@ pub struct Cost {
 }
 
 impl Provider {
-    /// This provider's API key from the environment, or `None` when
-    /// [`Provider::key_env`] is unset or blank.
+    /// This provider's API key, or `None` when neither the environment
+    /// nor `llmman.conf` has one. See [`key_for`].
     pub fn api_key(&self) -> Option<String> {
-        key_from_env(&self.key_env)
+        key_for(&self.id, &self.key_env)
     }
 
     /// Appends an OpenAI route to this provider's base URL. See
@@ -269,16 +269,66 @@ impl Provider {
     }
 }
 
-/// An API key read out of `var`, or `None` when it is unset or blank.
+/// The API key for provider `id`: `var` from the environment, else the
+/// `[providers.<id>]` entry in `llmman.conf` (see [`crate::config`]).
+/// `None` when neither has one.
 ///
-/// Free-standing because a `/llmman/providers` client (see
-/// `cmd::providers`) learns only the variable's *name* from the daemon,
-/// never a whole [`Provider`].
-pub fn key_from_env(var: &str) -> Option<String> {
+/// The environment wins, as it does for `aws` and `gh`: the file is the
+/// standing answer, an `export` the deliberate this-session-only
+/// override. The reverse would make `OPENAI_API_KEY=... llmman run`
+/// silently spend the wrong key.
+///
+/// Free-standing because a `/llmman/providers` client learns only the id
+/// and the variable's *name* from the daemon, never a [`Provider`].
+pub fn key_for(id: &str, var: &str) -> Option<String> {
+    resolve_key(key_from_env(var), crate::config::provider_api_key(id))
+}
+
+/// Split out so the precedence is testable without touching the process
+/// environment or the filesystem.
+fn resolve_key(from_env: Option<String>, from_conf: Option<&str>) -> Option<String> {
+    from_env.or_else(|| {
+        from_conf
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+    })
+}
+
+/// An API key read out of `var`, or `None` when it is unset or blank.
+fn key_from_env(var: &str) -> Option<String> {
     std::env::var(var)
         .ok()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
+}
+
+/// Both places llmman looks, named, for an error that fires because it
+/// found neither. One string so every such message agrees: a user told
+/// only about the variable would never learn the file exists.
+pub fn key_hint(id: &str, var: &str) -> String {
+    format!(
+        "set {var} in the environment, or add a [providers.{}] api_key to {}",
+        toml_key(id),
+        crate::config::user_path_display()
+    )
+}
+
+/// `id` as a TOML key, quoted when it is not a bare one.
+///
+/// models.dev has ids with a dot in them (`wafer.ai`), and
+/// `[providers.wafer.ai]` is two nested tables, not the key `wafer.ai` —
+/// so an unquoted hint tells the user to write something that silently
+/// does not configure the provider they asked about.
+fn toml_key(id: &str) -> String {
+    let bare = !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if bare {
+        id.to_string()
+    } else {
+        format!("{id:?}")
+    }
 }
 
 /// The provider id `--provider` names: `None` when the flag is absent,
@@ -1301,6 +1351,60 @@ mod tests {
             models: vec![],
         };
         assert_eq!(p.api_key(), None);
+    }
+
+    /// An `export` overrides the standing answer in `llmman.conf`. The
+    /// other way round would quietly spend the wrong key.
+    #[test]
+    fn the_environment_beats_the_config_file() {
+        assert_eq!(
+            resolve_key(Some("from-env".into()), Some("from-conf")),
+            Some("from-env".to_string())
+        );
+        assert_eq!(
+            resolve_key(None, Some("from-conf")),
+            Some("from-conf".to_string())
+        );
+        assert_eq!(
+            resolve_key(Some("from-env".into()), None),
+            Some("from-env".to_string())
+        );
+        assert_eq!(resolve_key(None, None), None);
+    }
+
+    /// What is only whitespace is no key — as in the environment.
+    #[test]
+    fn a_config_file_key_is_trimmed_and_a_blank_one_ignored() {
+        assert_eq!(
+            resolve_key(None, Some("  padded  ")),
+            Some("padded".to_string())
+        );
+        assert_eq!(resolve_key(None, Some("   ")), None);
+        assert_eq!(resolve_key(None, Some("")), None);
+    }
+
+    /// Both places, in one message.
+    #[test]
+    fn key_hint_names_the_variable_and_the_config_file() {
+        let hint = key_hint("openrouter", "OPENROUTER_API_KEY");
+        assert!(hint.contains("OPENROUTER_API_KEY"), "{hint}");
+        assert!(hint.contains("[providers.openrouter]"), "{hint}");
+        assert!(hint.contains("llmman.conf"), "{hint}");
+    }
+
+    /// models.dev ships `wafer.ai`, and `[providers.wafer.ai]` is two
+    /// nested tables rather than that key — a hint saying so would not
+    /// configure the provider it names.
+    #[test]
+    fn key_hint_quotes_a_provider_id_that_is_not_a_bare_toml_key() {
+        assert!(
+            key_hint("wafer.ai", "WAFER_API_KEY").contains(r#"[providers."wafer.ai"]"#),
+            "{}",
+            key_hint("wafer.ai", "WAFER_API_KEY")
+        );
+        assert_eq!(toml_key("openrouter"), "openrouter");
+        assert_eq!(toml_key("z-ai"), "z-ai");
+        assert_eq!(toml_key("wafer.ai"), r#""wafer.ai""#);
     }
 
     /// The listing has to stay short enough to read in an error message

--- a/src/shortnames.rs
+++ b/src/shortnames.rs
@@ -1,71 +1,28 @@
-//! Short-name alias resolution — loaded from config files at runtime.
+//! Short-name alias resolution — from the `[aliases]` table of
+//! `llmman.conf`, at runtime. Nothing is compiled into the binary.
 //!
-//! Mirrors podman's approach: TOML files are read from a priority-ordered set
-//! of locations; all files are merged with higher-priority entries winning.
-//! Nothing is compiled into the binary.
-//!
-//! Search order (ascending priority — later files override earlier ones):
-//!   1. /usr/share/llmman/shortnames.conf          distro / package default
-//!   2. /etc/llmman/shortnames.conf                 system-admin override
-//!   3. <binary>/../share/llmman/shortnames.conf    install-tree relative path
-//!   4. <binary-dir>/shortnames.conf                development (conf beside binary)
-//!   5. ~/.config/llmman/shortnames.conf            per-user aliases
+//! Mirrors podman's approach: files are merged in priority order, later
+//! entries winning. See [`crate::config`] for the locations.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::OnceLock;
 
-use serde::Deserialize;
-
-#[derive(Deserialize, Default)]
-struct Conf {
-    #[serde(default)]
-    aliases: HashMap<String, String>,
-}
-
-/// Return all candidate config-file paths in ascending priority order.
-fn config_paths() -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = vec![
-        PathBuf::from("/usr/share/llmman/shortnames.conf"),
-        PathBuf::from("/etc/llmman/shortnames.conf"),
-    ];
-
-    // Paths relative to the running binary.
-    if let Ok(exe) = std::env::current_exe() {
-        // <binary>/../share/llmman/shortnames.conf  (standard install layout)
-        if let Some(parent) = exe.parent() {
-            paths.push(parent.join("../share/llmman/shortnames.conf"));
-            // <binary-dir>/shortnames.conf  (development: cargo run / direct exec)
-            paths.push(parent.join("shortnames.conf"));
-        }
-    }
-
-    // ~/.config/llmman/shortnames.conf
-    if let Some(cfg) = dirs::config_dir() {
-        paths.push(cfg.join("llmman").join("shortnames.conf"));
-    }
-
-    paths
-}
-
-/// Load and merge aliases from all config files.
-/// Higher-priority files (later in the list) override lower-priority ones.
+/// Merge the `[aliases]` table of every `llmman.conf`, later files
+/// winning.
+///
+/// A file that will not parse is reported once by [`crate::config`] and
+/// leaves no aliases, degrading to "unknown reference" rather than
+/// resolving a short name somewhere unintended — an alias pointing at
+/// the wrong registry is how `gemma4` becomes someone else's model.
 fn load_aliases() -> HashMap<String, String> {
     let mut merged: HashMap<String, String> = HashMap::new();
-    for path in config_paths() {
-        let Ok(text) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        match toml::from_str::<Conf>(&text) {
-            Ok(conf) => {
-                for (k, v) in conf.aliases {
-                    merged.insert(k, v);
-                }
-            }
-            Err(e) => {
-                eprintln!("[llmman] warning: ignoring {}: {e}", path.display());
-            }
-        }
+    for file in crate::config::files().unwrap_or_default() {
+        merged.extend(
+            file.conf
+                .aliases
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone())),
+        );
     }
     merged
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,13 +4,15 @@
 //! through [`crate::ffi::verify`]); this module decides *when* to invoke
 //! it and *what a negative answer means*, which is a policy question.
 //!
-//! `verify.conf` is read from the same priority-ordered locations as
-//! `shortnames.conf`, merged with later files winning:
+//! Policy comes from the `[verify]` section of `llmman.conf` (see
+//! [`crate::config`] for the locations), merged with later files
+//! winning:
 //!
 //! ```toml
+//! [verify]
 //! default = "off"                  # for references no rule matches
 //!
-//! [[trust]]
+//! [[verify.trust]]
 //! pattern = "docker.io/myorg/**"
 //! keys    = ["keys/myorg.pub"]     # relative to this file's directory
 //! mode    = "enforce"              # off | warn | enforce
@@ -30,7 +32,8 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use anyhow::{anyhow, bail, Context};
-use serde::Deserialize;
+
+use crate::config::VerifyConf;
 
 /// Longest accepted `pattern`. Nothing real comes close; the bound just
 /// keeps a pathological one uninteresting.
@@ -75,25 +78,6 @@ impl std::fmt::Display for Mode {
 // Config
 // ---------------------------------------------------------------------------
 
-#[derive(Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-struct Conf {
-    #[serde(default)]
-    default: Option<String>,
-    #[serde(default)]
-    trust: Vec<TrustConf>,
-}
-
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct TrustConf {
-    pattern: String,
-    #[serde(default)]
-    keys: Vec<String>,
-    #[serde(default)]
-    mode: Option<String>,
-}
-
 #[derive(Debug, Clone)]
 struct Rule {
     pattern: String,
@@ -123,10 +107,10 @@ pub struct Decision {
 }
 
 impl Policy {
-    /// Parse one config file. `dir` is its own directory, which relative
-    /// key paths resolve against, so a policy can ship with its keys.
-    fn parse(text: &str, dir: &Path) -> anyhow::Result<Self> {
-        let conf: Conf = toml::from_str(text).context("parse TOML")?;
+    /// One file's `[verify]` section. `dir` is that file's own
+    /// directory, which relative key paths resolve against, so a policy
+    /// can ship with its keys.
+    fn from_conf(conf: &VerifyConf, dir: &Path) -> anyhow::Result<Self> {
         let default_mode = conf
             .default
             .as_deref()
@@ -134,17 +118,17 @@ impl Policy {
             .transpose()?;
 
         let mut rules = Vec::with_capacity(conf.trust.len());
-        for entry in conf.trust {
+        for entry in &conf.trust {
             validate_pattern(&entry.pattern)?;
             let mode = match entry.mode.as_deref() {
                 Some(s) => Mode::parse(s)
-                    .with_context(|| format!("[[trust]] pattern {:?}", entry.pattern))?,
+                    .with_context(|| format!("[[verify.trust]] pattern {:?}", entry.pattern))?,
                 // Keys but no mode means "check this, tell me, don't
                 // break my build".
                 None => Mode::Warn,
             };
             rules.push(Rule {
-                pattern: entry.pattern,
+                pattern: entry.pattern.clone(),
                 keys: entry
                     .keys
                     .iter()
@@ -158,6 +142,13 @@ impl Policy {
             forced_mode: None,
             rules,
         })
+    }
+
+    /// A `[verify]` section on its own, for tests that care about the
+    /// policy and not the file it came from.
+    #[cfg(test)]
+    fn parse(text: &str, dir: &Path) -> anyhow::Result<Self> {
+        Self::from_conf(&toml::from_str(text).context("parse TOML")?, dir)
     }
 
     /// The mode and trusted keys that apply to `reference`.
@@ -191,10 +182,12 @@ impl Policy {
 
     /// Load and merge every config file present, cached for the process.
     ///
-    /// A file that exists but cannot be read or parsed is fatal, not
-    /// skipped: it could be the one demanding enforcement, and treating
-    /// it like an absent file would silently downgrade to `off`. Only
-    /// "not there" is ignored.
+    /// A file that cannot be read or parsed is fatal here, not skipped:
+    /// it could be the one demanding enforcement, and treating it like
+    /// an absent file would silently downgrade to `off`. This is why
+    /// [`crate::config::files`] reports a parse failure rather than
+    /// deciding what it means — the other two readers of that file can
+    /// carry on without it, and this one cannot.
     pub fn load() -> anyhow::Result<&'static Policy> {
         static CACHE: OnceLock<Result<Policy, String>> = OnceLock::new();
         CACHE
@@ -206,17 +199,9 @@ impl Policy {
 
 fn load_uncached() -> anyhow::Result<Policy> {
     let mut merged = Policy::default();
-    for path in config_paths() {
-        let text = match std::fs::read_to_string(&path) {
-            Ok(text) => text,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => {
-                return Err(anyhow!(e)).context(format!("read {}", path.display()));
-            }
-        };
-        let dir = path.parent().unwrap_or(Path::new("."));
-        let policy =
-            Policy::parse(&text, dir).with_context(|| format!("read {}", path.display()))?;
+    for file in crate::config::files().map_err(|e| anyhow!("{e}"))? {
+        let policy = Policy::from_conf(&file.conf.verify, &file.dir)
+            .with_context(|| format!("read {}", file.path.display()))?;
         if let Some(mode) = policy.default_mode {
             merged.default_mode = Some(mode);
         }
@@ -232,19 +217,23 @@ fn load_uncached() -> anyhow::Result<Policy> {
 /// something. Same reasoning as rejecting an unknown `mode`.
 fn validate_pattern(pattern: &str) -> anyhow::Result<()> {
     if pattern.is_empty() {
-        bail!("a [[trust]] entry has an empty `pattern`");
+        bail!("a [[verify.trust]] entry has an empty `pattern`");
     }
     if pattern.len() > MAX_PATTERN_LEN {
-        bail!("[[trust]] pattern is longer than {MAX_PATTERN_LEN} bytes: {pattern:?}");
+        bail!("[[verify.trust]] pattern is longer than {MAX_PATTERN_LEN} bytes: {pattern:?}");
     }
     if pattern.contains('@') {
         bail!(
-            "[[trust]] pattern {pattern:?} contains a digest; patterns match the repository only"
+            "[[verify.trust]] pattern {pattern:?} contains a digest; patterns match the \
+             repository only"
         );
     }
     let last = pattern.rsplit('/').next().unwrap_or(pattern);
     if last.contains(':') {
-        bail!("[[trust]] pattern {pattern:?} contains a tag; patterns match the repository only");
+        bail!(
+            "[[verify.trust]] pattern {pattern:?} contains a tag; patterns match the \
+             repository only"
+        );
     }
     Ok(())
 }
@@ -266,24 +255,6 @@ fn parse_mode_override(raw: Option<&str>) -> anyhow::Result<Option<Mode>> {
         None | Some("") => Ok(None),
         Some(raw) => Mode::parse(raw).map(Some).context("LLMMAN_VERIFY"),
     }
-}
-
-/// The same set and order as `shortnames::config_paths`, different name.
-fn config_paths() -> Vec<PathBuf> {
-    let mut paths: Vec<PathBuf> = vec![
-        PathBuf::from("/usr/share/llmman/verify.conf"),
-        PathBuf::from("/etc/llmman/verify.conf"),
-    ];
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(parent) = exe.parent() {
-            paths.push(parent.join("../share/llmman/verify.conf"));
-            paths.push(parent.join("verify.conf"));
-        }
-    }
-    if let Some(cfg) = dirs::config_dir() {
-        paths.push(cfg.join("llmman").join("verify.conf"));
-    }
-    paths
 }
 
 /// Expand `~` and make a relative key path absolute against the config
@@ -552,7 +523,7 @@ fn check_with(
         // naming no keys. Nothing to check against.
         let msg = format!(
             "verification is set to {} for {reference}, but no trusted public keys are configured for it \
-             (add a [[trust]] rule with `keys` to verify.conf)",
+             (add a [[verify.trust]] rule with `keys` to llmman.conf)",
             decision.mode
         );
         if decision.mode == Mode::Enforce {
@@ -812,6 +783,46 @@ mod tests {
 
     fn policy(text: &str) -> Policy {
         Policy::parse(text, Path::new("/etc/llmman")).expect("parse policy")
+    }
+
+    /// The other tests hand `Policy` a `[verify]` section on its own.
+    /// This one goes the way the daemon does, through a whole
+    /// `llmman.conf`, so the two cannot drift into a policy that parses
+    /// in tests and is silently absent in production.
+    #[test]
+    fn a_nested_verify_section_of_a_whole_llmman_conf_becomes_a_policy() {
+        let conf = crate::config::parse(
+            r#"
+            [aliases]
+            gemma4 = "docker.io/ai/gemma4"
+
+            [providers.openai]
+            api_key = "sk-x"
+
+            [verify]
+            default = "warn"
+
+            [[verify.trust]]
+            pattern = "docker.io/myorg/**"
+            keys    = ["keys/myorg.pub"]
+            mode    = "enforce"
+            "#,
+        )
+        .expect("valid llmman.conf");
+
+        let policy =
+            Policy::from_conf(&conf.verify, Path::new("/etc/llmman")).expect("valid policy");
+
+        // The rule applies where it matches, keys resolved against the
+        // file's own directory...
+        let decision = policy.decide("docker.io/myorg/model:v1");
+        assert_eq!(decision.mode, Mode::Enforce);
+        assert_eq!(
+            decision.keys,
+            vec![PathBuf::from("/etc/llmman/keys/myorg.pub")]
+        );
+        // ...and `default` covers everything it does not.
+        assert_eq!(policy.decide("docker.io/other/model").mode, Mode::Warn);
     }
 
     #[test]


### PR DESCRIPTION
API keys could only be set through environment variables. This adds a config file for them, and — since that would have made three config files — folds the existing two into it.

## `llmman.conf`

```toml
# ~/.config/llmman/llmman.conf

[aliases]                        # was shortnames.conf
gemma4 = "docker.io/ai/gemma4"

[providers.openrouter]           # new
api_key = "sk-or-..."

[verify]                         # was verify.conf
default = "off"

[[verify.trust]]
pattern = "docker.io/myorg/**"
keys    = ["keys/myorg.pub"]
mode    = "enforce"
```

Read from `/etc/llmman/` then `~/.config/llmman/`, on every platform, with no environment variable to move them. `shortnames.conf` and `verify.conf` are no longer read, nor are the `/usr/share/llmman/`, `<binary>/../share/llmman/` and `<binary-dir>/` tiers — nothing ever shipped a file to them, and they are world-readable, which this file cannot be.

## Provider keys

Keyed by the provider id `llmman providers` prints, not by the environment variable — that name is models.dev's, not llmman's.

The environment still wins, as it does for `aws` and `gh`: the file is the standing answer, an `export` the deliberate this-session-only override. The reverse would make `OPENAI_API_KEY=... llmman run` silently spend the wrong key.

Resolution goes through one choke point (`providers::key_for`), so the CLI and daemon pick a key up identically, and every "no API key" message now names both places to put one. `llmman providers`' `set (shell)` became `set (client)`, since a client-side key no longer has to come from a shell.

## One file, three failure policies

A parse failure is not the same event for every reader. `verify` refuses to run — a trust policy llmman cannot read must not be mistaken for one that does not exist. Aliases and keys degrade to none, surfacing as "unknown reference" or "no API key". The error is printed once, centrally, so one typo is not announced three times.

## Permissions

A file carrying a key must not be readable by group or other, the way `ssh` refuses a loose private key. The check gates **the keys alone, not the read** — a world-readable `/etc/llmman/llmman.conf` still supplies its aliases and trust policy, which are not secrets.

## Testing

`cargo fmt --check`, `cargo clippy --release --all-targets -D warnings`, `cargo clippy --features fuzzing`, `cargo check` on the fuzz crate, and `cargo test --release --lib --bins` (536 passed) all clean.

Every pre-existing `verify` test passes unchanged — `Policy::parse` still takes a `[verify]` section body — so nothing silently weakened a security test. A new test drives a whole nested `llmman.conf` through to a `Policy`, so the two shapes cannot drift.

`config::load()` is `cfg!(test)`-guarded to return nothing, so no unit test can depend on whoever runs it having an `llmman.conf`; without that, a fixture provider named `openai` would resolve a real key and flip the assertions that prove no key leaks.

Smoke-tested against the release binary, since that path is `cfg!(test)`-guarded out:

- `[aliases]` resolves a short name from `~/.config/llmman/llmman.conf`
- malformed conf → one warning, `llmman verify` exits 1 (does **not** silently go `off`)
- daemon at `0600` → `llmman providers` reports the key `set`, with `OPENROUTER_API_KEY` unset
- same file at `0644` → `unset`, keys ignored with `chmod 600` advice, aliases unaffected
- `$XDG_CONFIG_HOME` and `~/Library/Application Support/llmman` are both ignored
- unknown section (`[alises]`) rejected rather than ignored
