### PR TITLE
docs: describe launch as exec'ing an agent, not Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ llmman launch claude --model gemma4
 ```
 
 That starts a local inference server, downloads a `llama.cpp` build matching your
-GPU, loads the model, and execs Claude Code against it.
+GPU, loads the model, and execs an agent against it.
 
 <!-- TODO: 20s asciinema/GIF here: launch claude -> boots -> wifi off -> still coding -->
 


### PR DESCRIPTION
Changes "execs Claude Code against it" to "execs an agent against it" in the README walkthrough, since `llmman launch` works with any supported agent.

Note: this touches the same hunk as #398, so whichever merges second will need a manual conflict resolve.