### PR TITLE
docs: refer to agents rather than coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">llmman</h1>
 
-<p align="center"><b>Run any coding agent on any model.</b></p>
+<p align="center"><b>Run any agent on any model.</b></p>
 
 <p align="center">
 Claude Code, Codex, OpenCode and friends, pointed at a model
@@ -41,7 +41,7 @@ irm https://raw.githubusercontent.com/llmmanorg/llmman/main/install.ps1 | iex
 Three commands cover most of it:
 
 ```sh
-llmman launch claude --model gemma4   # a coding agent on a local model
+llmman launch claude --model gemma4   # an agent on a local model
 llmman run gemma4                     # just chat with a model
 llmman serve                          # an Ollama/OpenAI/Anthropic-compatible endpoint
 ```

--- a/src/cmd/launch.rs
+++ b/src/cmd/launch.rs
@@ -1,4 +1,4 @@
-//! `llmman launch` — launch AI coding-assistant integrations backed by llmman serve.
+//! `llmman launch` — launch AI agent integrations backed by llmman serve.
 //!
 //! Mirrors `ollama launch`: sets integration-specific environment variables
 //! pointing at the local inference server, then exec's the integration binary.

--- a/src/modelpack.rs
+++ b/src/modelpack.rs
@@ -117,7 +117,7 @@ fn is_mmproj_layer(l: &crate::storage::oci::Descriptor) -> bool {
 // a bug to work around. Defeating that safety net via --override-kv
 // produces a real NaN/incoherent-output risk for out-of-distribution
 // RoPE positions that llama-server's own warning exists to prevent, for
-// a use case (fitting a real coding agent's system prompt) that a model
+// a use case (fitting a real agent's system prompt) that a model
 // whose trained context is that tight was never going to serve well
 // regardless — see docker/sandboxes' own llmmanCtxSize doc comment for the
 // model-selection fix that replaced this instead.


### PR DESCRIPTION
## What

Drops the "coding" qualifier from the places that described llmman's audience as coding agents:

- `README.md` tagline and quick-start comment
- `src/cmd/launch.rs` module doc ("AI coding-assistant integrations" -> "AI agent integrations")
- `src/modelpack.rs` comment about fitting an agent's system prompt

## Why

The launch integrations just point an agent at a local or hosted model. Nothing in the mechanism is specific to coding work, so the narrower phrasing understated who the tool is for.

Comment/doc-only; no behaviour change.